### PR TITLE
Switch default Ollama model to Gemma 4 26B, fix provider defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ On first launch, the CLI generates and prints an auth token. Save it:
 ### Option B: Run with a local model via Ollama
 
 ```bash
-# Pull a model (Qwen 3 32B recommended for tool-use)
-ollama pull qwen3:32b
+# Pull a model (Gemma 4 26B recommended for tool-use)
+ollama pull gemma4:26b
 
 # Start OpenClaw with Ollama
 export OPENCLAW_PROVIDER=ollama
@@ -54,7 +54,7 @@ All configuration is via environment variables. No plaintext config files.
 | `OPENCLAW_PROVIDER` | `anthropic` | Model backend: `anthropic` or `ollama` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use |
-| `OLLAMA_MODEL` | `qwen3:32b` | Ollama model name |
+| `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
 | `OPENCLAW_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `OPENCLAW_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
     let provider_name = provider_name.trim().to_lowercase();
     let provider: Arc<dyn ModelProvider> = match provider_name.as_str() {
         "ollama" => {
-            let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "qwen3:32b".to_string());
+            let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma4:26b".to_string());
             let base_url = std::env::var("OLLAMA_BASE_URL")
                 .unwrap_or_else(|_| "http://localhost:11434".to_string());
             tracing::info!(%model, %base_url, "using Ollama provider");

--- a/crates/openclaw-providers/src/ollama.rs
+++ b/crates/openclaw-providers/src/ollama.rs
@@ -28,10 +28,10 @@ impl Default for OllamaConfig {
     fn default() -> Self {
         Self {
             temperature: 0.1,
-            num_ctx: 65536,
+            num_ctx: 131_072,
             num_parallel: 6,
             top_p: 0.9,
-            num_predict: -1,
+            num_predict: 8192,
         }
     }
 }
@@ -41,7 +41,7 @@ impl OllamaConfig {
     pub fn tool_calling() -> Self {
         Self {
             temperature: 0.0,
-            num_ctx: 65536,
+            num_ctx: 131_072,
             num_parallel: 6,
             top_p: 0.9,
             num_predict: 4096,
@@ -52,15 +52,15 @@ impl OllamaConfig {
     pub fn creative() -> Self {
         Self {
             temperature: 0.7,
-            num_ctx: 65536,
+            num_ctx: 131_072,
             num_parallel: 6,
             top_p: 0.95,
-            num_predict: -1,
+            num_predict: 16384,
         }
     }
 }
 
-/// Ollama provider for local models (Qwen, Llama, Mistral, etc.).
+/// Ollama provider for local models (Gemma, Qwen, Llama, Mistral, etc.).
 pub struct OllamaProvider {
     client: reqwest::Client,
     base_url: String,
@@ -166,6 +166,20 @@ impl OllamaProvider {
             .collect()
     }
 
+    /// Normalize tool-call arguments: some models (notably Gemma) return
+    /// arguments as a JSON-encoded string rather than an object. Detect
+    /// that case and parse it into a proper `Value::Object`.
+    fn normalize_arguments(args: serde_json::Value) -> serde_json::Value {
+        if let serde_json::Value::String(ref s) = args {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s) {
+                if parsed.is_object() {
+                    return parsed;
+                }
+            }
+        }
+        args
+    }
+
     fn parse_response(resp: OllamaResponse) -> Result<ModelResponse> {
         let msg = resp.message;
 
@@ -177,7 +191,7 @@ impl OllamaProvider {
                     .map(|tc| ToolCall {
                         id: Uuid::new_v4().to_string(),
                         name: tc.function.name,
-                        arguments: tc.function.arguments,
+                        arguments: Self::normalize_arguments(tc.function.arguments),
                     })
                     .collect();
 


### PR DESCRIPTION
## Summary
- **Context window alignment**: `num_ctx` bumped from 65536 → 131072 across all `OllamaConfig` presets, matching the agent runner's 128K context budget. Previously the agent was budgeting for 128K tokens but Ollama only allocated 64K, causing silent truncation.
- **Output cap**: Default `num_predict` changed from -1 (unlimited) to 8192 to prevent runaway outputs from Gemma 4. Creative preset capped at 16384, tool_calling remains at 4096.
- **Argument normalization**: Added `normalize_arguments()` in `parse_response` to detect and parse string-encoded JSON tool arguments — some models (notably Gemma) return arguments as `"{ \"key\": \"val\" }"` instead of `{ "key": "val" }`.
- **Default model**: Updated fallback `OLLAMA_MODEL` from `qwen3:32b` to `gemma4:26b` in CLI and README.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — all 21 tests pass
- [ ] Manual smoke test with `gemma4:26b` on Ollama: verify tool calling, decomposition JSON output, and multi-turn agent loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)