### PR TITLE
Add file-based logging and HTTP request/response middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1369,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -1408,7 +1418,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
  "tracing",
  "uuid",
 ]
@@ -2579,6 +2588,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "1"
 # Logging / tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 
 # Storage
 sled = "0.34"

--- a/crates/openclaw-cli/Cargo.toml
+++ b/crates/openclaw-cli/Cargo.toml
@@ -18,6 +18,7 @@ axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -6,19 +6,33 @@ use openclaw_agent::{HarnessProfile, HarnessRouter, OrchestrationPipeline};
 use openclaw_core::model::ModelProvider;
 use openclaw_core::orchestration::OrchestrationConfig;
 use openclaw_skills::SkillRegistry;
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
-
     // --- Data directory ---
     let data_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("openclaw");
     std::fs::create_dir_all(&data_dir)?;
+
+    // --- Logging: stdout + rolling file ---
+    let log_dir = data_dir.join("logs");
+    std::fs::create_dir_all(&log_dir)?;
+
+    let file_appender = tracing_appender::rolling::daily(&log_dir, "openclaw.log");
+    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+
+    let env_filter = EnvFilter::from_default_env();
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt::layer().with_writer(std::io::stdout))
+        .with(fmt::layer().with_writer(non_blocking).with_ansi(false))
+        .init();
 
     // --- CLI subcommands ---
     let args: Vec<String> = std::env::args().collect();

--- a/crates/openclaw-gateway/src/lib.rs
+++ b/crates/openclaw-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+mod logging;
 mod orchestrate;
 pub mod origin;
 pub mod rate_limit;
@@ -55,6 +56,7 @@ pub fn router(state: AppState) -> Router {
             state.clone(),
             rate_limit::rate_limit_middleware,
         ))
+        .layer(middleware::from_fn(logging::request_logging_middleware))
         .with_state(state)
         .layer(middleware::map_response(add_security_headers))
 }

--- a/crates/openclaw-gateway/src/logging.rs
+++ b/crates/openclaw-gateway/src/logging.rs
@@ -1,0 +1,86 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use axum::extract::ConnectInfo;
+use axum::extract::Request;
+use axum::http::header;
+use axum::middleware::Next;
+use axum::response::Response;
+use uuid::Uuid;
+
+/// HTTP request/response logging middleware.
+///
+/// Logs method, path, status, latency, client IP, and content lengths
+/// for every request. Skips `/api/health` to reduce noise.
+/// Uses `info!` for successful responses and `warn!` for 4xx/5xx.
+pub async fn request_logging_middleware(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let path = request.uri().path().to_owned();
+
+    // Skip health checks — too noisy.
+    if path == "/api/health" {
+        return next.run(request).await;
+    }
+
+    let method = request.method().clone();
+    let query = request.uri().query().map(|q| q.to_owned());
+    let request_id = Uuid::new_v4();
+    let client_ip = addr.ip();
+    let user_agent = request
+        .headers()
+        .get(header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("-")
+        .to_owned();
+    let req_content_length = request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok());
+
+    let start = Instant::now();
+    let response = next.run(request).await;
+    let latency_ms = start.elapsed().as_millis();
+
+    let status = response.status().as_u16();
+    let resp_content_length = response
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok());
+
+    if status >= 400 {
+        tracing::warn!(
+            %request_id,
+            %method,
+            %path,
+            ?query,
+            %client_ip,
+            %user_agent,
+            ?req_content_length,
+            status,
+            ?resp_content_length,
+            latency_ms,
+            "request completed"
+        );
+    } else {
+        tracing::info!(
+            %request_id,
+            %method,
+            %path,
+            ?query,
+            %client_ip,
+            %user_agent,
+            ?req_content_length,
+            status,
+            ?resp_content_length,
+            latency_ms,
+            "request completed"
+        );
+    }
+
+    response
+}


### PR DESCRIPTION
## Summary
- Adds `tracing-appender` for daily rolling log files to `data_dir/logs/openclaw.log.YYYY-MM-DD`, preserving logs across restarts
- Introduces HTTP request/response logging middleware that captures method, path, status, latency, client IP, request ID, and user agent for every request (skips `/api/health`)
- 4xx/5xx responses log at `warn!` level; successful responses at `info!`

## Test plan
- [ ] `cargo build --release -p openclaw-cli` compiles cleanly
- [ ] Start server, confirm `data_dir/logs/openclaw.log.YYYY-MM-DD` file appears
- [ ] `curl http://127.0.0.1:3000/api/health` — no log line (skipped)
- [ ] Authenticated request to `/api/conversations` — log line with method, path, status=200, latency_ms in both stdout and log file
- [ ] Bad auth request — warn-level log line with status=401

🤖 Generated with [Claude Code](https://claude.com/claude-code)