### PR TITLE
Fix Gmail search parse errors and add pipeline heartbeat keepalive

### DIFF
--- a/crates/openclaw-gateway/src/orchestrate.rs
+++ b/crates/openclaw-gateway/src/orchestrate.rs
@@ -252,10 +252,30 @@ pub async fn run_agent_streaming(
             .and_then(|m| m.content.as_text())
             .map(|s| s.to_string());
 
+        // The pipeline runs synchronously and can take many minutes.
+        // Emit periodic heartbeat events so the SSE timeout doesn't
+        // kill the connection while the pipeline is working.
+        let heartbeat_event = on_event as &(dyn Fn(AgentEvent) + Send + Sync);
+        let keepalive = tokio::spawn({
+            // Safety: on_event lives for the duration of run_agent_streaming
+            // which is awaited below, so it outlives this spawned task.
+            let event_fn: &'static (dyn Fn(AgentEvent) + Send + Sync) =
+                unsafe { std::mem::transmute(heartbeat_event) };
+            async move {
+                loop {
+                    tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+                    event_fn(AgentEvent::Compressing); // reuse existing event as heartbeat
+                }
+            }
+        });
+
         let result = pipeline
             .run(user_content, TaskComplexity::Complex, context.as_deref())
-            .await
-            .map_err(|e| {
+            .await;
+
+        keepalive.abort(); // stop the heartbeat once pipeline finishes
+
+        let result = result.map_err(|e| {
                 tracing::error!("orchestration pipeline error: {e}");
                 on_event(AgentEvent::ToolCallEnd {
                     tool_name: "orchestration_pipeline".to_string(),

--- a/crates/openclaw-tools/src/gmail.rs
+++ b/crates/openclaw-tools/src/gmail.rs
@@ -122,8 +122,11 @@ impl GmailTool {
 
             // Use Gmail's X-GM-RAW extension for full search syntax,
             // falling back to standard IMAP SEARCH.
+            // Escape inner double quotes so the IMAP command parses correctly
+            // (e.g. query `from:"foo@bar.com"` becomes `X-GM-RAW "from:\"foo@bar.com\""`).
+            let escaped_query = query.replace('\\', "\\\\").replace('"', "\\\"");
             let uids = session
-                .uid_search(&format!("X-GM-RAW \"{query}\""))
+                .uid_search(&format!("X-GM-RAW \"{escaped_query}\""))
                 .or_else(|_| session.uid_search(&query))
                 .map_err(|e| Error::ToolExecution(format!("search failed: {e}").into()))?;
 
@@ -626,13 +629,15 @@ impl GmailTool {
 
             let mut all_uids = std::collections::HashSet::new();
             for mid in &msg_ids {
+                // Escape message IDs for IMAP query safety.
+                let escaped = mid.replace('\\', "\\\\").replace('"', "\\\"");
                 // Search for messages that reference this ID or have this ID.
-                let query = format!("X-GM-RAW \"rfc822msgid:{mid} OR references:{mid}\"");
+                let query = format!("X-GM-RAW \"rfc822msgid:{escaped} OR references:{escaped}\"");
                 if let Ok(uids) = session.uid_search(&query) {
                     all_uids.extend(uids);
                 }
                 // Also try standard HEADER search as fallback.
-                let query2 = format!("OR HEADER Message-ID \"<{mid}>\" HEADER References \"<{mid}>\"");
+                let query2 = format!("OR HEADER Message-ID \"<{escaped}>\" HEADER References \"<{escaped}>\"");
                 if let Ok(uids) = session.uid_search(&query2) {
                     all_uids.extend(uids);
                 }


### PR DESCRIPTION
## Summary
- **Gmail IMAP search broken on quoted queries** (`gmail.rs`): Queries like `from:"alvarezandmarsal"` produced malformed X-GM-RAW commands (`X-GM-RAW "from:"alvarezandmarsal""`) that Gmail rejected with "Bad Response: Could not parse command". Escapes inner double quotes and backslashes before wrapping. Same fix applied to thread action message ID interpolation.
- **Pipeline heartbeat keepalive** (`orchestrate.rs`): The orchestration streaming path emitted `ToolCallStart` at the beginning then went completely silent during the entire pipeline run (decompose → execute → synthesize → refine, potentially 20+ minutes with continuation loops). The SSE heartbeat timeout killed the connection after 5 minutes of inactivity. Spawns a keepalive task that emits an event every 60 seconds while the pipeline is running.

## Test plan
- [ ] Gmail search with quoted terms (`from:"someone@example.com" subject:"tax"`) succeeds
- [ ] Gmail search without quotes still works (regression check)
- [ ] Gmail thread action with message IDs containing special chars succeeds
- [ ] Long-running orchestration pipeline stays alive beyond 5 minutes
- [ ] Keepalive task is properly aborted when pipeline completes
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)