### PR TITLE
Add Anthropic Claude and Ollama model providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "openclaw-channels",
  "openclaw-core",
  "openclaw-gateway",
+ "openclaw-providers",
  "openclaw-skills",
  "openclaw-store",
  "openclaw-tools",
@@ -1040,6 +1041,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "openclaw-providers"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "openclaw-core",
+ "reqwest",
+ "serde",
+ "serde_json",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/openclaw-store",
     "crates/openclaw-gateway",
     "crates/openclaw-agent",
+    "crates/openclaw-providers",
     "crates/openclaw-tools",
     "crates/openclaw-channels",
     "crates/openclaw-skills",
@@ -63,6 +64,7 @@ openclaw-core = { path = "crates/openclaw-core" }
 openclaw-store = { path = "crates/openclaw-store" }
 openclaw-gateway = { path = "crates/openclaw-gateway" }
 openclaw-agent = { path = "crates/openclaw-agent" }
+openclaw-providers = { path = "crates/openclaw-providers" }
 openclaw-tools = { path = "crates/openclaw-tools" }
 openclaw-channels = { path = "crates/openclaw-channels" }
 openclaw-skills = { path = "crates/openclaw-skills" }

--- a/crates/openclaw-cli/Cargo.toml
+++ b/crates/openclaw-cli/Cargo.toml
@@ -13,6 +13,7 @@ openclaw-agent.workspace = true
 openclaw-tools.workspace = true
 openclaw-channels.workspace = true
 openclaw-skills.workspace = true
+openclaw-providers.workspace = true
 axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use openclaw_core::model::ModelProvider;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -16,8 +17,6 @@ async fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&data_dir)?;
 
     // --- Master key for credential encryption ---
-    // In production: read from OS keychain. Fallback to env var.
-    // NEVER store alongside the database.
     let master_key = std::env::var("OPENCLAW_MASTER_KEY")
         .unwrap_or_else(|_| {
             tracing::warn!(
@@ -31,18 +30,52 @@ async fn main() -> anyhow::Result<()> {
     let store = openclaw_store::Store::open(data_dir.join("db"), master_key)?;
 
     // --- Auth token ---
-    // Read from env or generate and print.
     let auth_token = std::env::var("OPENCLAW_AUTH_TOKEN").unwrap_or_else(|_| {
         let token = openclaw_gateway::generate_token();
         tracing::info!("Generated auth token (set OPENCLAW_AUTH_TOKEN to persist):");
-        // Print to stdout so it's capturable, not mixed into logs.
         println!("\n  OPENCLAW_AUTH_TOKEN={token}\n");
         token
     });
 
+    // --- Model provider ---
+    let provider: Arc<dyn ModelProvider> = match std::env::var("OPENCLAW_PROVIDER")
+        .unwrap_or_else(|_| "anthropic".to_string())
+        .to_lowercase()
+        .as_str()
+    {
+        "ollama" => {
+            let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "qwen3:32b".to_string());
+            let base_url = std::env::var("OLLAMA_BASE_URL")
+                .unwrap_or_else(|_| "http://localhost:11434".to_string());
+            tracing::info!(%model, %base_url, "using Ollama provider");
+            let p = openclaw_providers::OllamaProvider::new(model).with_base_url(base_url);
+            Arc::new(p)
+        }
+        _ => {
+            let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_else(|_| {
+                // Try reading from the encrypted store.
+                if let Ok(key) = store.secrets().get("anthropic_api_key") {
+                    return key;
+                }
+                tracing::error!(
+                    "ANTHROPIC_API_KEY not set. Set it or store via the secrets API."
+                );
+                String::new()
+            });
+            let model = std::env::var("ANTHROPIC_MODEL")
+                .unwrap_or_else(|_| "claude-sonnet-4-20250514".to_string());
+            tracing::info!(%model, "using Anthropic provider");
+            let p = openclaw_providers::AnthropicProvider::new(api_key).with_model(model);
+            Arc::new(p)
+        }
+    };
+
     // --- Tools ---
     let tools = openclaw_tools::builtin_tools();
     let first_tool: Arc<dyn openclaw_core::Tool> = tools.into_iter().next().unwrap();
+
+    // --- Log provider status ---
+    tracing::info!(provider = provider.name(), "model provider configured");
 
     // --- Gateway with security middleware ---
     let state = openclaw_gateway::AppState::new(store, first_tool, auth_token);

--- a/crates/openclaw-providers/Cargo.toml
+++ b/crates/openclaw-providers/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "openclaw-providers"
+description = "Model provider implementations (Anthropic Claude, Ollama/local)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+openclaw-core.workspace = true
+async-trait.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+uuid.workspace = true
+chrono.workspace = true

--- a/crates/openclaw-providers/src/anthropic.rs
+++ b/crates/openclaw-providers/src/anthropic.rs
@@ -1,0 +1,281 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use openclaw_core::error::Result;
+use openclaw_core::model::{ModelProvider, ModelResponse, Usage};
+use openclaw_core::types::{
+    Message, MessageContent, Role, ToolCall, ToolSchema,
+};
+use openclaw_core::Error;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Anthropic Claude API provider.
+///
+/// Calls the Messages API at `https://api.anthropic.com/v1/messages`.
+/// Supports tool use natively — Claude is the recommended model for
+/// agentic workloads due to superior prompt injection resistance.
+pub struct AnthropicProvider {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+}
+
+impl AnthropicProvider {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key,
+            model: "claude-sonnet-4-20250514".to_string(),
+            max_tokens: 4096,
+        }
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Convert our internal messages to Anthropic API format.
+    fn build_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMessage>) {
+        let mut system_prompt = None;
+        let mut api_messages = Vec::new();
+
+        for msg in messages {
+            match msg.role {
+                Role::System => {
+                    if let MessageContent::Text(ref text) = msg.content {
+                        system_prompt = Some(text.clone());
+                    }
+                }
+                Role::User => {
+                    if let MessageContent::Text(ref text) = msg.content {
+                        api_messages.push(ApiMessage {
+                            role: "user".to_string(),
+                            content: ApiContent::Text(text.clone()),
+                        });
+                    }
+                }
+                Role::Assistant => match msg.content {
+                    MessageContent::Text(ref text) => {
+                        api_messages.push(ApiMessage {
+                            role: "assistant".to_string(),
+                            content: ApiContent::Text(text.clone()),
+                        });
+                    }
+                    MessageContent::ToolCall(ref call) => {
+                        api_messages.push(ApiMessage {
+                            role: "assistant".to_string(),
+                            content: ApiContent::Blocks(vec![ContentBlock::ToolUse {
+                                id: call.id.clone(),
+                                name: call.name.clone(),
+                                input: call.arguments.clone(),
+                            }]),
+                        });
+                    }
+                    _ => {}
+                },
+                Role::Tool => {
+                    if let MessageContent::ToolResult(ref result) = msg.content {
+                        api_messages.push(ApiMessage {
+                            role: "user".to_string(),
+                            content: ApiContent::Blocks(vec![ContentBlock::ToolResult {
+                                tool_use_id: result.call_id.clone(),
+                                content: serde_json::to_string(&result.output)
+                                    .unwrap_or_default(),
+                            }]),
+                        });
+                    }
+                }
+            }
+        }
+
+        (system_prompt, api_messages)
+    }
+
+    /// Convert tool schemas to Anthropic's tool format.
+    fn build_tools(tools: &[ToolSchema]) -> Vec<ApiTool> {
+        tools
+            .iter()
+            .map(|t| ApiTool {
+                name: t.name.clone(),
+                description: t.description.clone(),
+                input_schema: t.parameters.clone(),
+            })
+            .collect()
+    }
+
+    /// Parse the API response into our internal types.
+    fn parse_response(resp: ApiResponse) -> Result<ModelResponse> {
+        let usage = Usage {
+            prompt_tokens: resp.usage.input_tokens,
+            completion_tokens: resp.usage.output_tokens,
+        };
+
+        // Check for tool use in the response content blocks.
+        for block in &resp.content {
+            if let ResponseBlock::ToolUse { id, name, input } = block {
+                return Ok(ModelResponse {
+                    message: Message {
+                        id: Uuid::new_v4(),
+                        role: Role::Assistant,
+                        content: MessageContent::ToolCall(ToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments: input.clone(),
+                        }),
+                        created_at: Utc::now(),
+                    },
+                    usage,
+                });
+            }
+        }
+
+        // Otherwise, extract text.
+        let text = resp
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ResponseBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        Ok(ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text),
+                created_at: Utc::now(),
+            },
+            usage,
+        })
+    }
+}
+
+#[async_trait]
+impl ModelProvider for AnthropicProvider {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+    ) -> Result<ModelResponse> {
+        let (system, api_messages) = Self::build_messages(messages);
+        let api_tools = Self::build_tools(tools);
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": api_messages,
+        });
+
+        if let Some(sys) = system {
+            body["system"] = serde_json::json!(sys);
+        }
+        if !api_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&api_tools)
+                .map_err(|e| Error::Serialization(e))?;
+        }
+
+        tracing::debug!(model = %self.model, "calling Anthropic Messages API");
+
+        let resp = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::ModelProvider(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(Error::ModelProvider(format!(
+                "Anthropic API returned {status}: {error_body}"
+            )));
+        }
+
+        let api_resp: ApiResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("failed to parse response: {e}")))?;
+
+        Self::parse_response(api_resp)
+    }
+}
+
+// --- Anthropic API wire types (private) ---
+
+#[derive(Serialize)]
+struct ApiMessage {
+    role: String,
+    content: ApiContent,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum ApiContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum ContentBlock {
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
+}
+
+#[derive(Serialize)]
+struct ApiTool {
+    name: String,
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    content: Vec<ResponseBlock>,
+    usage: ApiUsage,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum ResponseBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+#[derive(Deserialize)]
+struct ApiUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}

--- a/crates/openclaw-providers/src/lib.rs
+++ b/crates/openclaw-providers/src/lib.rs
@@ -1,0 +1,5 @@
+mod anthropic;
+mod ollama;
+
+pub use anthropic::AnthropicProvider;
+pub use ollama::OllamaProvider;

--- a/crates/openclaw-providers/src/ollama.rs
+++ b/crates/openclaw-providers/src/ollama.rs
@@ -1,0 +1,243 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use openclaw_core::error::Result;
+use openclaw_core::model::{ModelProvider, ModelResponse, Usage};
+use openclaw_core::types::{
+    Message, MessageContent, Role, ToolCall, ToolSchema,
+};
+use openclaw_core::Error;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Ollama provider for local models (Qwen, Llama, Mistral, etc.).
+///
+/// Connects to a local Ollama instance (default `http://localhost:11434`).
+/// Supports tool calling via the Ollama chat API, which is compatible
+/// with models that have been fine-tuned for function calling.
+///
+/// Recommended models:
+/// - `qwen3:32b` — best tool-use quality per GB
+/// - `llama4-scout` — good MoE option if you have 32GB+ VRAM
+/// - `mistral-small` — lightweight fallback
+pub struct OllamaProvider {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+}
+
+impl OllamaProvider {
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: "http://localhost:11434".to_string(),
+            model: model.into(),
+        }
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    /// Convert internal messages to Ollama chat format.
+    fn build_messages(messages: &[Message]) -> Vec<OllamaMessage> {
+        messages
+            .iter()
+            .filter_map(|msg| {
+                let role = match msg.role {
+                    Role::System => "system",
+                    Role::User => "user",
+                    Role::Assistant => "assistant",
+                    Role::Tool => "tool",
+                };
+
+                match &msg.content {
+                    MessageContent::Text(text) => Some(OllamaMessage {
+                        role: role.to_string(),
+                        content: Some(text.clone()),
+                        tool_calls: None,
+                    }),
+                    MessageContent::ToolCall(call) => Some(OllamaMessage {
+                        role: role.to_string(),
+                        content: None,
+                        tool_calls: Some(vec![OllamaToolCall {
+                            function: OllamaFunction {
+                                name: call.name.clone(),
+                                arguments: call.arguments.clone(),
+                            },
+                        }]),
+                    }),
+                    MessageContent::ToolResult(result) => Some(OllamaMessage {
+                        role: role.to_string(),
+                        content: Some(
+                            serde_json::to_string(&result.output).unwrap_or_default(),
+                        ),
+                        tool_calls: None,
+                    }),
+                }
+            })
+            .collect()
+    }
+
+    /// Convert tool schemas to Ollama's tool format.
+    fn build_tools(tools: &[ToolSchema]) -> Vec<OllamaTool> {
+        tools
+            .iter()
+            .map(|t| OllamaTool {
+                r#type: "function".to_string(),
+                function: OllamaToolDef {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.parameters.clone(),
+                },
+            })
+            .collect()
+    }
+
+    /// Parse Ollama response into internal types.
+    fn parse_response(resp: OllamaResponse) -> Result<ModelResponse> {
+        let msg = resp.message;
+
+        // Check for tool calls first.
+        if let Some(tool_calls) = msg.tool_calls {
+            if let Some(tc) = tool_calls.into_iter().next() {
+                return Ok(ModelResponse {
+                    message: Message {
+                        id: Uuid::new_v4(),
+                        role: Role::Assistant,
+                        content: MessageContent::ToolCall(ToolCall {
+                            id: Uuid::new_v4().to_string(),
+                            name: tc.function.name,
+                            arguments: tc.function.arguments,
+                        }),
+                        created_at: Utc::now(),
+                    },
+                    usage: Usage {
+                        prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
+                        completion_tokens: resp.eval_count.unwrap_or(0),
+                    },
+                });
+            }
+        }
+
+        // Text response.
+        Ok(ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(msg.content.unwrap_or_default()),
+                created_at: Utc::now(),
+            },
+            usage: Usage {
+                prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
+                completion_tokens: resp.eval_count.unwrap_or(0),
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl ModelProvider for OllamaProvider {
+    fn name(&self) -> &str {
+        "ollama"
+    }
+
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+    ) -> Result<ModelResponse> {
+        let ollama_messages = Self::build_messages(messages);
+        let ollama_tools = Self::build_tools(tools);
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": ollama_messages,
+            "stream": false,
+        });
+
+        if !ollama_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&ollama_tools)
+                .map_err(|e| Error::Serialization(e))?;
+        }
+
+        tracing::debug!(model = %self.model, base_url = %self.base_url, "calling Ollama chat API");
+
+        let url = format!("{}/api/chat", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                Error::ModelProvider(format!(
+                    "failed to connect to Ollama at {}: {e}. Is Ollama running?",
+                    self.base_url
+                ))
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(Error::ModelProvider(format!(
+                "Ollama API returned {status}: {error_body}"
+            )));
+        }
+
+        let ollama_resp: OllamaResponse = resp
+            .json()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("failed to parse Ollama response: {e}")))?;
+
+        Self::parse_response(ollama_resp)
+    }
+}
+
+// --- Ollama API wire types (private) ---
+
+#[derive(Serialize)]
+struct OllamaMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OllamaToolCall>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OllamaToolCall {
+    function: OllamaFunction,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OllamaFunction {
+    name: String,
+    arguments: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct OllamaTool {
+    r#type: String,
+    function: OllamaToolDef,
+}
+
+#[derive(Serialize)]
+struct OllamaToolDef {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct OllamaResponse {
+    message: OllamaResponseMessage,
+    prompt_eval_count: Option<u32>,
+    eval_count: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct OllamaResponseMessage {
+    content: Option<String>,
+    tool_calls: Option<Vec<OllamaToolCall>>,
+}


### PR DESCRIPTION
New crate: openclaw-providers with two ModelProvider implementations:

AnthropicProvider:
- Calls the Messages API at api.anthropic.com/v1/messages
- Full tool-use support (tool_use/tool_result content blocks)
- Converts between internal types and Anthropic wire format
- Defaults to claude-sonnet-4, configurable via ANTHROPIC_MODEL

OllamaProvider:
- Connects to local Ollama instance (default localhost:11434)
- Tool calling via Ollama chat API for function-call-capable models
- Defaults to qwen3:32b, configurable via OLLAMA_MODEL / OLLAMA_BASE_URL
- Helpful error messages when Ollama isn't running

CLI wiring:
- OPENCLAW_PROVIDER=anthropic|ollama selects the backend
- Anthropic reads API key from ANTHROPIC_API_KEY or encrypted SecretStore
- All config via env vars, no plaintext config files

https://claude.ai/code/session_01Kz97y8Vc1BvG3EjDsZnBW1