### PR TITLE
Show Telegram conversations in web UI, persist chat mapping across restarts

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -378,23 +378,48 @@ async fn telegram_agent_loop(
             }
 
             // Get or create conversation.
+            // First check in-memory cache, then persistent store, then create new.
             let conv_id = {
                 let mut states = chat_states.lock().await;
                 match states.get(&chat_id) {
                     Some(cs) => cs.conv_id,
-                    None => match state.store.conversations().create() {
-                        Ok(conv) => {
-                            let id = conv.id;
-                            states.insert(chat_id, ChatState { conv_id: id, busy: false });
-                            tracing::info!(chat_id, conv_id = %id, "created new conversation for Telegram chat");
-                            id
+                    None => {
+                        let chat_id_str = chat_id.to_string();
+                        // Check persistent store for an existing Telegram conversation.
+                        let existing = state
+                            .store
+                            .conversations()
+                            .find_by_channel("telegram", &chat_id_str)
+                            .ok()
+                            .flatten();
+
+                        match existing {
+                            Some(conv) => {
+                                let id = conv.id;
+                                states.insert(chat_id, ChatState { conv_id: id, busy: false });
+                                tracing::info!(chat_id, conv_id = %id, "resumed Telegram conversation from database");
+                                id
+                            }
+                            None => match state.store.conversations().create() {
+                                Ok(mut conv) => {
+                                    conv.channel_source = Some("telegram".to_string());
+                                    conv.channel_id = Some(chat_id_str);
+                                    if let Err(e) = state.store.conversations().save(&conv) {
+                                        tracing::error!(chat_id, "failed to save conversation metadata: {e}");
+                                    }
+                                    let id = conv.id;
+                                    states.insert(chat_id, ChatState { conv_id: id, busy: false });
+                                    tracing::info!(chat_id, conv_id = %id, "created new Telegram conversation");
+                                    id
+                                }
+                                Err(e) => {
+                                    tracing::error!(chat_id, "failed to create conversation: {e}");
+                                    let _ = tg.send_text(chat_id, "Internal error — please try again.").await;
+                                    return;
+                                }
+                            },
                         }
-                        Err(e) => {
-                            tracing::error!(chat_id, "failed to create conversation: {e}");
-                            let _ = tg.send_text(chat_id, "Internal error — please try again.").await;
-                            return;
-                        }
-                    },
+                    }
                 }
             };
 

--- a/crates/rustykrab-core/src/types.rs
+++ b/crates/rustykrab-core/src/types.rs
@@ -93,6 +93,12 @@ pub struct Conversation {
     /// Updated every turn — the model always tags its response.
     #[serde(default)]
     pub detected_profile: Option<String>,
+    /// Which channel created this conversation (e.g. "telegram", "signal", "web").
+    #[serde(default)]
+    pub channel_source: Option<String>,
+    /// Channel-specific identifier (e.g. Telegram chat_id as string).
+    #[serde(default)]
+    pub channel_id: Option<String>,
 }
 
 /// JSON-Schema-style description of a tool parameter.

--- a/crates/rustykrab-gateway/static/index.html
+++ b/crates/rustykrab-gateway/static/index.html
@@ -1025,6 +1025,7 @@
             created_at: conv.created_at,
             updated_at: conv.updated_at,
             preview: preview.slice(0, 60),
+            channel_source: conv.channel_source || null,
           });
         } catch { /* skip broken entries */ }
       }
@@ -1048,8 +1049,11 @@
     for (const conv of conversations) {
       const el = document.createElement('div');
       el.className = 'conversation-item' + (conv.id === activeConvId ? ' active' : '');
+      const channelBadge = conv.channel_source === 'telegram' ? '<span style="opacity:0.5;font-size:12px;margin-left:4px" title="Telegram">TG</span>'
+        : conv.channel_source === 'signal' ? '<span style="opacity:0.5;font-size:12px;margin-left:4px" title="Signal">SIG</span>'
+        : '';
       el.innerHTML = `
-        <div class="conversation-item-title">${escapeHtml(conv.preview)}</div>
+        <div class="conversation-item-title">${escapeHtml(conv.preview)}${channelBadge}</div>
         <div class="conversation-item-date">${formatDate(conv.updated_at)}</div>
         <button class="btn-icon delete-btn" data-id="${conv.id}" title="Delete">
           <svg viewBox="0 0 24 24" style="width:16px;height:16px"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>

--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -23,6 +23,8 @@ impl ConversationStore {
             updated_at: Utc::now(),
             summary: None,
             detected_profile: None,
+            channel_source: None,
+            channel_id: None,
         };
         self.save(&conv)?;
         Ok(conv)
@@ -61,6 +63,23 @@ impl ConversationStore {
             ids.push(id);
         }
         Ok(ids)
+    }
+
+    /// Find a conversation by channel source and channel ID.
+    ///
+    /// Used to persistently map e.g. a Telegram chat_id to a conversation
+    /// so the mapping survives server restarts.
+    pub fn find_by_channel(&self, source: &str, channel_id: &str) -> Result<Option<Conversation>, Error> {
+        for entry in self.tree.iter() {
+            let (_key, value) = entry.map_err(|e| Error::Storage(e.to_string()))?;
+            let conv: Conversation = serde_json::from_slice(&value)?;
+            if conv.channel_source.as_deref() == Some(source)
+                && conv.channel_id.as_deref() == Some(channel_id)
+            {
+                return Ok(Some(conv));
+            }
+        }
+        Ok(None)
     }
 
     /// Delete a conversation by ID.


### PR DESCRIPTION
## Summary
Telegram conversations are now visible and continuable from the web UI.

- **Channel metadata on Conversation** (`types.rs`): Added `channel_source` (e.g. "telegram", "signal") and `channel_id` (e.g. chat_id) fields with `serde(default)` for backward compat with existing data.
- **Persistent mapping** (`conversation.rs`): Added `find_by_channel()` that scans for conversations matching a source+id pair. On restart, the Telegram loop checks the database before creating a new conversation, so chat history survives server restarts.
- **Telegram loop** (`main.rs`): Three-tier lookup: in-memory cache → persistent DB scan → create new. New conversations are tagged with `channel_source: "telegram"` and `channel_id: "{chat_id}"`.
- **Frontend** (`index.html`): Sidebar shows "TG" badge next to Telegram conversations and "SIG" for Signal. Clicking any conversation loads it — users can seamlessly continue a Telegram chat from the web UI.

## Test plan
- [ ] Send message via Telegram → conversation appears in web UI sidebar with "TG" badge
- [ ] Click Telegram conversation in web UI → messages load correctly
- [ ] Send message via web UI in a Telegram conversation → response appears
- [ ] Restart server → Telegram conversation resumes (not duplicated)
- [ ] Web-created conversations show no badge (regression)
- [ ] Existing conversations without channel fields still load (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)