### PR TITLE
Fix conversation rendering for persisted messages

### DIFF
--- a/crates/openclaw-gateway/static/index.html
+++ b/crates/openclaw-gateway/static/index.html
@@ -1324,7 +1324,22 @@
   // ── Utilities ─────────────────────────────────────────────
   function extractText(content) {
     if (typeof content === 'string') return content;
+    // Tagged enum format: {"type": "text", "data": "..."}
+    if (content && content.type === 'text') return content.data || '';
+    // Legacy untagged format
     if (content && content.Text) return content.Text;
+    if (content && content.type === 'tool_call') {
+      const tc = content.data;
+      return tc ? `Tool: ${tc.name}` : 'Tool call';
+    }
+    if (content && content.type === 'multi_tool_call') {
+      const calls = content.data || [];
+      return calls.map(tc => `Tool: ${tc.name}`).join(', ');
+    }
+    if (content && content.type === 'tool_result') {
+      const tr = content.data;
+      return tr ? `Result for ${tr.call_id}` : 'Tool result';
+    }
     if (Array.isArray(content)) return 'Multiple tool calls';
     if (content && content.name) return `Tool: ${content.name}`;
     if (content && content.call_id) return `Result for ${content.call_id}`;


### PR DESCRIPTION
## Summary
- `extractText()` was written for the old `#[serde(untagged)]` format (`content.Text`) but `MessageContent` now serializes as a tagged enum (`{"type": "text", "data": "..."}`)
- Persisted conversations displayed raw JSON blobs instead of formatted messages
- Now handles both tagged and legacy formats, and properly labels tool calls/results

## Test plan
- [ ] Load a persisted conversation — messages should render as formatted text, not raw JSON
- [ ] Live streaming messages should still work as before
- [ ] Tool call and tool result messages should show descriptive labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)