### PR TITLE
Improve agent persistence: increase iteration limits, wire up tool retries, double sub-task budgets

### DIFF
--- a/crates/openclaw-agent/src/harness.rs
+++ b/crates/openclaw-agent/src/harness.rs
@@ -86,7 +86,7 @@ impl Default for HarnessProfile {
             trace_informed_guidance: true,
             trace_injection_interval: 5,
             task_type: TaskType::General,
-            max_iterations: 30,
+            max_iterations: 80,
             max_consecutive_errors: 3,
             max_tool_retries: 2,
             max_context_tokens: 128_000,
@@ -109,7 +109,7 @@ impl HarnessProfile {
             trace_informed_guidance: true,
             trace_injection_interval: 3, // More frequent feedback during coding.
             task_type: TaskType::Coding,
-            max_iterations: 50, // Coding tasks often need more steps.
+            max_iterations: 120, // Coding tasks often need more steps.
             max_consecutive_errors: 2, // Reflect sooner on code errors.
             max_tool_retries: 3,
             max_context_tokens: 128_000,
@@ -131,7 +131,7 @@ impl HarnessProfile {
             trace_informed_guidance: true,
             trace_injection_interval: 5,
             task_type: TaskType::Research,
-            max_iterations: 40,
+            max_iterations: 100,
             max_consecutive_errors: 3,
             max_tool_retries: 2,
             max_context_tokens: 128_000,
@@ -152,7 +152,7 @@ impl HarnessProfile {
             trace_informed_guidance: false,
             trace_injection_interval: 0,
             task_type: TaskType::Creative,
-            max_iterations: 20,
+            max_iterations: 50,
             max_consecutive_errors: 3,
             max_tool_retries: 1,
             max_context_tokens: 128_000,

--- a/crates/openclaw-agent/src/orchestrator/executor.rs
+++ b/crates/openclaw-agent/src/orchestrator/executor.rs
@@ -184,7 +184,8 @@ async fn execute_sub_task(
 
             let calls = response.message.content.tool_calls();
             for call in calls {
-                let result = execute_tool_for_subtask(call, tools, sandbox).await;
+                let result =
+                    execute_tool_for_subtask(call, tools, sandbox, config.max_tool_retries).await;
                 messages.push(Message {
                     id: Uuid::new_v4(),
                     role: Role::Tool,
@@ -228,34 +229,57 @@ async fn execute_sub_task(
     }
 }
 
-/// Execute a tool call within a sub-task (simplified, no session caps).
+/// Execute a tool call within a sub-task, retrying transient failures.
 async fn execute_tool_for_subtask(
     call: &ToolCall,
     tools: &[Arc<dyn Tool>],
     sandbox: &Arc<dyn Sandbox>,
+    max_retries: u32,
 ) -> ToolResult {
-    let tool = tools.iter().find(|t| t.name() == call.name);
-    match tool {
-        Some(t) => {
-            let policy = SandboxPolicy::trusted();
-            if let Err(e) = sandbox.execute(&call.name, call.arguments.clone(), &policy).await {
-                tracing::warn!(tool = call.name, "sandbox check failed: {e}");
-            }
-            match t.execute(call.arguments.clone()).await {
-                Ok(output) => ToolResult {
+    let tool = match tools.iter().find(|t| t.name() == call.name) {
+        Some(t) => t,
+        None => {
+            return ToolResult {
+                call_id: call.id.clone(),
+                output: serde_json::json!({ "error": format!("unknown tool: {}", call.name) }),
+            };
+        }
+    };
+
+    let policy = SandboxPolicy::trusted();
+    if let Err(e) = sandbox.execute(&call.name, call.arguments.clone(), &policy).await {
+        tracing::warn!(tool = call.name, "sandbox check failed: {e}");
+    }
+
+    let mut last_err = None;
+    for attempt in 0..=max_retries {
+        match tool.execute(call.arguments.clone()).await {
+            Ok(output) => {
+                return ToolResult {
                     call_id: call.id.clone(),
                     output,
-                },
-                Err(e) => ToolResult {
-                    call_id: call.id.clone(),
-                    output: serde_json::json!({ "error": e.to_string() }),
-                },
+                };
+            }
+            Err(e) => {
+                tracing::warn!(
+                    tool = call.name,
+                    attempt = attempt + 1,
+                    max_retries,
+                    error = %e,
+                    "sub-task tool call failed, retrying"
+                );
+                last_err = Some(e);
+                if attempt < max_retries {
+                    let delay = std::time::Duration::from_millis(500 * 2u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
             }
         }
-        None => ToolResult {
-            call_id: call.id.clone(),
-            output: serde_json::json!({ "error": format!("unknown tool: {}", call.name) }),
-        },
+    }
+
+    ToolResult {
+        call_id: call.id.clone(),
+        output: serde_json::json!({ "error": last_err.unwrap().to_string() }),
     }
 }
 

--- a/crates/openclaw-agent/src/rlm/context_manager.rs
+++ b/crates/openclaw-agent/src/rlm/context_manager.rs
@@ -76,11 +76,12 @@ mod tests {
     #[test]
     fn test_child_budget_decreases() {
         let config = OrchestrationConfig::default();
+        let parent_budget = config.sub_task_context_budget;
         let cm = ContextManager::new(config);
 
-        let b0 = cm.child_budget(8192, 0);
-        let b1 = cm.child_budget(8192, 1);
-        let b2 = cm.child_budget(8192, 2);
+        let b0 = cm.child_budget(parent_budget, 0);
+        let b1 = cm.child_budget(parent_budget, 1);
+        let b2 = cm.child_budget(parent_budget, 2);
 
         assert!(b0 > b1, "depth 0 budget should be > depth 1");
         assert!(b1 > b2, "depth 1 budget should be > depth 2");
@@ -92,10 +93,11 @@ mod tests {
             max_recursion_depth: 3,
             ..Default::default()
         };
+        let parent_budget = config.sub_task_context_budget;
         let cm = ContextManager::new(config);
 
-        assert_eq!(cm.child_budget(8192, 3), 0);
-        assert_eq!(cm.child_budget(8192, 10), 0);
+        assert_eq!(cm.child_budget(parent_budget, 3), 0);
+        assert_eq!(cm.child_budget(parent_budget, 10), 0);
     }
 
     #[test]

--- a/crates/openclaw-agent/src/runner.rs
+++ b/crates/openclaw-agent/src/runner.rs
@@ -66,7 +66,7 @@ pub struct AgentConfig {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            max_iterations: 30,
+            max_iterations: 80,
             max_consecutive_errors: 3,
             max_tool_retries: 2,
             max_context_tokens: 128_000,
@@ -432,16 +432,29 @@ impl AgentRunner {
     }
 
     /// Execute multiple tool calls in parallel, recording execution traces.
+    ///
+    /// Each tool call is retried up to `max_tool_retries` times on failure
+    /// before the error is surfaced to the model.
     async fn execute_tools_parallel_traced(
         &self,
         calls: Vec<&ToolCall>,
         session: &Session,
         tracer: &ExecutionTracer,
     ) -> Vec<Result<ToolResult>> {
+        let max_retries = self.config.max_tool_retries;
+
         if calls.len() == 1 {
             let call = calls[0];
             let start = Instant::now();
-            let result = self.execute_tool_checked(call, session).await;
+            let result = execute_with_retries(
+                call,
+                &self.tools,
+                &self.sandbox,
+                &session.capabilities,
+                session.id,
+                max_retries,
+            )
+            .await;
             tracer.record(ToolTrace {
                 tool_name: call.name.clone(),
                 success: result.is_ok(),
@@ -464,8 +477,15 @@ impl AgentRunner {
 
             handles.push(tokio::spawn(async move {
                 let start = Instant::now();
-                let result =
-                    execute_single_tool(&call, &tools, &sandbox, &session_caps, session_id).await;
+                let result = execute_with_retries(
+                    &call,
+                    &tools,
+                    &sandbox,
+                    &session_caps,
+                    session_id,
+                    max_retries,
+                )
+                .await;
                 (result, call.name.clone(), start.elapsed())
             }));
         }
@@ -495,21 +515,6 @@ impl AgentRunner {
         }
 
         results
-    }
-
-    async fn execute_tool_checked(
-        &self,
-        call: &ToolCall,
-        session: &Session,
-    ) -> Result<ToolResult> {
-        execute_single_tool(
-            call,
-            &self.tools,
-            &self.sandbox,
-            &session.capabilities,
-            session.id,
-        )
-        .await
     }
 
     /// Inject trace-informed context so the model can adapt its strategy.
@@ -672,6 +677,47 @@ impl AgentRunner {
 /// This prevents internal path and stack trace leakage to the model/client.
 fn sanitize_error(e: &str) -> String {
     e.chars().take(200).collect()
+}
+
+/// Retry a tool call up to `max_retries` times with exponential backoff.
+///
+/// Auth errors (permission denied, unknown tool) are not retried since
+/// they will fail deterministically. Only transient errors (timeouts,
+/// execution failures) are retried.
+async fn execute_with_retries(
+    call: &ToolCall,
+    tools: &[Arc<dyn Tool>],
+    sandbox: &Arc<dyn Sandbox>,
+    capabilities: &openclaw_core::capability::CapabilitySet,
+    session_id: uuid::Uuid,
+    max_retries: u32,
+) -> Result<ToolResult> {
+    let mut last_err = None;
+    for attempt in 0..=max_retries {
+        match execute_single_tool(call, tools, sandbox, capabilities, session_id).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                // Don't retry auth errors — they'll fail the same way every time.
+                if matches!(e, Error::Auth(_)) {
+                    return Err(e);
+                }
+                tracing::warn!(
+                    tool = call.name,
+                    attempt = attempt + 1,
+                    max_retries,
+                    error = %e,
+                    "tool call failed, retrying"
+                );
+                last_err = Some(e);
+                if attempt < max_retries {
+                    // Exponential backoff: 500ms, 1s, 2s, ...
+                    let delay = std::time::Duration::from_millis(500 * 2u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap())
 }
 
 /// Standalone function so it can be moved into a tokio::spawn.

--- a/crates/openclaw-core/src/orchestration.rs
+++ b/crates/openclaw-core/src/orchestration.rs
@@ -65,7 +65,7 @@ impl SubTask {
             description: description.into(),
             tool_hint: None,
             requires_reasoning: true,
-            context_budget: 8192,
+            context_budget: 16384,
             depends_on: Vec::new(),
         }
     }
@@ -123,6 +123,8 @@ pub struct OrchestrationConfig {
     pub consistency_temperature_spread: f32,
     /// Maximum refinement iterations.
     pub max_refinement_iterations: usize,
+    /// Maximum retries per failed tool call within sub-tasks.
+    pub max_tool_retries: u32,
     /// Whether to summarize sub-task results before synthesis.
     pub summarize_sub_results: bool,
     /// Which model to use for simple/trivial tasks (fallback model name).
@@ -134,12 +136,13 @@ pub struct OrchestrationConfig {
 impl Default for OrchestrationConfig {
     fn default() -> Self {
         Self {
-            sub_task_context_budget: 8192,
+            sub_task_context_budget: 16384,
             max_sub_tasks: 8,
             max_recursion_depth: 3,
             consistency_samples: 3,
             consistency_temperature_spread: 0.1,
             max_refinement_iterations: 3,
+            max_tool_retries: 2,
             summarize_sub_results: true,
             fallback_model: None,
             primary_model: None,


### PR DESCRIPTION
The agent was giving up too easily due to three issues:
- max_iterations was too low (30 default) for complex multi-step tasks
- max_tool_retries was defined in AgentConfig but never used by the runner
- sub_task_context_budget (8192) was too small for meaningful recursive reasoning

Changes:
- Increase max_iterations: default 30→80, coding 50→120, research 40→100, creative 20→50
- Wire up max_tool_retries with exponential backoff (500ms, 1s, 2s...) in both
  the main runner loop and the orchestrator's sub-task executor, skipping retries
  for deterministic auth errors
- Double sub_task_context_budget from 8192 to 16384 tokens
- Add max_tool_retries to OrchestrationConfig for sub-task executor
- Remove unused execute_tool_checked method
- Fix context_manager tests to use config defaults instead of hardcoded values

https://claude.ai/code/session_018B2VEvtSVadiJMePZZ7H5s