### PR TITLE
Add system tools for web browsing and service authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +368,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -874,6 +921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1003,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1103,6 +1162,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "openclaw-core",
+ "openclaw-store",
  "reqwest",
  "serde",
  "serde_json",
@@ -1196,6 +1256,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1287,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1412,6 +1494,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "http",
  "http-body",
@@ -1822,6 +1906,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -77,8 +77,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // --- Tools ---
-    let tools = openclaw_tools::builtin_tools();
-    let first_tool: Arc<dyn openclaw_core::Tool> = tools.into_iter().next().unwrap();
+    let tools = openclaw_tools::builtin_tools(store.secrets());
 
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");
@@ -91,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
     let router = Arc::new(HarnessRouter::new(classifier).with_base(profile));
 
     // --- Build gateway state ---
-    let mut state = openclaw_gateway::AppState::new(store, first_tool, provider, auth_token)
+    let mut state = openclaw_gateway::AppState::new(store, tools, provider, auth_token)
         .with_harness_router(router);
 
     // --- Telegram channel (optional) ---

--- a/crates/openclaw-gateway/src/state.rs
+++ b/crates/openclaw-gateway/src/state.rs
@@ -11,7 +11,7 @@ use crate::rate_limit::{RateLimitConfig, RateLimiter};
 #[derive(Clone)]
 pub struct AppState {
     pub store: Store,
-    pub tools: Arc<dyn openclaw_core::Tool>,
+    pub tools: Vec<Arc<dyn openclaw_core::Tool>>,
     pub provider: Arc<dyn ModelProvider>,
     pub auth_token: String,
     pub rate_limiter: Arc<RateLimiter>,
@@ -28,7 +28,7 @@ pub struct AppState {
 impl AppState {
     pub fn new(
         store: Store,
-        tools: Arc<dyn openclaw_core::Tool>,
+        tools: Vec<Arc<dyn openclaw_core::Tool>>,
         provider: Arc<dyn ModelProvider>,
         auth_token: String,
     ) -> Self {

--- a/crates/openclaw-tools/Cargo.toml
+++ b/crates/openclaw-tools/Cargo.toml
@@ -7,8 +7,9 @@ license.workspace = true
 
 [dependencies]
 openclaw-core.workspace = true
+openclaw-store.workspace = true
 async-trait.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["cookies"] }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/openclaw-tools/src/credential_read.rs
+++ b/crates/openclaw-tools/src/credential_read.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use openclaw_store::SecretStore;
+use serde_json::{json, Value};
+
+/// A tool that reads credentials from the encrypted SecretStore.
+///
+/// Supports retrieving a specific secret by name or listing all
+/// stored secret names (without revealing values).
+pub struct CredentialReadTool {
+    secrets: SecretStore,
+}
+
+impl CredentialReadTool {
+    pub fn new(secrets: SecretStore) -> Self {
+        Self { secrets }
+    }
+}
+
+#[async_trait]
+impl Tool for CredentialReadTool {
+    fn name(&self) -> &str {
+        "credential_read"
+    }
+
+    fn description(&self) -> &str {
+        "Read a stored credential/secret by name, or list all stored credential names. \
+         Use this to retrieve API keys, passwords, or tokens needed to authenticate \
+         with external services. Credentials are stored encrypted at rest."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["get", "list"],
+                        "description": "Action to perform: 'get' retrieves a specific secret, 'list' shows all secret names"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name/key of the secret to retrieve (required for 'get' action)"
+                    }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing action".into()))?;
+
+        match action {
+            "get" => {
+                let name = args["name"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("missing name for 'get' action".into()))?;
+
+                match self.secrets.get(name) {
+                    Ok(value) => Ok(json!({
+                        "name": name,
+                        "value": value,
+                    })),
+                    Err(openclaw_core::Error::NotFound(_)) => Ok(json!({
+                        "error": format!("no secret found with name '{name}'"),
+                        "hint": "Use action 'list' to see available secret names",
+                    })),
+                    Err(e) => Err(Error::ToolExecution(format!("failed to read secret: {e}"))),
+                }
+            }
+            "list" => {
+                let names = self
+                    .secrets
+                    .list_names()
+                    .map_err(|e| Error::ToolExecution(format!("failed to list secrets: {e}")))?;
+
+                Ok(json!({
+                    "secrets": names,
+                    "count": names.len(),
+                }))
+            }
+            other => Err(Error::ToolExecution(format!(
+                "unknown action '{other}', expected 'get' or 'list'"
+            ))),
+        }
+    }
+}

--- a/crates/openclaw-tools/src/credential_write.rs
+++ b/crates/openclaw-tools/src/credential_write.rs
@@ -1,0 +1,96 @@
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use openclaw_store::SecretStore;
+use serde_json::{json, Value};
+
+/// A tool that writes credentials to the encrypted SecretStore.
+///
+/// Supports storing, updating, and deleting secrets.
+pub struct CredentialWriteTool {
+    secrets: SecretStore,
+}
+
+impl CredentialWriteTool {
+    pub fn new(secrets: SecretStore) -> Self {
+        Self { secrets }
+    }
+}
+
+#[async_trait]
+impl Tool for CredentialWriteTool {
+    fn name(&self) -> &str {
+        "credential_write"
+    }
+
+    fn description(&self) -> &str {
+        "Store, update, or delete a credential/secret. Use this to save API keys, \
+         passwords, or tokens so they can be retrieved later with credential_read. \
+         All credentials are encrypted at rest."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set", "delete"],
+                        "description": "Action: 'set' stores/updates a secret, 'delete' removes one"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name/key for the secret"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The secret value to store (required for 'set' action)"
+                    }
+                },
+                "required": ["action", "name"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing action".into()))?;
+        let name = args["name"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing name".into()))?;
+
+        match action {
+            "set" => {
+                let value = args["value"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
+
+                self.secrets
+                    .set(name, value)
+                    .map_err(|e| Error::ToolExecution(format!("failed to store secret: {e}")))?;
+
+                Ok(json!({
+                    "status": "stored",
+                    "name": name,
+                }))
+            }
+            "delete" => {
+                self.secrets
+                    .delete(name)
+                    .map_err(|e| Error::ToolExecution(format!("failed to delete secret: {e}")))?;
+
+                Ok(json!({
+                    "status": "deleted",
+                    "name": name,
+                }))
+            }
+            other => Err(Error::ToolExecution(format!(
+                "unknown action '{other}', expected 'set' or 'delete'"
+            ))),
+        }
+    }
+}

--- a/crates/openclaw-tools/src/http_session.rs
+++ b/crates/openclaw-tools/src/http_session.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// A cookie-aware HTTP client with named sessions.
+///
+/// Unlike the stateless `http_request` tool, this maintains cookies
+/// across requests within named sessions — enabling login flows,
+/// authenticated API access, and multi-step web interactions.
+///
+/// Each named session has its own cookie jar, so multiple services
+/// can be accessed simultaneously without cookie conflicts.
+pub struct HttpSessionTool {
+    sessions: Arc<Mutex<HashMap<String, reqwest::Client>>>,
+}
+
+impl HttpSessionTool {
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn get_or_create_client(&self, session_name: &str) -> reqwest::Client {
+        let mut sessions = self.sessions.lock().unwrap();
+        sessions
+            .entry(session_name.to_string())
+            .or_insert_with(|| {
+                reqwest::Client::builder()
+                    .cookie_store(true)
+                    .user_agent("OpenClaw/0.1 (AI Agent)")
+                    .timeout(std::time::Duration::from_secs(30))
+                    .redirect(reqwest::redirect::Policy::limited(10))
+                    .build()
+                    .unwrap_or_else(|_| reqwest::Client::new())
+            })
+            .clone()
+    }
+}
+
+impl Default for HttpSessionTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for HttpSessionTool {
+    fn name(&self) -> &str {
+        "http_session"
+    }
+
+    fn description(&self) -> &str {
+        "Make HTTP requests with persistent cookie sessions. Unlike http_request, \
+         this tool maintains cookies across requests within a named session, enabling \
+         login flows and authenticated web interactions. Use different session names \
+         for different services."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "session": {
+                        "type": "string",
+                        "description": "Name for this session (e.g., 'github', 'jira'). Cookies persist within a session."
+                    },
+                    "method": {
+                        "type": "string",
+                        "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+                        "description": "HTTP method"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to request"
+                    },
+                    "headers": {
+                        "type": "object",
+                        "description": "Optional HTTP headers as key-value pairs",
+                        "additionalProperties": { "type": "string" }
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Optional request body (for POST/PUT/PATCH)"
+                    },
+                    "content_type": {
+                        "type": "string",
+                        "enum": ["json", "form", "text"],
+                        "description": "Content type shorthand: 'json' for application/json, 'form' for application/x-www-form-urlencoded, 'text' for text/plain (default: auto-detect)"
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["request", "clear"],
+                        "description": "Action: 'request' makes an HTTP request (default), 'clear' destroys the session and its cookies"
+                    }
+                },
+                "required": ["session"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let session_name = args["session"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing session name".into()))?;
+
+        let action = args["action"].as_str().unwrap_or("request");
+
+        if action == "clear" {
+            let mut sessions = self.sessions.lock().unwrap();
+            sessions.remove(session_name);
+            return Ok(json!({
+                "status": "session_cleared",
+                "session": session_name,
+            }));
+        }
+
+        let url = args["url"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing url".into()))?;
+        let method = args["method"]
+            .as_str()
+            .unwrap_or("GET")
+            .to_uppercase();
+
+        let client = self.get_or_create_client(session_name);
+
+        let mut req = match method.as_str() {
+            "POST" => client.post(url),
+            "PUT" => client.put(url),
+            "DELETE" => client.delete(url),
+            "PATCH" => client.patch(url),
+            "HEAD" => client.head(url),
+            _ => client.get(url),
+        };
+
+        // Apply custom headers
+        if let Some(headers) = args["headers"].as_object() {
+            for (key, value) in headers {
+                if let Some(val) = value.as_str() {
+                    req = req.header(key.as_str(), val);
+                }
+            }
+        }
+
+        // Apply body with content type
+        if let Some(body) = args["body"].as_str() {
+            let content_type = args["content_type"].as_str().unwrap_or("text");
+            req = match content_type {
+                "json" => req
+                    .header("Content-Type", "application/json")
+                    .body(body.to_string()),
+                "form" => req
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(body.to_string()),
+                _ => req.body(body.to_string()),
+            };
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("request failed: {e}")))?;
+
+        let status = resp.status().as_u16();
+        let status_text = resp.status().canonical_reason().unwrap_or("").to_string();
+
+        // Collect response headers
+        let response_headers: HashMap<String, String> = resp
+            .headers()
+            .iter()
+            .filter_map(|(k, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|val| (k.to_string(), val.to_string()))
+            })
+            .collect();
+
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("failed to read response: {e}")))?;
+
+        // Truncate very large responses
+        let max_len = 100_000;
+        let truncated = body.len() > max_len;
+        let body_out = if truncated {
+            format!("{}...\n[Truncated at {} chars]", &body[..max_len], max_len)
+        } else {
+            body
+        };
+
+        Ok(json!({
+            "session": session_name,
+            "status": status,
+            "status_text": status_text,
+            "headers": response_headers,
+            "body": body_out,
+            "truncated": truncated,
+        }))
+    }
+}

--- a/crates/openclaw-tools/src/lib.rs
+++ b/crates/openclaw-tools/src/lib.rs
@@ -1,8 +1,30 @@
+mod credential_read;
+mod credential_write;
 mod http_request;
+mod http_session;
+mod web_fetch;
+mod web_search;
 
+pub use credential_read::CredentialReadTool;
+pub use credential_write::CredentialWriteTool;
 pub use http_request::HttpRequestTool;
+pub use http_session::HttpSessionTool;
+pub use web_fetch::WebFetchTool;
+pub use web_search::WebSearchTool;
 
 /// Collect all built-in tools into a Vec.
-pub fn builtin_tools() -> Vec<std::sync::Arc<dyn openclaw_core::Tool>> {
-    vec![std::sync::Arc::new(HttpRequestTool::new())]
+///
+/// Tools that need access to the secret store (credential_read, credential_write)
+/// require a `SecretStore` handle. The remaining tools are stateless or self-contained.
+pub fn builtin_tools(
+    secrets: openclaw_store::SecretStore,
+) -> Vec<std::sync::Arc<dyn openclaw_core::Tool>> {
+    vec![
+        std::sync::Arc::new(HttpRequestTool::new()),
+        std::sync::Arc::new(WebFetchTool::new()),
+        std::sync::Arc::new(WebSearchTool::new()),
+        std::sync::Arc::new(HttpSessionTool::new()),
+        std::sync::Arc::new(CredentialReadTool::new(secrets.clone())),
+        std::sync::Arc::new(CredentialWriteTool::new(secrets)),
+    ]
 }

--- a/crates/openclaw-tools/src/web_fetch.rs
+++ b/crates/openclaw-tools/src/web_fetch.rs
@@ -1,0 +1,387 @@
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// Maximum characters to return from a fetched page to avoid context explosion.
+const MAX_CONTENT_LENGTH: usize = 50_000;
+
+/// A tool that fetches a web page and returns cleaned, readable text.
+///
+/// Unlike the raw `http_request` tool, this strips HTML tags, scripts,
+/// and styles to produce content the model can actually reason about.
+pub struct WebFetchTool {
+    client: reqwest::Client,
+}
+
+impl WebFetchTool {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .user_agent("OpenClaw/0.1 (AI Agent)")
+                .timeout(std::time::Duration::from_secs(30))
+                .redirect(reqwest::redirect::Policy::limited(10))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+}
+
+impl Default for WebFetchTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for WebFetchTool {
+    fn name(&self) -> &str {
+        "web_fetch"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch a web page and return its content as clean, readable text with HTML stripped. \
+         Use this to read articles, documentation, or any web page."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to fetch"
+                    },
+                    "include_links": {
+                        "type": "boolean",
+                        "description": "Whether to include [link text](url) in the output (default: false)"
+                    }
+                },
+                "required": ["url"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let url = args["url"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing url".into()))?;
+        let include_links = args["include_links"].as_bool().unwrap_or(false);
+
+        let resp = self
+            .client
+            .get(url)
+            .header("Accept", "text/html,application/xhtml+xml,text/plain")
+            .send()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch failed: {e}")))?;
+
+        let status = resp.status().as_u16();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("failed to read body: {e}")))?;
+
+        // If it's not HTML, return raw text (could be JSON, plain text, etc.)
+        let text = if content_type.contains("text/html") || content_type.contains("xhtml") {
+            html_to_text(&body, include_links)
+        } else {
+            body
+        };
+
+        // Truncate to avoid context explosion.
+        let truncated = text.len() > MAX_CONTENT_LENGTH;
+        let content = if truncated {
+            let end = text
+                .char_indices()
+                .take_while(|(i, _)| *i < MAX_CONTENT_LENGTH)
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(MAX_CONTENT_LENGTH);
+            format!("{}...\n\n[Content truncated at {} characters]", &text[..end], MAX_CONTENT_LENGTH)
+        } else {
+            text
+        };
+
+        Ok(json!({
+            "status": status,
+            "content": content,
+            "truncated": truncated,
+        }))
+    }
+}
+
+/// Convert HTML to readable plain text.
+fn html_to_text(html: &str, include_links: bool) -> String {
+    let mut result = String::with_capacity(html.len() / 2);
+    let mut in_tag = false;
+    let mut tag_name = String::new();
+    let mut in_script_or_style = false;
+    let mut skip_depth: u32 = 0;
+    let mut collecting_tag = false;
+    let mut current_href = String::new();
+    let mut in_anchor = false;
+    let mut anchor_text = String::new();
+
+    let chars: Vec<char> = html.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        let ch = chars[i];
+
+        if ch == '<' {
+            in_tag = true;
+            collecting_tag = true;
+            tag_name.clear();
+            i += 1;
+            continue;
+        }
+
+        if in_tag {
+            if ch == '>' {
+                in_tag = false;
+                collecting_tag = false;
+
+                let tag_lower = tag_name.to_lowercase();
+                let is_closing = tag_lower.starts_with('/');
+                let clean_tag = tag_lower.trim_start_matches('/').split_whitespace().next().unwrap_or("");
+
+                match clean_tag {
+                    "script" | "style" | "noscript" | "svg" | "head" => {
+                        if is_closing {
+                            skip_depth = skip_depth.saturating_sub(1);
+                            if skip_depth == 0 {
+                                in_script_or_style = false;
+                            }
+                        } else if !tag_lower.ends_with('/') {
+                            // Not self-closing
+                            skip_depth += 1;
+                            in_script_or_style = true;
+                        }
+                    }
+                    "br" | "hr" => {
+                        if !in_script_or_style {
+                            if in_anchor {
+                                anchor_text.push('\n');
+                            } else {
+                                result.push('\n');
+                            }
+                        }
+                    }
+                    "p" | "div" | "section" | "article" | "main" | "header" | "footer"
+                    | "nav" | "aside" | "blockquote" | "tr" | "table" => {
+                        if !in_script_or_style {
+                            if is_closing {
+                                if in_anchor {
+                                    anchor_text.push_str("\n\n");
+                                } else {
+                                    result.push_str("\n\n");
+                                }
+                            } else {
+                                if in_anchor {
+                                    anchor_text.push('\n');
+                                } else {
+                                    result.push('\n');
+                                }
+                            }
+                        }
+                    }
+                    "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+                        if !in_script_or_style {
+                            if is_closing {
+                                result.push_str("\n\n");
+                            } else {
+                                result.push_str("\n\n");
+                            }
+                        }
+                    }
+                    "li" => {
+                        if !in_script_or_style && !is_closing {
+                            result.push_str("\n- ");
+                        }
+                    }
+                    "a" => {
+                        if !in_script_or_style && include_links {
+                            if is_closing {
+                                // End of anchor — emit markdown link
+                                if !current_href.is_empty() && !anchor_text.trim().is_empty() {
+                                    result.push('[');
+                                    result.push_str(anchor_text.trim());
+                                    result.push_str("](");
+                                    result.push_str(&current_href);
+                                    result.push(')');
+                                } else {
+                                    result.push_str(anchor_text.trim());
+                                }
+                                in_anchor = false;
+                                anchor_text.clear();
+                                current_href.clear();
+                            } else {
+                                // Extract href from tag attributes
+                                current_href = extract_href(&tag_name);
+                                in_anchor = true;
+                                anchor_text.clear();
+                            }
+                        }
+                    }
+                    "td" | "th" => {
+                        if !in_script_or_style && is_closing {
+                            result.push('\t');
+                        }
+                    }
+                    _ => {}
+                }
+
+                i += 1;
+                continue;
+            }
+
+            if collecting_tag {
+                tag_name.push(ch);
+            }
+            i += 1;
+            continue;
+        }
+
+        // Not in a tag — this is text content
+        if in_script_or_style {
+            i += 1;
+            continue;
+        }
+
+        // Handle HTML entities
+        if ch == '&' {
+            let entity_end = chars[i..].iter().position(|&c| c == ';');
+            if let Some(end) = entity_end {
+                let entity: String = chars[i..i + end + 1].iter().collect();
+                let decoded = decode_entity(&entity);
+                if in_anchor {
+                    anchor_text.push_str(&decoded);
+                } else {
+                    result.push_str(&decoded);
+                }
+                i += end + 1;
+                continue;
+            }
+        }
+
+        if in_anchor {
+            anchor_text.push(ch);
+        } else {
+            result.push(ch);
+        }
+        i += 1;
+    }
+
+    // Collapse excessive whitespace but preserve paragraph breaks
+    collapse_whitespace(&result)
+}
+
+/// Extract href attribute value from a tag string like `a href="..."`
+fn extract_href(tag_content: &str) -> String {
+    let lower = tag_content.to_lowercase();
+    if let Some(pos) = lower.find("href=") {
+        let after_href = &tag_content[pos + 5..];
+        let trimmed = after_href.trim_start();
+        if trimmed.starts_with('"') {
+            trimmed[1..]
+                .split('"')
+                .next()
+                .unwrap_or("")
+                .to_string()
+        } else if trimmed.starts_with('\'') {
+            trimmed[1..]
+                .split('\'')
+                .next()
+                .unwrap_or("")
+                .to_string()
+        } else {
+            trimmed
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .to_string()
+        }
+    } else {
+        String::new()
+    }
+}
+
+/// Decode common HTML entities.
+fn decode_entity(entity: &str) -> String {
+    match entity {
+        "&amp;" => "&".to_string(),
+        "&lt;" => "<".to_string(),
+        "&gt;" => ">".to_string(),
+        "&quot;" => "\"".to_string(),
+        "&apos;" | "&#39;" => "'".to_string(),
+        "&nbsp;" | "&#160;" => " ".to_string(),
+        "&mdash;" | "&#8212;" => "\u{2014}".to_string(),
+        "&ndash;" | "&#8211;" => "\u{2013}".to_string(),
+        "&hellip;" | "&#8230;" => "\u{2026}".to_string(),
+        "&copy;" => "\u{00A9}".to_string(),
+        "&reg;" => "\u{00AE}".to_string(),
+        "&trade;" => "\u{2122}".to_string(),
+        other => {
+            // Try numeric entities: &#123; or &#x1F4A9;
+            if other.starts_with("&#x") || other.starts_with("&#X") {
+                let hex = &other[3..other.len() - 1];
+                u32::from_str_radix(hex, 16)
+                    .ok()
+                    .and_then(char::from_u32)
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| other.to_string())
+            } else if other.starts_with("&#") {
+                let num = &other[2..other.len() - 1];
+                num.parse::<u32>()
+                    .ok()
+                    .and_then(char::from_u32)
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| other.to_string())
+            } else {
+                other.to_string()
+            }
+        }
+    }
+}
+
+/// Collapse runs of whitespace: keep double newlines (paragraph breaks),
+/// collapse everything else to single spaces.
+fn collapse_whitespace(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut prev_newline_count = 0;
+    let mut prev_was_space = false;
+
+    for ch in text.chars() {
+        if ch == '\n' {
+            prev_newline_count += 1;
+            prev_was_space = false;
+            if prev_newline_count <= 2 {
+                result.push('\n');
+            }
+        } else if ch.is_whitespace() {
+            prev_newline_count = 0;
+            if !prev_was_space {
+                result.push(' ');
+                prev_was_space = true;
+            }
+        } else {
+            prev_newline_count = 0;
+            prev_was_space = false;
+            result.push(ch);
+        }
+    }
+
+    result.trim().to_string()
+}

--- a/crates/openclaw-tools/src/web_search.rs
+++ b/crates/openclaw-tools/src/web_search.rs
@@ -1,0 +1,320 @@
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// A tool that searches the web using DuckDuckGo and returns results.
+///
+/// Uses DuckDuckGo's HTML lite interface so no API key is required.
+pub struct WebSearchTool {
+    client: reqwest::Client,
+}
+
+impl WebSearchTool {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .user_agent("OpenClaw/0.1 (AI Agent)")
+                .timeout(std::time::Duration::from_secs(15))
+                .redirect(reqwest::redirect::Policy::limited(5))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+}
+
+impl Default for WebSearchTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn name(&self) -> &str {
+        "web_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the web using DuckDuckGo and return a list of results with titles, \
+         URLs, and snippets. Use this to find information, discover URLs, or research topics."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of results to return (default: 10, max: 25)",
+                        "default": 10
+                    }
+                },
+                "required": ["query"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let query = args["query"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing query".into()))?;
+        let max_results = args["max_results"]
+            .as_u64()
+            .unwrap_or(10)
+            .min(25) as usize;
+
+        let results = search_duckduckgo(&self.client, query, max_results).await?;
+
+        Ok(json!({
+            "query": query,
+            "results": results,
+            "count": results.len(),
+        }))
+    }
+}
+
+/// Search DuckDuckGo using the HTML lite endpoint.
+async fn search_duckduckgo(
+    client: &reqwest::Client,
+    query: &str,
+    max_results: usize,
+) -> Result<Vec<Value>> {
+    let resp = client
+        .get("https://html.duckduckgo.com/html/")
+        .query(&[("q", query)])
+        .header("Accept", "text/html")
+        .send()
+        .await
+        .map_err(|e| Error::ToolExecution(format!("search request failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        return Err(Error::ToolExecution(format!(
+            "search returned status {}",
+            resp.status()
+        )));
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| Error::ToolExecution(format!("failed to read search response: {e}")))?;
+
+    let results = parse_duckduckgo_results(&body, max_results);
+    Ok(results)
+}
+
+/// Parse DuckDuckGo HTML lite results page.
+///
+/// The lite page has a predictable structure:
+/// - Result links are in `<a class="result-link" href="...">title</a>`
+/// - Snippets are in `<td class="result-snippet">...</td>`
+/// - Or result blocks with `<a class="result__a" href="...">` and
+///   `<a class="result__snippet">...</a>`
+fn parse_duckduckgo_results(html: &str, max_results: usize) -> Vec<Value> {
+    let mut results = Vec::new();
+
+    // DuckDuckGo lite uses table-based layout. Each result has:
+    // 1. A link row with the title/URL
+    // 2. A snippet row
+    // We'll parse by finding result links and their associated snippets.
+
+    // Strategy: find all <a> tags with class containing "result" and href,
+    // then find the next snippet text.
+    let mut pos = 0;
+    let html_lower = html.to_lowercase();
+
+    while results.len() < max_results {
+        // Find next result link — DuckDuckGo lite uses class="result-link"
+        // or sometimes class="result__a"
+        let link_pos = find_result_link(&html_lower, pos);
+        if link_pos.is_none() {
+            break;
+        }
+        let link_start = link_pos.unwrap();
+
+        // Extract href
+        let href = extract_attribute(&html[link_start..], "href");
+        if href.is_empty() {
+            pos = link_start + 1;
+            continue;
+        }
+
+        // Resolve DuckDuckGo redirect URLs
+        let url = resolve_ddg_url(&href);
+
+        // Extract title (text between > and </a>)
+        let title = extract_tag_text(&html[link_start..]);
+
+        // Find snippet — look for "result-snippet" or "result__snippet" after this link
+        let snippet = extract_snippet(&html[link_start..], &html_lower[link_start..]);
+
+        if !url.is_empty() && !title.is_empty() {
+            results.push(json!({
+                "title": title.trim(),
+                "url": url,
+                "snippet": snippet.trim(),
+            }));
+        }
+
+        pos = link_start + 1;
+    }
+
+    results
+}
+
+/// Find the position of the next result link in the HTML.
+fn find_result_link(html_lower: &str, start: usize) -> Option<usize> {
+    let search_from = &html_lower[start..];
+
+    // Look for result-link class (DuckDuckGo lite format)
+    if let Some(p) = search_from.find("class=\"result-link\"") {
+        // Find the opening <a that precedes this
+        let before = &search_from[..p];
+        if let Some(a_pos) = before.rfind("<a ") {
+            return Some(start + a_pos);
+        }
+    }
+
+    // Also try result__a class (alternative DDG format)
+    if let Some(p) = search_from.find("class=\"result__a\"") {
+        let before = &search_from[..p];
+        if let Some(a_pos) = before.rfind("<a ") {
+            return Some(start + a_pos);
+        }
+    }
+
+    // Fallback: look for links in result blocks
+    if let Some(p) = search_from.find("class=\"result-link") {
+        let before = &search_from[..p];
+        if let Some(a_pos) = before.rfind("<a ") {
+            return Some(start + a_pos);
+        }
+    }
+
+    None
+}
+
+/// Extract an HTML attribute value from a tag.
+fn extract_attribute(html: &str, attr: &str) -> String {
+    let lower = html.to_lowercase();
+    let pattern = format!("{attr}=\"");
+    if let Some(pos) = lower.find(&pattern) {
+        let value_start = pos + pattern.len();
+        if let Some(end) = html[value_start..].find('"') {
+            return html[value_start..value_start + end].to_string();
+        }
+    }
+    // Try single quotes
+    let pattern = format!("{attr}='");
+    if let Some(pos) = lower.find(&pattern) {
+        let value_start = pos + pattern.len();
+        if let Some(end) = html[value_start..].find('\'') {
+            return html[value_start..value_start + end].to_string();
+        }
+    }
+    String::new()
+}
+
+/// Extract text content from between > and </a> of an anchor tag.
+fn extract_tag_text(html: &str) -> String {
+    if let Some(gt) = html.find('>') {
+        let after = &html[gt + 1..];
+        if let Some(end) = after.to_lowercase().find("</a>") {
+            let raw = &after[..end];
+            // Strip any inner HTML tags
+            return strip_tags(raw);
+        }
+    }
+    String::new()
+}
+
+/// Extract snippet text from result block.
+fn extract_snippet(html: &str, html_lower: &str) -> String {
+    // Look for result-snippet class
+    for class in &["result-snippet", "result__snippet"] {
+        let pattern = format!("class=\"{class}\"");
+        if let Some(pos) = html_lower.find(&pattern) {
+            let from = &html[pos..];
+            if let Some(gt) = from.find('>') {
+                let after = &from[gt + 1..];
+                // Find the closing tag
+                if let Some(end) = after.find("</") {
+                    return strip_tags(&after[..end]);
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+/// Resolve DuckDuckGo redirect URL to the actual URL.
+fn resolve_ddg_url(href: &str) -> String {
+    // DDG lite uses direct URLs or //duckduckgo.com/l/?uddg=ENCODED_URL
+    if href.contains("uddg=") {
+        // Extract the actual URL from the redirect
+        if let Some(pos) = href.find("uddg=") {
+            let encoded = &href[pos + 5..];
+            let encoded = encoded.split('&').next().unwrap_or(encoded);
+            return url_decode(encoded);
+        }
+    }
+    // Direct URL
+    href.to_string()
+}
+
+/// Simple URL decoding for search result URLs.
+fn url_decode(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(
+                &String::from_utf8_lossy(&bytes[i + 1..i + 3]),
+                16,
+            ) {
+                result.push(byte as char);
+                i += 3;
+                continue;
+            }
+        }
+        result.push(bytes[i] as char);
+        i += 1;
+    }
+
+    result
+}
+
+/// Strip HTML tags from a string, returning only text content.
+fn strip_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut in_tag = false;
+
+    for ch in html.chars() {
+        if ch == '<' {
+            in_tag = true;
+        } else if ch == '>' {
+            in_tag = false;
+        } else if !in_tag {
+            result.push(ch);
+        }
+    }
+
+    // Decode basic entities
+    result
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&nbsp;", " ")
+}


### PR DESCRIPTION
Implements five new built-in tools:
- web_fetch: fetches URLs and strips HTML to clean readable text
- web_search: searches the web via DuckDuckGo (no API key needed)
- credential_read: reads secrets from the encrypted SecretStore
- credential_write: stores/deletes secrets in the encrypted SecretStore
- http_session: cookie-aware HTTP client with named sessions for login flows

Updates AppState to hold Vec<Arc<dyn Tool>> and wires SecretStore
into the tool registry so credential tools can access encrypted storage.

https://claude.ai/code/session_012y2MiA7FgGnh2cMXNMpQrp