### PR TITLE
Frame executor sub-tasks as action instructions to force tool use

### DIFF
--- a/crates/openclaw-agent/src/orchestrator/executor.rs
+++ b/crates/openclaw-agent/src/orchestrator/executor.rs
@@ -150,10 +150,18 @@ async fn execute_sub_task(
         });
     }
 
+    // Frame the sub-task as a direct action instruction, not a topic to
+    // discuss. Without this framing the model tends to describe how to do
+    // the task or investigate tool availability rather than executing it.
+    let instruction = format!(
+        "Execute the following task now using your tools. Do NOT explain how to do it — \
+         call the appropriate tool(s) and return the results.\n\nTask: {}",
+        task.description
+    );
     messages.push(Message {
         id: Uuid::new_v4(),
         role: Role::User,
-        content: MessageContent::Text(task.description.clone()),
+        content: MessageContent::Text(instruction),
         created_at: Utc::now(),
     });
 


### PR DESCRIPTION
## Summary
- The executor sent decomposed sub-task descriptions directly as User messages (e.g. "Search Gmail for tax documents"). Models interpreted these as topics to discuss rather than actions to execute, producing "I investigated the tool and it's working" instead of actually calling the tool.
- Wraps each sub-task with explicit action framing: *"Execute the following task now using your tools. Do NOT explain how to do it — call the appropriate tool(s) and return the results."*
- Combined with the prior fixes (#43: context threading, #44: system prompt building, `5596707`: synthesizer/refiner context), this completes the orchestration pipeline repair. Every stage now receives agent identity AND sub-tasks are framed as imperative actions.

## Test plan
- [ ] Multi-step task (e.g. "search Gmail for tax documents from accountant") produces actual tool calls in executor sub-tasks, not descriptions
- [ ] Sub-task results contain real data from tool outputs, not instructions for the user
- [ ] Synthesizer combines real tool results into a coherent response
- [ ] Refiner does not override tool results with "I cannot access" disclaimers

🤖 Generated with [Claude Code](https://claude.com/claude-code)