### PR TITLE
Improve streaming reliability and observability

### DIFF
--- a/crates/openclaw-agent/src/runner.rs
+++ b/crates/openclaw-agent/src/runner.rs
@@ -170,11 +170,21 @@ impl AgentRunner {
                 tracer.record_compression();
             }
 
+            let llm_start = std::time::Instant::now();
             let ModelResponse {
                 message,
-                usage: _,
+                usage,
                 stop_reason,
             } = self.provider.chat(&conv.messages, &schemas).await?;
+            let llm_elapsed = llm_start.elapsed();
+            tracing::info!(
+                iteration,
+                duration_ms = llm_elapsed.as_millis() as u64,
+                prompt_tokens = usage.prompt_tokens,
+                completion_tokens = usage.completion_tokens,
+                ?stop_reason,
+                "LLM call completed"
+            );
 
             conv.messages.push(message.clone());
             conv.updated_at = Utc::now();
@@ -337,14 +347,24 @@ impl AgentRunner {
                 }
             };
 
+            let llm_start = std::time::Instant::now();
             let ModelResponse {
                 message,
-                usage: _,
+                usage,
                 stop_reason,
             } = self
                 .provider
                 .chat_stream(&conv.messages, &schemas, &stream_callback)
                 .await?;
+            let llm_elapsed = llm_start.elapsed();
+            tracing::info!(
+                iteration,
+                duration_ms = llm_elapsed.as_millis() as u64,
+                prompt_tokens = usage.prompt_tokens,
+                completion_tokens = usage.completion_tokens,
+                ?stop_reason,
+                "LLM call completed"
+            );
 
             conv.messages.push(message.clone());
             conv.updated_at = Utc::now();

--- a/crates/openclaw-gateway/src/routes.rs
+++ b/crates/openclaw-gateway/src/routes.rs
@@ -182,7 +182,7 @@ async fn send_message_stream(
     // Channel for streaming events from the agent task to the SSE response.
     let (tx, rx) = tokio::sync::mpsc::channel::<SsePayload>(128);
 
-    // Spawn the agent loop in a background task with a 5-minute timeout
+    // Spawn the agent loop in a background task with a 10-minute timeout
     // to prevent unbounded connection exhaustion.
     let agent_state = state.clone();
     tokio::spawn(async move {
@@ -192,7 +192,7 @@ async fn send_message_stream(
         };
 
         let result = tokio::time::timeout(
-            tokio::time::Duration::from_secs(300),
+            tokio::time::Duration::from_secs(600),
             crate::orchestrate::run_agent_streaming(
                 &agent_state,
                 &mut conv,
@@ -205,7 +205,7 @@ async fn send_message_stream(
         let result = match result {
             Ok(r) => r,
             Err(_) => {
-                tracing::warn!("streaming agent timed out after 300s");
+                tracing::warn!("streaming agent timed out after 600s");
                 Err(StatusCode::REQUEST_TIMEOUT)
             }
         };
@@ -258,13 +258,20 @@ async fn send_message_stream(
             SsePayload::Done(Ok(message)) => Event::default().event("done").data(
                 serde_json::json!({"type": "done", "message": message}).to_string(),
             ),
-            SsePayload::Done(Err(_)) => Event::default().event("error").data(
-                serde_json::json!({"type": "error", "delta": "an internal error occurred"})
-                    .to_string(),
-            ),
+            SsePayload::Done(Err(e)) => {
+                tracing::error!(error = %e, "agent stream ended with error");
+                Event::default().event("error").data(
+                    serde_json::json!({"type": "error", "delta": format!("{e}")})
+                        .to_string(),
+                )
+            }
         };
         Ok(event)
     });
 
-    Ok(Sse::new(stream))
+    Ok(Sse::new(stream).keep_alive(
+        axum::response::sse::KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text("ping"),
+    ))
 }


### PR DESCRIPTION
## Summary
- **Surface real errors**: Stop swallowing errors with generic "an internal error occurred" — log and send the actual error to the frontend
- **LLM call telemetry**: Log duration, prompt/completion token counts, and stop reason for every LLM call
- **SSE keep-alive**: Send heartbeat every 15s to prevent browsers/proxies from killing the connection during long tool calls
- **Bump timeout**: 5min → 10min to accommodate complex multi-tool requests

## Test plan
- [ ] Trigger an error condition — frontend should show the real error message, not "an internal error occurred"
- [ ] Run with `RUST_LOG=info` — verify LLM timing/token logs appear
- [ ] Send a message requiring long tool execution — verify connection stays alive via heartbeats
- [ ] Verify requests completing under 10min succeed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)