### PR TITLE
Fix Gmail IMAP mailbox name errors

### DIFF
--- a/crates/openclaw-tools/src/gmail.rs
+++ b/crates/openclaw-tools/src/gmail.rs
@@ -543,7 +543,7 @@ impl Tool for GmailTool {
                     },
                     "mailbox": {
                         "type": "string",
-                        "description": "Mailbox/label to operate on (default 'INBOX')"
+                        "description": "IMAP mailbox name (default 'INBOX'). Gmail folders: '[Gmail]/Sent Mail', '[Gmail]/All Mail', '[Gmail]/Drafts', '[Gmail]/Spam', '[Gmail]/Trash', '[Gmail]/Starred'. Custom labels use their name directly."
                     },
                     "uid": {
                         "type": "integer",


### PR DESCRIPTION
## Summary
- The `mailbox` parameter description didn't list Gmail's actual IMAP folder names, so the LLM was guessing names like `SENT` and `ALL` which don't exist
- Added the correct Gmail IMAP names (`[Gmail]/Sent Mail`, `[Gmail]/All Mail`, etc.) to the tool schema description

Fixes errors like:
```
select SENT failed: [NONEXISTENT] Unknown Mailbox: SENT
select ALL failed: [NONEXISTENT] Unknown Mailbox: ALL
```

## Test plan
- [ ] Ask the agent to search sent mail — should use `[Gmail]/Sent Mail` instead of `SENT`
- [ ] Ask the agent to search all mail — should use `[Gmail]/All Mail` instead of `ALL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)