### PR TITLE
Add macOS Keychain credential retrieval for remote deployment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ hex = "0.4"
 base64 = "0.22"
 aes-gcm = "0.10"
 argon2 = "0.5"
-security-framework = "3"
+security-framework = { version = "3", features = ["OSX_10_15"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # Browser automation (Chrome DevTools Protocol)

--- a/crates/openclaw-cli/src/main.rs
+++ b/crates/openclaw-cli/src/main.rs
@@ -46,6 +46,9 @@ async fn main() -> anyhow::Result<()> {
     if args.len() >= 2 && args[1] == "skill" {
         return handle_skill_subcommand(&data_dir, &args[2..]);
     }
+    if args.len() >= 2 && args[1] == "keychain" {
+        return handle_keychain_subcommand(&data_dir, &args[2..]);
+    }
 
     // --- Harness profile ---
     // Load from file or use a preset. Supported: default, coding, research, creative
@@ -61,12 +64,12 @@ async fn main() -> anyhow::Result<()> {
     let store = openclaw_store::Store::open(data_dir.join("db"), master_key)?;
 
     // --- Auth token ---
-    let auth_token = std::env::var("OPENCLAW_AUTH_TOKEN").unwrap_or_else(|_| {
-        let token = openclaw_gateway::generate_token();
-        tracing::info!("Generated auth token (set OPENCLAW_AUTH_TOKEN to persist):");
-        println!("\n  OPENCLAW_AUTH_TOKEN={token}\n");
-        token
-    });
+    // Resolution order:
+    // 1. OPENCLAW_AUTH_TOKEN env var (CI, Docker, explicit override)
+    // 2. macOS Keychain (persists across restarts without env var)
+    // 3. Encrypted local SecretStore
+    // 4. Generate a new token and persist it in Keychain + SecretStore
+    let auth_token = resolve_auth_token(&store);
 
     // --- Model provider ---
     let provider_name = std::env::var("OPENCLAW_PROVIDER")
@@ -82,15 +85,7 @@ async fn main() -> anyhow::Result<()> {
             Arc::new(p)
         }
         _ => {
-            let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_else(|_| {
-                if let Ok(key) = store.secrets().get("anthropic_api_key") {
-                    return key;
-                }
-                tracing::error!(
-                    "ANTHROPIC_API_KEY not set. Set it or store via the secrets API."
-                );
-                String::new()
-            });
+            let api_key = resolve_api_key(&store);
             let model = std::env::var("ANTHROPIC_MODEL")
                 .unwrap_or_else(|_| "claude-sonnet-4-20250514".to_string());
             tracing::info!(%model, "using Anthropic provider");
@@ -573,6 +568,284 @@ fn handle_skill_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyho
             std::process::exit(1);
         }
     }
+    Ok(())
+}
+
+// --- Credential resolution helpers ---
+// These functions implement a multi-source lookup chain:
+//   env var → macOS Keychain → SecretStore → generate/error
+// When a credential is found or generated, it is persisted to the sources
+// below so it survives future restarts without the env var.
+
+/// Keychain service names for OpenClaw credentials.
+const KEYCHAIN_SERVICE: &str = "com.openclaw.credentials";
+const KEYCHAIN_ACCOUNT_AUTH_TOKEN: &str = "auth-token";
+const KEYCHAIN_ACCOUNT_API_KEY: &str = "anthropic-api-key";
+
+/// Resolve the bearer auth token for the gateway.
+///
+/// Lookup chain: env var → Keychain → SecretStore → generate new.
+/// A newly generated token is persisted to Keychain and SecretStore so
+/// subsequent restarts pick it up automatically.
+fn resolve_auth_token(store: &openclaw_store::Store) -> String {
+    // 1. Environment variable (highest priority — explicit override).
+    if let Ok(token) = std::env::var("OPENCLAW_AUTH_TOKEN") {
+        tracing::info!("auth token loaded from OPENCLAW_AUTH_TOKEN env var");
+        // Persist downward so removing the env var still works next time.
+        persist_credential(store, KEYCHAIN_ACCOUNT_AUTH_TOKEN, "openclaw_auth_token", &token);
+        return token;
+    }
+
+    // 2. macOS Keychain.
+    if openclaw_store::keychain::keychain_available() {
+        if let Ok(Some(cred)) =
+            openclaw_store::keychain::get_credential(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN)
+        {
+            tracing::info!("auth token loaded from macOS Keychain");
+            // Also ensure it's in the SecretStore.
+            let _ = store.secrets().set("openclaw_auth_token", &cred.value);
+            return cred.value;
+        }
+    }
+
+    // 3. Encrypted SecretStore.
+    if let Ok(token) = store.secrets().get("openclaw_auth_token") {
+        tracing::info!("auth token loaded from encrypted store");
+        // Back-fill into Keychain if available.
+        if openclaw_store::keychain::keychain_available() {
+            let _ = openclaw_store::keychain::set_credential(
+                KEYCHAIN_SERVICE,
+                KEYCHAIN_ACCOUNT_AUTH_TOKEN,
+                &token,
+            );
+        }
+        return token;
+    }
+
+    // 4. Generate a new token and persist everywhere.
+    let token = openclaw_gateway::generate_token();
+    tracing::info!("generated new auth token — persisting for future restarts");
+    println!("\n  Auth token (also saved to Keychain/store): {token}\n");
+    persist_credential(store, KEYCHAIN_ACCOUNT_AUTH_TOKEN, "openclaw_auth_token", &token);
+    token
+}
+
+/// Resolve the Anthropic API key.
+///
+/// Lookup chain: env var → Keychain → SecretStore → empty (with error log).
+fn resolve_api_key(store: &openclaw_store::Store) -> String {
+    // 1. Environment variable.
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        tracing::info!("API key loaded from ANTHROPIC_API_KEY env var");
+        persist_credential(store, KEYCHAIN_ACCOUNT_API_KEY, "anthropic_api_key", &key);
+        return key;
+    }
+
+    // 2. macOS Keychain.
+    if openclaw_store::keychain::keychain_available() {
+        if let Ok(Some(cred)) =
+            openclaw_store::keychain::get_credential(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY)
+        {
+            tracing::info!("API key loaded from macOS Keychain");
+            let _ = store.secrets().set("anthropic_api_key", &cred.value);
+            return cred.value;
+        }
+    }
+
+    // 3. SecretStore.
+    if let Ok(key) = store.secrets().get("anthropic_api_key") {
+        tracing::info!("API key loaded from encrypted store");
+        if openclaw_store::keychain::keychain_available() {
+            let _ = openclaw_store::keychain::set_credential(
+                KEYCHAIN_SERVICE,
+                KEYCHAIN_ACCOUNT_API_KEY,
+                &key,
+            );
+        }
+        return key;
+    }
+
+    tracing::error!(
+        "ANTHROPIC_API_KEY not set. Set the env var, store it via the secrets API, \
+         or add it to macOS Keychain (service: {KEYCHAIN_SERVICE}, account: {KEYCHAIN_ACCOUNT_API_KEY})."
+    );
+    String::new()
+}
+
+/// Persist a credential to both the macOS Keychain and the encrypted
+/// SecretStore. Errors are logged but not fatal — best-effort persistence.
+fn persist_credential(
+    store: &openclaw_store::Store,
+    keychain_account: &str,
+    store_name: &str,
+    value: &str,
+) {
+    if openclaw_store::keychain::keychain_available() {
+        if let Err(e) =
+            openclaw_store::keychain::set_credential(KEYCHAIN_SERVICE, keychain_account, value)
+        {
+            tracing::warn!("failed to persist credential to Keychain: {e}");
+        }
+    }
+    if let Err(e) = store.secrets().set(store_name, value) {
+        tracing::warn!("failed to persist credential to store: {e}");
+    }
+}
+
+/// Handle `keychain status`, `keychain migrate`, and `keychain set` subcommands.
+///
+/// These let the user verify Keychain connectivity, migrate legacy keychain
+/// items to the Data Protection Keychain, and manually seed credentials.
+fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyhow::Result<()> {
+    let sub = args.first().map(|s| s.as_str()).unwrap_or("status");
+
+    match sub {
+        "status" => {
+            println!("macOS Keychain support: {}", if openclaw_store::keychain::keychain_available() {
+                "available (Data Protection Keychain)"
+            } else {
+                "not available (this platform does not support macOS Keychain)"
+            });
+
+            if !openclaw_store::keychain::keychain_available() {
+                println!("\nOn non-macOS platforms, use environment variables or the encrypted store.");
+                return Ok(());
+            }
+
+            // Check each known credential.
+            let checks = [
+                ("Master key", "com.openclaw.master-key", "openclaw-encryption-key"),
+                ("Auth token", KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN),
+                ("Anthropic API key", KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY),
+            ];
+
+            println!("\n{:<25} {:<40} {}", "CREDENTIAL", "SERVICE/ACCOUNT", "STATUS");
+            println!("{}", "-".repeat(80));
+            for (label, service, account) in &checks {
+                let status = match openclaw_store::keychain::get_credential(service, account) {
+                    Ok(Some(_)) => "present",
+                    Ok(None) => "not set",
+                    Err(_) => "error",
+                };
+                println!("{:<25} {}/{:<14} {}", label, service, account, status);
+            }
+            println!();
+            println!("All items use the Data Protection Keychain (no password prompts).");
+        }
+
+        "set" => {
+            let name = args.get(1).ok_or_else(|| anyhow::anyhow!(
+                "usage: openclaw-cli keychain set <name> <value>\n  \
+                 names: auth-token, api-key"
+            ))?;
+            let value = args.get(2).ok_or_else(|| anyhow::anyhow!(
+                "usage: openclaw-cli keychain set <name> <value>"
+            ))?;
+
+            if !openclaw_store::keychain::keychain_available() {
+                anyhow::bail!("macOS Keychain is not available on this platform");
+            }
+
+            let (service, account) = match name.as_str() {
+                "auth-token" => (KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN),
+                "api-key" => (KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY),
+                other => {
+                    // Allow arbitrary service/account if specified as service:account
+                    if let Some((s, a)) = other.split_once(':') {
+                        (s, a)
+                    } else {
+                        anyhow::bail!(
+                            "unknown credential name '{other}'. \
+                             Use: auth-token, api-key, or service:account"
+                        );
+                    }
+                }
+            };
+
+            openclaw_store::keychain::set_credential(service, account, value)
+                .map_err(|e| anyhow::anyhow!("failed to store: {e}"))?;
+            println!("Stored in Keychain: {service}/{account}");
+
+            // Also persist to the encrypted store if the DB exists.
+            let db_path = data_dir.join("db");
+            if db_path.exists() {
+                if let Ok(master_key) = openclaw_store::keychain::resolve_master_key() {
+                    if let Ok(store) = openclaw_store::Store::open(&db_path, master_key) {
+                        let store_name = match name.as_str() {
+                            "auth-token" => "openclaw_auth_token",
+                            "api-key" => "anthropic_api_key",
+                            _ => name.as_str(),
+                        };
+                        let _ = store.secrets().set(store_name, value);
+                        println!("Also stored in encrypted store as '{store_name}'");
+                    }
+                }
+            }
+        }
+
+        "migrate" => {
+            if !openclaw_store::keychain::keychain_available() {
+                anyhow::bail!("macOS Keychain is not available on this platform");
+            }
+
+            println!("Migrating credentials to Data Protection Keychain...");
+            println!("(This re-creates items without per-app ACLs so no password prompts occur.)\n");
+
+            // Re-resolve master key — this migrates it to the DP keychain.
+            match openclaw_store::keychain::resolve_master_key() {
+                Ok(_) => println!("  master key: OK"),
+                Err(e) => println!("  master key: FAILED ({e})"),
+            }
+
+            // Migrate auth token and API key from env vars or existing store.
+            let db_path = data_dir.join("db");
+            if db_path.exists() {
+                if let Ok(master_key) = openclaw_store::keychain::resolve_master_key() {
+                    if let Ok(store) = openclaw_store::Store::open(&db_path, master_key) {
+                        // Auth token
+                        if let Ok(token) = store.secrets().get("openclaw_auth_token") {
+                            match openclaw_store::keychain::set_credential(
+                                KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN, &token,
+                            ) {
+                                Ok(()) => println!("  auth token: migrated to DP Keychain"),
+                                Err(e) => println!("  auth token: FAILED ({e})"),
+                            }
+                        } else {
+                            println!("  auth token: not in store (will be generated on next start)");
+                        }
+
+                        // API key
+                        if let Ok(key) = store.secrets().get("anthropic_api_key") {
+                            match openclaw_store::keychain::set_credential(
+                                KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY, &key,
+                            ) {
+                                Ok(()) => println!("  API key: migrated to DP Keychain"),
+                                Err(e) => println!("  API key: FAILED ({e})"),
+                            }
+                        } else {
+                            println!("  API key: not in store (set via env var or 'keychain set api-key')");
+                        }
+                    }
+                }
+            } else {
+                println!("  No database found at {} — skipping store migration", db_path.display());
+            }
+
+            println!("\nMigration complete. Restart openclaw-cli to verify.");
+        }
+
+        _ => {
+            eprintln!("Unknown keychain subcommand: {sub}");
+            eprintln!("Usage:");
+            eprintln!("  openclaw-cli keychain status              Show Keychain credential status");
+            eprintln!("  openclaw-cli keychain set <name> <value>  Store a credential");
+            eprintln!("  openclaw-cli keychain migrate             Migrate to Data Protection Keychain");
+            eprintln!();
+            eprintln!("Credential names: auth-token, api-key, or <service>:<account>");
+            std::process::exit(1);
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/openclaw-store/src/keychain.rs
+++ b/crates/openclaw-store/src/keychain.rs
@@ -1,17 +1,18 @@
-//! macOS Keychain integration for master key storage.
+//! macOS Keychain integration for credential storage.
 //!
-//! On macOS, the master encryption key is stored in the system Keychain
-//! rather than in an environment variable. The Keychain is protected by:
+//! Uses the **Data Protection Keychain** (`kSecUseDataProtectionKeychain`)
+//! available on macOS 10.15+. Unlike the legacy keychain, the Data Protection
+//! Keychain does **not** use per-application ACLs, so credentials are
+//! accessible to any process running as the current user without password
+//! prompts or code-signing requirements. Items are protected by the user's
+//! login session — they are available after first unlock (i.e. once the user
+//! logs in after boot) and do not require further interaction.
 //!
-//! - The user's login password (required to unlock)
-//! - The Secure Enclave on Apple Silicon Macs (hardware-backed protection)
-//! - Touch ID (if enabled, macOS prompts biometric auth for keychain access)
-//! - Per-app ACLs (only OpenClaw can read its own keychain item)
-//!
-//! On first launch, if no master key exists in the Keychain or env var,
-//! a random 32-byte key is generated and stored in the Keychain. On
-//! subsequent launches, the key is retrieved from the Keychain — macOS
-//! may prompt for Touch ID or password depending on system settings.
+//! This means:
+//! - No password prompts when the binary is rebuilt during development
+//! - No Touch ID / biometric gates on credential reads
+//! - Credentials survive restarts without environment variables
+//! - Items are still encrypted at rest by macOS and tied to the user account
 
 use openclaw_core::Error;
 
@@ -20,67 +21,110 @@ const SERVICE_NAME: &str = "com.openclaw.master-key";
 #[cfg(target_os = "macos")]
 const ACCOUNT_NAME: &str = "openclaw-encryption-key";
 
-/// Retrieve the master key from the macOS Keychain.
-///
-/// Returns `None` if no key is stored yet.
-#[cfg(target_os = "macos")]
-pub fn get_master_key() -> Result<Option<Vec<u8>>, Error> {
-    use security_framework::passwords::get_generic_password;
+// ---------------------------------------------------------------------------
+// Internal helpers — Data Protection Keychain read/write
+// ---------------------------------------------------------------------------
 
-    match get_generic_password(SERVICE_NAME, ACCOUNT_NAME) {
-        Ok(bytes) => {
-            // The key is stored as hex — decode it.
-            let hex_str = String::from_utf8(bytes.to_vec())
-                .map_err(|e| Error::Storage(format!("keychain: invalid utf-8: {e}")))?;
-            let key = hex::decode(hex_str.trim())
-                .map_err(|e| Error::Storage(format!("keychain: invalid hex: {e}")))?;
-            Ok(Some(key))
-        }
+/// Read a generic password from the Data Protection Keychain.
+///
+/// Returns `Ok(None)` when the item does not exist (errSecItemNotFound).
+#[cfg(target_os = "macos")]
+fn dp_get(service: &str, account: &str) -> Result<Option<Vec<u8>>, Error> {
+    use security_framework::passwords::{generic_password, PasswordOptions};
+
+    let mut opts = PasswordOptions::new_generic_password(service, account);
+    opts.use_protected_keychain();
+
+    match generic_password(opts) {
+        Ok(bytes) => Ok(Some(bytes)),
         Err(e) => {
             let msg = e.to_string();
-            // "The specified item could not be found in the keychain" means
-            // no key has been stored yet — not an error.
             if msg.contains("could not be found") || msg.contains("errSecItemNotFound") {
                 Ok(None)
             } else {
-                Err(Error::Storage(format!("keychain read failed: {e}")))
+                Err(Error::Storage(format!(
+                    "keychain read failed for {service}/{account}: {e}"
+                )))
             }
         }
     }
 }
 
-/// Store the master key in the macOS Keychain.
+/// Write a generic password to the Data Protection Keychain.
 ///
-/// If a key already exists, it is updated. The key is stored as hex.
+/// Deletes any existing item first to avoid duplicate-item errors, then
+/// creates a new item in the Data Protection Keychain with
+/// `kSecUseDataProtectionKeychain = true` so no per-app ACLs are applied.
+#[cfg(target_os = "macos")]
+fn dp_set(service: &str, account: &str, password: &[u8]) -> Result<(), Error> {
+    use security_framework::passwords::{
+        delete_generic_password_options, set_generic_password_options, PasswordOptions,
+    };
+
+    // Delete from Data Protection Keychain (ignore "not found").
+    let mut del_opts = PasswordOptions::new_generic_password(service, account);
+    del_opts.use_protected_keychain();
+    let _ = delete_generic_password_options(del_opts);
+
+    // Also try deleting from legacy keychain to avoid stale entries that
+    // would shadow the new Data Protection item during migration.
+    let legacy_del = PasswordOptions::new_generic_password(service, account);
+    let _ = delete_generic_password_options(legacy_del);
+
+    let mut opts = PasswordOptions::new_generic_password(service, account);
+    opts.use_protected_keychain();
+    set_generic_password_options(password, opts)
+        .map_err(|e| Error::Storage(format!("keychain write failed for {service}/{account}: {e}")))
+}
+
+/// Delete a generic password from the Data Protection Keychain.
+#[cfg(target_os = "macos")]
+fn dp_delete(service: &str, account: &str) -> Result<(), Error> {
+    use security_framework::passwords::{delete_generic_password_options, PasswordOptions};
+
+    let mut opts = PasswordOptions::new_generic_password(service, account);
+    opts.use_protected_keychain();
+    delete_generic_password_options(opts)
+        .map_err(|e| Error::Storage(format!("keychain delete failed for {service}/{account}: {e}")))
+}
+
+// ---------------------------------------------------------------------------
+// Master key — the encryption key for the local SecretStore
+// ---------------------------------------------------------------------------
+
+/// Retrieve the master key from the macOS Keychain.
+///
+/// Returns `None` if no key is stored yet.
+#[cfg(target_os = "macos")]
+pub fn get_master_key() -> Result<Option<Vec<u8>>, Error> {
+    match dp_get(SERVICE_NAME, ACCOUNT_NAME)? {
+        Some(bytes) => {
+            let hex_str = String::from_utf8(bytes)
+                .map_err(|e| Error::Storage(format!("keychain: invalid utf-8: {e}")))?;
+            let key = hex::decode(hex_str.trim())
+                .map_err(|e| Error::Storage(format!("keychain: invalid hex: {e}")))?;
+            Ok(Some(key))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Store the master key in the macOS Keychain (as hex).
 #[cfg(target_os = "macos")]
 pub fn set_master_key(key: &[u8]) -> Result<(), Error> {
-    use security_framework::passwords::{delete_generic_password, set_generic_password};
-
-    let hex_key = hex::encode(key);
-
-    // Try to delete any existing item first (set_generic_password errors on duplicates).
-    let _ = delete_generic_password(SERVICE_NAME, ACCOUNT_NAME);
-
-    set_generic_password(SERVICE_NAME, ACCOUNT_NAME, hex_key.as_bytes())
-        .map_err(|e| Error::Storage(format!("keychain write failed: {e}")))?;
-
-    Ok(())
+    dp_set(SERVICE_NAME, ACCOUNT_NAME, hex::encode(key).as_bytes())
 }
 
 /// Delete the master key from the Keychain.
 #[cfg(target_os = "macos")]
 pub fn delete_master_key() -> Result<(), Error> {
-    use security_framework::passwords::delete_generic_password;
-
-    delete_generic_password(SERVICE_NAME, ACCOUNT_NAME)
-        .map_err(|e| Error::Storage(format!("keychain delete failed: {e}")))?;
-    Ok(())
+    dp_delete(SERVICE_NAME, ACCOUNT_NAME)
 }
 
 /// Retrieve or generate the master key using the macOS Keychain.
 ///
 /// 1. Try env var `OPENCLAW_MASTER_KEY`
-/// 2. Try macOS Keychain
+/// 2. Try macOS Keychain (Data Protection Keychain — no password prompt)
 /// 3. Generate a new random key and store it in the Keychain
 ///
 /// This is the primary entry point for CLI startup.
@@ -89,15 +133,16 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     // Priority 1: environment variable (for CI, Docker, non-macOS deployments).
     if let Ok(env_key) = std::env::var("OPENCLAW_MASTER_KEY") {
         tracing::info!("using master key from OPENCLAW_MASTER_KEY env var");
-        return hex::decode(env_key.trim())
-            .map_err(|e| Error::Storage(format!(
+        return hex::decode(env_key.trim()).map_err(|e| {
+            Error::Storage(format!(
                 "OPENCLAW_MASTER_KEY must be a hex-encoded string: {e}"
-            )));
+            ))
+        });
     }
 
-    // Priority 2: macOS Keychain.
+    // Priority 2: macOS Data Protection Keychain (no password prompt).
     if let Some(key) = get_master_key()? {
-        tracing::info!("master key loaded from macOS Keychain (Secure Enclave backed)");
+        tracing::info!("master key loaded from macOS Keychain (Data Protection)");
         return Ok(key);
     }
 
@@ -107,8 +152,8 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut key);
     set_master_key(&key)?;
     tracing::info!(
-        "master key stored in macOS Keychain under '{SERVICE_NAME}'. \
-         It is protected by your login password and Touch ID."
+        "master key stored in macOS Keychain under '{SERVICE_NAME}' \
+         (Data Protection Keychain — no password prompt on access)."
     );
     Ok(key.to_vec())
 }
@@ -118,10 +163,11 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
 pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     if let Ok(env_key) = std::env::var("OPENCLAW_MASTER_KEY") {
         tracing::info!("using master key from OPENCLAW_MASTER_KEY env var");
-        return hex::decode(env_key.trim())
-            .map_err(|e| Error::Storage(format!(
+        return hex::decode(env_key.trim()).map_err(|e| {
+            Error::Storage(format!(
                 "OPENCLAW_MASTER_KEY must be a hex-encoded string: {e}"
-            )));
+            ))
+        });
     }
 
     tracing::warn!(
@@ -131,4 +177,84 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     let mut key = [0u8; 32];
     rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut key);
     Ok(key.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Generic credential access — read arbitrary credentials from macOS Keychain
+// for use during remote deployment.
+// ---------------------------------------------------------------------------
+
+/// A credential retrieved from the macOS Keychain.
+#[derive(Debug, Clone)]
+pub struct KeychainCredential {
+    pub service: String,
+    pub account: String,
+    /// The raw password / secret value.
+    pub value: String,
+}
+
+/// Returns `true` when the current platform supports Keychain credential
+/// lookups (i.e. the binary was compiled for macOS).
+pub fn keychain_available() -> bool {
+    cfg!(target_os = "macos")
+}
+
+/// Retrieve a credential from the macOS Keychain by service and account.
+///
+/// Uses the Data Protection Keychain — no password prompt or per-app ACL.
+/// `service` corresponds to the "Where" field visible in Keychain Access,
+/// and `account` to the "Account" field.
+///
+/// Returns `Ok(None)` when the item does not exist.
+#[cfg(target_os = "macos")]
+pub fn get_credential(service: &str, account: &str) -> Result<Option<KeychainCredential>, Error> {
+    match dp_get(service, account)? {
+        Some(bytes) => {
+            let value = String::from_utf8(bytes)
+                .map_err(|e| Error::Storage(format!("keychain: credential is not valid utf-8: {e}")))?;
+            Ok(Some(KeychainCredential {
+                service: service.to_string(),
+                account: account.to_string(),
+                value,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn get_credential(_service: &str, _account: &str) -> Result<Option<KeychainCredential>, Error> {
+    Err(Error::Storage(
+        "macOS Keychain is not available on this platform".into(),
+    ))
+}
+
+/// Store a credential in the macOS Keychain under the given service/account.
+///
+/// Uses the Data Protection Keychain — no password prompt or per-app ACL.
+/// If a credential already exists for this service/account pair, it is
+/// replaced.
+#[cfg(target_os = "macos")]
+pub fn set_credential(service: &str, account: &str, value: &str) -> Result<(), Error> {
+    dp_set(service, account, value.as_bytes())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn set_credential(_service: &str, _account: &str, _value: &str) -> Result<(), Error> {
+    Err(Error::Storage(
+        "macOS Keychain is not available on this platform".into(),
+    ))
+}
+
+/// Delete a credential from the macOS Keychain.
+#[cfg(target_os = "macos")]
+pub fn delete_credential(service: &str, account: &str) -> Result<(), Error> {
+    dp_delete(service, account)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn delete_credential(_service: &str, _account: &str) -> Result<(), Error> {
+    Err(Error::Storage(
+        "macOS Keychain is not available on this platform".into(),
+    ))
 }

--- a/crates/openclaw-tools/src/credential_read.rs
+++ b/crates/openclaw-tools/src/credential_read.rs
@@ -4,10 +4,23 @@ use openclaw_core::{Error, Result, Tool};
 use openclaw_store::SecretStore;
 use serde_json::{json, Value};
 
-/// A tool that reads credentials from the encrypted SecretStore.
+/// Mask a secret value so only the first 4 and last 4 characters are visible.
+fn mask_secret(value: &str) -> String {
+    if value.len() > 8 {
+        format!("{}...{}", &value[..4], &value[value.len() - 4..])
+    } else {
+        "*".repeat(value.len())
+    }
+}
+
+/// A tool that reads credentials from the encrypted SecretStore or from the
+/// macOS Keychain.
 ///
-/// Supports retrieving a specific secret by name or listing all
-/// stored secret names (without revealing values).
+/// Supports retrieving a specific secret by name or listing all stored secret
+/// names (without revealing values). When `source` is set to `"keychain"`, the
+/// tool reads directly from the macOS Keychain using a service/account pair —
+/// useful for pulling deployment credentials (SSH keys, deploy tokens, API
+/// keys) that are already stored in the system Keychain.
 pub struct CredentialReadTool {
     secrets: SecretStore,
 }
@@ -27,7 +40,11 @@ impl Tool for CredentialReadTool {
     fn description(&self) -> &str {
         "Read a stored credential/secret by name, or list all stored credential names. \
          Use this to retrieve API keys, passwords, or tokens needed to authenticate \
-         with external services. Credentials are stored encrypted at rest."
+         with external services. Credentials are stored encrypted at rest.\n\n\
+         Set source to 'keychain' to read credentials directly from the macOS Keychain \
+         (requires service and account parameters). This is useful during remote \
+         deployment to pull SSH keys, deploy tokens, or API keys stored in the \
+         system Keychain."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -44,7 +61,21 @@ impl Tool for CredentialReadTool {
                     },
                     "name": {
                         "type": "string",
-                        "description": "The name/key of the secret to retrieve (required for 'get' action)"
+                        "description": "The name/key of the secret to retrieve (required for 'get' action when source is 'store')"
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["store", "keychain"],
+                        "default": "store",
+                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
+                    },
+                    "service": {
+                        "type": "string",
+                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). Required when source is 'keychain'."
+                    },
+                    "account": {
+                        "type": "string",
+                        "description": "macOS Keychain account name. Required when source is 'keychain'."
                     }
                 },
                 "required": ["action"]
@@ -57,6 +88,18 @@ impl Tool for CredentialReadTool {
             .as_str()
             .ok_or_else(|| Error::ToolExecution("missing action".into()))?;
 
+        let source = args["source"].as_str().unwrap_or("store");
+
+        match source {
+            "keychain" => self.execute_keychain(action, &args).await,
+            "store" | _ => self.execute_store(action, &args).await,
+        }
+    }
+}
+
+impl CredentialReadTool {
+    /// Read credentials from the encrypted local SecretStore.
+    async fn execute_store(&self, action: &str, args: &Value) -> Result<Value> {
         match action {
             "get" | "read" => {
                 let name = args["name"]
@@ -65,40 +108,97 @@ impl Tool for CredentialReadTool {
 
                 match self.secrets.get(name) {
                     Ok(value) => {
-                        // Mask the secret value to prevent leaking full secrets
-                        // into the conversation. The full value remains available
-                        // in the SecretStore for tools that need it directly.
-                        let masked = if value.len() > 8 {
-                            format!("{}...{}", &value[..4], &value[value.len()-4..])
-                        } else {
-                            "*".repeat(value.len())
-                        };
                         Ok(json!({
+                            "source": "store",
                             "name": name,
-                            "value": masked,
+                            "value": mask_secret(&value),
                         }))
                     }
                     Err(openclaw_core::Error::NotFound(_)) => Ok(json!({
                         "error": format!("no secret found with name '{name}'"),
-                        "hint": "Use action 'list' to see available secret names",
+                        "hint": "Use action 'list' to see available secret names, or try source 'keychain' to check the macOS Keychain",
                     })),
-                    Err(e) => Err(Error::ToolExecution(format!("failed to read secret: {e}").into())),
+                    Err(e) => Err(Error::ToolExecution(
+                        format!("failed to read secret: {e}").into(),
+                    )),
                 }
             }
             "list" => {
-                let names = self
-                    .secrets
-                    .list_names()
-                    .map_err(|e| Error::ToolExecution(format!("failed to list secrets: {e}").into()))?;
+                let names = self.secrets.list_names().map_err(|e| {
+                    Error::ToolExecution(format!("failed to list secrets: {e}").into())
+                })?;
 
                 Ok(json!({
+                    "source": "store",
                     "secrets": names,
                     "count": names.len(),
+                    "keychain_available": openclaw_store::keychain::keychain_available(),
                 }))
             }
-            other => Err(Error::ToolExecution(format!(
-                "unknown action '{other}', expected 'get' or 'list'"
-            ).into())),
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}', expected 'get' or 'list'").into(),
+            )),
+        }
+    }
+
+    /// Read credentials from the macOS Keychain.
+    async fn execute_keychain(&self, action: &str, args: &Value) -> Result<Value> {
+        if !openclaw_store::keychain::keychain_available() {
+            return Ok(json!({
+                "error": "macOS Keychain is not available on this platform",
+                "hint": "Use source 'store' to read from the encrypted local store instead",
+            }));
+        }
+
+        match action {
+            "get" | "read" => {
+                let service = args["service"].as_str().ok_or_else(|| {
+                    Error::ToolExecution(
+                        "missing 'service' parameter (required when source is 'keychain')".into(),
+                    )
+                })?;
+                let account = args["account"].as_str().ok_or_else(|| {
+                    Error::ToolExecution(
+                        "missing 'account' parameter (required when source is 'keychain')".into(),
+                    )
+                })?;
+
+                match openclaw_store::keychain::get_credential(service, account) {
+                    Ok(Some(cred)) => {
+                        tracing::info!(
+                            service = service,
+                            account = account,
+                            "credential retrieved from macOS Keychain"
+                        );
+                        Ok(json!({
+                            "source": "keychain",
+                            "service": cred.service,
+                            "account": cred.account,
+                            "value": mask_secret(&cred.value),
+                        }))
+                    }
+                    Ok(None) => Ok(json!({
+                        "error": format!("no credential found in Keychain for service '{service}', account '{account}'"),
+                        "hint": "Verify the service and account names in Keychain Access.app, or store the credential with credential_write using source 'keychain'",
+                    })),
+                    Err(e) => Err(Error::ToolExecution(
+                        format!("keychain lookup failed: {e}").into(),
+                    )),
+                }
+            }
+            "list" => {
+                // macOS Keychain does not provide a generic "list all items" API
+                // via security-framework. Direct the user to use Keychain Access
+                // or `security dump-keychain` for discovery.
+                Ok(json!({
+                    "source": "keychain",
+                    "error": "listing all Keychain items is not supported via this tool",
+                    "hint": "Use Keychain Access.app or `security dump-keychain` to discover service/account names, then use action 'get' with the specific service and account",
+                }))
+            }
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}', expected 'get' or 'list'").into(),
+            )),
         }
     }
 }

--- a/crates/openclaw-tools/src/credential_write.rs
+++ b/crates/openclaw-tools/src/credential_write.rs
@@ -4,9 +4,12 @@ use openclaw_core::{Error, Result, Tool};
 use openclaw_store::SecretStore;
 use serde_json::{json, Value};
 
-/// A tool that writes credentials to the encrypted SecretStore.
+/// A tool that writes credentials to the encrypted SecretStore or macOS
+/// Keychain.
 ///
-/// Supports storing, updating, and deleting secrets.
+/// Supports storing, updating, and deleting secrets. The `import_from_keychain`
+/// action copies a credential from the macOS Keychain into the encrypted local
+/// store so it is available even when not running on macOS.
 pub struct CredentialWriteTool {
     secrets: SecretStore,
 }
@@ -26,7 +29,12 @@ impl Tool for CredentialWriteTool {
     fn description(&self) -> &str {
         "Store, update, or delete a credential/secret. Use this to save API keys, \
          passwords, or tokens so they can be retrieved later with credential_read. \
-         All credentials are encrypted at rest."
+         All credentials are encrypted at rest.\n\n\
+         Set source to 'keychain' to write to the macOS Keychain instead of the \
+         local store (requires service and account parameters).\n\n\
+         Use the 'import_from_keychain' action to copy a credential from the macOS \
+         Keychain into the encrypted local store — useful for preparing deployment \
+         bundles that work on non-macOS targets."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -38,16 +46,30 @@ impl Tool for CredentialWriteTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["set", "delete"],
-                        "description": "Action: 'set' stores/updates a secret, 'delete' removes one"
+                        "enum": ["set", "delete", "import_from_keychain"],
+                        "description": "Action: 'set' stores/updates, 'delete' removes, 'import_from_keychain' copies a macOS Keychain credential into the local store"
                     },
                     "name": {
                         "type": "string",
-                        "description": "The name/key for the secret"
+                        "description": "The name/key for the secret in the local store"
                     },
                     "value": {
                         "type": "string",
                         "description": "The secret value to store (required for 'set' action)"
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": ["store", "keychain"],
+                        "default": "store",
+                        "description": "Where to write: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
+                    },
+                    "service": {
+                        "type": "string",
+                        "description": "macOS Keychain service name. Required when source is 'keychain' or action is 'import_from_keychain'."
+                    },
+                    "account": {
+                        "type": "string",
+                        "description": "macOS Keychain account name. Required when source is 'keychain' or action is 'import_from_keychain'."
                     }
                 },
                 "required": ["action", "name"]
@@ -63,34 +85,169 @@ impl Tool for CredentialWriteTool {
             .as_str()
             .ok_or_else(|| Error::ToolExecution("missing name".into()))?;
 
+        if action == "import_from_keychain" {
+            return self.import_from_keychain(name, &args).await;
+        }
+
+        let source = args["source"].as_str().unwrap_or("store");
+
+        match source {
+            "keychain" => self.execute_keychain(action, name, &args).await,
+            "store" | _ => self.execute_store(action, name, &args).await,
+        }
+    }
+}
+
+impl CredentialWriteTool {
+    /// Write to the encrypted local SecretStore.
+    async fn execute_store(&self, action: &str, name: &str, args: &Value) -> Result<Value> {
         match action {
             "set" => {
                 let value = args["value"]
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
 
-                self.secrets
-                    .set(name, value)
-                    .map_err(|e| Error::ToolExecution(format!("failed to store secret: {e}").into()))?;
+                self.secrets.set(name, value).map_err(|e| {
+                    Error::ToolExecution(format!("failed to store secret: {e}").into())
+                })?;
 
                 Ok(json!({
                     "status": "stored",
+                    "source": "store",
                     "name": name,
                 }))
             }
             "delete" => {
-                self.secrets
-                    .delete(name)
-                    .map_err(|e| Error::ToolExecution(format!("failed to delete secret: {e}").into()))?;
+                self.secrets.delete(name).map_err(|e| {
+                    Error::ToolExecution(format!("failed to delete secret: {e}").into())
+                })?;
 
                 Ok(json!({
                     "status": "deleted",
+                    "source": "store",
                     "name": name,
                 }))
             }
-            other => Err(Error::ToolExecution(format!(
-                "unknown action '{other}', expected 'set' or 'delete'"
-            ).into())),
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}', expected 'set', 'delete', or 'import_from_keychain'").into(),
+            )),
         }
+    }
+
+    /// Write to the macOS Keychain.
+    async fn execute_keychain(&self, action: &str, name: &str, args: &Value) -> Result<Value> {
+        if !openclaw_store::keychain::keychain_available() {
+            return Ok(json!({
+                "error": "macOS Keychain is not available on this platform",
+                "hint": "Use source 'store' to write to the encrypted local store instead",
+            }));
+        }
+
+        let service = args["service"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'service' parameter (required when source is 'keychain')".into(),
+            )
+        })?;
+        let account = args["account"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'account' parameter (required when source is 'keychain')".into(),
+            )
+        })?;
+
+        match action {
+            "set" => {
+                let value = args["value"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
+
+                openclaw_store::keychain::set_credential(service, account, value).map_err(|e| {
+                    Error::ToolExecution(format!("failed to store in keychain: {e}").into())
+                })?;
+
+                tracing::info!(
+                    service = service,
+                    account = account,
+                    "credential stored in macOS Keychain"
+                );
+
+                Ok(json!({
+                    "status": "stored",
+                    "source": "keychain",
+                    "name": name,
+                    "service": service,
+                    "account": account,
+                }))
+            }
+            "delete" => {
+                openclaw_store::keychain::delete_credential(service, account).map_err(|e| {
+                    Error::ToolExecution(format!("failed to delete from keychain: {e}").into())
+                })?;
+
+                Ok(json!({
+                    "status": "deleted",
+                    "source": "keychain",
+                    "service": service,
+                    "account": account,
+                }))
+            }
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}' for keychain source").into(),
+            )),
+        }
+    }
+
+    /// Import a credential from the macOS Keychain into the local encrypted
+    /// store. This is the key operation for remote deployment: pull credentials
+    /// from Keychain on a macOS dev machine and persist them in the portable
+    /// encrypted store that travels with the deployment.
+    async fn import_from_keychain(&self, name: &str, args: &Value) -> Result<Value> {
+        if !openclaw_store::keychain::keychain_available() {
+            return Ok(json!({
+                "error": "macOS Keychain is not available on this platform",
+                "hint": "import_from_keychain must be run on macOS where the Keychain is accessible",
+            }));
+        }
+
+        let service = args["service"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'service' parameter for import_from_keychain".into(),
+            )
+        })?;
+        let account = args["account"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'account' parameter for import_from_keychain".into(),
+            )
+        })?;
+
+        // Read from Keychain.
+        let cred = openclaw_store::keychain::get_credential(service, account)
+            .map_err(|e| Error::ToolExecution(format!("keychain read failed: {e}").into()))?
+            .ok_or_else(|| {
+                Error::ToolExecution(
+                    format!(
+                        "no credential found in Keychain for service '{service}', account '{account}'"
+                    )
+                    .into(),
+                )
+            })?;
+
+        // Write to local encrypted store.
+        self.secrets.set(name, &cred.value).map_err(|e| {
+            Error::ToolExecution(format!("failed to store imported secret: {e}").into())
+        })?;
+
+        tracing::info!(
+            name = name,
+            service = service,
+            account = account,
+            "credential imported from macOS Keychain into local store"
+        );
+
+        Ok(json!({
+            "status": "imported",
+            "name": name,
+            "keychain_service": service,
+            "keychain_account": account,
+        }))
     }
 }


### PR DESCRIPTION
Switch from legacy Keychain to the Data Protection Keychain
(kSecUseDataProtectionKeychain) which eliminates per-application ACLs and
password prompts on every binary rebuild. Credentials are now accessible
to any process running as the current user once the session is unlocked.

Key changes:
- Extend keychain.rs with generic credential CRUD (get/set/delete by
  service+account) alongside the existing master key functions
- Auth token and Anthropic API key now resolve via a multi-source chain:
  env var → macOS Keychain → encrypted SecretStore → generate/error
- credential_read tool gains source="keychain" option for reading directly
  from macOS Keychain by service/account pair
- credential_write tool gains source="keychain" and import_from_keychain
  action to copy Keychain credentials into the portable encrypted store
- Add CLI `keychain` subcommand (status, set, migrate) for setup and
  migration from legacy keychain items
- Enable security-framework OSX_10_15 feature for Data Protection Keychain

https://claude.ai/code/session_01NiYiXPhWmV2BZusyyJkTS7