### PR TITLE
Add skill_create tool for LLM-driven skill authoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1281,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -1718,6 +1731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,6 +2043,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -71,8 +71,13 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
+    // --- Skills directory (needed by skill tools and skill loader) ---
+    let skills_dir = data_dir.join("skills");
+    std::fs::create_dir_all(&skills_dir)?;
+
     // --- Tools ---
-    let tools = openclaw_tools::builtin_tools(store.secrets());
+    let mut tools = openclaw_tools::builtin_tools(store.secrets());
+    tools.extend(openclaw_tools::skill_tools(skills_dir.clone()));
 
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");

--- a/crates/openclaw-tools/Cargo.toml
+++ b/crates/openclaw-tools/Cargo.toml
@@ -17,3 +17,6 @@ tokio.workspace = true
 base64.workspace = true
 uuid.workspace = true
 url = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/openclaw-tools/src/lib.rs
+++ b/crates/openclaw-tools/src/lib.rs
@@ -64,6 +64,9 @@ mod http_session;
 mod credential_read;
 mod credential_write;
 
+// Skill tools
+mod skill_create;
+
 // --- Public re-exports ---
 
 // Filesystem
@@ -128,6 +131,9 @@ pub use http_session::HttpSessionTool;
 // Credentials
 pub use credential_read::CredentialReadTool;
 pub use credential_write::CredentialWriteTool;
+
+// Skills
+pub use skill_create::SkillCreateTool;
 
 /// Collect all built-in tools that require no external backend into a Vec.
 ///
@@ -200,6 +206,13 @@ pub fn message_tools(
     backend: std::sync::Arc<dyn MessageBackend>,
 ) -> Vec<std::sync::Arc<dyn openclaw_core::Tool>> {
     vec![std::sync::Arc::new(MessageTool::new(backend))]
+}
+
+/// Collect skill tools that require a skills directory into a Vec.
+pub fn skill_tools(
+    skills_dir: std::path::PathBuf,
+) -> Vec<std::sync::Arc<dyn openclaw_core::Tool>> {
+    vec![std::sync::Arc::new(SkillCreateTool::new(skills_dir))]
 }
 
 /// Collect automation tools that require backends into a Vec.

--- a/crates/openclaw-tools/src/skill_create.rs
+++ b/crates/openclaw-tools/src/skill_create.rs
@@ -1,0 +1,279 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// A tool that creates new SKILL.md skills on disk.
+///
+/// The agent can use this to author reusable skills during a conversation.
+/// Skills are written to `$DATA_DIR/skills/<name>/SKILL.md` and become
+/// available on the next server restart.
+pub struct SkillCreateTool {
+    skills_dir: PathBuf,
+}
+
+impl SkillCreateTool {
+    pub fn new(skills_dir: PathBuf) -> Self {
+        Self { skills_dir }
+    }
+}
+
+/// Validate that a skill name contains only `[a-z0-9_-]` and is 1–64 chars.
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+}
+
+#[async_trait]
+impl Tool for SkillCreateTool {
+    fn name(&self) -> &str {
+        "skill_create"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new SKILL.md skill on disk. The skill becomes available on next restart. \
+         Provide a name (lowercase a-z, 0-9, hyphens, underscores), a short description, \
+         and the markdown instructions body."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Skill name: lowercase alphanumeric, hyphens, underscores. Max 64 chars."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Short human-readable description of what the skill does."
+                    },
+                    "instructions": {
+                        "type": "string",
+                        "description": "Markdown body — the system prompt instructions for the skill."
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Skill version string (default: \"1.0\")."
+                    },
+                    "user_invocable": {
+                        "type": "boolean",
+                        "description": "Whether users can invoke this skill directly (default: true)."
+                    },
+                    "emoji": {
+                        "type": "string",
+                        "description": "Optional emoji for display."
+                    },
+                    "requires_env": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Environment variables the skill requires."
+                    },
+                    "requires_bins": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Binaries the skill requires on PATH."
+                    }
+                },
+                "required": ["name", "description", "instructions"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let name = args["name"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing 'name'".into()))?;
+        let description = args["description"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing 'description'".into()))?;
+        let instructions = args["instructions"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing 'instructions'".into()))?;
+
+        // Validate name (strict allowlist blocks path traversal)
+        if !is_valid_name(name) {
+            return Err(Error::ToolExecution(
+                "invalid skill name: must be 1-64 chars, lowercase a-z, 0-9, hyphens, underscores only".into(),
+            ));
+        }
+
+        // Reject if skill already exists
+        let skill_dir = self.skills_dir.join(name);
+        if skill_dir.exists() {
+            return Err(Error::ToolExecution(format!(
+                "skill '{name}' already exists at {}",
+                skill_dir.display()
+            )));
+        }
+
+        // Optional fields
+        let version = args["version"].as_str().unwrap_or("1.0");
+        let user_invocable = args["user_invocable"].as_bool().unwrap_or(true);
+        let emoji = args["emoji"].as_str();
+        let requires_env: Vec<&str> = args["requires_env"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        let requires_bins: Vec<&str> = args["requires_bins"]
+            .as_array()
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+
+        // Build YAML frontmatter
+        let mut yaml = format!(
+            "name: {name}\ndescription: \"{}\"\nversion: \"{version}\"\nuser_invocable: {user_invocable}",
+            description.replace('"', "\\\""),
+        );
+        if let Some(e) = emoji {
+            yaml.push_str(&format!("\nemoji: \"{}\"", e.replace('"', "\\\"")));
+        }
+        if !requires_env.is_empty() || !requires_bins.is_empty() {
+            yaml.push_str("\nrequires:");
+            if !requires_env.is_empty() {
+                yaml.push_str("\n  env:");
+                for v in &requires_env {
+                    yaml.push_str(&format!("\n    - {v}"));
+                }
+            }
+            if !requires_bins.is_empty() {
+                yaml.push_str("\n  bins:");
+                for b in &requires_bins {
+                    yaml.push_str(&format!("\n    - {b}"));
+                }
+            }
+        }
+
+        let content = format!("---\n{yaml}\n---\n{instructions}");
+
+        // Write to disk
+        std::fs::create_dir_all(&skill_dir)
+            .map_err(|e| Error::ToolExecution(format!("failed to create skill directory: {e}")))?;
+
+        let path = skill_dir.join("SKILL.md");
+        std::fs::write(&path, &content)
+            .map_err(|e| Error::ToolExecution(format!("failed to write SKILL.md: {e}")))?;
+
+        Ok(json!({
+            "created": true,
+            "name": name,
+            "path": path.display().to_string(),
+            "note": "Skill will be available on next server restart."
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_tool() -> (SkillCreateTool, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let tool = SkillCreateTool::new(tmp.path().to_path_buf());
+        (tool, tmp)
+    }
+
+    #[tokio::test]
+    async fn creates_skill_on_disk() {
+        let (tool, tmp) = make_tool();
+        let result = tool
+            .execute(json!({
+                "name": "my-skill",
+                "description": "A test skill",
+                "instructions": "Do the thing.\n\nWith **markdown**."
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["created"], true);
+        assert_eq!(result["name"], "my-skill");
+
+        let path = tmp.path().join("my-skill/SKILL.md");
+        assert!(path.exists());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with("---\n"));
+        assert!(content.contains("name: my-skill"));
+        assert!(content.contains("Do the thing."));
+    }
+
+    #[tokio::test]
+    async fn rejects_path_traversal_names() {
+        let (tool, _tmp) = make_tool();
+        let result = tool
+            .execute(json!({
+                "name": "../escape",
+                "description": "bad",
+                "instructions": "nope"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("invalid skill name"));
+    }
+
+    #[tokio::test]
+    async fn rejects_existing_skill() {
+        let (tool, tmp) = make_tool();
+        // Pre-create the skill directory
+        std::fs::create_dir_all(tmp.path().join("existing")).unwrap();
+
+        let result = tool
+            .execute(json!({
+                "name": "existing",
+                "description": "dup",
+                "instructions": "dup"
+            }))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_characters() {
+        let (tool, _tmp) = make_tool();
+        for bad_name in &["Has.Dot", "slash/bad", "UPPER", "has space"] {
+            let result = tool
+                .execute(json!({
+                    "name": bad_name,
+                    "description": "bad",
+                    "instructions": "nope"
+                }))
+                .await;
+            assert!(result.is_err(), "should reject name: {bad_name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_minimal_skill_with_defaults() {
+        let (tool, tmp) = make_tool();
+        let result = tool
+            .execute(json!({
+                "name": "minimal",
+                "description": "Bare minimum",
+                "instructions": "Just do it."
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["created"], true);
+
+        let content = std::fs::read_to_string(tmp.path().join("minimal/SKILL.md")).unwrap();
+        assert!(content.contains("version: \"1.0\""));
+        assert!(content.contains("user_invocable: true"));
+        // Should not contain requires section
+        assert!(!content.contains("requires:"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SkillCreateTool` that lets the agent create SKILL.md skills on disk during a conversation
- Skills are written to `$DATA_DIR/skills/<name>/SKILL.md` with strict name validation (`[a-z0-9_-]` only, blocking path traversal)
- Wired into the CLI via `skill_tools()` factory following the existing `session_tools()` / `memory_tools()` pattern

## Test plan
- [x] `cargo build --release -p openclaw-cli` compiles
- [x] `cargo test -p openclaw-tools -- skill_create` — all 5 tests pass (create on disk, reject path traversal, reject existing, reject invalid chars, minimal defaults)
- [ ] Start server, ask agent to create a skill, verify SKILL.md written to `~/.local/share/openclaw/skills/`
- [x] No changes to memory/context management code

🤖 Generated with [Claude Code](https://claude.com/claude-code)