### PR TITLE
Add Gmail attachment support and thread fetching

### DIFF
--- a/crates/openclaw-tools/src/gmail.rs
+++ b/crates/openclaw-tools/src/gmail.rs
@@ -243,13 +243,30 @@ impl GmailTool {
                         .unwrap_or_else(|| a.address().unwrap_or("").to_string())
                 })
                 .unwrap_or_default();
-            let to = parsed
+            let to: Vec<String> = parsed
                 .to()
+                .map(|addrs| addrs.iter().map(|a| {
+                    a.name()
+                        .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                        .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                }).collect())
+                .unwrap_or_default();
+            let cc: Vec<String> = parsed
+                .cc()
+                .map(|addrs| addrs.iter().map(|a| {
+                    a.name()
+                        .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                        .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                }).collect())
+                .unwrap_or_default();
+            let date = parsed.date().map(|d| d.to_string()).unwrap_or_default();
+            let message_id = parsed.message_id().unwrap_or("").to_string();
+            let reply_to = parsed
+                .reply_to()
                 .and_then(|a| a.first())
                 .and_then(|a| a.address())
                 .unwrap_or("")
                 .to_string();
-            let date = parsed.date().map(|d| d.to_string()).unwrap_or_default();
             let body_text = parsed
                 .body_text(0)
                 .unwrap_or_else(|| {
@@ -267,11 +284,40 @@ impl GmailTool {
                 body_text
             };
 
+            // Attachment metadata
+            use mail_parser::MimeHeaders;
+            let attachments: Vec<Value> = parsed
+                .attachments()
+                .enumerate()
+                .map(|(i, part)| {
+                    let filename = part
+                        .content_disposition()
+                        .and_then(|cd| cd.attribute("filename"))
+                        .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
+                        .unwrap_or("unnamed")
+                        .to_string();
+                    let content_type = part
+                        .content_type()
+                        .map(|ct| {
+                            let sub = ct.subtype().unwrap_or("octet-stream");
+                            format!("{}/{sub}", ct.ctype())
+                        })
+                        .unwrap_or_else(|| "application/octet-stream".to_string());
+                    let size = part.contents().len();
+                    json!({
+                        "index": i,
+                        "filename": filename,
+                        "content_type": content_type,
+                        "size_bytes": size,
+                    })
+                })
+                .collect();
+
             let flags: Vec<String> = fetch.flags().iter().map(|f| format!("{f:?}")).collect();
 
             let _ = session.logout();
 
-            Ok(json!({
+            let mut result = json!({
                 "uid": uid,
                 "subject": subject,
                 "from": from,
@@ -279,7 +325,19 @@ impl GmailTool {
                 "date": date,
                 "body": body_text,
                 "flags": flags,
-            }))
+                "message_id": message_id,
+            });
+            if !cc.is_empty() {
+                result["cc"] = json!(cc);
+            }
+            if !reply_to.is_empty() {
+                result["reply_to"] = json!(reply_to);
+            }
+            if !attachments.is_empty() {
+                result["attachments"] = json!(attachments);
+                result["attachment_count"] = json!(attachments.len());
+            }
+            Ok(result)
         })
         .await
         .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
@@ -495,6 +553,274 @@ impl GmailTool {
         .await
         .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
     }
+    // -----------------------------------------------------------------------
+    // Action: thread (fetch full reply chain for a message)
+    // -----------------------------------------------------------------------
+
+    async fn action_thread(&self, args: &Value) -> Result<Value> {
+        let uid: u32 = args["uid"]
+            .as_u64()
+            .ok_or_else(|| Error::ToolExecution("missing 'uid'".into()))?
+            as u32;
+        let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
+
+        let secrets = self.secrets.clone();
+        let mailbox = mailbox.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let (email, password) = get_creds(&secrets)?;
+            let mut session = connect_imap_blocking(&email, &password)?;
+
+            // First, fetch the target message to get its References/In-Reply-To/Message-ID.
+            session
+                .select(&mailbox)
+                .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+
+            let fetches = session
+                .uid_fetch(uid.to_string(), "(UID RFC822)")
+                .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?;
+
+            let fetch = fetches
+                .iter()
+                .next()
+                .ok_or_else(|| Error::ToolExecution(format!("message uid {uid} not found").into()))?;
+
+            let raw = fetch.body().unwrap_or_default();
+            let parsed = mail_parser::MessageParser::default()
+                .parse(raw)
+                .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
+
+            // Collect all Message-IDs in the thread: this message + References header.
+            let mut msg_ids: Vec<String> = Vec::new();
+            if let Some(mid) = parsed.message_id() {
+                msg_ids.push(mid.to_string());
+            }
+            // References header contains the full chain of Message-IDs.
+            let refs_header = parsed.header_raw("References").unwrap_or("");
+            for token in refs_header.split_whitespace() {
+                let id = token.trim_matches(|c| c == '<' || c == '>');
+                if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
+                    msg_ids.push(id.to_string());
+                }
+            }
+            if let Some(irt) = parsed.header_raw("In-Reply-To") {
+                let id = irt.trim().trim_matches(|c| c == '<' || c == '>');
+                if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
+                    msg_ids.push(id.to_string());
+                }
+            }
+
+            if msg_ids.is_empty() {
+                let _ = session.logout();
+                return Ok(json!({
+                    "thread": [],
+                    "count": 0,
+                    "note": "no threading headers found on this message"
+                }));
+            }
+
+            // Search [Gmail]/All Mail for all messages matching any of these IDs.
+            session
+                .select("[Gmail]/All Mail")
+                .map_err(|e| Error::ToolExecution(format!("select All Mail failed: {e}").into()))?;
+
+            let mut all_uids = std::collections::HashSet::new();
+            for mid in &msg_ids {
+                // Search for messages that reference this ID or have this ID.
+                let query = format!("X-GM-RAW \"rfc822msgid:{mid} OR references:{mid}\"");
+                if let Ok(uids) = session.uid_search(&query) {
+                    all_uids.extend(uids);
+                }
+                // Also try standard HEADER search as fallback.
+                let query2 = format!("OR HEADER Message-ID \"<{mid}>\" HEADER References \"<{mid}>\"");
+                if let Ok(uids) = session.uid_search(&query2) {
+                    all_uids.extend(uids);
+                }
+            }
+
+            if all_uids.is_empty() {
+                let _ = session.logout();
+                return Ok(json!({
+                    "thread": [],
+                    "count": 0,
+                    "note": "could not find thread messages"
+                }));
+            }
+
+            // Fetch all thread messages.
+            let mut uid_list: Vec<u32> = all_uids.into_iter().collect();
+            uid_list.sort_unstable(); // chronological (oldest first)
+
+            let uid_set = uid_list
+                .iter()
+                .map(|u| u.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+
+            let fetches = session
+                .uid_fetch(&uid_set, "(UID RFC822 FLAGS)")
+                .map_err(|e| Error::ToolExecution(format!("fetch thread failed: {e}").into()))?;
+
+            let mut messages = Vec::new();
+            for fetch in fetches.iter() {
+                let raw_body = fetch.body().unwrap_or_default();
+                let msg = match mail_parser::MessageParser::default().parse(raw_body) {
+                    Some(m) => m,
+                    None => continue,
+                };
+
+                let subject = msg.subject().unwrap_or("").to_string();
+                let from = msg
+                    .from()
+                    .and_then(|a| a.first())
+                    .map(|a| {
+                        a.name()
+                            .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                            .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                    })
+                    .unwrap_or_default();
+                let to: Vec<String> = msg
+                    .to()
+                    .map(|addrs| addrs.iter().map(|a| {
+                        a.name()
+                            .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                            .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                    }).collect())
+                    .unwrap_or_default();
+                let date = msg.date().map(|d| d.to_string()).unwrap_or_default();
+                let message_id = msg.message_id().unwrap_or("").to_string();
+                let body_text = msg
+                    .body_text(0)
+                    .unwrap_or_else(|| {
+                        msg.body_html(0)
+                            .map(|h| strip_html_tags(&h).into())
+                            .unwrap_or_default()
+                    })
+                    .to_string();
+
+                // Truncate long bodies.
+                let body_text = if body_text.len() > 4000 {
+                    format!(
+                        "{}…\n[truncated, {} chars total]",
+                        &body_text[..body_text.floor_char_boundary(4000)],
+                        body_text.len()
+                    )
+                } else {
+                    body_text
+                };
+
+                messages.push(json!({
+                    "uid": fetch.uid.unwrap_or(0),
+                    "subject": subject,
+                    "from": from,
+                    "to": to,
+                    "date": date,
+                    "message_id": message_id,
+                    "body": body_text,
+                }));
+            }
+
+            let _ = session.logout();
+
+            Ok(json!({
+                "thread": messages,
+                "count": messages.len(),
+            }))
+        })
+        .await
+        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+    }
+
+    // -----------------------------------------------------------------------
+    // Action: download_attachment
+    // -----------------------------------------------------------------------
+
+    async fn action_download_attachment(&self, args: &Value) -> Result<Value> {
+        let uid: u32 = args["uid"]
+            .as_u64()
+            .ok_or_else(|| Error::ToolExecution("missing 'uid'".into()))?
+            as u32;
+        let attachment_index: usize = args["attachment_index"]
+            .as_u64()
+            .ok_or_else(|| {
+                Error::ToolExecution(
+                    "missing 'attachment_index' (use read action to list attachments)".into(),
+                )
+            })? as usize;
+        let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
+
+        let secrets = self.secrets.clone();
+        let mailbox = mailbox.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let (email, password) = get_creds(&secrets)?;
+            let mut session = connect_imap_blocking(&email, &password)?;
+
+            session
+                .select(&mailbox)
+                .map_err(|e| {
+                    Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
+                })?;
+
+            let fetches = session
+                .uid_fetch(uid.to_string(), "(UID RFC822)")
+                .map_err(|e| {
+                    Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into())
+                })?;
+
+            let fetch = fetches
+                .iter()
+                .next()
+                .ok_or_else(|| {
+                    Error::ToolExecution(format!("message uid {uid} not found").into())
+                })?;
+
+            let raw_body = fetch.body().unwrap_or_default();
+            let parsed = mail_parser::MessageParser::default()
+                .parse(raw_body)
+                .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
+
+            use mail_parser::MimeHeaders;
+            let part = parsed.attachment(attachment_index).ok_or_else(|| {
+                Error::ToolExecution(
+                    format!(
+                        "attachment index {attachment_index} not found (message has {} attachments)",
+                        parsed.attachment_count()
+                    )
+                    .into(),
+                )
+            })?;
+
+            let filename = part
+                .content_disposition()
+                .and_then(|cd| cd.attribute("filename"))
+                .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
+                .unwrap_or("attachment.bin")
+                .to_string();
+
+            let contents = part.contents();
+
+            // Save to a temp directory
+            let download_dir = std::env::temp_dir().join("openclaw-attachments");
+            std::fs::create_dir_all(&download_dir)
+                .map_err(|e| Error::ToolExecution(format!("create dir failed: {e}").into()))?;
+
+            let dest = download_dir.join(&filename);
+            std::fs::write(&dest, contents)
+                .map_err(|e| Error::ToolExecution(format!("write failed: {e}").into()))?;
+
+            let _ = session.logout();
+
+            Ok(json!({
+                "status": "downloaded",
+                "filename": filename,
+                "path": dest.to_string_lossy(),
+                "size_bytes": contents.len(),
+            }))
+        })
+        .await
+        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -522,7 +848,7 @@ impl Tool for GmailTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["setup", "search", "read", "send", "labels", "move", "trash", "mark_read", "mark_unread"],
+                        "enum": ["setup", "search", "read", "send", "labels", "move", "trash", "mark_read", "mark_unread", "download_attachment", "thread"],
                         "description": "Action to perform"
                     },
                     "email": {
@@ -572,6 +898,10 @@ impl Tool for GmailTool {
                     "to_mailbox": {
                         "type": "string",
                         "description": "Destination mailbox/label (for 'move' action)"
+                    },
+                    "attachment_index": {
+                        "type": "integer",
+                        "description": "Attachment index to download (for 'download_attachment' action, 0-based, from 'read' response)"
                     }
                 },
                 "required": ["action"]
@@ -594,8 +924,10 @@ impl Tool for GmailTool {
             "trash" => self.action_trash(&args).await,
             "mark_read" => self.action_mark(&args, true).await,
             "mark_unread" => self.action_mark(&args, false).await,
+            "download_attachment" => self.action_download_attachment(&args).await,
+            "thread" => self.action_thread(&args).await,
             other => Err(Error::ToolExecution(format!(
-                "unknown action '{other}', expected one of: setup, search, read, send, labels, move, trash, mark_read, mark_unread"
+                "unknown action '{other}', expected one of: setup, search, read, send, labels, move, trash, mark_read, mark_unread, download_attachment, thread"
             ).into())),
         }
     }


### PR DESCRIPTION
## Summary
- **Enriched `read` response**: now includes `cc`, `message_id`, `reply_to`, and `attachments` array (filename, content_type, size_bytes, index)
- **New `download_attachment` action**: saves an attachment by index to `/tmp/openclaw-attachments/` and returns the file path
- **New `thread` action**: given a message UID, follows `References`/`In-Reply-To` headers to fetch the full reply chain from `[Gmail]/All Mail`

## Test plan
- [ ] Read an email with attachments — verify attachment metadata appears in response
- [ ] Download an attachment — verify file is saved and path is returned
- [ ] Fetch a thread from a reply chain — verify all messages in the conversation are returned in chronological order
- [ ] Read an email without attachments — verify no `attachments` field clutters the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)