### PR TITLE
Add rustykrab-memory crate: production agent memory with hybrid retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustykrab-memory"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "hex",
+ "regex",
+ "rustykrab-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sled",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rustykrab-providers"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +902,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1304,6 +1325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1966,6 +1998,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,11 +2215,11 @@ dependencies = [
  "chrono",
  "hex",
  "regex",
+ "rusqlite",
  "rustykrab-core",
  "serde",
  "serde_json",
  "sha2",
- "sled",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/rustykrab-channels",
     "crates/rustykrab-skills",
     "crates/rustykrab-cli",
+    "crates/rustykrab-memory",
 ]
 
 [workspace.package]
@@ -86,3 +87,4 @@ rustykrab-tools = { path = "crates/rustykrab-tools" }
 rustykrab-channels = { path = "crates/rustykrab-channels" }
 rustykrab-skills = { path = "crates/rustykrab-skills" }
 rustykrab-cli = { path = "crates/rustykrab-cli" }
+rustykrab-memory = { path = "crates/rustykrab-memory" }

--- a/crates/rustykrab-memory/Cargo.toml
+++ b/crates/rustykrab-memory/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rustykrab-memory"
+description = "Production agent memory: verbatim storage, hybrid retrieval, value-driven lifecycle"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+rustykrab-core.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
+chrono.workspace = true
+sha2.workspace = true
+hex.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+sled.workspace = true
+regex = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/rustykrab-memory/Cargo.toml
+++ b/crates/rustykrab-memory/Cargo.toml
@@ -17,8 +17,8 @@ sha2.workspace = true
 hex.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-sled.workspace = true
 regex = "1"
+rusqlite = { version = "0.34", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -1,0 +1,145 @@
+use std::sync::Arc;
+
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::MemorySystem;
+
+/// Adapter that bridges [MemorySystem] to the `MemoryBackend` trait
+/// used by the existing tool system in `rustykrab-tools`.
+///
+/// This allows the hybrid memory system to be used as a drop-in
+/// replacement for the old tag-based `MemoryStore`, providing the same
+/// tool interface (memory_save, memory_search, memory_get, memory_delete)
+/// while transparently using vector search, BM25, and lifecycle scoring.
+///
+/// The trait itself is defined in `rustykrab-tools::memory_backend`.
+/// We re-implement it here structurally to avoid a circular dependency;
+/// the gateway wires this into the tool system via a thin wrapper.
+pub struct HybridMemoryBackend {
+    system: Arc<MemorySystem>,
+    agent_id: Uuid,
+    session_id: Uuid,
+}
+
+impl HybridMemoryBackend {
+    pub fn new(system: Arc<MemorySystem>, agent_id: Uuid, session_id: Uuid) -> Self {
+        Self {
+            system,
+            agent_id,
+            session_id,
+        }
+    }
+
+    /// Search memories using hybrid retrieval (vector + BM25 + graph + temporal).
+    pub async fn search(
+        &self,
+        query: &str,
+        _tags: &[String],
+        limit: usize,
+    ) -> rustykrab_core::Result<Value> {
+        let results = self.system.recall(query, self.agent_id, limit).await?;
+
+        let items: Vec<Value> = results
+            .iter()
+            .map(|r| {
+                json!({
+                    "id": r.memory_id.to_string(),
+                    "content": r.content,
+                    "score": r.effective_score,
+                    "rrf_score": r.rrf_score,
+                    "sources": r.sources.iter().map(|s| format!("{:?}", s)).collect::<Vec<_>>(),
+                    "lifecycle_stage": format!("{:?}", r.memory.lifecycle_stage),
+                    "importance": r.memory.importance,
+                    "access_count": r.memory.access_count,
+                    "created_at": r.memory.created_at.to_rfc3339(),
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "results": items,
+            "count": items.len(),
+        }))
+    }
+
+    /// Get a specific memory by ID.
+    pub async fn get(&self, memory_id: &str) -> rustykrab_core::Result<Value> {
+        let id = Uuid::parse_str(memory_id).map_err(|e| {
+            rustykrab_core::Error::Internal(format!("invalid memory ID: {e}"))
+        })?;
+
+        match self.system.get_memory(id).await? {
+            Some(mem) => Ok(json!({
+                "id": mem.id.to_string(),
+                "content": mem.content,
+                "importance": mem.importance,
+                "lifecycle_stage": format!("{:?}", mem.lifecycle_stage),
+                "access_count": mem.access_count,
+                "tags": mem.tags,
+                "created_at": mem.created_at.to_rfc3339(),
+                "last_accessed_at": mem.last_accessed_at.map(|t| t.to_rfc3339()),
+            })),
+            None => Err(rustykrab_core::Error::NotFound(format!(
+                "memory {memory_id}"
+            ))),
+        }
+    }
+
+    /// Save a fact with association tags, creating a new memory.
+    pub async fn save(&self, fact: &str, tags: &[String]) -> rustykrab_core::Result<Value> {
+        let memory_id = self
+            .system
+            .writer()
+            .save_fact(self.agent_id, self.session_id, fact, tags)
+            .await?;
+
+        Ok(json!({
+            "id": memory_id.to_string(),
+            "status": "saved",
+        }))
+    }
+
+    /// Delete (invalidate) a memory by ID.
+    pub async fn delete(&self, memory_id: &str) -> rustykrab_core::Result<Value> {
+        let id = Uuid::parse_str(memory_id).map_err(|e| {
+            rustykrab_core::Error::Internal(format!("invalid memory ID: {e}"))
+        })?;
+
+        self.system.invalidate_memory(id, None).await?;
+
+        Ok(json!({
+            "id": memory_id,
+            "status": "deleted",
+        }))
+    }
+
+    /// List all valid memories for the current agent.
+    pub async fn list(&self) -> rustykrab_core::Result<Value> {
+        let memories = self
+            .system
+            .storage()
+            .list_retrievable(self.agent_id)
+            .await?;
+
+        let items: Vec<Value> = memories
+            .iter()
+            .map(|m| {
+                json!({
+                    "id": m.id.to_string(),
+                    "content": m.content,
+                    "importance": m.importance,
+                    "lifecycle_stage": format!("{:?}", m.lifecycle_stage),
+                    "access_count": m.access_count,
+                    "tags": m.tags,
+                    "created_at": m.created_at.to_rfc3339(),
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "memories": items,
+            "count": items.len(),
+        }))
+    }
+}

--- a/crates/rustykrab-memory/src/bm25.rs
+++ b/crates/rustykrab-memory/src/bm25.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Stopwords list for tokenization (shared with keyword extraction).
+const STOPWORDS: &[&str] = &[
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being", "have",
+    "has", "had", "do", "does", "did", "will", "would", "could", "should", "may",
+    "might", "shall", "can", "need", "dare", "ought", "used", "to", "of", "in",
+    "for", "on", "with", "at", "by", "from", "as", "into", "through", "during",
+    "before", "after", "above", "below", "between", "out", "off", "over", "under",
+    "again", "further", "then", "once", "here", "there", "when", "where", "why",
+    "how", "all", "both", "each", "few", "more", "most", "other", "some", "such",
+    "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very", "just",
+    "don", "now", "and", "but", "or", "because", "if", "while", "that", "this",
+    "these", "those", "what", "which", "who", "whom", "its", "it", "he", "she",
+    "they", "them", "his", "her", "their", "our", "your", "my", "me", "we", "you",
+    "about", "also", "get", "got", "like", "make", "made", "want", "let", "know",
+    "think", "see", "come", "look", "use", "find", "give", "tell", "say", "said",
+    "try", "ask", "work", "seem", "feel", "leave", "call", "keep", "put", "show",
+    "take",
+];
+
+/// Tokenize text into lowercase terms, removing stopwords and short tokens.
+pub fn tokenize(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
+        .map(|w| w.to_lowercase())
+        .filter(|w| w.len() >= 2 && !STOPWORDS.contains(&w.as_str()))
+        .collect()
+}
+
+/// In-process BM25 index for keyword-based retrieval.
+///
+/// Maintains an inverted index mapping terms to (doc_id, term_frequency)
+/// pairs, plus document-level statistics for BM25 scoring.
+pub struct Bm25Index {
+    /// term → [(doc_id, term_freq)]
+    inverted: HashMap<String, Vec<(Uuid, u32)>>,
+    /// doc_id → total token count
+    doc_lengths: HashMap<Uuid, u32>,
+    /// Total documents indexed.
+    doc_count: u32,
+    /// Sum of all doc lengths (for average doc length).
+    total_length: u64,
+    /// BM25 parameter: term frequency saturation. Typical: 1.2–2.0.
+    k1: f64,
+    /// BM25 parameter: document length normalization. Typical: 0.75.
+    b: f64,
+}
+
+impl Bm25Index {
+    /// Create a new empty BM25 index with default parameters.
+    pub fn new() -> Self {
+        Self {
+            inverted: HashMap::new(),
+            doc_lengths: HashMap::new(),
+            doc_count: 0,
+            total_length: 0,
+            k1: 1.2,
+            b: 0.75,
+        }
+    }
+
+    /// Index a document. If the document was previously indexed, it is
+    /// replaced.
+    pub fn index_document(&mut self, doc_id: Uuid, content: &str) {
+        // Remove old entry if re-indexing.
+        self.remove_document(doc_id);
+
+        let tokens = tokenize(content);
+        let doc_len = tokens.len() as u32;
+
+        // Count term frequencies.
+        let mut tf: HashMap<String, u32> = HashMap::new();
+        for token in &tokens {
+            *tf.entry(token.clone()).or_default() += 1;
+        }
+
+        // Insert into inverted index.
+        for (term, freq) in tf {
+            self.inverted
+                .entry(term)
+                .or_default()
+                .push((doc_id, freq));
+        }
+
+        self.doc_lengths.insert(doc_id, doc_len);
+        self.doc_count += 1;
+        self.total_length += doc_len as u64;
+    }
+
+    /// Remove a document from the index.
+    pub fn remove_document(&mut self, doc_id: Uuid) {
+        if let Some(old_len) = self.doc_lengths.remove(&doc_id) {
+            self.doc_count = self.doc_count.saturating_sub(1);
+            self.total_length = self.total_length.saturating_sub(old_len as u64);
+
+            // Remove from inverted index entries.
+            for postings in self.inverted.values_mut() {
+                postings.retain(|(id, _)| *id != doc_id);
+            }
+            // Clean up empty posting lists.
+            self.inverted.retain(|_, v| !v.is_empty());
+        }
+    }
+
+    /// Search for documents matching the query, returning (doc_id, bm25_score)
+    /// sorted by descending score. Returns at most `limit` results.
+    pub fn search(&self, query: &str, limit: usize) -> Vec<(Uuid, f64)> {
+        if self.doc_count == 0 {
+            return Vec::new();
+        }
+
+        let query_tokens = tokenize(query);
+        let avgdl = self.total_length as f64 / self.doc_count.max(1) as f64;
+
+        let mut scores: HashMap<Uuid, f64> = HashMap::new();
+
+        for token in &query_tokens {
+            if let Some(postings) = self.inverted.get(token) {
+                // IDF: log((N - df + 0.5) / (df + 0.5) + 1)
+                let df = postings.len() as f64;
+                let n = self.doc_count as f64;
+                let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+
+                for &(doc_id, tf) in postings {
+                    let dl = *self.doc_lengths.get(&doc_id).unwrap_or(&0) as f64;
+                    let tf_f = tf as f64;
+
+                    // BM25: IDF * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl/avgdl))
+                    let numerator = tf_f * (self.k1 + 1.0);
+                    let denominator =
+                        tf_f + self.k1 * (1.0 - self.b + self.b * dl / avgdl);
+                    let bm25 = idf * numerator / denominator;
+
+                    *scores.entry(doc_id).or_default() += bm25;
+                }
+            }
+        }
+
+        let mut results: Vec<(Uuid, f64)> = scores.into_iter().collect();
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(limit);
+        results
+    }
+
+    /// Number of documents in the index.
+    pub fn len(&self) -> usize {
+        self.doc_count as usize
+    }
+
+    /// Whether the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.doc_count == 0
+    }
+}
+
+impl Default for Bm25Index {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tokenize() {
+        let tokens = tokenize("Hello World! This is a test.");
+        assert!(tokens.contains(&"hello".to_string()));
+        assert!(tokens.contains(&"world".to_string()));
+        assert!(tokens.contains(&"test".to_string()));
+        // Stopwords removed.
+        assert!(!tokens.contains(&"this".to_string()));
+        assert!(!tokens.contains(&"is".to_string()));
+    }
+
+    #[test]
+    fn test_bm25_basic_search() {
+        let mut index = Bm25Index::new();
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        let id3 = Uuid::new_v4();
+
+        index.index_document(id1, "Rust programming language systems");
+        index.index_document(id2, "Python programming language scripting");
+        index.index_document(id3, "Rust systems programming memory safety");
+
+        let results = index.search("Rust memory", 10);
+        assert!(!results.is_empty());
+        // id3 mentions both "rust" and "memory" — should rank highest.
+        assert_eq!(results[0].0, id3);
+    }
+
+    #[test]
+    fn test_bm25_no_results() {
+        let mut index = Bm25Index::new();
+        let id1 = Uuid::new_v4();
+        index.index_document(id1, "completely unrelated topic");
+        let results = index.search("quantum physics", 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_bm25_remove_document() {
+        let mut index = Bm25Index::new();
+        let id1 = Uuid::new_v4();
+        index.index_document(id1, "Rust programming");
+        assert_eq!(index.len(), 1);
+
+        index.remove_document(id1);
+        assert_eq!(index.len(), 0);
+
+        let results = index.search("Rust", 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_bm25_reindex() {
+        let mut index = Bm25Index::new();
+        let id1 = Uuid::new_v4();
+        index.index_document(id1, "Rust programming");
+        index.index_document(id1, "Python scripting");
+        assert_eq!(index.len(), 1);
+
+        let results = index.search("Python", 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, id1);
+
+        // Old content should not match.
+        let results = index.search("Rust", 10);
+        assert!(results.is_empty());
+    }
+}

--- a/crates/rustykrab-memory/src/chunking.rs
+++ b/crates/rustykrab-memory/src/chunking.rs
@@ -1,0 +1,169 @@
+/// Estimate token count for a text string (~3.5 chars per token).
+pub fn estimate_tokens(text: &str) -> usize {
+    (text.len() as f64 / 3.5).ceil() as usize
+}
+
+/// Estimate character count for a given token budget.
+fn tokens_to_chars(tokens: usize) -> usize {
+    (tokens as f64 * 3.5) as usize
+}
+
+/// Split text into overlapping chunks of approximately `max_tokens` tokens
+/// with `overlap_ratio` fraction of overlap between consecutive chunks.
+///
+/// Splits prefer natural boundaries (sentence endings, newlines) over
+/// hard character cuts. For conversation memory, call `chunk_by_turns`
+/// first, then subdivide long turns with this function.
+pub fn chunk_text(content: &str, max_tokens: usize, overlap_ratio: f64) -> Vec<String> {
+    if content.is_empty() {
+        return Vec::new();
+    }
+
+    let max_chars = tokens_to_chars(max_tokens);
+    let overlap_chars = (max_chars as f64 * overlap_ratio.clamp(0.0, 0.5)) as usize;
+
+    if content.len() <= max_chars {
+        return vec![content.to_string()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+
+    while start < content.len() {
+        let end = (start + max_chars).min(content.len());
+
+        // Try to find a natural break point near the end boundary.
+        let chunk_end = if end < content.len() {
+            find_break_point(content, start, end)
+        } else {
+            end
+        };
+
+        chunks.push(content[start..chunk_end].to_string());
+
+        if chunk_end >= content.len() {
+            break;
+        }
+
+        // Advance by (chunk_size - overlap), but at least 1 char to avoid infinite loop.
+        let advance = (chunk_end - start).saturating_sub(overlap_chars).max(1);
+        start += advance;
+    }
+
+    chunks
+}
+
+/// Find the best break point near `target_end` by looking for sentence
+/// boundaries, then newlines, then word boundaries.
+fn find_break_point(content: &str, start: usize, target_end: usize) -> usize {
+    let search_start = start + (target_end - start) * 3 / 4; // Look in the last 25%
+    let region = &content[search_start..target_end];
+
+    // Prefer sentence boundaries (. ! ? followed by whitespace).
+    if let Some(pos) = region.rfind(". ") {
+        return search_start + pos + 2;
+    }
+    if let Some(pos) = region.rfind("! ") {
+        return search_start + pos + 2;
+    }
+    if let Some(pos) = region.rfind("? ") {
+        return search_start + pos + 2;
+    }
+
+    // Then newlines.
+    if let Some(pos) = region.rfind('\n') {
+        return search_start + pos + 1;
+    }
+
+    // Then word boundaries.
+    if let Some(pos) = region.rfind(' ') {
+        return search_start + pos + 1;
+    }
+
+    // Fall back to hard cut.
+    target_end
+}
+
+/// Split conversation text by speaker turn boundaries first, then
+/// subdivide long turns. Input format: lines starting with "Speaker: ".
+pub fn chunk_by_turns(content: &str, max_tokens: usize, overlap_ratio: f64) -> Vec<String> {
+    let mut turns = Vec::new();
+    let mut current_turn = String::new();
+
+    for line in content.lines() {
+        // Detect speaker change: line starts with a word followed by ": "
+        let is_new_turn = line
+            .find(": ")
+            .map(|pos| {
+                let prefix = &line[..pos];
+                !prefix.is_empty()
+                    && prefix
+                        .chars()
+                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            })
+            .unwrap_or(false);
+
+        if is_new_turn && !current_turn.is_empty() {
+            turns.push(std::mem::take(&mut current_turn));
+        }
+        if !current_turn.is_empty() {
+            current_turn.push('\n');
+        }
+        current_turn.push_str(line);
+    }
+    if !current_turn.is_empty() {
+        turns.push(current_turn);
+    }
+
+    // Subdivide any turn that exceeds max_tokens.
+    let mut chunks = Vec::new();
+    for turn in turns {
+        if estimate_tokens(&turn) <= max_tokens {
+            chunks.push(turn);
+        } else {
+            chunks.extend(chunk_text(&turn, max_tokens, overlap_ratio));
+        }
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_tokens() {
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("hello"), 2); // 5 / 3.5 = 1.43 → ceil = 2
+    }
+
+    #[test]
+    fn test_short_text_single_chunk() {
+        let text = "This is a short text.";
+        let chunks = chunk_text(text, 512, 0.15);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], text);
+    }
+
+    #[test]
+    fn test_long_text_multiple_chunks() {
+        let text = "Hello world. ".repeat(500); // ~6500 chars
+        let chunks = chunk_text(&text, 100, 0.15); // ~350 chars per chunk
+        assert!(chunks.len() > 1);
+        // All content should be covered
+        for chunk in &chunks {
+            assert!(!chunk.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_chunk_by_turns() {
+        let conv = "Alice: Hello, how are you?\nBob: I'm doing well.\nAlice: Great!";
+        let chunks = chunk_by_turns(conv, 512, 0.15);
+        assert_eq!(chunks.len(), 3);
+        assert!(chunks[0].starts_with("Alice: Hello"));
+        assert!(chunks[1].starts_with("Bob:"));
+        assert!(chunks[2].starts_with("Alice: Great"));
+    }
+}

--- a/crates/rustykrab-memory/src/config.rs
+++ b/crates/rustykrab-memory/src/config.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the memory system.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryConfig {
+    // Chunking
+    /// Maximum tokens per chunk (estimated at ~3.5 chars/token).
+    pub chunk_max_tokens: usize,
+    /// Overlap between chunks as a fraction (0.0–1.0). 0.15 = 15% overlap.
+    pub chunk_overlap_ratio: f64,
+
+    // Retrieval
+    /// Number of candidates to over-fetch from each retrieval arm before fusion.
+    pub retrieval_candidates_per_arm: usize,
+    /// RRF fusion constant k (default 60).
+    pub rrf_k: f64,
+    /// Weight for semantic retrieval in RRF.
+    pub rrf_weight_semantic: f64,
+    /// Weight for keyword/BM25 retrieval in RRF.
+    pub rrf_weight_keyword: f64,
+    /// Weight for graph-based retrieval in RRF.
+    pub rrf_weight_graph: f64,
+    /// Weight for temporal retrieval in RRF.
+    pub rrf_weight_temporal: f64,
+    /// Default number of results to return from recall.
+    pub default_recall_limit: usize,
+
+    // Lifecycle
+    /// Default decay rate for new memories (1.0 = 37% after one idle week).
+    pub default_decay_rate: f64,
+    /// Default importance for new memories.
+    pub default_importance: f64,
+    /// Minimum effective score below which episodic memories get archived.
+    pub archive_score_threshold: f64,
+    /// Minimum access count to promote episodic → semantic.
+    pub promote_min_access_count: u32,
+    /// Minimum age in days before episodic → semantic promotion.
+    pub promote_min_age_days: u32,
+    /// Days of idleness before archival → tombstone.
+    pub tombstone_idle_days: u32,
+    /// Importance threshold below which archival memories get tombstoned.
+    pub tombstone_importance_threshold: f64,
+
+    // Deduplication
+    /// Cosine similarity threshold for auto-merge (≥0.95).
+    pub dedup_auto_merge_threshold: f64,
+    /// Cosine similarity below which memories are considered distinct.
+    pub dedup_distinct_threshold: f64,
+
+    // Embedding
+    /// Dimensionality of embedding vectors.
+    pub embedding_dimensions: usize,
+    /// Model version string for provenance tracking.
+    pub embedding_model_version: String,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            // Chunking: 512 tokens with 15% overlap (NVIDIA benchmark optimal)
+            chunk_max_tokens: 512,
+            chunk_overlap_ratio: 0.15,
+
+            // Retrieval
+            retrieval_candidates_per_arm: 50,
+            rrf_k: 60.0,
+            rrf_weight_semantic: 1.0,
+            rrf_weight_keyword: 1.0,
+            rrf_weight_graph: 0.8,
+            rrf_weight_temporal: 0.6,
+            default_recall_limit: 10,
+
+            // Lifecycle
+            default_decay_rate: 1.0,
+            default_importance: 0.5,
+            archive_score_threshold: 0.05,
+            promote_min_access_count: 3,
+            promote_min_age_days: 7,
+            tombstone_idle_days: 180,
+            tombstone_importance_threshold: 0.3,
+
+            // Dedup
+            dedup_auto_merge_threshold: 0.95,
+            dedup_distinct_threshold: 0.85,
+
+            // Embedding (Nomic-embed-text-v1.5 default)
+            embedding_dimensions: 768,
+            embedding_model_version: "nomic-embed-text-v1.5".to_string(),
+        }
+    }
+}

--- a/crates/rustykrab-memory/src/embedding.rs
+++ b/crates/rustykrab-memory/src/embedding.rs
@@ -1,0 +1,205 @@
+use async_trait::async_trait;
+use rustykrab_core::Result;
+
+/// Trait for generating text embeddings.
+///
+/// Implementations can wrap fastembed (ONNX), OpenAI API, or any other
+/// embedding provider. The trait is async to support both local inference
+/// (via `spawn_blocking`) and API-based embedding.
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    /// Embed a batch of texts, returning one vector per input.
+    async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>>;
+
+    /// The dimensionality of produced vectors.
+    fn dimensions(&self) -> usize;
+
+    /// Model version string for provenance tracking.
+    fn model_version(&self) -> &str;
+}
+
+/// Cosine similarity between two vectors. Returns 0.0 for zero-norm vectors.
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "vector dimension mismatch");
+
+    let mut dot = 0.0f32;
+    let mut norm_a = 0.0f32;
+    let mut norm_b = 0.0f32;
+
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        norm_a += a[i] * a[i];
+        norm_b += b[i] * b[i];
+    }
+
+    let denom = norm_a.sqrt() * norm_b.sqrt();
+    if denom < f32::EPSILON {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+/// Find the top-k most similar vectors to `query` from `candidates`.
+/// Returns (index, similarity) pairs sorted by descending similarity.
+pub fn top_k_similar(
+    query: &[f32],
+    candidates: &[(uuid::Uuid, Vec<f32>)],
+    k: usize,
+) -> Vec<(uuid::Uuid, f32)> {
+    let mut scores: Vec<(uuid::Uuid, f32)> = candidates
+        .iter()
+        .map(|(id, vec)| (*id, cosine_similarity(query, vec)))
+        .collect();
+
+    // Sort descending by similarity.
+    scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scores.truncate(k);
+    scores
+}
+
+/// A no-op embedder that produces zero vectors. For testing only.
+pub struct ZeroEmbedder {
+    dims: usize,
+}
+
+impl ZeroEmbedder {
+    pub fn new(dims: usize) -> Self {
+        Self { dims }
+    }
+}
+
+#[async_trait]
+impl Embedder for ZeroEmbedder {
+    async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|_| vec![0.0f32; self.dims]).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    fn model_version(&self) -> &str {
+        "zero-embedder-test"
+    }
+}
+
+/// A deterministic embedder that hashes text content to produce
+/// reproducible vectors. Useful for integration tests where you need
+/// consistent but non-zero embeddings without a real model.
+pub struct HashEmbedder {
+    dims: usize,
+}
+
+impl HashEmbedder {
+    pub fn new(dims: usize) -> Self {
+        Self { dims }
+    }
+}
+
+#[async_trait]
+impl Embedder for HashEmbedder {
+    async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        use sha2::{Digest, Sha256};
+
+        Ok(texts
+            .iter()
+            .map(|text| {
+                let mut vec = Vec::with_capacity(self.dims);
+                let mut hasher = Sha256::new();
+                hasher.update(text.as_bytes());
+
+                // Chain hashes to fill the full dimensionality.
+                let mut hash = hasher.finalize().to_vec();
+                let mut offset = 0;
+                for _ in 0..self.dims {
+                    if offset + 4 > hash.len() {
+                        let mut h = Sha256::new();
+                        h.update(&hash);
+                        hash = h.finalize().to_vec();
+                        offset = 0;
+                    }
+                    let bytes: [u8; 4] =
+                        hash[offset..offset + 4].try_into().unwrap_or([0; 4]);
+                    // Map to [-1, 1] range.
+                    let val = (f32::from_bits(u32::from_le_bytes(bytes)) % 2.0) - 1.0;
+                    vec.push(if val.is_finite() { val } else { 0.0 });
+                    offset += 4;
+                }
+
+                // L2-normalize so cosine similarity is meaningful.
+                let norm: f32 = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
+                if norm > f32::EPSILON {
+                    for v in &mut vec {
+                        *v /= norm;
+                    }
+                }
+
+                vec
+            })
+            .collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    fn model_version(&self) -> &str {
+        "hash-embedder-test"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cosine_identical() {
+        let a = vec![1.0, 2.0, 3.0];
+        let sim = cosine_similarity(&a, &a);
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_orthogonal() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!(sim.abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_opposite() {
+        let a = vec![1.0, 0.0];
+        let b = vec![-1.0, 0.0];
+        let sim = cosine_similarity(&a, &b);
+        assert!((sim + 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_zero_vector() {
+        let a = vec![0.0, 0.0];
+        let b = vec![1.0, 2.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_hash_embedder_deterministic() {
+        let embedder = HashEmbedder::new(64);
+        let v1 = embedder.embed(vec!["hello".into()]).await.unwrap();
+        let v2 = embedder.embed(vec!["hello".into()]).await.unwrap();
+        assert_eq!(v1, v2);
+    }
+
+    #[tokio::test]
+    async fn test_hash_embedder_different_texts() {
+        let embedder = HashEmbedder::new(64);
+        let vecs = embedder
+            .embed(vec!["hello".into(), "world".into()])
+            .await
+            .unwrap();
+        let sim = cosine_similarity(&vecs[0], &vecs[1]);
+        // Different texts should produce different (non-identical) vectors.
+        assert!(sim < 0.99);
+    }
+}

--- a/crates/rustykrab-memory/src/extraction.rs
+++ b/crates/rustykrab-memory/src/extraction.rs
@@ -1,0 +1,205 @@
+use chrono::Utc;
+use regex::Regex;
+use uuid::Uuid;
+
+use crate::types::ExtractedFact;
+
+/// Regex-based fact and entity extractor. Runs deterministically with
+/// zero LLM calls. Extracts:
+/// - Preferences ("I prefer X", "I like X", "my favorite is X")
+/// - Decisions ("I decided to X", "we chose X", "let's go with X")
+/// - Named entities (capitalized multi-word sequences)
+/// - Key-value patterns ("X is Y", "X = Y")
+pub struct RegexExtractor;
+
+impl RegexExtractor {
+    /// Extract structured facts from text content.
+    pub fn extract(content: &str, source_memory_id: Uuid) -> Vec<ExtractedFact> {
+        let mut facts = Vec::new();
+        let now = Utc::now();
+
+        // Preference patterns.
+        let preference_patterns = [
+            r"(?i)\b(?:i|we)\s+(?:prefer|like|love|enjoy|want)\s+(.+?)(?:\.|$|\n)",
+            r"(?i)\bmy\s+(?:favorite|preferred)\s+(?:\w+\s+)?is\s+(.+?)(?:\.|$|\n)",
+            r"(?i)\b(?:i|we)\s+(?:always|usually)\s+(?:use|choose)\s+(.+?)(?:\.|$|\n)",
+        ];
+
+        for pattern in &preference_patterns {
+            if let Ok(re) = Regex::new(pattern) {
+                for cap in re.captures_iter(content) {
+                    if let Some(obj) = cap.get(1) {
+                        let object = obj.as_str().trim().to_string();
+                        if object.len() >= 2 && object.len() <= 200 {
+                            facts.push(ExtractedFact {
+                                id: Uuid::new_v4(),
+                                source_memory_id,
+                                fact_type: "preference".to_string(),
+                                subject: "user".to_string(),
+                                predicate: "prefers".to_string(),
+                                object,
+                                confidence: 0.7,
+                                valid_from: now,
+                                valid_to: None,
+                                extraction_method: "regex".to_string(),
+                                created_at: now,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Decision patterns.
+        let decision_patterns = [
+            r"(?i)\b(?:i|we)\s+(?:decided|chose|picked|selected|went with)\s+(.+?)(?:\.|$|\n)",
+            r"(?i)\blet'?s?\s+(?:go with|use|choose)\s+(.+?)(?:\.|$|\n)",
+        ];
+
+        for pattern in &decision_patterns {
+            if let Ok(re) = Regex::new(pattern) {
+                for cap in re.captures_iter(content) {
+                    if let Some(obj) = cap.get(1) {
+                        let object = obj.as_str().trim().to_string();
+                        if object.len() >= 2 && object.len() <= 200 {
+                            facts.push(ExtractedFact {
+                                id: Uuid::new_v4(),
+                                source_memory_id,
+                                fact_type: "decision".to_string(),
+                                subject: "user".to_string(),
+                                predicate: "decided".to_string(),
+                                object,
+                                confidence: 0.8,
+                                valid_from: now,
+                                valid_to: None,
+                                extraction_method: "regex".to_string(),
+                                created_at: now,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Key-value / "X is Y" patterns (limited to short, concrete statements).
+        if let Ok(re) =
+            Regex::new(r"(?i)\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*)\s+is\s+(?:a\s+)?(\w[\w\s]{1,50}?)(?:\.|$|\n)")
+        {
+            for cap in re.captures_iter(content) {
+                if let (Some(subj), Some(obj)) = (cap.get(1), cap.get(2)) {
+                    let subject = subj.as_str().trim().to_string();
+                    let object = obj.as_str().trim().to_string();
+                    if subject.len() >= 2 && object.len() >= 2 {
+                        facts.push(ExtractedFact {
+                            id: Uuid::new_v4(),
+                            source_memory_id,
+                            fact_type: "entity".to_string(),
+                            subject,
+                            predicate: "is".to_string(),
+                            object,
+                            confidence: 0.6,
+                            valid_from: now,
+                            valid_to: None,
+                            extraction_method: "regex".to_string(),
+                            created_at: now,
+                        });
+                    }
+                }
+            }
+        }
+
+        facts
+    }
+
+    /// Extract potential named entities from text.
+    /// Returns unique entity strings (e.g., "John Smith", "Project Alpha").
+    pub fn extract_entities(content: &str) -> Vec<String> {
+        let mut entities = Vec::new();
+
+        // Multi-word capitalized sequences (potential proper nouns).
+        if let Ok(re) = Regex::new(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b") {
+            for cap in re.captures_iter(content) {
+                if let Some(m) = cap.get(1) {
+                    let entity = m.as_str().to_string();
+                    if !entities.contains(&entity) {
+                        entities.push(entity);
+                    }
+                }
+            }
+        }
+
+        // Single capitalized words that aren't at sentence start (heuristic).
+        // We check by looking for words preceded by lowercase or punctuation.
+        if let Ok(re) = Regex::new(r"(?:^|[.!?]\s+)\w") {
+            let sentence_starts: Vec<usize> = re
+                .find_iter(content)
+                .map(|m| m.end().saturating_sub(1))
+                .collect();
+
+            if let Ok(cap_re) = Regex::new(r"\b([A-Z][a-z]{2,})\b") {
+                for m in cap_re.find_iter(content) {
+                    // Skip if this is at a sentence start.
+                    if sentence_starts.contains(&m.start()) {
+                        continue;
+                    }
+                    let word = m.as_str().to_string();
+                    if !entities.contains(&word) {
+                        entities.push(word);
+                    }
+                }
+            }
+        }
+
+        entities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_preferences() {
+        let id = Uuid::new_v4();
+        let content = "I prefer Rust over Python. My favorite editor is Neovim.";
+        let facts = RegexExtractor::extract(content, id);
+
+        let prefs: Vec<_> = facts
+            .iter()
+            .filter(|f| f.fact_type == "preference")
+            .collect();
+        assert!(!prefs.is_empty());
+        assert!(prefs.iter().any(|f| f.object.contains("Rust")));
+    }
+
+    #[test]
+    fn test_extract_decisions() {
+        let id = Uuid::new_v4();
+        let content = "We decided to use PostgreSQL for the database.";
+        let facts = RegexExtractor::extract(content, id);
+
+        let decisions: Vec<_> = facts
+            .iter()
+            .filter(|f| f.fact_type == "decision")
+            .collect();
+        assert!(!decisions.is_empty());
+        assert!(decisions.iter().any(|f| f.object.contains("PostgreSQL")));
+    }
+
+    #[test]
+    fn test_extract_entities() {
+        let content = "I talked to John Smith about Project Alpha yesterday.";
+        let entities = RegexExtractor::extract_entities(content);
+        assert!(entities.contains(&"John Smith".to_string()));
+        assert!(entities.contains(&"Project Alpha".to_string()));
+    }
+
+    #[test]
+    fn test_empty_content() {
+        let id = Uuid::new_v4();
+        let facts = RegexExtractor::extract("", id);
+        assert!(facts.is_empty());
+        let entities = RegexExtractor::extract_entities("");
+        assert!(entities.is_empty());
+    }
+}

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -1,0 +1,227 @@
+//! # rustykrab-memory
+//!
+//! Production agent memory: verbatim storage, hybrid retrieval, value-driven lifecycle.
+//!
+//! This crate implements a three-pillar memory architecture:
+//!
+//! 1. **Verbatim storage** — raw conversation text is always stored synchronously
+//!    as the source of truth, with extracted facts computed asynchronously in the
+//!    background. This beats extraction-heavy approaches on retrieval benchmarks.
+//!
+//! 2. **Four-way parallel retrieval** — semantic (vector), keyword (BM25), graph
+//!    (link expansion), and temporal (recency) strategies run in parallel via
+//!    `tokio::join!`, then fuse with weighted Reciprocal Rank Fusion (k=60).
+//!
+//! 3. **Value-driven lifecycle** — importance-modulated exponential decay bounds
+//!    the retrieval working set, with promotion (episodic→semantic) and demotion
+//!    (episodic→archival→tombstone) keeping tail latency low as memory grows.
+//!
+//! ## Quick start
+//!
+//! ```rust,ignore
+//! use rustykrab_memory::{MemorySystem, MemoryConfig};
+//! use rustykrab_memory::embedding::HashEmbedder;
+//! use rustykrab_memory::storage::SledMemoryStorage;
+//! use std::sync::Arc;
+//! use uuid::Uuid;
+//!
+//! # async fn example() -> rustykrab_core::Result<()> {
+//! let db = sled::open("/tmp/memory_test")?;
+//! let storage = Arc::new(SledMemoryStorage::open(&db)?);
+//! let embedder = Arc::new(HashEmbedder::new(768));
+//! let config = MemoryConfig::default();
+//!
+//! let system = MemorySystem::new(config, storage, embedder);
+//!
+//! // Write
+//! let agent_id = Uuid::new_v4();
+//! let turn = rustykrab_memory::types::ConversationTurn {
+//!     id: Uuid::new_v4(),
+//!     session_id: Uuid::new_v4(),
+//!     turn_number: 1,
+//!     speaker: "user".into(),
+//!     content: "I prefer Rust for systems programming.".into(),
+//!     token_count: None,
+//!     metadata: Default::default(),
+//! };
+//! let memory_id = system.retain(turn, agent_id).await?;
+//!
+//! // Read
+//! let results = system.recall("Rust programming", agent_id, 5).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod backend;
+pub mod bm25;
+pub mod chunking;
+pub mod config;
+pub mod embedding;
+pub mod extraction;
+pub mod lifecycle;
+pub mod retrieval;
+pub mod scoring;
+pub mod storage;
+pub mod types;
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+pub use config::MemoryConfig;
+
+use bm25::Bm25Index;
+use lifecycle::{LifecycleManager, LifecycleSweepStats};
+use retrieval::MemoryRetriever;
+use storage::MemoryStorage;
+use types::{ConversationTurn, Memory, RetrievalResult};
+use writer::MemoryWriter;
+
+mod writer;
+
+/// The main entry point for the memory system.
+///
+/// Composes the write path ([MemoryWriter]), read path ([MemoryRetriever]),
+/// and lifecycle management ([LifecycleManager]) into a single facade.
+pub struct MemorySystem {
+    writer: MemoryWriter,
+    retriever: MemoryRetriever,
+    lifecycle: LifecycleManager,
+    storage: Arc<dyn MemoryStorage>,
+    config: MemoryConfig,
+}
+
+impl MemorySystem {
+    /// Create a new memory system.
+    ///
+    /// - `config`: tuning parameters for chunking, retrieval, and lifecycle.
+    /// - `storage`: the backing store (sled, SQLite, PostgreSQL, etc.).
+    /// - `embedder`: the text embedding model (fastembed, API-based, etc.).
+    pub fn new(
+        config: MemoryConfig,
+        storage: Arc<dyn MemoryStorage>,
+        embedder: Arc<dyn embedding::Embedder>,
+    ) -> Self {
+        let bm25_index = Arc::new(tokio::sync::Mutex::new(Bm25Index::new()));
+
+        let writer = MemoryWriter::new(
+            Arc::clone(&storage),
+            Arc::clone(&embedder),
+            config.clone(),
+            Arc::clone(&bm25_index),
+        );
+
+        let retriever = MemoryRetriever::new(
+            Arc::clone(&storage),
+            Arc::clone(&embedder),
+            config.clone(),
+            Arc::clone(&bm25_index),
+        );
+
+        let lifecycle = LifecycleManager::new(
+            Arc::clone(&storage),
+            Arc::clone(&embedder),
+            config.clone(),
+        );
+
+        Self {
+            writer,
+            retriever,
+            lifecycle,
+            storage,
+            config,
+        }
+    }
+
+    // ── Write path ──────────────────────────────────────────────
+
+    /// Retain a conversation turn in memory (dual-track write).
+    pub async fn retain(
+        &self,
+        turn: ConversationTurn,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<Uuid> {
+        self.writer.retain(turn, agent_id).await
+    }
+
+    /// Access the writer directly (e.g., for `save_fact` or `rebuild_bm25_index`).
+    pub fn writer(&self) -> &MemoryWriter {
+        &self.writer
+    }
+
+    // ── Read path ───────────────────────────────────────────────
+
+    /// Recall memories relevant to a query using four-way parallel
+    /// retrieval with RRF fusion and lifecycle scoring.
+    pub async fn recall(
+        &self,
+        query: &str,
+        agent_id: Uuid,
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
+        self.retriever.recall(query, agent_id, limit).await
+    }
+
+    // ── Lifecycle management ────────────────────────────────────
+
+    /// Run a lifecycle sweep: promote, demote, and tombstone memories.
+    pub async fn lifecycle_sweep(
+        &self,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<LifecycleSweepStats> {
+        self.lifecycle.sweep(agent_id).await
+    }
+
+    /// Detect near-duplicate memories and create similarity links.
+    pub async fn detect_near_duplicates(
+        &self,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<u32> {
+        self.lifecycle.detect_near_duplicates(agent_id).await
+    }
+
+    /// Check for embedding drift (re-embed sample, compare to stored).
+    pub async fn check_embedding_drift(
+        &self,
+        agent_id: Uuid,
+        sample_size: usize,
+    ) -> rustykrab_core::Result<f64> {
+        self.lifecycle
+            .check_embedding_drift(agent_id, sample_size)
+            .await
+    }
+
+    // ── Direct access ───────────────────────────────────────────
+
+    /// Get a memory by ID.
+    pub async fn get_memory(&self, id: Uuid) -> rustykrab_core::Result<Option<Memory>> {
+        self.storage.get_memory(id).await
+    }
+
+    /// Invalidate (soft-delete) a memory.
+    pub async fn invalidate_memory(
+        &self,
+        id: Uuid,
+        superseded_by: Option<Uuid>,
+    ) -> rustykrab_core::Result<()> {
+        self.lifecycle.invalidate_memory(id, superseded_by).await
+    }
+
+    /// Access the underlying storage (for advanced queries).
+    pub fn storage(&self) -> &Arc<dyn MemoryStorage> {
+        &self.storage
+    }
+
+    /// Access the configuration.
+    pub fn config(&self) -> &MemoryConfig {
+        &self.config
+    }
+
+    /// Rebuild the BM25 index from persisted memories (call on startup).
+    pub async fn rebuild_indexes(
+        &self,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<usize> {
+        self.writer.rebuild_bm25_index(agent_id).await
+    }
+}

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -21,13 +21,12 @@
 //! ```rust,ignore
 //! use rustykrab_memory::{MemorySystem, MemoryConfig};
 //! use rustykrab_memory::embedding::HashEmbedder;
-//! use rustykrab_memory::storage::SledMemoryStorage;
+//! use rustykrab_memory::storage::SqliteMemoryStorage;
 //! use std::sync::Arc;
 //! use uuid::Uuid;
 //!
 //! # async fn example() -> rustykrab_core::Result<()> {
-//! let db = sled::open("/tmp/memory_test")?;
-//! let storage = Arc::new(SledMemoryStorage::open(&db)?);
+//! let storage = Arc::new(SqliteMemoryStorage::open("memory.db")?);
 //! let embedder = Arc::new(HashEmbedder::new(768));
 //! let config = MemoryConfig::default();
 //!
@@ -95,7 +94,7 @@ impl MemorySystem {
     /// Create a new memory system.
     ///
     /// - `config`: tuning parameters for chunking, retrieval, and lifecycle.
-    /// - `storage`: the backing store (sled, SQLite, PostgreSQL, etc.).
+    /// - `storage`: the backing store (SQLite, PostgreSQL, etc.).
     /// - `embedder`: the text embedding model (fastembed, API-based, etc.).
     pub fn new(
         config: MemoryConfig,

--- a/crates/rustykrab-memory/src/lifecycle.rs
+++ b/crates/rustykrab-memory/src/lifecycle.rs
@@ -1,0 +1,295 @@
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info};
+use uuid::Uuid;
+
+use crate::config::MemoryConfig;
+use crate::embedding::{cosine_similarity, Embedder};
+use crate::storage::MemoryStorage;
+use crate::types::{LifecycleStage, Memory, MemoryLink, LinkType};
+
+/// Statistics from a lifecycle sweep operation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LifecycleSweepStats {
+    pub promoted_to_semantic: u32,
+    pub demoted_to_archival: u32,
+    pub tombstoned: u32,
+    pub near_duplicates_found: u32,
+}
+
+/// Lifecycle manager: handles promotion, demotion, consolidation,
+/// and deduplication of memories.
+///
+/// Runs as a background job (typically after session end or on a
+/// periodic schedule), never on the hot read/write path.
+pub struct LifecycleManager {
+    storage: Arc<dyn MemoryStorage>,
+    embedder: Arc<dyn Embedder>,
+    config: MemoryConfig,
+}
+
+impl LifecycleManager {
+    pub fn new(
+        storage: Arc<dyn MemoryStorage>,
+        embedder: Arc<dyn Embedder>,
+        config: MemoryConfig,
+    ) -> Self {
+        Self {
+            storage,
+            embedder,
+            config,
+        }
+    }
+
+    /// Run a full lifecycle sweep for an agent's memories.
+    ///
+    /// 1. Promote: episodic → semantic (accessed ≥3×, older than 7 days).
+    /// 2. Demote: episodic → archival (effective score < threshold, idle > 30 days).
+    /// 3. Tombstone: archival → tombstone (idle > 180 days, low importance).
+    pub async fn sweep(&self, agent_id: Uuid) -> rustykrab_core::Result<LifecycleSweepStats> {
+        let now = Utc::now();
+        let mut stats = LifecycleSweepStats::default();
+
+        // ── Promote: episodic → semantic ────────────────────────
+        let episodic = self
+            .storage
+            .list_by_stage(agent_id, LifecycleStage::Episodic)
+            .await?;
+
+        let promote_age = Duration::days(self.config.promote_min_age_days as i64);
+        let mut promotions = Vec::new();
+        let mut demotions = Vec::new();
+
+        for mem in &episodic {
+            let age = now - mem.created_at;
+
+            // Promotion criteria: accessed enough times AND old enough.
+            if mem.access_count >= self.config.promote_min_access_count
+                && age >= promote_age
+            {
+                promotions.push((mem.id, LifecycleStage::Semantic));
+                continue;
+            }
+
+            // Demotion criteria: low effective score AND idle > 30 days.
+            let idle_hours = (now - mem.last_accessed_at.unwrap_or(mem.created_at))
+                .num_hours()
+                .unsigned_abs() as f64;
+            let effective_decay = mem.decay_rate * (1.0 - mem.importance * 0.8);
+            let score = mem.importance * (-effective_decay * idle_hours / 168.0).exp();
+
+            let idle_days = idle_hours / 24.0;
+            if score < self.config.archive_score_threshold && idle_days > 30.0 {
+                demotions.push((mem.id, LifecycleStage::Archival));
+            }
+        }
+
+        if !promotions.is_empty() {
+            stats.promoted_to_semantic = self
+                .storage
+                .batch_update_stages(&promotions)
+                .await?;
+        }
+        if !demotions.is_empty() {
+            stats.demoted_to_archival = self
+                .storage
+                .batch_update_stages(&demotions)
+                .await?;
+        }
+
+        // ── Tombstone: archival → tombstone ─────────────────────
+        let archival = self
+            .storage
+            .list_by_stage(agent_id, LifecycleStage::Archival)
+            .await?;
+
+        let tombstone_threshold = Duration::days(self.config.tombstone_idle_days as i64);
+        let mut tombstones = Vec::new();
+
+        for mem in &archival {
+            let idle = now - mem.last_accessed_at.unwrap_or(mem.created_at);
+            if idle >= tombstone_threshold
+                && mem.importance < self.config.tombstone_importance_threshold
+            {
+                tombstones.push((mem.id, LifecycleStage::Tombstone));
+            }
+        }
+
+        if !tombstones.is_empty() {
+            stats.tombstoned = self
+                .storage
+                .batch_update_stages(&tombstones)
+                .await?;
+        }
+
+        info!(
+            agent_id = %agent_id,
+            promoted = stats.promoted_to_semantic,
+            demoted = stats.demoted_to_archival,
+            tombstoned = stats.tombstoned,
+            "lifecycle sweep complete"
+        );
+
+        Ok(stats)
+    }
+
+    /// Detect near-duplicate memories and create links between them.
+    ///
+    /// Thresholds (from production systems):
+    /// - ≥0.95 cosine: auto-link as near-duplicate
+    /// - 0.85–0.95: link as semantically similar
+    /// - <0.85: distinct, no link
+    ///
+    /// Bounded to 50 links per memory to prevent graph explosion.
+    pub async fn detect_near_duplicates(
+        &self,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<u32> {
+        let memories = self.storage.list_retrievable(agent_id).await?;
+        if memories.len() < 2 {
+            return Ok(0);
+        }
+
+        // Get embeddings for all memories (use first chunk of each).
+        let mut mem_embeddings: Vec<(Uuid, Vec<f32>)> = Vec::new();
+        for mem in &memories {
+            let chunks = self.storage.get_chunks_for_memory(mem.id).await?;
+            if let Some(first) = chunks.first() {
+                if !first.embedding.is_empty() {
+                    mem_embeddings.push((mem.id, first.embedding.clone()));
+                }
+            }
+        }
+
+        let mut link_count = 0u32;
+        let now = Utc::now();
+
+        // Pairwise comparison (O(n²) — acceptable for reasonable memory counts).
+        for i in 0..mem_embeddings.len() {
+            let mut links_for_i = 0u32;
+            for j in (i + 1)..mem_embeddings.len() {
+                if links_for_i >= 50 {
+                    break; // Bound links per memory.
+                }
+
+                let sim = cosine_similarity(&mem_embeddings[i].1, &mem_embeddings[j].1);
+
+                if sim >= self.config.dedup_auto_merge_threshold as f32 {
+                    // Near-duplicate: create bidirectional links.
+                    let link = MemoryLink {
+                        source_id: mem_embeddings[i].0,
+                        target_id: mem_embeddings[j].0,
+                        link_type: LinkType::SemanticSimilar,
+                        weight: sim as f64,
+                        created_at: now,
+                    };
+                    self.storage.upsert_link(&link).await?;
+
+                    let reverse = MemoryLink {
+                        source_id: mem_embeddings[j].0,
+                        target_id: mem_embeddings[i].0,
+                        link_type: LinkType::SemanticSimilar,
+                        weight: sim as f64,
+                        created_at: now,
+                    };
+                    self.storage.upsert_link(&reverse).await?;
+
+                    link_count += 2;
+                    links_for_i += 1;
+                } else if sim >= self.config.dedup_distinct_threshold as f32 {
+                    // Semantically similar but distinct.
+                    let link = MemoryLink {
+                        source_id: mem_embeddings[i].0,
+                        target_id: mem_embeddings[j].0,
+                        link_type: LinkType::SemanticSimilar,
+                        weight: sim as f64,
+                        created_at: now,
+                    };
+                    self.storage.upsert_link(&link).await?;
+                    link_count += 1;
+                    links_for_i += 1;
+                }
+            }
+        }
+
+        debug!(
+            agent_id = %agent_id,
+            links_created = link_count,
+            "near-duplicate detection complete"
+        );
+
+        Ok(link_count)
+    }
+
+    /// Invalidate a memory (soft delete), optionally recording which
+    /// memory supersedes it.
+    pub async fn invalidate_memory(
+        &self,
+        id: Uuid,
+        superseded_by: Option<Uuid>,
+    ) -> rustykrab_core::Result<()> {
+        self.storage.invalidate(id, superseded_by).await
+    }
+
+    /// Check for embedding drift by re-embedding a sample of memories
+    /// and comparing to stored embeddings.
+    ///
+    /// Returns the average cosine distance between old and new embeddings.
+    /// Alert if this exceeds ~0.05 (indicates model or preprocessing change).
+    pub async fn check_embedding_drift(
+        &self,
+        agent_id: Uuid,
+        sample_size: usize,
+    ) -> rustykrab_core::Result<f64> {
+        let memories = self.storage.list_retrievable(agent_id).await?;
+        let sample: Vec<&Memory> = memories.iter().take(sample_size).collect();
+
+        if sample.is_empty() {
+            return Ok(0.0);
+        }
+
+        let mut total_distance = 0.0;
+        let mut compared = 0usize;
+
+        for mem in &sample {
+            let chunks = self.storage.get_chunks_for_memory(mem.id).await?;
+            if let Some(old_chunk) = chunks.first() {
+                if old_chunk.embedding.is_empty() {
+                    continue;
+                }
+
+                // Re-embed the same content.
+                let new_embeddings = self
+                    .embedder
+                    .embed(vec![old_chunk.content.clone()])
+                    .await?;
+
+                if let Some(new_emb) = new_embeddings.first() {
+                    let sim = cosine_similarity(&old_chunk.embedding, new_emb);
+                    let distance = 1.0 - sim;
+                    total_distance += distance as f64;
+                    compared += 1;
+                }
+            }
+        }
+
+        let avg_distance = if compared > 0 {
+            total_distance / compared as f64
+        } else {
+            0.0
+        };
+
+        if avg_distance > 0.05 {
+            tracing::warn!(
+                agent_id = %agent_id,
+                avg_distance = avg_distance,
+                samples = compared,
+                "embedding drift detected! Consider re-indexing."
+            );
+        }
+
+        Ok(avg_distance)
+    }
+}

--- a/crates/rustykrab-memory/src/retrieval.rs
+++ b/crates/rustykrab-memory/src/retrieval.rs
@@ -1,0 +1,259 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::bm25::Bm25Index;
+use crate::config::MemoryConfig;
+use crate::embedding::{self, Embedder};
+use crate::scoring::rrf_fuse_with_sources;
+use crate::types::RetrievalSource;
+use crate::storage::MemoryStorage;
+use crate::types::RetrievalResult;
+
+/// Four-way parallel retrieval pipeline with RRF fusion.
+///
+/// Executes semantic (vector), keyword (BM25), graph (link expansion),
+/// and temporal (recency) retrieval arms in parallel via `tokio::join!`,
+/// then fuses results with weighted Reciprocal Rank Fusion (k=60).
+pub struct MemoryRetriever {
+    storage: Arc<dyn MemoryStorage>,
+    embedder: Arc<dyn Embedder>,
+    config: MemoryConfig,
+    bm25_index: Arc<tokio::sync::Mutex<Bm25Index>>,
+}
+
+impl MemoryRetriever {
+    pub fn new(
+        storage: Arc<dyn MemoryStorage>,
+        embedder: Arc<dyn Embedder>,
+        config: MemoryConfig,
+        bm25_index: Arc<tokio::sync::Mutex<Bm25Index>>,
+    ) -> Self {
+        Self {
+            storage,
+            embedder,
+            config,
+            bm25_index,
+        }
+    }
+
+    /// Recall memories relevant to a query.
+    ///
+    /// Pipeline:
+    /// 1. Embed query + tokenize for BM25 (parallel with dispatch setup).
+    /// 2. Dispatch four retrieval arms in parallel via `tokio::join!`.
+    /// 3. Fuse with weighted RRF.
+    /// 4. Multiply by lifecycle effective_score.
+    /// 5. Update access metadata on returned memories.
+    /// 6. Return top-K with provenance.
+    pub async fn recall(
+        &self,
+        query: &str,
+        agent_id: Uuid,
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
+        let candidates = self.config.retrieval_candidates_per_arm;
+
+        // ── Stage 1: Query preprocessing ────────────────────────
+        // Embed query in parallel with the rest of setup.
+        let query_embedding = {
+            let vecs = self.embedder.embed(vec![query.to_string()]).await?;
+            vecs.into_iter().next().unwrap_or_default()
+        };
+
+        // ── Stage 2: Parallel dispatch ──────────────────────────
+        let (semantic_results, keyword_results, graph_results, temporal_results) = tokio::join!(
+            self.retrieve_semantic(agent_id, &query_embedding, candidates),
+            self.retrieve_bm25(query, candidates),
+            self.retrieve_graph(agent_id, &query_embedding, candidates),
+            self.retrieve_temporal(agent_id, candidates),
+        );
+
+        let semantic = semantic_results.unwrap_or_default();
+        let keyword = keyword_results.unwrap_or_default();
+        let graph = graph_results.unwrap_or_default();
+        let temporal = temporal_results.unwrap_or_default();
+
+        debug!(
+            semantic = semantic.len(),
+            keyword = keyword.len(),
+            graph = graph.len(),
+            temporal = temporal.len(),
+            "retrieval arms completed"
+        );
+
+        // ── Stage 3: RRF fusion with sources ────────────────────
+        let ranked_lists = vec![
+            (semantic, self.config.rrf_weight_semantic, RetrievalSource::Semantic),
+            (keyword, self.config.rrf_weight_keyword, RetrievalSource::Keyword),
+            (graph, self.config.rrf_weight_graph, RetrievalSource::Graph),
+            (temporal, self.config.rrf_weight_temporal, RetrievalSource::Temporal),
+        ];
+
+        let fused = rrf_fuse_with_sources(&ranked_lists, self.config.rrf_k);
+
+        // ── Stage 4: Fetch full memories and apply lifecycle boost ──
+        let now = Utc::now();
+        let candidate_ids: Vec<Uuid> = fused.iter().map(|(id, _, _)| *id).collect();
+        let memories = self.storage.get_memories(&candidate_ids).await?;
+
+        let mut results: Vec<RetrievalResult> = Vec::new();
+
+        for (memory_id, rrf_score, sources) in &fused {
+            if let Some(mem) = memories.iter().find(|m| m.id == *memory_id) {
+                if !mem.is_valid || !mem.lifecycle_stage.is_retrievable() {
+                    continue;
+                }
+
+                // Use RRF score as a proxy for query similarity in effective_score.
+                // Normalize to [0, 1] range approximately.
+                let normalized_rrf = (*rrf_score * self.config.rrf_k).min(1.0);
+                let eff_score = mem.effective_score(normalized_rrf, now);
+
+                results.push(RetrievalResult {
+                    memory_id: *memory_id,
+                    content: mem.content.clone(),
+                    rrf_score: *rrf_score,
+                    effective_score: eff_score,
+                    sources: sources.clone(),
+                    memory: mem.clone(),
+                });
+            }
+        }
+
+        // Sort by effective score (lifecycle-adjusted).
+        results.sort_by(|a, b| {
+            b.effective_score
+                .partial_cmp(&a.effective_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        results.truncate(limit);
+
+        // ── Stage 5: Record access on returned results ──────────
+        for result in &results {
+            // Fire-and-forget access recording.
+            let storage = Arc::clone(&self.storage);
+            let id = result.memory_id;
+            tokio::spawn(async move {
+                let _ = storage.record_access(id).await;
+            });
+        }
+
+        debug!(
+            returned = results.len(),
+            total_candidates = fused.len(),
+            "recall complete"
+        );
+
+        Ok(results)
+    }
+
+    /// Semantic retrieval: embed query and find nearest neighbors via
+    /// brute-force cosine similarity over all chunk embeddings.
+    async fn retrieve_semantic(
+        &self,
+        agent_id: Uuid,
+        query_vec: &[f32],
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<(Uuid, usize)>> {
+        if query_vec.is_empty() || query_vec.iter().all(|v| *v == 0.0) {
+            return Ok(Vec::new());
+        }
+
+        let chunk_embeddings = self.storage.get_all_chunk_embeddings(agent_id).await?;
+        let top = embedding::top_k_similar(query_vec, &chunk_embeddings, limit * 2);
+
+        // Deduplicate to memory level (multiple chunks may belong to same memory).
+        let mut seen = HashSet::new();
+        let mut results = Vec::new();
+        for (memory_id, _sim) in top {
+            if seen.insert(memory_id) {
+                results.push((memory_id, results.len())); // rank = position
+            }
+            if results.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Keyword retrieval: BM25 search over in-memory inverted index.
+    async fn retrieve_bm25(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<(Uuid, usize)>> {
+        let index = self.bm25_index.lock().await;
+        let results = index.search(query, limit);
+        Ok(results
+            .into_iter()
+            .enumerate()
+            .map(|(rank, (id, _score))| (id, rank))
+            .collect())
+    }
+
+    /// Graph retrieval: find semantically similar memories, then expand
+    /// via precomputed links (1-hop).
+    async fn retrieve_graph(
+        &self,
+        agent_id: Uuid,
+        query_vec: &[f32],
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<(Uuid, usize)>> {
+        if query_vec.is_empty() || query_vec.iter().all(|v| *v == 0.0) {
+            return Ok(Vec::new());
+        }
+
+        // Seed: top-5 from semantic search.
+        let chunk_embeddings = self.storage.get_all_chunk_embeddings(agent_id).await?;
+        let seeds = embedding::top_k_similar(query_vec, &chunk_embeddings, 5);
+
+        let mut seen = HashSet::new();
+        let mut linked = Vec::new();
+
+        for (seed_id, _sim) in &seeds {
+            seen.insert(*seed_id);
+            let links = self.storage.get_links_from(*seed_id).await?;
+            for link in links {
+                if seen.insert(link.target_id) {
+                    linked.push((link.target_id, link.weight));
+                }
+            }
+        }
+
+        // Sort by link weight descending, assign ranks.
+        linked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        linked.truncate(limit);
+
+        Ok(linked
+            .into_iter()
+            .enumerate()
+            .map(|(rank, (id, _))| (id, rank))
+            .collect())
+    }
+
+    /// Temporal retrieval: most recent memories within a sliding window.
+    async fn retrieve_temporal(
+        &self,
+        agent_id: Uuid,
+        limit: usize,
+    ) -> rustykrab_core::Result<Vec<(Uuid, usize)>> {
+        let now = Utc::now();
+        let from = now - Duration::days(30); // 30-day window
+
+        let memories = self
+            .storage
+            .list_by_time_range(agent_id, from, now, limit)
+            .await?;
+
+        Ok(memories
+            .into_iter()
+            .enumerate()
+            .map(|(rank, mem)| (mem.id, rank))
+            .collect())
+    }
+}

--- a/crates/rustykrab-memory/src/scoring.rs
+++ b/crates/rustykrab-memory/src/scoring.rs
@@ -1,0 +1,257 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::types::TurnMetadata;
+
+/// Compute heuristic importance score for a piece of content.
+///
+/// Returns a value in [0.0, 1.0] based on content features:
+/// - Named entities (+0.05 each, max +0.25)
+/// - Temporal markers (+0.05)
+/// - Tool usage (+0.15)
+/// - User flagged (+0.30)
+///
+/// This runs synchronously at write time with zero LLM calls.
+pub fn compute_importance(content: &str, metadata: &TurnMetadata) -> f64 {
+    let mut score = 0.3; // baseline
+
+    // Named entities: capitalized words not at sentence start.
+    let entity_count = count_named_entities(content);
+    score += (entity_count as f64).min(5.0) * 0.05;
+
+    // Sentiment intensity as a proxy for emotional significance.
+    score += sentiment_intensity(content) * 0.15;
+
+    // Tool usage indicates actionable/significant interaction.
+    if metadata.involves_tool_use {
+        score += 0.15;
+    }
+
+    // Explicit user flagging is the strongest signal.
+    if metadata.user_flagged {
+        score += 0.30;
+    }
+
+    // Temporal markers suggest time-bound information worth tracking.
+    if has_temporal_markers(content) {
+        score += 0.05;
+    }
+
+    score.clamp(0.0, 1.0)
+}
+
+/// Count words that look like named entities (capitalized, not at sentence
+/// start, not common words).
+fn count_named_entities(content: &str) -> usize {
+    let mut count = 0;
+    for sentence in content.split(['.', '!', '?', '\n']) {
+        let words: Vec<&str> = sentence.split_whitespace().collect();
+        for (i, word) in words.iter().enumerate() {
+            if i == 0 {
+                continue; // Skip sentence-initial capitalization.
+            }
+            let trimmed = word.trim_matches(|c: char| !c.is_alphanumeric());
+            if trimmed.len() >= 2 {
+                if let Some(first) = trimmed.chars().next() {
+                    if first.is_uppercase() {
+                        count += 1;
+                    }
+                }
+            }
+        }
+    }
+    count
+}
+
+/// Simple sentiment intensity based on the presence of strong words.
+/// Returns a value in [0.0, 1.0].
+fn sentiment_intensity(content: &str) -> f64 {
+    const STRONG_WORDS: &[&str] = &[
+        "love", "hate", "amazing", "terrible", "critical", "urgent",
+        "important", "essential", "never", "always", "must", "definitely",
+        "absolutely", "crucial", "disaster", "excellent", "perfect", "worst",
+        "best", "emergency", "breakthrough", "deadline", "required",
+    ];
+
+    let lower = content.to_lowercase();
+    let matches = STRONG_WORDS
+        .iter()
+        .filter(|w| lower.contains(**w))
+        .count();
+
+    (matches as f64 / 3.0).min(1.0) // 3+ strong words → max intensity
+}
+
+/// Check for temporal markers (dates, days, relative time references).
+fn has_temporal_markers(content: &str) -> bool {
+    let lower = content.to_lowercase();
+    let markers = [
+        "today",
+        "tomorrow",
+        "yesterday",
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+        "next week",
+        "last week",
+        "next month",
+        "this morning",
+        "tonight",
+        "deadline",
+        "by end of",
+        "due date",
+        "scheduled",
+        "january",
+        "february",
+        "march",
+        "april",
+        "may",
+        "june",
+        "july",
+        "august",
+        "september",
+        "october",
+        "november",
+        "december",
+    ];
+
+    markers.iter().any(|m| lower.contains(m))
+}
+
+/// Reciprocal Rank Fusion: merge multiple ranked lists into a single
+/// scored list.
+///
+/// `ranked_lists` is a slice of (ranked_doc_ids_with_ranks, weight) tuples.
+/// Each inner vec contains (doc_id, rank) where rank is 0-based.
+/// `k` is the RRF constant (default 60).
+///
+/// Formula: `RRF_score(d) = Σ w_r / (k + rank_r(d))`
+pub fn rrf_fuse(
+    ranked_lists: &[(Vec<(Uuid, usize)>, f64)],
+    k: f64,
+) -> Vec<(Uuid, f64)> {
+    let mut scores: HashMap<Uuid, f64> = HashMap::new();
+
+    for (list, weight) in ranked_lists {
+        for &(doc_id, rank) in list {
+            *scores.entry(doc_id).or_default() += weight / (k + rank as f64);
+        }
+    }
+
+    let mut results: Vec<(Uuid, f64)> = scores.into_iter().collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+
+/// Track which retrieval sources contributed to each fused result.
+pub fn rrf_fuse_with_sources(
+    ranked_lists: &[(Vec<(Uuid, usize)>, f64, crate::types::RetrievalSource)],
+    k: f64,
+) -> Vec<(Uuid, f64, Vec<crate::types::RetrievalSource>)> {
+    let mut scores: HashMap<Uuid, f64> = HashMap::new();
+    let mut sources: HashMap<Uuid, Vec<crate::types::RetrievalSource>> = HashMap::new();
+
+    for (list, weight, source) in ranked_lists {
+        for &(doc_id, rank) in list {
+            *scores.entry(doc_id).or_default() += weight / (k + rank as f64);
+            sources.entry(doc_id).or_default().push(*source);
+        }
+    }
+
+    let mut results: Vec<_> = scores
+        .into_iter()
+        .map(|(id, score)| {
+            let srcs = sources.remove(&id).unwrap_or_default();
+            (id, score, srcs)
+        })
+        .collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TurnMetadata;
+
+    #[test]
+    fn test_importance_baseline() {
+        let meta = TurnMetadata::default();
+        let score = compute_importance("hello world", &meta);
+        assert!((score - 0.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_importance_tool_use() {
+        let meta = TurnMetadata {
+            involves_tool_use: true,
+            ..Default::default()
+        };
+        let score = compute_importance("hello", &meta);
+        assert!(score > 0.4);
+    }
+
+    #[test]
+    fn test_importance_user_flagged() {
+        let meta = TurnMetadata {
+            user_flagged: true,
+            ..Default::default()
+        };
+        let score = compute_importance("hello", &meta);
+        assert!(score >= 0.6);
+    }
+
+    #[test]
+    fn test_importance_clamp() {
+        let meta = TurnMetadata {
+            involves_tool_use: true,
+            user_flagged: true,
+            ..Default::default()
+        };
+        let content = "This is absolutely critical! John from Microsoft said the deadline for the Project Alpha emergency is tomorrow.";
+        let score = compute_importance(content, &meta);
+        assert!(score <= 1.0);
+        assert!(score > 0.8);
+    }
+
+    #[test]
+    fn test_rrf_fusion() {
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let id_c = Uuid::new_v4();
+
+        let lists = vec![
+            (vec![(id_a, 0), (id_b, 1), (id_c, 2)], 1.0), // semantic
+            (vec![(id_b, 0), (id_c, 1), (id_a, 2)], 1.0), // keyword
+        ];
+
+        let results = rrf_fuse(&lists, 60.0);
+        assert_eq!(results.len(), 3);
+        // id_b should rank highest: rank 1 in semantic + rank 0 in keyword
+        // id_b = 1/(60+1) + 1/(60+0) = 0.01639 + 0.01667 = 0.03306
+        // id_a = 1/(60+0) + 1/(60+2) = 0.01667 + 0.01613 = 0.03280
+        // id_b > id_a
+        assert_eq!(results[0].0, id_b);
+    }
+
+    #[test]
+    fn test_rrf_weighted() {
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+
+        let lists = vec![
+            (vec![(id_a, 0)], 1.0),
+            (vec![(id_b, 0)], 0.5), // half weight
+        ];
+
+        let results = rrf_fuse(&lists, 60.0);
+        assert_eq!(results.len(), 2);
+        // id_a: 1.0/60 > id_b: 0.5/60
+        assert_eq!(results[0].0, id_a);
+        assert!(results[0].1 > results[1].1);
+    }
+}

--- a/crates/rustykrab-memory/src/storage.rs
+++ b/crates/rustykrab-memory/src/storage.rs
@@ -1,0 +1,433 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use rustykrab_core::Result;
+use uuid::Uuid;
+
+use crate::types::{
+    ExtractedFact, LifecycleStage, Memory, MemoryChunk, MemoryLink,
+};
+
+/// Abstract storage backend for the memory system.
+///
+/// All retrieval, write, and lifecycle operations go through this trait,
+/// allowing different backends (sled, SQLite, PostgreSQL) to be swapped.
+#[async_trait]
+pub trait MemoryStorage: Send + Sync {
+    // ── Memory CRUD ─────────────────────────────────────────────
+
+    /// Insert or update a memory record.
+    async fn upsert_memory(&self, memory: &Memory) -> Result<()>;
+
+    /// Retrieve a memory by ID.
+    async fn get_memory(&self, id: Uuid) -> Result<Option<Memory>>;
+
+    /// Retrieve multiple memories by IDs.
+    async fn get_memories(&self, ids: &[Uuid]) -> Result<Vec<Memory>>;
+
+    /// Check for exact content duplicate within a time window.
+    async fn find_by_content_hash(
+        &self,
+        agent_id: Uuid,
+        content_hash: &str,
+    ) -> Result<Option<Memory>>;
+
+    /// List all valid memories for an agent in a given lifecycle stage.
+    async fn list_by_stage(
+        &self,
+        agent_id: Uuid,
+        stage: LifecycleStage,
+    ) -> Result<Vec<Memory>>;
+
+    /// List all valid, retrievable memories for an agent.
+    async fn list_retrievable(&self, agent_id: Uuid) -> Result<Vec<Memory>>;
+
+    /// List memories created within a time range, sorted by recency.
+    async fn list_by_time_range(
+        &self,
+        agent_id: Uuid,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Memory>>;
+
+    /// Update lifecycle stage for a memory.
+    async fn update_stage(&self, id: Uuid, stage: LifecycleStage) -> Result<()>;
+
+    /// Record an access (increment access_count, update last_accessed_at).
+    async fn record_access(&self, id: Uuid) -> Result<()>;
+
+    /// Soft-delete: mark a memory as invalid.
+    async fn invalidate(&self, id: Uuid, invalidated_by: Option<Uuid>) -> Result<()>;
+
+    // ── Chunk operations ────────────────────────────────────────
+
+    /// Store embedding chunks for a memory.
+    async fn store_chunks(&self, chunks: &[MemoryChunk]) -> Result<()>;
+
+    /// Retrieve all chunks for a memory.
+    async fn get_chunks_for_memory(&self, memory_id: Uuid) -> Result<Vec<MemoryChunk>>;
+
+    /// Retrieve all chunks with embeddings for an agent (for vector search).
+    async fn get_all_chunk_embeddings(
+        &self,
+        agent_id: Uuid,
+    ) -> Result<Vec<(Uuid, Vec<f32>)>>;
+
+    // ── Extracted facts ─────────────────────────────────────────
+
+    /// Store extracted facts.
+    async fn store_facts(&self, facts: &[ExtractedFact]) -> Result<()>;
+
+    /// Get facts extracted from a specific memory.
+    async fn get_facts_for_memory(&self, memory_id: Uuid) -> Result<Vec<ExtractedFact>>;
+
+    // ── Memory links (graph) ────────────────────────────────────
+
+    /// Add or update a link between two memories.
+    async fn upsert_link(&self, link: &MemoryLink) -> Result<()>;
+
+    /// Get all outgoing links from a memory.
+    async fn get_links_from(&self, source_id: Uuid) -> Result<Vec<MemoryLink>>;
+
+    /// Get all links involving a memory (incoming + outgoing).
+    async fn get_links_for(&self, memory_id: Uuid) -> Result<Vec<MemoryLink>>;
+
+    // ── Bulk operations ─────────────────────────────────────────
+
+    /// Batch update lifecycle stages (used by sweep).
+    async fn batch_update_stages(
+        &self,
+        updates: &[(Uuid, LifecycleStage)],
+    ) -> Result<u32>;
+}
+
+/// Sled-backed implementation of MemoryStorage.
+///
+/// Uses separate sled trees for memories, chunks, facts, and links.
+/// This keeps the embedded, single-file-database approach consistent
+/// with the rest of the RustyKrab storage layer.
+pub struct SledMemoryStorage {
+    memories: sled::Tree,
+    chunks: sled::Tree,
+    facts: sled::Tree,
+    links: sled::Tree,
+    /// Secondary index: content_hash → memory_id for dedup.
+    hash_index: sled::Tree,
+    /// Secondary index: memory_id → [chunk_id] for chunk lookup.
+    memory_chunks: sled::Tree,
+}
+
+impl SledMemoryStorage {
+    /// Open or create sled trees under the given database.
+    pub fn open(db: &sled::Db) -> Result<Self> {
+        Ok(Self {
+            memories: db
+                .open_tree("hybrid_memories")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            chunks: db
+                .open_tree("hybrid_chunks")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            facts: db
+                .open_tree("hybrid_facts")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            links: db
+                .open_tree("hybrid_links")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            hash_index: db
+                .open_tree("hybrid_hash_idx")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            memory_chunks: db
+                .open_tree("hybrid_mem_chunks")
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+        })
+    }
+
+    fn serialize<T: serde::Serialize>(val: &T) -> Result<Vec<u8>> {
+        serde_json::to_vec(val).map_err(rustykrab_core::Error::Serialization)
+    }
+
+    fn deserialize<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+        serde_json::from_slice(bytes)
+            .map_err(rustykrab_core::Error::Serialization)
+    }
+}
+
+#[async_trait]
+impl MemoryStorage for SledMemoryStorage {
+    async fn upsert_memory(&self, memory: &Memory) -> Result<()> {
+        let key = memory.id.as_bytes().to_vec();
+        let value = Self::serialize(memory)?;
+        self.memories
+            .insert(key, value)
+            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+
+        // Update hash index.
+        let hash_key = format!("{}:{}", memory.agent_id, memory.content_hash);
+        self.hash_index
+            .insert(hash_key.as_bytes(), memory.id.as_bytes().as_slice())
+            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_memory(&self, id: Uuid) -> Result<Option<Memory>> {
+        match self
+            .memories
+            .get(id.as_bytes())
+            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
+        {
+            Some(bytes) => Ok(Some(Self::deserialize(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_memories(&self, ids: &[Uuid]) -> Result<Vec<Memory>> {
+        let mut results = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(mem) = self.get_memory(*id).await? {
+                results.push(mem);
+            }
+        }
+        Ok(results)
+    }
+
+    async fn find_by_content_hash(
+        &self,
+        agent_id: Uuid,
+        content_hash: &str,
+    ) -> Result<Option<Memory>> {
+        let hash_key = format!("{agent_id}:{content_hash}");
+        match self
+            .hash_index
+            .get(hash_key.as_bytes())
+            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
+        {
+            Some(id_bytes) => {
+                let id_arr: [u8; 16] = id_bytes
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| rustykrab_core::Error::Storage("invalid uuid bytes".into()))?;
+                let id = Uuid::from_bytes(id_arr);
+                self.get_memory(id).await
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn list_by_stage(
+        &self,
+        agent_id: Uuid,
+        stage: LifecycleStage,
+    ) -> Result<Vec<Memory>> {
+        let mut results = Vec::new();
+        for item in self.memories.iter() {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let mem: Memory = Self::deserialize(&value)?;
+            if mem.agent_id == agent_id && mem.lifecycle_stage == stage && mem.is_valid {
+                results.push(mem);
+            }
+        }
+        Ok(results)
+    }
+
+    async fn list_retrievable(&self, agent_id: Uuid) -> Result<Vec<Memory>> {
+        let mut results = Vec::new();
+        for item in self.memories.iter() {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let mem: Memory = Self::deserialize(&value)?;
+            if mem.agent_id == agent_id
+                && mem.is_valid
+                && mem.lifecycle_stage.is_retrievable()
+            {
+                results.push(mem);
+            }
+        }
+        Ok(results)
+    }
+
+    async fn list_by_time_range(
+        &self,
+        agent_id: Uuid,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+        limit: usize,
+    ) -> Result<Vec<Memory>> {
+        let mut results = Vec::new();
+        for item in self.memories.iter() {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let mem: Memory = Self::deserialize(&value)?;
+            if mem.agent_id == agent_id
+                && mem.is_valid
+                && mem.lifecycle_stage.is_retrievable()
+                && mem.created_at >= from
+                && mem.created_at <= to
+            {
+                results.push(mem);
+            }
+        }
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        results.truncate(limit);
+        Ok(results)
+    }
+
+    async fn update_stage(&self, id: Uuid, stage: LifecycleStage) -> Result<()> {
+        if let Some(mut mem) = self.get_memory(id).await? {
+            mem.lifecycle_stage = stage;
+            self.upsert_memory(&mem).await?;
+        }
+        Ok(())
+    }
+
+    async fn record_access(&self, id: Uuid) -> Result<()> {
+        if let Some(mut mem) = self.get_memory(id).await? {
+            mem.access_count += 1;
+            mem.last_accessed_at = Some(Utc::now());
+            self.upsert_memory(&mem).await?;
+        }
+        Ok(())
+    }
+
+    async fn invalidate(&self, id: Uuid, invalidated_by: Option<Uuid>) -> Result<()> {
+        if let Some(mut mem) = self.get_memory(id).await? {
+            mem.is_valid = false;
+            mem.invalidated_by = invalidated_by;
+            mem.invalidated_at = Some(Utc::now());
+            mem.lifecycle_stage = LifecycleStage::Tombstone;
+            self.upsert_memory(&mem).await?;
+        }
+        Ok(())
+    }
+
+    async fn store_chunks(&self, chunks: &[MemoryChunk]) -> Result<()> {
+        for chunk in chunks {
+            let key = chunk.id.as_bytes().to_vec();
+            let value = Self::serialize(chunk)?;
+            self.chunks
+                .insert(key, value)
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+
+            // Update memory → chunks index.
+            let idx_key = format!("{}:{}", chunk.memory_id, chunk.chunk_index);
+            self.memory_chunks
+                .insert(idx_key.as_bytes(), chunk.id.as_bytes().as_slice())
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn get_chunks_for_memory(&self, memory_id: Uuid) -> Result<Vec<MemoryChunk>> {
+        let prefix = format!("{memory_id}:");
+        let mut chunks = Vec::new();
+        for item in self.memory_chunks.scan_prefix(prefix.as_bytes()) {
+            let (_, chunk_id_bytes) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            if let Some(chunk_bytes) = self
+                .chunks
+                .get(&chunk_id_bytes)
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
+            {
+                chunks.push(Self::deserialize(&chunk_bytes)?);
+            }
+        }
+        chunks.sort_by_key(|c: &MemoryChunk| c.chunk_index);
+        Ok(chunks)
+    }
+
+    async fn get_all_chunk_embeddings(
+        &self,
+        agent_id: Uuid,
+    ) -> Result<Vec<(Uuid, Vec<f32>)>> {
+        // First get all retrievable memory IDs for this agent.
+        let memories = self.list_retrievable(agent_id).await?;
+        let mem_ids: std::collections::HashSet<Uuid> =
+            memories.iter().map(|m| m.id).collect();
+
+        let mut results = Vec::new();
+        for item in self.chunks.iter() {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let chunk: MemoryChunk = Self::deserialize(&value)?;
+            if mem_ids.contains(&chunk.memory_id) && !chunk.embedding.is_empty() {
+                // Return memory_id (not chunk_id) for RRF dedup at memory level.
+                results.push((chunk.memory_id, chunk.embedding));
+            }
+        }
+        Ok(results)
+    }
+
+    async fn store_facts(&self, facts: &[ExtractedFact]) -> Result<()> {
+        for fact in facts {
+            let key = fact.id.as_bytes().to_vec();
+            let value = Self::serialize(fact)?;
+            self.facts
+                .insert(key, value)
+                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn get_facts_for_memory(&self, memory_id: Uuid) -> Result<Vec<ExtractedFact>> {
+        let mut results = Vec::new();
+        for item in self.facts.iter() {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let fact: ExtractedFact = Self::deserialize(&value)?;
+            if fact.source_memory_id == memory_id {
+                results.push(fact);
+            }
+        }
+        Ok(results)
+    }
+
+    async fn upsert_link(&self, link: &MemoryLink) -> Result<()> {
+        let key = format!(
+            "{}:{}:{:?}",
+            link.source_id, link.target_id, link.link_type
+        );
+        let value = Self::serialize(link)?;
+        self.links
+            .insert(key.as_bytes(), value)
+            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn get_links_from(&self, source_id: Uuid) -> Result<Vec<MemoryLink>> {
+        let prefix = format!("{source_id}:");
+        let mut results = Vec::new();
+        for item in self.links.scan_prefix(prefix.as_bytes()) {
+            let (_, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            results.push(Self::deserialize(&value)?);
+        }
+        Ok(results)
+    }
+
+    async fn get_links_for(&self, memory_id: Uuid) -> Result<Vec<MemoryLink>> {
+        let mut results = Vec::new();
+        let id_str = memory_id.to_string();
+        for item in self.links.iter() {
+            let (key, value) =
+                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+            let key_str = String::from_utf8_lossy(&key);
+            if key_str.contains(&id_str) {
+                results.push(Self::deserialize(&value)?);
+            }
+        }
+        Ok(results)
+    }
+
+    async fn batch_update_stages(
+        &self,
+        updates: &[(Uuid, LifecycleStage)],
+    ) -> Result<u32> {
+        let mut count = 0u32;
+        for &(id, stage) in updates {
+            self.update_stage(id, stage).await?;
+            count += 1;
+        }
+        Ok(count)
+    }
+}

--- a/crates/rustykrab-memory/src/storage.rs
+++ b/crates/rustykrab-memory/src/storage.rs
@@ -1,16 +1,20 @@
+use std::path::Path;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use rusqlite::params;
 use rustykrab_core::Result;
 use uuid::Uuid;
 
 use crate::types::{
-    ExtractedFact, LifecycleStage, Memory, MemoryChunk, MemoryLink,
+    ExtractedFact, LifecycleStage, LinkType, Memory, MemoryChunk, MemoryLink,
 };
 
 /// Abstract storage backend for the memory system.
 ///
 /// All retrieval, write, and lifecycle operations go through this trait,
-/// allowing different backends (sled, SQLite, PostgreSQL) to be swapped.
+/// allowing different backends (SQLite, PostgreSQL) to be swapped.
 #[async_trait]
 pub trait MemoryStorage: Send + Sync {
     // ── Memory CRUD ─────────────────────────────────────────────
@@ -101,94 +105,413 @@ pub trait MemoryStorage: Send + Sync {
     ) -> Result<u32>;
 }
 
-/// Sled-backed implementation of MemoryStorage.
-///
-/// Uses separate sled trees for memories, chunks, facts, and links.
-/// This keeps the embedded, single-file-database approach consistent
-/// with the rest of the RustyKrab storage layer.
-pub struct SledMemoryStorage {
-    memories: sled::Tree,
-    chunks: sled::Tree,
-    facts: sled::Tree,
-    links: sled::Tree,
-    /// Secondary index: content_hash → memory_id for dedup.
-    hash_index: sled::Tree,
-    /// Secondary index: memory_id → [chunk_id] for chunk lookup.
-    memory_chunks: sled::Tree,
+// ── SQLite helpers ──────────────────────────────────────────────
+
+fn storage_err(e: impl std::fmt::Display) -> rustykrab_core::Error {
+    rustykrab_core::Error::Storage(e.to_string())
 }
 
-impl SledMemoryStorage {
-    /// Open or create sled trees under the given database.
-    pub fn open(db: &sled::Db) -> Result<Self> {
+fn lifecycle_to_str(stage: LifecycleStage) -> &'static str {
+    match stage {
+        LifecycleStage::Working => "working",
+        LifecycleStage::Episodic => "episodic",
+        LifecycleStage::Semantic => "semantic",
+        LifecycleStage::Archival => "archival",
+        LifecycleStage::Tombstone => "tombstone",
+    }
+}
+
+fn str_to_lifecycle(s: &str) -> LifecycleStage {
+    match s {
+        "working" => LifecycleStage::Working,
+        "episodic" => LifecycleStage::Episodic,
+        "semantic" => LifecycleStage::Semantic,
+        "archival" => LifecycleStage::Archival,
+        _ => LifecycleStage::Tombstone,
+    }
+}
+
+fn str_to_link_type(s: &str) -> LinkType {
+    match s {
+        "semantic_similar" => LinkType::SemanticSimilar,
+        "entity_cooccurrence" => LinkType::EntityCooccurrence,
+        "causal_chain" => LinkType::CausalChain,
+        "consolidation" => LinkType::Consolidation,
+        "contradicts" => LinkType::Contradicts,
+        _ => LinkType::SemanticSimilar,
+    }
+}
+
+fn link_type_to_str(lt: LinkType) -> &'static str {
+    match lt {
+        LinkType::SemanticSimilar => "semantic_similar",
+        LinkType::EntityCooccurrence => "entity_cooccurrence",
+        LinkType::CausalChain => "causal_chain",
+        LinkType::Consolidation => "consolidation",
+        LinkType::Contradicts => "contradicts",
+    }
+}
+
+/// Encode a Vec<f32> embedding as little-endian bytes for SQLite BLOB storage.
+fn embedding_to_blob(v: &[f32]) -> Vec<u8> {
+    v.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+/// Decode a BLOB back to Vec<f32>.
+fn blob_to_embedding(blob: &[u8]) -> Vec<f32> {
+    blob.chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
+/// Encode a Vec<Uuid> as JSON text for SQLite TEXT storage.
+fn uuids_to_json(ids: &[Uuid]) -> String {
+    serde_json::to_string(ids).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Decode JSON text back to Vec<Uuid>.
+fn json_to_uuids(s: &str) -> Vec<Uuid> {
+    serde_json::from_str(s).unwrap_or_default()
+}
+
+// ── SQLite implementation ───────────────────────────────────────
+
+/// SQLite-backed implementation of [MemoryStorage].
+///
+/// Uses WAL mode for concurrent reads, with proper indexes for each
+/// query pattern. All blocking SQLite calls are dispatched to a
+/// `spawn_blocking` pool to avoid starving the async runtime.
+pub struct SqliteMemoryStorage {
+    conn: Arc<tokio::sync::Mutex<rusqlite::Connection>>,
+}
+
+impl SqliteMemoryStorage {
+    /// Open (or create) the memory database at the given path.
+    /// Runs migrations to ensure the schema is up to date.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let conn = rusqlite::Connection::open(path).map_err(storage_err)?;
+        Self::init(conn)
+    }
+
+    /// Create an in-memory database (useful for tests).
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = rusqlite::Connection::open_in_memory().map_err(storage_err)?;
+        Self::init(conn)
+    }
+
+    fn init(conn: rusqlite::Connection) -> Result<Self> {
+        // WAL mode: concurrent readers + single writer, crash-safe.
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             PRAGMA foreign_keys = ON;
+             PRAGMA busy_timeout = 5000;",
+        )
+        .map_err(storage_err)?;
+
+        Self::run_migrations(&conn)?;
+
         Ok(Self {
-            memories: db
-                .open_tree("hybrid_memories")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
-            chunks: db
-                .open_tree("hybrid_chunks")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
-            facts: db
-                .open_tree("hybrid_facts")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
-            links: db
-                .open_tree("hybrid_links")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
-            hash_index: db
-                .open_tree("hybrid_hash_idx")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
-            memory_chunks: db
-                .open_tree("hybrid_mem_chunks")
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?,
+            conn: Arc::new(tokio::sync::Mutex::new(conn)),
         })
     }
 
-    fn serialize<T: serde::Serialize>(val: &T) -> Result<Vec<u8>> {
-        serde_json::to_vec(val).map_err(rustykrab_core::Error::Serialization)
-    }
+    fn run_migrations(conn: &rusqlite::Connection) -> Result<()> {
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS memories (
+                id              TEXT PRIMARY KEY,
+                agent_id        TEXT NOT NULL,
+                content         TEXT NOT NULL,
+                content_hash    TEXT NOT NULL,
 
-    fn deserialize<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T> {
-        serde_json::from_slice(bytes)
-            .map_err(rustykrab_core::Error::Serialization)
-    }
-}
+                -- Lifecycle
+                lifecycle_stage TEXT NOT NULL DEFAULT 'episodic'
+                    CHECK (lifecycle_stage IN ('working','episodic','semantic','archival','tombstone')),
 
-#[async_trait]
-impl MemoryStorage for SledMemoryStorage {
-    async fn upsert_memory(&self, memory: &Memory) -> Result<()> {
-        let key = memory.id.as_bytes().to_vec();
-        let value = Self::serialize(memory)?;
-        self.memories
-            .insert(key, value)
-            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+                -- Scoring
+                importance          REAL NOT NULL DEFAULT 0.5,
+                importance_source   TEXT NOT NULL DEFAULT 'heuristic',
+                decay_rate          REAL NOT NULL DEFAULT 1.0,
+                confidence          REAL NOT NULL DEFAULT 1.0,
 
-        // Update hash index.
-        let hash_key = format!("{}:{}", memory.agent_id, memory.content_hash);
-        self.hash_index
-            .insert(hash_key.as_bytes(), memory.id.as_bytes().as_slice())
-            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+                -- Access patterns
+                access_count        INTEGER NOT NULL DEFAULT 0,
+                last_accessed_at    TEXT,
+                last_relevant_at    TEXT,
+                created_at          TEXT NOT NULL,
+
+                -- Consolidation
+                parent_memory_ids   TEXT NOT NULL DEFAULT '[]',
+                consolidation_generation INTEGER NOT NULL DEFAULT 0,
+                proof_count         INTEGER NOT NULL DEFAULT 1,
+
+                -- Temporal context
+                occurred_start      TEXT,
+                occurred_end        TEXT,
+
+                -- Soft delete
+                is_valid            INTEGER NOT NULL DEFAULT 1,
+                invalidated_by      TEXT,
+                invalidated_at      TEXT,
+
+                -- Tags
+                tags                TEXT NOT NULL DEFAULT '[]',
+
+                -- Metadata
+                metadata            TEXT NOT NULL DEFAULT '{}'
+            );
+
+            -- Hot-path indexes
+            CREATE INDEX IF NOT EXISTS idx_memories_agent_stage
+                ON memories(agent_id, lifecycle_stage) WHERE is_valid = 1;
+            CREATE INDEX IF NOT EXISTS idx_memories_agent_time
+                ON memories(agent_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_memories_dedup
+                ON memories(agent_id, content_hash);
+
+            CREATE TABLE IF NOT EXISTS chunks (
+                id                      TEXT PRIMARY KEY,
+                memory_id               TEXT NOT NULL REFERENCES memories(id),
+                chunk_index             INTEGER NOT NULL,
+                content                 TEXT NOT NULL,
+                embedding               BLOB,
+                embedding_model_version TEXT,
+                created_at              TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_chunks_memory
+                ON chunks(memory_id, chunk_index);
+
+            CREATE TABLE IF NOT EXISTS extracted_facts (
+                id                  TEXT PRIMARY KEY,
+                source_memory_id    TEXT NOT NULL REFERENCES memories(id),
+                fact_type           TEXT,
+                subject             TEXT,
+                predicate           TEXT,
+                object              TEXT,
+                confidence          REAL DEFAULT 1.0,
+                valid_from          TEXT,
+                valid_to            TEXT,
+                extraction_method   TEXT,
+                created_at          TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_facts_memory
+                ON extracted_facts(source_memory_id);
+
+            CREATE TABLE IF NOT EXISTS memory_links (
+                source_id   TEXT NOT NULL,
+                target_id   TEXT NOT NULL,
+                link_type   TEXT NOT NULL,
+                weight      REAL NOT NULL DEFAULT 1.0,
+                created_at  TEXT NOT NULL,
+                PRIMARY KEY (source_id, target_id, link_type)
+            );
+            CREATE INDEX IF NOT EXISTS idx_links_source
+                ON memory_links(source_id);
+            CREATE INDEX IF NOT EXISTS idx_links_target
+                ON memory_links(target_id);
+            ",
+        )
+        .map_err(storage_err)?;
 
         Ok(())
     }
 
+    /// Helper: run a blocking closure on the connection inside spawn_blocking.
+    async fn with_conn<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = Arc::clone(&self.conn);
+        tokio::task::spawn_blocking(move || {
+            let conn = conn.blocking_lock();
+            f(&conn)
+        })
+        .await
+        .map_err(|e| rustykrab_core::Error::Storage(format!("join error: {e}")))?
+    }
+}
+
+/// Read a Memory row from a rusqlite Row.
+fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
+    let id_str: String = row.get("id")?;
+    let agent_id_str: String = row.get("agent_id")?;
+    let stage_str: String = row.get("lifecycle_stage")?;
+    let importance_source_str: String = row.get("importance_source")?;
+    let last_accessed_str: Option<String> = row.get("last_accessed_at")?;
+    let last_relevant_str: Option<String> = row.get("last_relevant_at")?;
+    let created_str: String = row.get("created_at")?;
+    let parent_ids_str: String = row.get("parent_memory_ids")?;
+    let occurred_start_str: Option<String> = row.get("occurred_start")?;
+    let occurred_end_str: Option<String> = row.get("occurred_end")?;
+    let invalidated_by_str: Option<String> = row.get("invalidated_by")?;
+    let invalidated_at_str: Option<String> = row.get("invalidated_at")?;
+    let tags_str: String = row.get("tags")?;
+    let metadata_str: String = row.get("metadata")?;
+
+    Ok(Memory {
+        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+        agent_id: Uuid::parse_str(&agent_id_str).unwrap_or_default(),
+        content: row.get("content")?,
+        content_hash: row.get("content_hash")?,
+        lifecycle_stage: str_to_lifecycle(&stage_str),
+        importance: row.get("importance")?,
+        importance_source: match importance_source_str.as_str() {
+            "llm" => crate::types::ImportanceSource::Llm,
+            "user" => crate::types::ImportanceSource::User,
+            _ => crate::types::ImportanceSource::Heuristic,
+        },
+        decay_rate: row.get("decay_rate")?,
+        confidence: row.get("confidence")?,
+        access_count: row.get::<_, u32>("access_count")?,
+        last_accessed_at: last_accessed_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        last_relevant_at: last_relevant_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        created_at: DateTime::parse_from_rfc3339(&created_str)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+        parent_memory_ids: json_to_uuids(&parent_ids_str),
+        consolidation_generation: row.get::<_, u32>("consolidation_generation")?,
+        proof_count: row.get::<_, u32>("proof_count")?,
+        occurred_start: occurred_start_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        occurred_end: occurred_end_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        is_valid: row.get::<_, i32>("is_valid")? != 0,
+        invalidated_by: invalidated_by_str
+            .and_then(|s| Uuid::parse_str(&s).ok()),
+        invalidated_at: invalidated_at_str
+            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+            .map(|dt| dt.with_timezone(&Utc)),
+        tags: serde_json::from_str(&tags_str).unwrap_or_default(),
+        metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
+    })
+}
+
+#[async_trait]
+impl MemoryStorage for SqliteMemoryStorage {
+    async fn upsert_memory(&self, memory: &Memory) -> Result<()> {
+        let m = memory.clone();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT INTO memories (
+                    id, agent_id, content, content_hash,
+                    lifecycle_stage, importance, importance_source,
+                    decay_rate, confidence, access_count,
+                    last_accessed_at, last_relevant_at, created_at,
+                    parent_memory_ids, consolidation_generation, proof_count,
+                    occurred_start, occurred_end,
+                    is_valid, invalidated_by, invalidated_at,
+                    tags, metadata
+                ) VALUES (
+                    ?1, ?2, ?3, ?4,
+                    ?5, ?6, ?7,
+                    ?8, ?9, ?10,
+                    ?11, ?12, ?13,
+                    ?14, ?15, ?16,
+                    ?17, ?18,
+                    ?19, ?20, ?21,
+                    ?22, ?23
+                ) ON CONFLICT(id) DO UPDATE SET
+                    lifecycle_stage = excluded.lifecycle_stage,
+                    importance = excluded.importance,
+                    importance_source = excluded.importance_source,
+                    decay_rate = excluded.decay_rate,
+                    confidence = excluded.confidence,
+                    access_count = excluded.access_count,
+                    last_accessed_at = excluded.last_accessed_at,
+                    last_relevant_at = excluded.last_relevant_at,
+                    parent_memory_ids = excluded.parent_memory_ids,
+                    consolidation_generation = excluded.consolidation_generation,
+                    proof_count = excluded.proof_count,
+                    occurred_start = excluded.occurred_start,
+                    occurred_end = excluded.occurred_end,
+                    is_valid = excluded.is_valid,
+                    invalidated_by = excluded.invalidated_by,
+                    invalidated_at = excluded.invalidated_at,
+                    tags = excluded.tags,
+                    metadata = excluded.metadata",
+                params![
+                    m.id.to_string(),
+                    m.agent_id.to_string(),
+                    m.content,
+                    m.content_hash,
+                    lifecycle_to_str(m.lifecycle_stage),
+                    m.importance,
+                    match m.importance_source {
+                        crate::types::ImportanceSource::Heuristic => "heuristic",
+                        crate::types::ImportanceSource::Llm => "llm",
+                        crate::types::ImportanceSource::User => "user",
+                    },
+                    m.decay_rate,
+                    m.confidence,
+                    m.access_count,
+                    m.last_accessed_at.map(|t| t.to_rfc3339()),
+                    m.last_relevant_at.map(|t| t.to_rfc3339()),
+                    m.created_at.to_rfc3339(),
+                    uuids_to_json(&m.parent_memory_ids),
+                    m.consolidation_generation,
+                    m.proof_count,
+                    m.occurred_start.map(|t| t.to_rfc3339()),
+                    m.occurred_end.map(|t| t.to_rfc3339()),
+                    m.is_valid as i32,
+                    m.invalidated_by.map(|u| u.to_string()),
+                    m.invalidated_at.map(|t| t.to_rfc3339()),
+                    serde_json::to_string(&m.tags).unwrap_or_else(|_| "[]".into()),
+                    m.metadata.to_string(),
+                ],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
+    }
+
     async fn get_memory(&self, id: Uuid) -> Result<Option<Memory>> {
-        match self
-            .memories
-            .get(id.as_bytes())
-            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
-        {
-            Some(bytes) => Ok(Some(Self::deserialize(&bytes)?)),
-            None => Ok(None),
-        }
+        let id_str = id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT * FROM memories WHERE id = ?1")
+                .map_err(storage_err)?;
+            let mut rows = stmt
+                .query_map(params![id_str], row_to_memory)
+                .map_err(storage_err)?;
+            match rows.next() {
+                Some(Ok(mem)) => Ok(Some(mem)),
+                Some(Err(e)) => Err(storage_err(e)),
+                None => Ok(None),
+            }
+        })
+        .await
     }
 
     async fn get_memories(&self, ids: &[Uuid]) -> Result<Vec<Memory>> {
-        let mut results = Vec::with_capacity(ids.len());
-        for id in ids {
-            if let Some(mem) = self.get_memory(*id).await? {
-                results.push(mem);
-            }
+        if ids.is_empty() {
+            return Ok(Vec::new());
         }
-        Ok(results)
+        let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
+        self.with_conn(move |conn| {
+            let placeholders: String = id_strings
+                .iter()
+                .map(|s| format!("'{s}'"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let sql = format!("SELECT * FROM memories WHERE id IN ({placeholders})");
+            let mut stmt = conn.prepare(&sql).map_err(storage_err)?;
+            let rows = stmt.query_map([], row_to_memory).map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
+            }
+            Ok(results)
+        })
+        .await
     }
 
     async fn find_by_content_hash(
@@ -196,22 +519,26 @@ impl MemoryStorage for SledMemoryStorage {
         agent_id: Uuid,
         content_hash: &str,
     ) -> Result<Option<Memory>> {
-        let hash_key = format!("{agent_id}:{content_hash}");
-        match self
-            .hash_index
-            .get(hash_key.as_bytes())
-            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
-        {
-            Some(id_bytes) => {
-                let id_arr: [u8; 16] = id_bytes
-                    .as_ref()
-                    .try_into()
-                    .map_err(|_| rustykrab_core::Error::Storage("invalid uuid bytes".into()))?;
-                let id = Uuid::from_bytes(id_arr);
-                self.get_memory(id).await
+        let agent_str = agent_id.to_string();
+        let hash = content_hash.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM memories
+                     WHERE agent_id = ?1 AND content_hash = ?2 AND is_valid = 1
+                     LIMIT 1",
+                )
+                .map_err(storage_err)?;
+            let mut rows = stmt
+                .query_map(params![agent_str, hash], row_to_memory)
+                .map_err(storage_err)?;
+            match rows.next() {
+                Some(Ok(mem)) => Ok(Some(mem)),
+                Some(Err(e)) => Err(storage_err(e)),
+                None => Ok(None),
             }
-            None => Ok(None),
-        }
+        })
+        .await
     }
 
     async fn list_by_stage(
@@ -219,32 +546,47 @@ impl MemoryStorage for SledMemoryStorage {
         agent_id: Uuid,
         stage: LifecycleStage,
     ) -> Result<Vec<Memory>> {
-        let mut results = Vec::new();
-        for item in self.memories.iter() {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let mem: Memory = Self::deserialize(&value)?;
-            if mem.agent_id == agent_id && mem.lifecycle_stage == stage && mem.is_valid {
-                results.push(mem);
+        let agent_str = agent_id.to_string();
+        let stage_str = lifecycle_to_str(stage).to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM memories
+                     WHERE agent_id = ?1 AND lifecycle_stage = ?2 AND is_valid = 1",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![agent_str, stage_str], row_to_memory)
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
     async fn list_retrievable(&self, agent_id: Uuid) -> Result<Vec<Memory>> {
-        let mut results = Vec::new();
-        for item in self.memories.iter() {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let mem: Memory = Self::deserialize(&value)?;
-            if mem.agent_id == agent_id
-                && mem.is_valid
-                && mem.lifecycle_stage.is_retrievable()
-            {
-                results.push(mem);
+        let agent_str = agent_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM memories
+                     WHERE agent_id = ?1 AND is_valid = 1
+                       AND lifecycle_stage IN ('working', 'episodic', 'semantic')",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![agent_str], row_to_memory)
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
     async fn list_by_time_range(
@@ -254,180 +596,403 @@ impl MemoryStorage for SledMemoryStorage {
         to: DateTime<Utc>,
         limit: usize,
     ) -> Result<Vec<Memory>> {
-        let mut results = Vec::new();
-        for item in self.memories.iter() {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let mem: Memory = Self::deserialize(&value)?;
-            if mem.agent_id == agent_id
-                && mem.is_valid
-                && mem.lifecycle_stage.is_retrievable()
-                && mem.created_at >= from
-                && mem.created_at <= to
-            {
-                results.push(mem);
+        let agent_str = agent_id.to_string();
+        let from_str = from.to_rfc3339();
+        let to_str = to.to_rfc3339();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM memories
+                     WHERE agent_id = ?1 AND is_valid = 1
+                       AND lifecycle_stage IN ('working', 'episodic', 'semantic')
+                       AND created_at >= ?2 AND created_at <= ?3
+                     ORDER BY created_at DESC
+                     LIMIT ?4",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(
+                    params![agent_str, from_str, to_str, limit as u32],
+                    row_to_memory,
+                )
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        results.truncate(limit);
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
     async fn update_stage(&self, id: Uuid, stage: LifecycleStage) -> Result<()> {
-        if let Some(mut mem) = self.get_memory(id).await? {
-            mem.lifecycle_stage = stage;
-            self.upsert_memory(&mem).await?;
-        }
-        Ok(())
+        let id_str = id.to_string();
+        let stage_str = lifecycle_to_str(stage).to_string();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE memories SET lifecycle_stage = ?2 WHERE id = ?1",
+                params![id_str, stage_str],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn record_access(&self, id: Uuid) -> Result<()> {
-        if let Some(mut mem) = self.get_memory(id).await? {
-            mem.access_count += 1;
-            mem.last_accessed_at = Some(Utc::now());
-            self.upsert_memory(&mem).await?;
-        }
-        Ok(())
+        let id_str = id.to_string();
+        let now = Utc::now().to_rfc3339();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE memories
+                 SET access_count = access_count + 1,
+                     last_accessed_at = ?2
+                 WHERE id = ?1",
+                params![id_str, now],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn invalidate(&self, id: Uuid, invalidated_by: Option<Uuid>) -> Result<()> {
-        if let Some(mut mem) = self.get_memory(id).await? {
-            mem.is_valid = false;
-            mem.invalidated_by = invalidated_by;
-            mem.invalidated_at = Some(Utc::now());
-            mem.lifecycle_stage = LifecycleStage::Tombstone;
-            self.upsert_memory(&mem).await?;
-        }
-        Ok(())
+        let id_str = id.to_string();
+        let by_str = invalidated_by.map(|u| u.to_string());
+        let now = Utc::now().to_rfc3339();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE memories
+                 SET is_valid = 0,
+                     lifecycle_stage = 'tombstone',
+                     invalidated_by = ?2,
+                     invalidated_at = ?3
+                 WHERE id = ?1",
+                params![id_str, by_str, now],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
-    async fn store_chunks(&self, chunks: &[MemoryChunk]) -> Result<()> {
-        for chunk in chunks {
-            let key = chunk.id.as_bytes().to_vec();
-            let value = Self::serialize(chunk)?;
-            self.chunks
-                .insert(key, value)
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
+    // ── Chunks ──────────────────────────────────────────────────
 
-            // Update memory → chunks index.
-            let idx_key = format!("{}:{}", chunk.memory_id, chunk.chunk_index);
-            self.memory_chunks
-                .insert(idx_key.as_bytes(), chunk.id.as_bytes().as_slice())
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-        }
-        Ok(())
+    async fn store_chunks(&self, chunks: &[MemoryChunk]) -> Result<()> {
+        let chunks = chunks.to_vec();
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(storage_err)?;
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT OR REPLACE INTO chunks
+                         (id, memory_id, chunk_index, content, embedding,
+                          embedding_model_version, created_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    )
+                    .map_err(storage_err)?;
+
+                for chunk in &chunks {
+                    let emb_blob = embedding_to_blob(&chunk.embedding);
+                    stmt.execute(params![
+                        chunk.id.to_string(),
+                        chunk.memory_id.to_string(),
+                        chunk.chunk_index,
+                        chunk.content,
+                        emb_blob,
+                        chunk.embedding_model_version,
+                        chunk.created_at.to_rfc3339(),
+                    ])
+                    .map_err(storage_err)?;
+                }
+            }
+            tx.commit().map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_chunks_for_memory(&self, memory_id: Uuid) -> Result<Vec<MemoryChunk>> {
-        let prefix = format!("{memory_id}:");
-        let mut chunks = Vec::new();
-        for item in self.memory_chunks.scan_prefix(prefix.as_bytes()) {
-            let (_, chunk_id_bytes) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            if let Some(chunk_bytes) = self
-                .chunks
-                .get(&chunk_id_bytes)
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?
-            {
-                chunks.push(Self::deserialize(&chunk_bytes)?);
+        let mem_str = memory_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM chunks
+                     WHERE memory_id = ?1
+                     ORDER BY chunk_index",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![mem_str], |row| {
+                    let id_str: String = row.get("id")?;
+                    let mem_id_str: String = row.get("memory_id")?;
+                    let emb_blob: Vec<u8> = row.get("embedding")?;
+                    let created_str: String = row.get("created_at")?;
+
+                    Ok(MemoryChunk {
+                        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+                        memory_id: Uuid::parse_str(&mem_id_str).unwrap_or_default(),
+                        chunk_index: row.get("chunk_index")?,
+                        content: row.get("content")?,
+                        embedding: blob_to_embedding(&emb_blob),
+                        embedding_model_version: row
+                            .get::<_, Option<String>>("embedding_model_version")?
+                            .unwrap_or_default(),
+                        created_at: DateTime::parse_from_rfc3339(&created_str)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                    })
+                })
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        chunks.sort_by_key(|c: &MemoryChunk| c.chunk_index);
-        Ok(chunks)
+            Ok(results)
+        })
+        .await
     }
 
     async fn get_all_chunk_embeddings(
         &self,
         agent_id: Uuid,
     ) -> Result<Vec<(Uuid, Vec<f32>)>> {
-        // First get all retrievable memory IDs for this agent.
-        let memories = self.list_retrievable(agent_id).await?;
-        let mem_ids: std::collections::HashSet<Uuid> =
-            memories.iter().map(|m| m.id).collect();
-
-        let mut results = Vec::new();
-        for item in self.chunks.iter() {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let chunk: MemoryChunk = Self::deserialize(&value)?;
-            if mem_ids.contains(&chunk.memory_id) && !chunk.embedding.is_empty() {
-                // Return memory_id (not chunk_id) for RRF dedup at memory level.
-                results.push((chunk.memory_id, chunk.embedding));
+        let agent_str = agent_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT c.memory_id, c.embedding
+                     FROM chunks c
+                     JOIN memories m ON m.id = c.memory_id
+                     WHERE m.agent_id = ?1 AND m.is_valid = 1
+                       AND m.lifecycle_stage IN ('working', 'episodic', 'semantic')
+                       AND c.embedding IS NOT NULL",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![agent_str], |row| {
+                    let mem_id_str: String = row.get(0)?;
+                    let emb_blob: Vec<u8> = row.get(1)?;
+                    Ok((
+                        Uuid::parse_str(&mem_id_str).unwrap_or_default(),
+                        blob_to_embedding(&emb_blob),
+                    ))
+                })
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                let (id, emb) = row.map_err(storage_err)?;
+                if !emb.is_empty() {
+                    results.push((id, emb));
+                }
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
+    // ── Extracted facts ─────────────────────────────────────────
+
     async fn store_facts(&self, facts: &[ExtractedFact]) -> Result<()> {
-        for fact in facts {
-            let key = fact.id.as_bytes().to_vec();
-            let value = Self::serialize(fact)?;
-            self.facts
-                .insert(key, value)
-                .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-        }
-        Ok(())
+        let facts = facts.to_vec();
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(storage_err)?;
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT OR REPLACE INTO extracted_facts
+                         (id, source_memory_id, fact_type, subject, predicate, object,
+                          confidence, valid_from, valid_to, extraction_method, created_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    )
+                    .map_err(storage_err)?;
+
+                for fact in &facts {
+                    stmt.execute(params![
+                        fact.id.to_string(),
+                        fact.source_memory_id.to_string(),
+                        fact.fact_type,
+                        fact.subject,
+                        fact.predicate,
+                        fact.object,
+                        fact.confidence,
+                        fact.valid_from.to_rfc3339(),
+                        fact.valid_to.map(|t| t.to_rfc3339()),
+                        fact.extraction_method,
+                        fact.created_at.to_rfc3339(),
+                    ])
+                    .map_err(storage_err)?;
+                }
+            }
+            tx.commit().map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_facts_for_memory(&self, memory_id: Uuid) -> Result<Vec<ExtractedFact>> {
-        let mut results = Vec::new();
-        for item in self.facts.iter() {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let fact: ExtractedFact = Self::deserialize(&value)?;
-            if fact.source_memory_id == memory_id {
-                results.push(fact);
+        let mem_str = memory_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT * FROM extracted_facts WHERE source_memory_id = ?1")
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![mem_str], |row| {
+                    let id_str: String = row.get("id")?;
+                    let src_str: String = row.get("source_memory_id")?;
+                    let valid_from_str: String = row.get("valid_from")?;
+                    let valid_to_str: Option<String> = row.get("valid_to")?;
+                    let created_str: String = row.get("created_at")?;
+
+                    Ok(ExtractedFact {
+                        id: Uuid::parse_str(&id_str).unwrap_or_default(),
+                        source_memory_id: Uuid::parse_str(&src_str).unwrap_or_default(),
+                        fact_type: row.get("fact_type")?,
+                        subject: row.get("subject")?,
+                        predicate: row.get("predicate")?,
+                        object: row.get("object")?,
+                        confidence: row.get("confidence")?,
+                        valid_from: DateTime::parse_from_rfc3339(&valid_from_str)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                        valid_to: valid_to_str
+                            .and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+                            .map(|dt| dt.with_timezone(&Utc)),
+                        extraction_method: row.get("extraction_method")?,
+                        created_at: DateTime::parse_from_rfc3339(&created_str)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                    })
+                })
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
 
+    // ── Memory links ────────────────────────────────────────────
+
     async fn upsert_link(&self, link: &MemoryLink) -> Result<()> {
-        let key = format!(
-            "{}:{}:{:?}",
-            link.source_id, link.target_id, link.link_type
-        );
-        let value = Self::serialize(link)?;
-        self.links
-            .insert(key.as_bytes(), value)
-            .map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-        Ok(())
+        let link = link.clone();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT INTO memory_links (source_id, target_id, link_type, weight, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(source_id, target_id, link_type) DO UPDATE SET
+                     weight = excluded.weight,
+                     created_at = excluded.created_at",
+                params![
+                    link.source_id.to_string(),
+                    link.target_id.to_string(),
+                    link_type_to_str(link.link_type),
+                    link.weight,
+                    link.created_at.to_rfc3339(),
+                ],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
     }
 
     async fn get_links_from(&self, source_id: Uuid) -> Result<Vec<MemoryLink>> {
-        let prefix = format!("{source_id}:");
-        let mut results = Vec::new();
-        for item in self.links.scan_prefix(prefix.as_bytes()) {
-            let (_, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            results.push(Self::deserialize(&value)?);
-        }
-        Ok(results)
+        let src_str = source_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT * FROM memory_links WHERE source_id = ?1")
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![src_str], |row| {
+                    let src: String = row.get("source_id")?;
+                    let tgt: String = row.get("target_id")?;
+                    let lt: String = row.get("link_type")?;
+                    let created_str: String = row.get("created_at")?;
+                    Ok(MemoryLink {
+                        source_id: Uuid::parse_str(&src).unwrap_or_default(),
+                        target_id: Uuid::parse_str(&tgt).unwrap_or_default(),
+                        link_type: str_to_link_type(&lt),
+                        weight: row.get("weight")?,
+                        created_at: DateTime::parse_from_rfc3339(&created_str)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                    })
+                })
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
+            }
+            Ok(results)
+        })
+        .await
     }
 
     async fn get_links_for(&self, memory_id: Uuid) -> Result<Vec<MemoryLink>> {
-        let mut results = Vec::new();
         let id_str = memory_id.to_string();
-        for item in self.links.iter() {
-            let (key, value) =
-                item.map_err(|e| rustykrab_core::Error::Storage(e.to_string()))?;
-            let key_str = String::from_utf8_lossy(&key);
-            if key_str.contains(&id_str) {
-                results.push(Self::deserialize(&value)?);
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT * FROM memory_links
+                     WHERE source_id = ?1 OR target_id = ?1",
+                )
+                .map_err(storage_err)?;
+            let rows = stmt
+                .query_map(params![id_str], |row| {
+                    let src: String = row.get("source_id")?;
+                    let tgt: String = row.get("target_id")?;
+                    let lt: String = row.get("link_type")?;
+                    let created_str: String = row.get("created_at")?;
+                    Ok(MemoryLink {
+                        source_id: Uuid::parse_str(&src).unwrap_or_default(),
+                        target_id: Uuid::parse_str(&tgt).unwrap_or_default(),
+                        link_type: str_to_link_type(&lt),
+                        weight: row.get("weight")?,
+                        created_at: DateTime::parse_from_rfc3339(&created_str)
+                            .map(|dt| dt.with_timezone(&Utc))
+                            .unwrap_or_else(|_| Utc::now()),
+                    })
+                })
+                .map_err(storage_err)?;
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(storage_err)?);
             }
-        }
-        Ok(results)
+            Ok(results)
+        })
+        .await
     }
+
+    // ── Bulk operations ─────────────────────────────────────────
 
     async fn batch_update_stages(
         &self,
         updates: &[(Uuid, LifecycleStage)],
     ) -> Result<u32> {
-        let mut count = 0u32;
-        for &(id, stage) in updates {
-            self.update_stage(id, stage).await?;
-            count += 1;
-        }
-        Ok(count)
+        let updates: Vec<(String, String)> = updates
+            .iter()
+            .map(|(id, stage)| (id.to_string(), lifecycle_to_str(*stage).to_string()))
+            .collect();
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(storage_err)?;
+            let mut count = 0u32;
+            {
+                let mut stmt = tx
+                    .prepare("UPDATE memories SET lifecycle_stage = ?2 WHERE id = ?1")
+                    .map_err(storage_err)?;
+                for (id_str, stage_str) in &updates {
+                    let affected = stmt
+                        .execute(params![id_str, stage_str])
+                        .map_err(storage_err)?;
+                    count += affected as u32;
+                }
+            }
+            tx.commit().map_err(storage_err)?;
+            Ok(count)
+        })
+        .await
     }
 }

--- a/crates/rustykrab-memory/src/types.rs
+++ b/crates/rustykrab-memory/src/types.rs
@@ -1,0 +1,202 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Lifecycle stage for memory promotion/demotion.
+///
+/// Memories progress through stages based on access patterns and value:
+/// Working → Episodic → Semantic (promoted) or Archival → Tombstone (demoted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleStage {
+    /// Active working memory for the current session.
+    Working,
+    /// Recent episodic memories from past conversations.
+    Episodic,
+    /// Consolidated long-term knowledge (promoted from episodic).
+    Semantic,
+    /// Low-value memories moved out of the hot retrieval set.
+    Archival,
+    /// Soft-deleted; retained for audit but excluded from all retrieval.
+    Tombstone,
+}
+
+impl LifecycleStage {
+    /// Whether this stage is included in the hot retrieval set.
+    pub fn is_retrievable(&self) -> bool {
+        matches!(self, Self::Working | Self::Episodic | Self::Semantic)
+    }
+}
+
+/// How the importance score was determined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportanceSource {
+    Heuristic,
+    Llm,
+    User,
+}
+
+/// A single memory record — the core unit of the memory system.
+///
+/// Stores verbatim content as the source of truth, with lifecycle metadata
+/// for value-driven retrieval and decay management.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Memory {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    pub content: String,
+    pub content_hash: String,
+
+    // Lifecycle
+    pub lifecycle_stage: LifecycleStage,
+
+    // Scoring
+    pub importance: f64,
+    pub importance_source: ImportanceSource,
+    pub decay_rate: f64,
+    pub confidence: f64,
+
+    // Access patterns
+    pub access_count: u32,
+    pub last_accessed_at: Option<DateTime<Utc>>,
+    pub last_relevant_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+
+    // Consolidation
+    pub parent_memory_ids: Vec<Uuid>,
+    pub consolidation_generation: u32,
+    pub proof_count: u32,
+
+    // Temporal context
+    pub occurred_start: Option<DateTime<Utc>>,
+    pub occurred_end: Option<DateTime<Utc>>,
+
+    // Soft delete
+    pub is_valid: bool,
+    pub invalidated_by: Option<Uuid>,
+    pub invalidated_at: Option<DateTime<Utc>>,
+
+    // Tags for backward compatibility with existing tag-based retrieval.
+    pub tags: Vec<String>,
+
+    // Free-form metadata.
+    pub metadata: serde_json::Value,
+}
+
+impl Memory {
+    /// Compute the effective retrieval score combining importance, temporal
+    /// decay, access pattern boost, and query similarity.
+    ///
+    /// Decay formula: `importance × e^(−effective_decay × idle_hours / 168)`
+    /// where `effective_decay = decay_rate × (1 − importance × 0.8)` so that
+    /// high-importance memories decay up to 5× slower.
+    pub fn effective_score(&self, query_similarity: f64, now: DateTime<Utc>) -> f64 {
+        let idle_hours = (now - self.last_accessed_at.unwrap_or(self.created_at))
+            .num_hours()
+            .unsigned_abs() as f64;
+
+        // High-importance memories decay up to 5× slower.
+        let effective_decay = self.decay_rate * (1.0 - self.importance * 0.8);
+        let temporal_decay = (-effective_decay * idle_hours / 168.0).exp();
+
+        // Each recall adds 2% boost, capped at 100% bonus.
+        let access_boost = 1.0 + (self.access_count.min(50) as f64) * 0.02;
+
+        self.importance * temporal_decay * access_boost * query_similarity
+    }
+}
+
+/// A chunk of a memory's content, embedded for vector retrieval.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryChunk {
+    pub id: Uuid,
+    pub memory_id: Uuid,
+    pub chunk_index: u32,
+    pub content: String,
+    pub embedding: Vec<f32>,
+    pub embedding_model_version: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A conversation turn as received from the agent loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationTurn {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub turn_number: u32,
+    pub speaker: String,
+    pub content: String,
+    pub token_count: Option<u32>,
+    pub metadata: TurnMetadata,
+}
+
+/// Metadata attached to a conversation turn for importance scoring.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TurnMetadata {
+    pub involves_tool_use: bool,
+    pub user_flagged: bool,
+    pub tags: Vec<String>,
+}
+
+/// An extracted fact (subject-predicate-object triple).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedFact {
+    pub id: Uuid,
+    pub source_memory_id: Uuid,
+    pub fact_type: String,
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    pub confidence: f64,
+    pub valid_from: DateTime<Utc>,
+    pub valid_to: Option<DateTime<Utc>>,
+    pub extraction_method: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A link between two memories (for graph-based retrieval).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryLink {
+    pub source_id: Uuid,
+    pub target_id: Uuid,
+    pub link_type: LinkType,
+    pub weight: f64,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Types of relationships between memories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkType {
+    /// Semantic similarity (cosine ≥ 0.7).
+    SemanticSimilar,
+    /// Shared entity co-occurrence.
+    EntityCooccurrence,
+    /// Causal/temporal chain.
+    CausalChain,
+    /// Consolidation parent-child.
+    Consolidation,
+    /// Contradiction between memories.
+    Contradicts,
+}
+
+/// Which retrieval strategy produced a result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RetrievalSource {
+    Semantic,
+    Keyword,
+    Graph,
+    Temporal,
+}
+
+/// A single result from the retrieval pipeline.
+#[derive(Debug, Clone)]
+pub struct RetrievalResult {
+    pub memory_id: Uuid,
+    pub content: String,
+    pub rrf_score: f64,
+    pub effective_score: f64,
+    pub sources: Vec<RetrievalSource>,
+    pub memory: Memory,
+}

--- a/crates/rustykrab-memory/src/writer.rs
+++ b/crates/rustykrab-memory/src/writer.rs
@@ -1,0 +1,215 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::bm25::Bm25Index;
+use crate::chunking::chunk_text;
+use crate::config::MemoryConfig;
+use crate::embedding::Embedder;
+use crate::extraction::RegexExtractor;
+use crate::scoring::compute_importance;
+use crate::storage::MemoryStorage;
+use crate::types::{
+    ConversationTurn, ImportanceSource, LifecycleStage, Memory, MemoryChunk,
+};
+
+/// Dual-track memory writer.
+///
+/// Track 1 (synchronous): Store verbatim content, chunk, embed, and index.
+/// Track 2 (asynchronous): Extract facts/entities in the background.
+///
+/// The write path never blocks on extraction — raw verbatim storage is
+/// always the synchronous, reliable path.
+pub struct MemoryWriter {
+    storage: Arc<dyn MemoryStorage>,
+    embedder: Arc<dyn Embedder>,
+    config: MemoryConfig,
+    /// Shared mutable BM25 index, protected by a tokio Mutex.
+    bm25_index: Arc<tokio::sync::Mutex<Bm25Index>>,
+}
+
+impl MemoryWriter {
+    pub fn new(
+        storage: Arc<dyn MemoryStorage>,
+        embedder: Arc<dyn Embedder>,
+        config: MemoryConfig,
+        bm25_index: Arc<tokio::sync::Mutex<Bm25Index>>,
+    ) -> Self {
+        Self {
+            storage,
+            embedder,
+            config,
+            bm25_index,
+        }
+    }
+
+    /// Retain a conversation turn in memory.
+    ///
+    /// 1. Dedup check via SHA-256 content hash.
+    /// 2. Store verbatim memory record (sync).
+    /// 3. Chunk, embed, and store chunk embeddings (sync).
+    /// 4. Index in BM25 (sync).
+    /// 5. Compute heuristic importance (sync).
+    /// 6. Spawn background extraction (async, never blocks).
+    ///
+    /// Returns the memory ID.
+    pub async fn retain(
+        &self,
+        turn: ConversationTurn,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<Uuid> {
+        // ── SHA-256 dedup ───────────────────────────────────────
+        let content_hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(turn.content.as_bytes());
+            hex::encode(hasher.finalize())
+        };
+
+        if let Some(existing) = self
+            .storage
+            .find_by_content_hash(agent_id, &content_hash)
+            .await?
+        {
+            debug!(memory_id = %existing.id, "exact duplicate, skipping write");
+            // Still record an access on the existing memory.
+            self.storage.record_access(existing.id).await?;
+            return Ok(existing.id);
+        }
+
+        // ── Track 1: Synchronous verbatim storage ───────────────
+        let importance = compute_importance(&turn.content, &turn.metadata);
+        let memory_id = Uuid::new_v4();
+        let now = Utc::now();
+
+        let memory = Memory {
+            id: memory_id,
+            agent_id,
+            content: turn.content.clone(),
+            content_hash,
+            lifecycle_stage: LifecycleStage::Episodic,
+            importance,
+            importance_source: ImportanceSource::Heuristic,
+            decay_rate: self.config.default_decay_rate,
+            confidence: 1.0,
+            access_count: 0,
+            last_accessed_at: None,
+            last_relevant_at: None,
+            created_at: now,
+            parent_memory_ids: Vec::new(),
+            consolidation_generation: 0,
+            proof_count: 1,
+            occurred_start: None,
+            occurred_end: None,
+            is_valid: true,
+            invalidated_by: None,
+            invalidated_at: None,
+            tags: turn.metadata.tags.clone(),
+            metadata: serde_json::json!({
+                "session_id": turn.session_id.to_string(),
+                "turn_number": turn.turn_number,
+                "speaker": turn.speaker,
+            }),
+        };
+
+        self.storage.upsert_memory(&memory).await?;
+
+        // ── Chunk + embed ───────────────────────────────────────
+        let chunk_texts = chunk_text(
+            &turn.content,
+            self.config.chunk_max_tokens,
+            self.config.chunk_overlap_ratio,
+        );
+
+        if !chunk_texts.is_empty() {
+            let embeddings = self.embedder.embed(chunk_texts.clone()).await?;
+            let model_version = self.embedder.model_version().to_string();
+
+            let chunks: Vec<MemoryChunk> = chunk_texts
+                .iter()
+                .zip(embeddings.iter())
+                .enumerate()
+                .map(|(i, (text, emb))| MemoryChunk {
+                    id: Uuid::new_v4(),
+                    memory_id,
+                    chunk_index: i as u32,
+                    content: text.clone(),
+                    embedding: emb.clone(),
+                    embedding_model_version: model_version.clone(),
+                    created_at: now,
+                })
+                .collect();
+
+            self.storage.store_chunks(&chunks).await?;
+        }
+
+        // ── BM25 index ─────────────────────────────────────────
+        {
+            let mut index = self.bm25_index.lock().await;
+            index.index_document(memory_id, &turn.content);
+        }
+
+        // ── Track 2: Async background extraction ────────────────
+        let storage = Arc::clone(&self.storage);
+        let content = turn.content.clone();
+        tokio::spawn(async move {
+            let facts = RegexExtractor::extract(&content, memory_id);
+            if !facts.is_empty() {
+                if let Err(e) = storage.store_facts(&facts).await {
+                    warn!(memory_id = %memory_id, error = %e, "background extraction failed");
+                }
+            }
+        });
+
+        debug!(
+            memory_id = %memory_id,
+            importance = importance,
+            chunks = chunk_texts.len(),
+            "memory retained"
+        );
+
+        Ok(memory_id)
+    }
+
+    /// Store a simple fact with tags (backward-compatible with the old
+    /// MemoryStore interface). Creates a memory record from the fact string.
+    pub async fn save_fact(
+        &self,
+        agent_id: Uuid,
+        session_id: Uuid,
+        fact: &str,
+        tags: &[String],
+    ) -> rustykrab_core::Result<Uuid> {
+        let turn = ConversationTurn {
+            id: Uuid::new_v4(),
+            session_id,
+            turn_number: 0,
+            speaker: "agent".to_string(),
+            content: fact.to_string(),
+            token_count: None,
+            metadata: crate::types::TurnMetadata {
+                tags: tags.to_vec(),
+                ..Default::default()
+            },
+        };
+        self.retain(turn, agent_id).await
+    }
+
+    /// Rebuild the BM25 index from all retrievable memories in storage.
+    /// Call this on startup to hydrate the in-memory index.
+    pub async fn rebuild_bm25_index(
+        &self,
+        agent_id: Uuid,
+    ) -> rustykrab_core::Result<usize> {
+        let memories = self.storage.list_retrievable(agent_id).await?;
+        let mut index = self.bm25_index.lock().await;
+        let count = memories.len();
+        for mem in memories {
+            index.index_document(mem.id, &mem.content);
+        }
+        debug!(agent_id = %agent_id, indexed = count, "BM25 index rebuilt");
+        Ok(count)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `rustykrab-memory` crate implementing a three-pillar agent memory architecture: verbatim storage, four-way parallel hybrid retrieval with RRF fusion, and value-driven lifecycle management
- Storage backed by SQLite (rusqlite, WAL mode) with proper indexes, replacing sled which is effectively unmaintained
- 25 unit tests covering BM25, chunking, embedding, extraction, and scoring; full workspace compiles clean

## Architecture

| Pillar | Implementation |
|--------|---------------|
| **Verbatim storage** | Dual-track writer: sync raw storage + SHA-256 dedup + chunking/embedding, async regex fact extraction |
| **Hybrid retrieval** | 4-way parallel via `tokio::join!` (semantic vectors, BM25, graph links, temporal) → weighted RRF fusion (k=60) → lifecycle-adjusted scoring |
| **Lifecycle management** | Importance-modulated exponential decay, sweep with promote/demote/tombstone stages |

## Modules

- **types** — Memory, MemoryChunk, ConversationTurn, LifecycleStage, RetrievalResult
- **writer** — Dual-track write path (sync verbatim + async extraction)
- **retrieval** — Parallel dispatch + RRF fusion pipeline
- **lifecycle** — Sweep, near-duplicate detection, embedding drift check
- **bm25** — In-process inverted index with BM25 scoring
- **embedding** — Pluggable Embedder trait + cosine similarity + test embedders
- **scoring** — Heuristic importance, RRF fusion, effective_score with decay
- **extraction** — Regex-based fact/entity extraction (zero LLM calls)
- **storage** — Async MemoryStorage trait + SQLite implementation (WAL mode, proper indexes, transaction batching)
- **backend** — HybridMemoryBackend adapter for tool system integration
- **config** — Tunable parameters for chunking, retrieval weights, lifecycle thresholds

## Deferred work

Tracked in `crates/rustykrab-memory/DEFERRED.md`. Key items: fastembed integration for real embeddings, gateway wiring, cross-encoder reranking, FTS5, LLM importance scoring, HNSW index.

## Test plan

- [x] `cargo test -p rustykrab-memory` — 25 tests pass
- [x] `cargo check --workspace` — full workspace compiles
- [ ] Integration test through full MemorySystem facade (tracked in DEFERRED.md)
- [ ] Gateway wiring + agent-level smoke test

https://claude.ai/code/session_01KF3dtaigfyU8WBiZVyPZ7n