### PR TITLE
Wire gateway to full agent loop with streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "openclaw-agent",
  "openclaw-channels",
  "openclaw-core",
+ "openclaw-skills",
  "openclaw-store",
  "rand 0.8.5",
  "rust-embed",

--- a/crates/openclaw-agent/src/lib.rs
+++ b/crates/openclaw-agent/src/lib.rs
@@ -6,6 +6,6 @@ pub mod trace;
 
 pub use harness::{HarnessProfile, TaskType};
 pub use router::HarnessRouter;
-pub use runner::{AgentConfig, AgentRunner};
+pub use runner::{AgentConfig, AgentEvent, AgentRunner};
 pub use sandbox::{NoSandbox, ProcessSandbox, Sandbox, SandboxPolicy};
 pub use trace::{ExecutionTracer, ToolStats, ToolTrace};

--- a/crates/openclaw-agent/src/runner.rs
+++ b/crates/openclaw-agent/src/runner.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use chrono::Utc;
 use openclaw_core::capability::Capability;
-use openclaw_core::model::{ModelProvider, ModelResponse, StopReason};
+use openclaw_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent};
 use openclaw_core::session::Session;
 use openclaw_core::types::{
     Conversation, Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema,
@@ -13,6 +13,34 @@ use uuid::Uuid;
 
 use crate::sandbox::{Sandbox, SandboxPolicy};
 use crate::trace::{ExecutionTracer, ToolTrace};
+
+/// Events emitted by the agent loop during streaming execution.
+///
+/// These give callers (e.g. WebSocket handlers) real-time visibility
+/// into the agent's progress: text tokens as they arrive, tool execution
+/// lifecycle, and internal state changes like reflections and compression.
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    /// A partial text token from the model's response.
+    TextDelta(String),
+    /// The agent is about to execute a tool.
+    ToolCallStart {
+        tool_name: String,
+        call_id: String,
+    },
+    /// A tool call has completed.
+    ToolCallEnd {
+        tool_name: String,
+        call_id: String,
+        success: bool,
+    },
+    /// The agent is reflecting after repeated errors.
+    Reflecting,
+    /// The agent is compressing conversation memory.
+    Compressing,
+    /// The agent loop has completed.
+    Done,
+}
 
 /// Configuration for the agent runner.
 #[derive(Debug, Clone)]
@@ -210,6 +238,167 @@ impl AgentRunner {
             }
 
             // Text response — done.
+            return Ok(());
+        }
+
+        Err(Error::Internal(format!(
+            "agent exceeded max iterations ({})",
+            self.config.max_iterations
+        )))
+    }
+
+    /// Run the agent loop with streaming: text deltas are forwarded through
+    /// the callback as they arrive, and tool lifecycle events are emitted
+    /// so callers can show real-time progress.
+    ///
+    /// The callback must be `Send + Sync` because it may be invoked from
+    /// the provider's streaming internals on a different task.
+    pub async fn run_streaming(
+        &self,
+        conv: &mut Conversation,
+        session: &Session,
+        on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    ) -> Result<()> {
+        if session.is_expired() {
+            return Err(Error::Auth("session has expired".into()));
+        }
+
+        let schemas: Vec<ToolSchema> = self
+            .tools
+            .iter()
+            .filter(|t| session.capabilities.can_use_tool(t.name()))
+            .map(|t| t.schema())
+            .collect();
+
+        let mut consecutive_errors = 0;
+
+        for iteration in 0..self.config.max_iterations {
+            self.tracer.record_iteration();
+
+            if self.should_compress(conv) {
+                on_event(AgentEvent::Compressing);
+                self.compress_memory(conv).await?;
+                self.tracer.record_compression();
+            }
+
+            // Use chat_stream so text deltas are forwarded in real time.
+            let stream_callback = |event: StreamEvent| {
+                if let StreamEvent::TextDelta(delta) = event {
+                    on_event(AgentEvent::TextDelta(delta));
+                }
+            };
+
+            let ModelResponse {
+                message,
+                usage: _,
+                stop_reason,
+            } = self
+                .provider
+                .chat_stream(&conv.messages, &schemas, &stream_callback)
+                .await?;
+
+            conv.messages.push(message.clone());
+            conv.updated_at = Utc::now();
+
+            // Handle tool calls.
+            if message.content.has_tool_calls() {
+                let calls = message.content.tool_calls();
+                tracing::info!(
+                    iteration,
+                    tool_count = calls.len(),
+                    "executing tool calls"
+                );
+
+                // Emit start events.
+                for call in &calls {
+                    on_event(AgentEvent::ToolCallStart {
+                        tool_name: call.name.clone(),
+                        call_id: call.id.clone(),
+                    });
+                }
+
+                let results = self
+                    .execute_tools_parallel_traced(calls, session)
+                    .await;
+
+                let had_errors = results.iter().any(|r| {
+                    if let Ok(tr) = r {
+                        tr.output.get("error").is_some()
+                    } else {
+                        true
+                    }
+                });
+
+                for result in results {
+                    let (tool_msg, tool_name, call_id, success) = match result {
+                        Ok(tr) => {
+                            let msg = Message {
+                                id: Uuid::new_v4(),
+                                role: Role::Tool,
+                                content: MessageContent::ToolResult(tr.clone()),
+                                created_at: Utc::now(),
+                            };
+                            (msg, String::new(), tr.call_id, true)
+                        }
+                        Err(e) => {
+                            let msg = Message {
+                                id: Uuid::new_v4(),
+                                role: Role::Tool,
+                                content: MessageContent::ToolResult(ToolResult {
+                                    call_id: "error".to_string(),
+                                    output: serde_json::json!({ "error": e.to_string() }),
+                                }),
+                                created_at: Utc::now(),
+                            };
+                            (msg, String::new(), "error".to_string(), false)
+                        }
+                    };
+                    on_event(AgentEvent::ToolCallEnd {
+                        tool_name,
+                        call_id,
+                        success,
+                    });
+                    conv.messages.push(tool_msg);
+                }
+                conv.updated_at = Utc::now();
+
+                if let Some(trace_guidance) = self.tracer.summary_for_prompt() {
+                    if iteration > 0 && iteration % 5 == 0 {
+                        self.inject_trace_context(conv, &trace_guidance);
+                    }
+                }
+
+                if had_errors {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= self.config.max_consecutive_errors {
+                        tracing::warn!(
+                            consecutive_errors,
+                            "injecting reflection prompt after repeated errors"
+                        );
+                        on_event(AgentEvent::Reflecting);
+                        self.inject_reflection(conv);
+                        consecutive_errors = 0;
+                    }
+                } else {
+                    consecutive_errors = 0;
+                }
+
+                continue;
+            }
+
+            if stop_reason == StopReason::MaxTokens {
+                tracing::warn!("model hit max tokens, prompting to continue");
+                conv.messages.push(Message {
+                    id: Uuid::new_v4(),
+                    role: Role::User,
+                    content: MessageContent::Text("Continue.".to_string()),
+                    created_at: Utc::now(),
+                });
+                continue;
+            }
+
+            // Text response — done.
+            on_event(AgentEvent::Done);
             return Ok(());
         }
 

--- a/crates/openclaw-core/src/capability.rs
+++ b/crates/openclaw-core/src/capability.rs
@@ -72,6 +72,20 @@ impl CapabilitySet {
         self.capabilities.contains(&Capability::Tool(tool_name.to_string()))
     }
 
+    /// Create a capability set that grants access to a specific set of tools
+    /// plus standard resource capabilities (file, shell, http).
+    pub fn for_tools(tool_names: &[&str]) -> Self {
+        let mut caps = HashSet::new();
+        caps.insert(Capability::FileRead);
+        caps.insert(Capability::FileWrite);
+        caps.insert(Capability::ShellExec);
+        caps.insert(Capability::HttpRequest);
+        for name in tool_names {
+            caps.insert(Capability::Tool(name.to_string()));
+        }
+        Self { capabilities: caps }
+    }
+
     /// Return all granted capabilities.
     pub fn list(&self) -> impl Iterator<Item = &Capability> {
         self.capabilities.iter()

--- a/crates/openclaw-gateway/Cargo.toml
+++ b/crates/openclaw-gateway/Cargo.toml
@@ -10,6 +10,7 @@ openclaw-core.workspace = true
 openclaw-store.workspace = true
 openclaw-agent.workspace = true
 openclaw-channels.workspace = true
+openclaw-skills.workspace = true
 axum = { workspace = true, features = ["ws"] }
 tokio.workspace = true
 serde.workspace = true

--- a/crates/openclaw-gateway/src/lib.rs
+++ b/crates/openclaw-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+mod orchestrate;
 pub mod origin;
 pub mod rate_limit;
 mod routes;

--- a/crates/openclaw-gateway/src/orchestrate.rs
+++ b/crates/openclaw-gateway/src/orchestrate.rs
@@ -1,0 +1,132 @@
+use axum::http::StatusCode;
+use chrono::Utc;
+use uuid::Uuid;
+
+use openclaw_agent::{AgentEvent, AgentRunner};
+use openclaw_core::capability::CapabilitySet;
+use openclaw_core::session::Session;
+use openclaw_core::types::{Conversation, Message, MessageContent, Role};
+use openclaw_skills::SystemPromptBuilder;
+
+use crate::AppState;
+
+/// Shared setup: resolve profile, build system prompt, inject it,
+/// create session and runner. Returns `(AgentRunner, Session)`.
+async fn prepare_agent(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+) -> Result<(AgentRunner, Session), StatusCode> {
+    // 1. Resolve the harness profile for this message.
+    let profile = state.profile_for(user_content).await;
+    tracing::info!(profile = %profile.name, "harness profile selected");
+
+    // 2. Collect tool schemas for the prompt builder.
+    let schemas: Vec<_> = state.tools.iter().map(|t| t.schema()).collect();
+
+    // 3. Build the system prompt.
+    let mut builder = SystemPromptBuilder::new()
+        .with_identity(&profile.agent_name, &profile.agent_description)
+        .with_tool_guidance(&schemas);
+
+    if profile.chain_of_thought {
+        builder = builder.with_chain_of_thought();
+    }
+    if let Some(task_guidance) = profile.task_type_guidance() {
+        builder = builder.with_task_guidance(task_guidance);
+    }
+    if let Some(ref summary) = conv.summary {
+        builder = builder.with_memory(summary);
+    }
+
+    let system_prompt = builder.build();
+
+    // 4. Inject system prompt as first message.
+    if conv
+        .messages
+        .first()
+        .map(|m| m.role == Role::System)
+        .unwrap_or(false)
+    {
+        conv.messages[0].content = MessageContent::Text(system_prompt);
+    } else {
+        conv.messages.insert(
+            0,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::System,
+                content: MessageContent::Text(system_prompt),
+                created_at: Utc::now(),
+            },
+        );
+    }
+
+    // 5. Create an ephemeral session with capabilities for all registered tools.
+    let tool_names: Vec<&str> = state.tools.iter().map(|t| t.name()).collect();
+    let caps = CapabilitySet::for_tools(&tool_names);
+    let session = Session::with_capabilities(conv.id, caps);
+
+    // 6. Create the agent runner with profile-derived config.
+    let runner = AgentRunner::new(
+        state.provider.clone(),
+        state.tools.clone(),
+        state.sandbox.clone(),
+    )
+    .with_config(profile.to_agent_config());
+
+    Ok((runner, session))
+}
+
+/// Extract the last assistant text message from a conversation.
+fn extract_assistant_message(conv: &Conversation) -> Result<Message, StatusCode> {
+    conv.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+        .cloned()
+        .ok_or_else(|| {
+            tracing::error!("agent loop completed but no assistant text message found");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
+}
+
+/// Run the full agent pipeline on a conversation (non-streaming).
+///
+/// Used by the HTTP handler where the full response is returned at once.
+pub async fn run_agent(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+) -> Result<Message, StatusCode> {
+    let (runner, session) = prepare_agent(state, conv, user_content).await?;
+
+    runner.run(conv, &session).await.map_err(|e| {
+        tracing::error!("agent error: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    extract_assistant_message(conv)
+}
+
+/// Run the full agent pipeline with streaming events.
+///
+/// Used by the WebSocket handler to forward text deltas and tool
+/// lifecycle events to the client in real time.
+pub async fn run_agent_streaming(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+) -> Result<Message, StatusCode> {
+    let (runner, session) = prepare_agent(state, conv, user_content).await?;
+
+    runner
+        .run_streaming(conv, &session, on_event)
+        .await
+        .map_err(|e| {
+            tracing::error!("agent error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    extract_assistant_message(conv)
+}

--- a/crates/openclaw-gateway/src/routes.rs
+++ b/crates/openclaw-gateway/src/routes.rs
@@ -88,6 +88,9 @@ async fn send_message(
         .get(id)
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
+    // Clone content before moving into the message (needed for profile classification).
+    let user_content = body.content.clone();
+
     // Add the user message.
     let user_msg = Message {
         id: Uuid::new_v4(),
@@ -98,26 +101,17 @@ async fn send_message(
     conv.messages.push(user_msg);
     conv.updated_at = Utc::now();
 
-    // Call the model provider.
-    let response = state
-        .provider
-        .chat(&conv.messages, &[])
-        .await
-        .map_err(|e| {
-            tracing::error!("model error: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    // Run the full agent pipeline.
+    let assistant_msg =
+        crate::orchestrate::run_agent(&state, &mut conv, &user_content).await?;
 
-    // Add assistant response to conversation.
-    conv.messages.push(response.message.clone());
+    // Persist the full conversation (including intermediate tool call messages).
     conv.updated_at = Utc::now();
-
-    // Persist.
     state
         .store
         .conversations()
         .save(&conv)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(Json(response.message))
+    Ok(Json(assistant_msg))
 }

--- a/crates/openclaw-gateway/src/state.rs
+++ b/crates/openclaw-gateway/src/state.rs
@@ -1,4 +1,4 @@
-use openclaw_agent::{HarnessProfile, HarnessRouter};
+use openclaw_agent::{HarnessProfile, HarnessRouter, ProcessSandbox, Sandbox};
 use openclaw_channels::{SignalChannel, TelegramChannel};
 use openclaw_core::model::ModelProvider;
 use openclaw_store::Store;
@@ -18,6 +18,8 @@ pub struct AppState {
     pub origin_policy: OriginPolicy,
     pub telegram: Option<Arc<TelegramChannel>>,
     pub signal: Option<Arc<SignalChannel>>,
+    /// Sandbox for tool execution isolation.
+    pub sandbox: Arc<dyn Sandbox>,
     /// Base harness profile (used as fallback and template).
     pub harness_profile: HarnessProfile,
     /// Auto-router that classifies messages and selects profiles on-the-fly.
@@ -41,6 +43,7 @@ impl AppState {
             origin_policy: OriginPolicy::default(),
             telegram: None,
             signal: None,
+            sandbox: Arc::new(ProcessSandbox::new()),
             harness_profile: HarnessProfile::default(),
             harness_router: None,
         }
@@ -67,6 +70,12 @@ impl AppState {
     /// Attach a Signal channel.
     pub fn with_signal(mut self, signal: Arc<SignalChannel>) -> Self {
         self.signal = Some(signal);
+        self
+    }
+
+    /// Override the sandbox implementation.
+    pub fn with_sandbox(mut self, sandbox: Arc<dyn Sandbox>) -> Self {
+        self.sandbox = sandbox;
         self
     }
 

--- a/crates/openclaw-gateway/src/ws.rs
+++ b/crates/openclaw-gateway/src/ws.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use openclaw_core::model::StreamEvent;
+use openclaw_agent::AgentEvent;
 use openclaw_core::types::{Message, MessageContent, Role};
 
 use crate::AppState;
@@ -75,6 +75,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
         };
 
         // Add user message.
+        let user_content = incoming.content.clone();
         let user_msg = Message {
             id: Uuid::new_v4(),
             role: Role::User,
@@ -84,85 +85,103 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
         conv.messages.push(user_msg);
         conv.updated_at = Utc::now();
 
-        // Stream the response using chat_stream.
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamEvent>(64);
-        let provider = state.provider.clone();
-        let messages = conv.messages.clone();
+        // Stream agent events to the WebSocket via a channel.
+        // The agent loop runs in a spawned task so we can forward
+        // events to the socket concurrently as they arrive.
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<AgentEvent>(128);
+        let agent_state = state.clone();
+        let agent_content = user_content.clone();
 
-        let stream_handle = tokio::spawn(async move {
-            let callback = move |event: StreamEvent| {
-                let _ = tx.try_send(event);
+        let agent_handle = tokio::spawn(async move {
+            let on_event = move |event: AgentEvent| {
+                let _ = event_tx.try_send(event);
             };
-            provider
-                .chat_stream(&messages, &[], &callback)
-                .await
+            crate::orchestrate::run_agent_streaming(
+                &agent_state,
+                &mut conv,
+                &agent_content,
+                &on_event,
+            )
+            .await
+            .map(|msg| (msg, conv))
         });
 
-        // Forward stream events to the WebSocket.
-        let mut final_message: Option<Message> = None;
-        while let Some(event) = rx.recv().await {
-            match event {
-                StreamEvent::TextDelta(delta) => {
-                    let out = WsOutgoing {
-                        msg_type: "delta",
-                        delta: Some(delta),
-                        message: None,
-                    };
-                    if socket
-                        .send(WsMessage::Text(serde_json::to_string(&out).unwrap().into()))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                StreamEvent::Done(resp) => {
-                    final_message = Some(resp.message);
-                }
+        // Forward events to the WebSocket as they arrive.
+        while let Some(event) = event_rx.recv().await {
+            let ws_msg = match event {
+                AgentEvent::TextDelta(delta) => WsOutgoing {
+                    msg_type: "delta",
+                    delta: Some(delta),
+                    message: None,
+                },
+                AgentEvent::ToolCallStart { tool_name, .. } => WsOutgoing {
+                    msg_type: "tool_start",
+                    delta: Some(tool_name),
+                    message: None,
+                },
+                AgentEvent::ToolCallEnd { tool_name, success, .. } => WsOutgoing {
+                    msg_type: if success { "tool_end" } else { "tool_error" },
+                    delta: Some(tool_name),
+                    message: None,
+                },
+                AgentEvent::Reflecting => WsOutgoing {
+                    msg_type: "thinking",
+                    delta: Some("reflecting on errors".to_string()),
+                    message: None,
+                },
+                AgentEvent::Compressing => WsOutgoing {
+                    msg_type: "thinking",
+                    delta: Some("compressing memory".to_string()),
+                    message: None,
+                },
+                AgentEvent::Done => continue, // handled below
+            };
+            if socket
+                .send(WsMessage::Text(
+                    serde_json::to_string(&ws_msg).unwrap().into(),
+                ))
+                .await
+                .is_err()
+            {
+                break;
             }
         }
 
-        // Wait for the provider task to complete.
-        match stream_handle.await {
-            Ok(Ok(resp)) => {
-                if final_message.is_none() {
-                    final_message = Some(resp.message);
-                }
-            }
-            Ok(Err(e)) => {
+        // Collect the final result.
+        match agent_handle.await {
+            Ok(Ok((assistant_msg, finished_conv))) => {
+                // Persist the full conversation from the agent task.
+                let _ = state.store.conversations().save(&finished_conv);
+
+                let done_out = WsOutgoing {
+                    msg_type: "done",
+                    delta: None,
+                    message: Some(assistant_msg),
+                };
                 let _ = socket
                     .send(WsMessage::Text(
-                        serde_json::json!({"type": "error", "delta": e.to_string()})
-                            .to_string().into(),
+                        serde_json::to_string(&done_out).unwrap().into(),
                     ))
                     .await;
-                continue;
+            }
+            Ok(Err(_)) => {
+                let _ = socket
+                    .send(WsMessage::Text(
+                        serde_json::json!({"type": "error", "delta": "agent pipeline error"})
+                            .to_string()
+                            .into(),
+                    ))
+                    .await;
             }
             Err(e) => {
                 let _ = socket
                     .send(WsMessage::Text(
                         serde_json::json!({"type": "error", "delta": e.to_string()})
-                            .to_string().into(),
+                            .to_string()
+                            .into(),
                     ))
                     .await;
-                continue;
             }
-        }
-
-        // Add assistant message and persist.
-        if let Some(ref assistant_msg) = final_message {
-            conv.messages.push(assistant_msg.clone());
-            conv.updated_at = Utc::now();
-            let _ = state.store.conversations().save(&conv);
-
-            let out = WsOutgoing {
-                msg_type: "done",
-                delta: None,
-                message: Some(assistant_msg.clone()),
-            };
-            let _ = socket
-                .send(WsMessage::Text(serde_json::to_string(&out).unwrap().into()))
-                .await;
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Both gateway paths (HTTP + WebSocket) were bypassing the entire agent infrastructure** — calling `provider.chat(&messages, &[])` with empty tool arrays, making OpenClaw a plain chatbot with no tool-use capability
- Introduces an `orchestrate` module that wires the full pipeline: `HarnessRouter` profile selection → `SystemPromptBuilder` prompt construction → capability-scoped `Session` → `AgentRunner` execution with tool calls, memory compression, error reflection, and trace-informed guidance
- Adds `AgentEvent` enum and `AgentRunner::run_streaming()` so the WebSocket path streams real-time events (text deltas, tool start/end, reflection, compression) instead of blocking until the agent loop completes

### Changes by crate

| Crate | File | Change |
|-------|------|--------|
| `openclaw-core` | `capability.rs` | Add `CapabilitySet::for_tools()` — grants `FileRead`, `FileWrite`, `ShellExec`, `HttpRequest` + `Tool(name)` per tool |
| `openclaw-agent` | `runner.rs` | Add `AgentEvent` enum (6 variants) and `run_streaming()` method using `chat_stream` with event callback |
| `openclaw-agent` | `lib.rs` | Export `AgentEvent` |
| `openclaw-gateway` | `orchestrate.rs` | **New** — `run_agent()` (non-streaming) and `run_agent_streaming()` with shared `prepare_agent()` setup |
| `openclaw-gateway` | `state.rs` | Add `sandbox: Arc<dyn Sandbox>` field (defaults to `ProcessSandbox`) |
| `openclaw-gateway` | `routes.rs` | Rewire `send_message` to use `orchestrate::run_agent()` |
| `openclaw-gateway` | `ws.rs` | Rewire `handle_socket` to use `orchestrate::run_agent_streaming()` via mpsc channel |
| `openclaw-gateway` | `Cargo.toml` | Add `openclaw-skills` dependency |

## Test plan

- [x] `cargo build` — clean compilation across all crates
- [x] `cargo test` — all existing tests pass
- [ ] Manual: start gateway, create conversation via `POST /api/conversations`, send message via `POST /api/conversations/{id}/messages`, verify tool-informed response
- [ ] Manual: connect via WebSocket to `/ws/chat`, verify `delta`, `tool_start`, `tool_end`, and `done` events stream correctly
- [ ] Verify logs show `harness profile selected` and `executing tool in sandbox` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)