### PR TITLE
Build system prompt for orchestration, feed tools to decomposer, raise round limit

### DIFF
--- a/crates/openclaw-agent/src/orchestrator/decomposer.rs
+++ b/crates/openclaw-agent/src/orchestrator/decomposer.rs
@@ -54,11 +54,27 @@ impl Decomposer {
     /// Returns a list of `SubTask`s with dependency information.
     /// If decomposition fails or the request is simple enough,
     /// returns a single sub-task wrapping the original request.
-    pub async fn decompose(&self, user_request: &str, context: Option<&str>) -> Result<Vec<SubTask>> {
+    pub async fn decompose(
+        &self,
+        user_request: &str,
+        context: Option<&str>,
+        available_tools: &[&str],
+    ) -> Result<Vec<SubTask>> {
         let decompose_instructions = DECOMPOSE_PROMPT.replace(
             "{max_tasks}",
             &self.config.max_sub_tasks.to_string(),
         );
+
+        // Append the concrete list of tool names so the model generates
+        // accurate tool_hint values instead of guessing.
+        let decompose_instructions = if available_tools.is_empty() {
+            decompose_instructions
+        } else {
+            let tool_list = available_tools.join(", ");
+            format!(
+                "{decompose_instructions}\n\nAvailable tools (use these exact names for tool_hint): [{tool_list}]"
+            )
+        };
 
         // Combine agent system context with decomposition instructions so the
         // model understands the agent's identity, available tools, and

--- a/crates/openclaw-agent/src/orchestrator/executor.rs
+++ b/crates/openclaw-agent/src/orchestrator/executor.rs
@@ -171,8 +171,8 @@ async fn execute_sub_task(
         tools.iter().map(|t| t.schema()).collect()
     };
 
-    // Run the model, handling up to 3 tool-call rounds per sub-task.
-    let max_rounds = 3;
+    // Run the model, handling multiple tool-call rounds per sub-task.
+    let max_rounds = config.max_tool_rounds;
     for _round in 0..max_rounds {
         let response = match provider.chat(&messages, &schemas).await {
             Ok(r) => r,

--- a/crates/openclaw-agent/src/orchestrator/pipeline.rs
+++ b/crates/openclaw-agent/src/orchestrator/pipeline.rs
@@ -142,8 +142,10 @@ impl OrchestrationPipeline {
         );
         let synthesizer = Synthesizer::new(self.provider.clone());
 
-        // Decompose (with system context so the model understands the agent's role).
-        let sub_tasks = decomposer.decompose(request, context).await?;
+        // Decompose (with system context and tool names so the model
+        // understands the agent's role and can produce accurate tool hints).
+        let tool_names: Vec<&str> = self.tools.iter().map(|t| t.name()).collect();
+        let sub_tasks = decomposer.decompose(request, context, &tool_names).await?;
         let sub_task_count = sub_tasks.len();
 
         // Execute in parallel (with system context for each sub-task).

--- a/crates/openclaw-core/src/orchestration.rs
+++ b/crates/openclaw-core/src/orchestration.rs
@@ -125,6 +125,8 @@ pub struct OrchestrationConfig {
     pub max_refinement_iterations: usize,
     /// Maximum retries per failed tool call within sub-tasks.
     pub max_tool_retries: u32,
+    /// Maximum tool-call rounds per sub-task before giving up.
+    pub max_tool_rounds: usize,
     /// Whether to summarize sub-task results before synthesis.
     pub summarize_sub_results: bool,
     /// Which model to use for simple/trivial tasks (fallback model name).
@@ -143,6 +145,7 @@ impl Default for OrchestrationConfig {
             consistency_temperature_spread: 0.1,
             max_refinement_iterations: 3,
             max_tool_retries: 2,
+            max_tool_rounds: 10,
             summarize_sub_results: true,
             fallback_model: None,
             primary_model: None,

--- a/crates/openclaw-gateway/src/orchestrate.rs
+++ b/crates/openclaw-gateway/src/orchestrate.rs
@@ -12,16 +12,17 @@ use openclaw_store::memory::extract_keywords;
 
 use crate::AppState;
 
-/// Shared setup: resolve profile, build system prompt, inject it,
-/// create session and runner. Returns `(AgentRunner, Session)`.
-async fn prepare_agent(
+/// Build the system prompt and inject it as the first message in the conversation.
+///
+/// This is shared between the orchestration pipeline path and the
+/// direct agent loop so both get the same identity, tool guidance,
+/// security policy, memory recall, and skills catalog.
+async fn build_and_inject_system_prompt(
     state: &AppState,
     conv: &mut Conversation,
     user_content: &str,
-) -> Result<(AgentRunner, Session), StatusCode> {
+) {
     // 1. Resolve the harness profile.
-    // If the model self-classified on a previous turn, use that.
-    // Otherwise, fall back to the router (keyword or LLM based).
     let profile = if let Some(ref detected) = conv.detected_profile {
         let profile = state.profile_for_name(detected);
         tracing::info!(profile = %profile.name, source = "self-classified", "harness profile selected");
@@ -109,13 +110,29 @@ async fn prepare_agent(
             },
         );
     }
+}
 
-    // 5. Create an ephemeral session with capabilities for all registered tools.
+/// Shared setup: build system prompt, inject it, create session and runner.
+/// Returns `(AgentRunner, Session)`.
+async fn prepare_agent(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+) -> Result<(AgentRunner, Session), StatusCode> {
+    build_and_inject_system_prompt(state, conv, user_content).await;
+
+    // Create an ephemeral session with capabilities for all registered tools.
     let tool_names: Vec<&str> = state.tools.iter().map(|t| t.name()).collect();
     let caps = CapabilitySet::for_tools_permissive(&tool_names);
     let session = Session::with_capabilities(conv.id, caps);
 
-    // 6. Create the agent runner with profile-derived config.
+    // Resolve profile again for agent config (cheap — no LLM call on cache hit).
+    let profile = if let Some(ref detected) = conv.detected_profile {
+        state.profile_for_name(detected)
+    } else {
+        state.profile_for(user_content).await
+    };
+
     let runner = AgentRunner::new(
         state.provider.clone(),
         state.tools.clone(),
@@ -153,7 +170,10 @@ pub async fn run_agent(
     if let Some(ref pipeline) = state.orchestration_pipeline {
         tracing::info!("routing through orchestration pipeline");
 
-        // Build context from the system prompt (first message if System role).
+        // Build and inject the system prompt so the pipeline has full
+        // agent identity, tool guidance, security policy, and memory.
+        build_and_inject_system_prompt(state, conv, user_content).await;
+
         let context = conv
             .messages
             .first()
@@ -215,6 +235,10 @@ pub async fn run_agent_streaming(
     // Try the orchestration pipeline first if enabled.
     if let Some(ref pipeline) = state.orchestration_pipeline {
         tracing::info!("routing through orchestration pipeline (streaming path)");
+
+        // Build and inject the system prompt so the pipeline has full
+        // agent identity, tool guidance, security policy, and memory.
+        build_and_inject_system_prompt(state, conv, user_content).await;
 
         on_event(AgentEvent::ToolCallStart {
             tool_name: "orchestration_pipeline".to_string(),


### PR DESCRIPTION
## Summary
- **System prompt never built for orchestration path**: `run_agent` and `run_agent_streaming` skipped `prepare_agent()` entirely when the pipeline was enabled, so the model had no agent identity, tool guidance, security policy, memory, or skills. Extracted prompt building into `build_and_inject_system_prompt()` shared by both paths.
- **Decomposer guessed tool names blindly**: The decompose prompt said "mention a tool" but never listed available tools. Wrong guesses + `requires_reasoning=false` caused the executor's `tool_hint` filter to match nothing, leaving sub-tasks with zero tool schemas. Now passes concrete tool names to `decompose()`.
- **Hardcoded 3-round tool limit too low**: Complex sub-tasks (email search → read → search again) need more than 3 tool calls. Added `max_tool_rounds` to `OrchestrationConfig` (default: 10).

## Test plan
- [ ] New conversation through orchestration pipeline — verify system prompt is present (check logs for "harness profile selected" in pipeline path)
- [ ] Multi-step task requiring >3 tool calls per sub-task completes successfully
- [ ] Decomposer generates accurate `tool_hint` values matching actual tool names
- [ ] Direct agent loop (pipeline disabled) still works unchanged
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)