### PR TITLE
Fix browser CDP connection 404 by using http:// for websocket discovery

### DIFF
--- a/crates/rustykrab-tools/src/browser.rs
+++ b/crates/rustykrab-tools/src/browser.rs
@@ -12,7 +12,9 @@ use tokio_stream::StreamExt;
 
 use crate::security;
 
-const DEFAULT_CDP_URL: &str = "ws://127.0.0.1:9222";
+// Use http:// so chromiumoxide auto-discovers the websocket URL via /json/version.
+// A ws:// URL skips discovery and 404s because there's no handler at the root path.
+const DEFAULT_CDP_URL: &str = "http://127.0.0.1:9222";
 const MAX_CONTENT_BYTES: usize = 50 * 1024; // 50KB cap for page content
 
 /// Browser automation tool using Chrome DevTools Protocol.
@@ -28,7 +30,7 @@ const MAX_CONTENT_BYTES: usize = 50 * 1024; // 50KB cap for page content
 /// available without re-authenticating. The user's active profile is
 /// detected from Chrome's `Local State` file.
 ///
-/// Configure the CDP URL via `CHROME_CDP_URL` env var (default: ws://127.0.0.1:9222).
+/// Configure the CDP URL via `CHROME_CDP_URL` env var (default: http://127.0.0.1:9222).
 pub struct BrowserTool {
     cdp_url: String,
     user_data_dir: std::path::PathBuf,


### PR DESCRIPTION
## Summary
- The default CDP URL was `ws://127.0.0.1:9222`, but chromiumoxide's `Browser::connect()` only auto-discovers the websocket URL via `/json/version` when the URL starts with `http://`. With a `ws://` URL, it connected directly to the root path → **404 Not Found**.
- This caused a retry loop: connect fails → launch Chrome → 2s wait → connect fails again (same 404) → retry launches *another* Chrome instance. After 3 retries: 3 Chrome instances all fighting over port 9222, none connectable.
- Fix: change default from `ws://127.0.0.1:9222` to `http://127.0.0.1:9222` so chromiumoxide fetches `/json/version`, discovers the real `ws://...devtools/browser/UUID` endpoint, and connects.

## Test plan
- [ ] Browser tool connects successfully on first attempt
- [ ] Only one Chrome instance is launched
- [ ] Navigation, click, content extraction all work after connection
- [ ] Custom `CHROME_CDP_URL` with `http://` scheme still works
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)