### PR TITLE
Add spreadsheet_read tool and improve code_execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +66,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "argon2"
@@ -244,6 +259,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "calamine"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+dependencies = [
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "quick-xml",
+ "serde",
+ "zip",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +381,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -519,6 +558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +716,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1392,6 +1452,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1693,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "calamine",
  "chromiumoxide",
  "imap",
  "imap-proto",
@@ -1848,6 +1919,16 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
+ "memchr",
 ]
 
 [[package]]
@@ -2437,6 +2518,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -3624,7 +3711,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 # Browser automation (Chrome DevTools Protocol)
 chromiumoxide = { version = "0.9", default-features = false }
 
+# Spreadsheet reading
+calamine = "0.26"
+
 # Email (IMAP + SMTP)
 imap = "2"
 native-tls = "0.2"

--- a/crates/openclaw-tools/Cargo.toml
+++ b/crates/openclaw-tools/Cargo.toml
@@ -24,6 +24,7 @@ imap-proto = "0.10"
 native-tls.workspace = true
 lettre.workspace = true
 mail-parser.workspace = true
+calamine.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/openclaw-tools/src/code_execution.rs
+++ b/crates/openclaw-tools/src/code_execution.rs
@@ -5,6 +5,28 @@ use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::timeout;
 
+/// Resolve the full path to python3, checking common locations
+/// so that pyenv/Homebrew/conda installs are found even after env_clear().
+fn which_python() -> Option<std::path::PathBuf> {
+    // Check the current PATH first (before we clear it)
+    if let Ok(output) = std::process::Command::new("which")
+        .arg("python3")
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                // Resolve shims (pyenv) to the actual binary
+                if let Ok(canonical) = std::fs::canonicalize(&path) {
+                    return Some(canonical);
+                }
+                return Some(path.into());
+            }
+        }
+    }
+    None
+}
+
 /// A built-in tool that executes Python code in a sandboxed environment.
 ///
 /// Security improvements:
@@ -32,7 +54,11 @@ impl Tool for CodeExecutionTool {
     }
 
     fn description(&self) -> &str {
-        "Execute Python code in a sandboxed environment and return the result."
+        "Execute Python code and return stdout/stderr. Has access to the user's \
+         Python environment including installed packages. If a package is missing, \
+         install it with subprocess.check_call(['pip', 'install', 'package_name']). \
+         Use this for data processing, file format conversion, calculations, \
+         and any task that benefits from Python libraries."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -79,13 +105,29 @@ impl Tool for CodeExecutionTool {
             .await
             .map_err(|e| openclaw_core::Error::ToolExecution(e.to_string().into()))?;
 
-        let future = tokio::process::Command::new("python3")
+        // Resolve the full path to python3 before clearing the environment.
+        // This ensures we find the user's Python (e.g., pyenv, Homebrew)
+        // rather than falling back to a system Python that may lack packages.
+        let python_path = which_python().unwrap_or_else(|| "python3".into());
+
+        // Include the Python's bin directory in PATH so pip is also available.
+        // This allows the model to install packages if needed.
+        let python_bin_dir = python_path
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let sandbox_path = if python_bin_dir.is_empty() {
+            "/usr/local/bin:/usr/bin:/bin".to_string()
+        } else {
+            format!("{python_bin_dir}:/usr/local/bin:/usr/bin:/bin")
+        };
+
+        let future = tokio::process::Command::new(&python_path)
             .arg(&tmp_file)
             .env_clear()
-            .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+            .env("PATH", &sandbox_path)
             .env("HOME", std::env::temp_dir())
             .env("LANG", "C.UTF-8")
-            // Prevent Python from importing from arbitrary locations
             .env("PYTHONDONTWRITEBYTECODE", "1")
             .current_dir(&tmp_dir)
             .output();

--- a/crates/openclaw-tools/src/lib.rs
+++ b/crates/openclaw-tools/src/lib.rs
@@ -50,6 +50,7 @@ mod gateway;
 mod image;
 mod image_generate;
 mod pdf;
+mod spreadsheet;
 mod tts;
 
 // UI tools
@@ -123,6 +124,7 @@ pub use gateway_backend::GatewayBackend;
 pub use self::image::ImageTool;
 pub use image_generate::ImageGenerateTool;
 pub use pdf::PdfTool;
+pub use spreadsheet::SpreadsheetTool;
 pub use tts::TtsTool;
 
 // UI
@@ -175,6 +177,7 @@ pub fn builtin_tools(
         std::sync::Arc::new(ImageGenerateTool::new()),
         std::sync::Arc::new(TtsTool::new()),
         std::sync::Arc::new(PdfTool::new()),
+        std::sync::Arc::new(SpreadsheetTool::new()),
         // UI
         std::sync::Arc::new(BrowserTool::new()),
         std::sync::Arc::new(CanvasTool::new()),

--- a/crates/openclaw-tools/src/spreadsheet.rs
+++ b/crates/openclaw-tools/src/spreadsheet.rs
@@ -1,0 +1,166 @@
+use async_trait::async_trait;
+use calamine::{open_workbook_auto, Data, Reader};
+use openclaw_core::types::ToolSchema;
+use openclaw_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+use crate::security;
+
+/// A built-in tool that reads spreadsheet files (xlsx, xls, ods).
+///
+/// Uses the `calamine` crate for pure-Rust parsing — no external
+/// dependencies required. Returns sheet data as JSON arrays.
+pub struct SpreadsheetTool;
+
+impl SpreadsheetTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SpreadsheetTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for SpreadsheetTool {
+    fn name(&self) -> &str {
+        "spreadsheet_read"
+    }
+
+    fn description(&self) -> &str {
+        "Read data from spreadsheet files (xlsx, xls, ods). Returns sheet names and cell data as JSON arrays."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the spreadsheet file (.xlsx, .xls, or .ods)"
+                    },
+                    "sheet": {
+                        "type": "string",
+                        "description": "Name of the sheet to read. If omitted, reads the first sheet."
+                    },
+                    "max_rows": {
+                        "type": "integer",
+                        "description": "Maximum number of rows to return (default: 500). Use this to limit output size for large spreadsheets."
+                    }
+                },
+                "required": ["path"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let path = args["path"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing path".into()))?;
+
+        let safe_path = security::validate_path(path)
+            .map_err(|e| Error::ToolExecution(format!("path rejected: {e}").into()))?;
+
+        let sheet_name = args["sheet"].as_str().map(|s| s.to_string());
+        let max_rows = args["max_rows"].as_u64().unwrap_or(500) as usize;
+
+        // calamine is synchronous — run in a blocking thread
+        let safe_path_clone = safe_path.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            read_spreadsheet(&safe_path_clone, sheet_name.as_deref(), max_rows)
+        })
+        .await
+        .map_err(|e| Error::ToolExecution(format!("task join error: {e}").into()))?
+        .map_err(|e| Error::ToolExecution(e.into()))?;
+
+        Ok(result)
+    }
+}
+
+fn read_spreadsheet(
+    path: &std::path::Path,
+    sheet_name: Option<&str>,
+    max_rows: usize,
+) -> std::result::Result<Value, String> {
+    let mut workbook = open_workbook_auto(path)
+        .map_err(|e| format!("failed to open spreadsheet: {e}"))?;
+
+    let sheet_names: Vec<String> = workbook.sheet_names().to_vec();
+
+    if sheet_names.is_empty() {
+        return Ok(json!({
+            "path": path.display().to_string(),
+            "sheets": [],
+            "error": "no sheets found in workbook"
+        }));
+    }
+
+    // Determine which sheet to read
+    let target_sheet = match sheet_name {
+        Some(name) => {
+            if !sheet_names.contains(&name.to_string()) {
+                return Ok(json!({
+                    "path": path.display().to_string(),
+                    "sheets": sheet_names,
+                    "error": format!("sheet '{}' not found. Available sheets: {:?}", name, sheet_names)
+                }));
+            }
+            name.to_string()
+        }
+        None => sheet_names[0].clone(),
+    };
+
+    let range = workbook
+        .worksheet_range(&target_sheet)
+        .map_err(|e| format!("failed to read sheet '{}': {e}", target_sheet))?;
+
+    let total_rows = range.height();
+    let total_cols = range.width();
+    let rows_to_read = max_rows.min(total_rows);
+
+    let mut rows: Vec<Vec<Value>> = Vec::with_capacity(rows_to_read);
+
+    for row in range.rows().take(rows_to_read) {
+        let cells: Vec<Value> = row
+            .iter()
+            .map(|cell| match cell {
+                Data::Empty => Value::Null,
+                Data::String(s) => Value::String(s.clone()),
+                Data::Float(f) => {
+                    // Represent whole numbers as integers for cleaner output
+                    if f.fract() == 0.0 && *f >= i64::MIN as f64 && *f <= i64::MAX as f64 {
+                        json!(*f as i64)
+                    } else {
+                        json!(f)
+                    }
+                }
+                Data::Int(i) => json!(i),
+                Data::Bool(b) => Value::Bool(*b),
+                Data::Error(e) => Value::String(format!("#ERR:{:?}", e)),
+                Data::DateTime(dt) => Value::String(format!("{}", dt)),
+                Data::DateTimeIso(s) => Value::String(s.clone()),
+                Data::DurationIso(s) => Value::String(s.clone()),
+            })
+            .collect();
+        rows.push(cells);
+    }
+
+    let truncated = total_rows > rows_to_read;
+
+    Ok(json!({
+        "path": path.display().to_string(),
+        "sheet": target_sheet,
+        "sheets": sheet_names,
+        "total_rows": total_rows,
+        "total_columns": total_cols,
+        "rows_returned": rows_to_read,
+        "truncated": truncated,
+        "data": rows,
+    }))
+}


### PR DESCRIPTION
## Summary
- Add `spreadsheet_read` tool using the `calamine` crate for pure-Rust parsing of xlsx, xls, and ods files — the agent previously failed to read Excel attachments (UTF-8 error from the text-based `read` tool)
- Fix `code_execution` to resolve the user's actual Python binary (pyenv/Homebrew/conda) before `env_clear()`, so installed packages are available
- Improve `code_execution` tool description so the model knows it can `pip install` missing packages

## Test plan
- [ ] `cargo build` compiles cleanly
- [ ] Download an xlsx attachment via Gmail, then call `spreadsheet_read` on it — should return JSON cell data
- [ ] Run `code_execution` with a script that imports a pip-installed package — should work without errors
- [ ] Verify `spreadsheet_read` with `sheet` param selects the correct sheet
- [ ] Verify `max_rows` param limits output for large spreadsheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)