### PR TITLE
Fix agent passivity: rewrite system prompt for autonomous task completion

### DIFF
--- a/crates/openclaw-agent/src/harness.rs
+++ b/crates/openclaw-agent/src/harness.rs
@@ -81,7 +81,9 @@ impl Default for HarnessProfile {
         Self {
             name: "default".to_string(),
             agent_name: "OpenClaw".to_string(),
-            agent_description: "a capable AI assistant with tool access.".to_string(),
+            agent_description: "an autonomous agent that completes tasks by using tools. \
+                You take action directly — you do not tell the user to do things themselves."
+                .to_string(),
             chain_of_thought: true,
             trace_informed_guidance: true,
             trace_injection_interval: 5,

--- a/crates/openclaw-skills/src/prompt.rs
+++ b/crates/openclaw-skills/src/prompt.rs
@@ -30,15 +30,20 @@ impl SystemPromptBuilder {
         self.sections.push(format!(
             "You are {name}, {description}\n\n\
              CORE RULES:\n\
-             - Always use tools when you need external information. Never guess or make up data.\n\
-             - If a tool call fails, read the error message carefully and try a different approach.\n\
-             - Think step by step. For complex tasks, break them into smaller tool calls.\n\
-             - When you have the answer, respond directly. Do not make unnecessary tool calls.\n\
+             - You are an AGENT. Your job is to COMPLETE tasks, not describe how to do them. \
+               Use your tools to take action and deliver results.\n\
+             - Always use tools when you need information or need to perform an action. \
+               Never guess, make up data, or tell the user to do something you could do yourself.\n\
+             - If a tool call fails, read the error carefully and try a DIFFERENT approach. \
+               Do not give up after one failure — adapt and retry with a new strategy.\n\
+             - For complex tasks, break them into steps and execute each step with tool calls. \
+               Keep going until the task is fully complete.\n\
+             - If you need a Python library that is not installed, install it with \
+               code_execution and subprocess.check_call(['pip', 'install', 'package']).\n\
              - MEMORY: Use memory_save to store important facts, decisions, user preferences, \
                and error resolutions with descriptive tags. Your context window is limited — \
                facts you don't save will be lost when old messages scroll out. When you learn \
-               something important, save it immediately. Relevant memories are automatically \
-               recalled based on conversation keywords."
+               something important, save it immediately."
         ));
         self
     }


### PR DESCRIPTION
## Problem

The model (qwen3:32b) was consistently giving up after 1-2 tool calls and telling the user to do things manually — "here's a script you can run locally", "you can open the file in Excel", etc. The logs show the model choosing `EndTurn` after minimal effort despite having 80 iterations available.

## Root Cause

The system prompt said **"Do not make unnecessary tool calls"** which a 32B model interprets very conservatively as "stop as soon as possible." The agent description ("a capable AI assistant with tool access") positioned it as a passive assistant rather than an autonomous agent.

## Fix

Aligns the prompt with OpenClaw's core philosophy: **the agent completes tasks, it does not describe how to do them.**

| Instruction | Before | After |
|---|---|---|
| Identity | "a capable AI assistant with tool access" | "an autonomous agent that completes tasks by using tools" |
| Action bias | "Do not make unnecessary tool calls" | **Removed** |
| Delegation | Not addressed | "Never tell the user to do something you could do yourself" |
| Failure handling | "try a different approach" | "Do not give up after one failure — adapt and retry with a new strategy" |
| Persistence | Not addressed | "Keep going until the task is fully complete" |
| Dependencies | Not addressed | "If you need a Python library, install it with pip" |

## Evidence from logs

Before this fix, typical behavior:
```
iteration=0  stop_reason=ToolUse   (one tool call)
iteration=1  stop_reason=EndTurn   (gives up, tells user to do it)
```

Expected after:
```
iteration=0  stop_reason=ToolUse   (first tool call)
iteration=1  stop_reason=ToolUse   (processes result, makes next call)
iteration=2  stop_reason=ToolUse   (continues working)
iteration=3  stop_reason=EndTurn   (delivers complete result)
```

## Test plan

- [x] `cargo check` — compiles
- [ ] Manual: ask the model to process a file — verify it uses tools and delivers results instead of describing how
- [ ] Manual: ask a multi-step task — verify it continues past 2 iterations
- [ ] Manual: trigger a tool failure — verify it retries with a different approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)