### PR TITLE
Fix pipeline dropping system context, causing false security refusals

### DIFF
--- a/crates/openclaw-agent/src/orchestrator/decomposer.rs
+++ b/crates/openclaw-agent/src/orchestrator/decomposer.rs
@@ -54,17 +54,25 @@ impl Decomposer {
     /// Returns a list of `SubTask`s with dependency information.
     /// If decomposition fails or the request is simple enough,
     /// returns a single sub-task wrapping the original request.
-    pub async fn decompose(&self, user_request: &str) -> Result<Vec<SubTask>> {
-        let prompt = DECOMPOSE_PROMPT.replace(
+    pub async fn decompose(&self, user_request: &str, context: Option<&str>) -> Result<Vec<SubTask>> {
+        let decompose_instructions = DECOMPOSE_PROMPT.replace(
             "{max_tasks}",
             &self.config.max_sub_tasks.to_string(),
         );
+
+        // Combine agent system context with decomposition instructions so the
+        // model understands the agent's identity, available tools, and
+        // permissions when planning sub-tasks.
+        let system_prompt = match context {
+            Some(ctx) => format!("{ctx}\n\n---\n\n{decompose_instructions}"),
+            None => decompose_instructions,
+        };
 
         let messages = vec![
             Message {
                 id: Uuid::new_v4(),
                 role: Role::System,
-                content: MessageContent::Text(prompt),
+                content: MessageContent::Text(system_prompt),
                 created_at: Utc::now(),
             },
             Message {

--- a/crates/openclaw-agent/src/orchestrator/executor.rs
+++ b/crates/openclaw-agent/src/orchestrator/executor.rs
@@ -46,7 +46,11 @@ impl ParallelExecutor {
     /// Tasks with no dependencies run concurrently. Tasks with
     /// dependencies wait for their prerequisites to complete, then
     /// receive the prerequisite results as context.
-    pub async fn execute(&self, tasks: &[SubTask]) -> Vec<SubTaskResult> {
+    ///
+    /// The optional `system_context` carries the agent's identity, tool
+    /// permissions, and security policies so that sub-task model calls
+    /// understand they are operating within an authorized agent.
+    pub async fn execute(&self, tasks: &[SubTask], system_context: Option<&str>) -> Vec<SubTaskResult> {
         let mut results: HashMap<Uuid, SubTaskResult> = HashMap::new();
         let mut completed: HashSet<Uuid> = HashSet::new();
         let all_ids: HashSet<Uuid> = tasks.iter().map(|t| t.id).collect();
@@ -86,9 +90,10 @@ impl ParallelExecutor {
                 let tools = self.tools.clone();
                 let sandbox = self.sandbox.clone();
                 let config = self.config.clone();
+                let sys_ctx = system_context.map(|s| s.to_string());
 
                 handles.push(tokio::spawn(async move {
-                    execute_sub_task(&task, &dep_context, &provider, &tools, &sandbox, &config)
+                    execute_sub_task(&task, &dep_context, sys_ctx.as_deref(), &provider, &tools, &sandbox, &config)
                         .await
                 }));
             }
@@ -118,6 +123,7 @@ impl ParallelExecutor {
 async fn execute_sub_task(
     task: &SubTask,
     dep_context: &[String],
+    system_context: Option<&str>,
     provider: &Arc<dyn ModelProvider>,
     tools: &[Arc<dyn Tool>],
     sandbox: &Arc<dyn Sandbox>,
@@ -126,15 +132,20 @@ async fn execute_sub_task(
     // Build focused context for this sub-task.
     let mut messages = Vec::new();
 
-    // System context with dependency results.
+    // System context: agent identity/permissions + dependency results.
+    let mut system_parts = Vec::new();
+    if let Some(sys_ctx) = system_context {
+        system_parts.push(sys_ctx.to_string());
+    }
     if !dep_context.is_empty() {
         let ctx = dep_context.join("\n\n---\n\n");
+        system_parts.push(format!("Context from prerequisite tasks:\n{ctx}"));
+    }
+    if !system_parts.is_empty() {
         messages.push(Message {
             id: Uuid::new_v4(),
             role: Role::System,
-            content: MessageContent::Text(format!(
-                "Context from prerequisite tasks:\n{ctx}"
-            )),
+            content: MessageContent::Text(system_parts.join("\n\n---\n\n")),
             created_at: Utc::now(),
         });
     }

--- a/crates/openclaw-agent/src/orchestrator/pipeline.rs
+++ b/crates/openclaw-agent/src/orchestrator/pipeline.rs
@@ -131,7 +131,7 @@ impl OrchestrationPipeline {
     async fn run_moderate(
         &self,
         request: &str,
-        _context: Option<&str>,
+        context: Option<&str>,
     ) -> Result<PipelineResult> {
         let decomposer = Decomposer::new(self.provider.clone(), self.config.clone());
         let executor = ParallelExecutor::new(
@@ -142,12 +142,12 @@ impl OrchestrationPipeline {
         );
         let synthesizer = Synthesizer::new(self.provider.clone());
 
-        // Decompose.
-        let sub_tasks = decomposer.decompose(request).await?;
+        // Decompose (with system context so the model understands the agent's role).
+        let sub_tasks = decomposer.decompose(request, context).await?;
         let sub_task_count = sub_tasks.len();
 
-        // Execute in parallel.
-        let results = executor.execute(&sub_tasks).await;
+        // Execute in parallel (with system context for each sub-task).
+        let results = executor.execute(&sub_tasks, context).await;
 
         // Synthesize.
         let response = synthesizer.synthesize(request, &results).await?;


### PR DESCRIPTION
## Summary
- **`run_moderate`** in `pipeline.rs` declared `_context: Option<&str>` (underscore prefix), silently discarding the agent's system context for all Moderate/Complex/Critical task paths
- The decomposer and executor then made model calls with **no system prompt**, so the model saw raw requests like "search Gmail for tax documents and find credentials" with zero knowledge that it was an authorized agent — and refused with false-positive "Critical Security Alert" responses
- Threads system context through `Decomposer::decompose()` and `ParallelExecutor::execute()` → `execute_sub_task()` so every pipeline stage has the same identity/permissions context that the direct (trivial/simple) path already had

## Test plan
- [ ] Send a multi-step request that gets routed as Moderate complexity (e.g. Gmail search + document compilation) and verify it executes instead of refusing
- [ ] Verify trivial/simple requests still work (regression — `run_direct` was already correct)
- [ ] Verify Critical path still works (the `ConsistencyVoter` already handled context correctly)
- [ ] `cargo check --package openclaw-agent` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)