### PR TITLE
Fix 8 critical bugs across security, safety, and correctness domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,7 @@ dependencies = [
  "chrono",
  "reqwest 0.12.28",
  "rustykrab-core",
+ "secrecy",
  "serde",
  "serde_json",
  "tracing",
@@ -2332,6 +2333,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ aes-gcm = "0.10"
 argon2 = "0.5"
 security-framework = { version = "3", features = ["OSX_10_15"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
+secrecy = "0.10"
 
 # Browser automation (Chrome DevTools Protocol)
 chromiumoxide = { version = "0.9", default-features = false }

--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -312,7 +312,7 @@ async fn execute_tool_for_subtask(
 
     ToolResult {
         call_id: call.id.clone(),
-        output: serde_json::json!({ "error": last_err.unwrap().to_string() }),
+        output: serde_json::json!({ "error": last_err.unwrap_or_else(|| rustykrab_core::Error::ToolExecution("all retries exhausted".into())).to_string() }),
     }
 }
 

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -857,7 +857,7 @@ async fn execute_with_retries(
             }
         }
     }
-    Err(last_err.unwrap())
+    Err(last_err.unwrap_or_else(|| rustykrab_core::Error::ToolExecution("all retries exhausted".into())))
 }
 
 /// Wrap string values in a JSON `Value` with adversarial-content markers.

--- a/crates/rustykrab-channels/src/webchat.rs
+++ b/crates/rustykrab-channels/src/webchat.rs
@@ -44,8 +44,9 @@ impl Channel for WebChatChannel {
     async fn receive(&self) -> Result<Message> {
         // We need &mut self for recv, but the trait takes &self.
         // In practice this will be wrapped in a Mutex or redesigned with streams.
-        // For now, provide the shape of the API.
-        unimplemented!("use WebChatHandle with a stream adapter in production")
+        Err(rustykrab_core::Error::Channel(
+            "WebChatChannel::receive() requires &mut self; use WebChatHandle with a stream adapter instead".into(),
+        ))
     }
 
     async fn send(&self, message: &Message) -> Result<()> {

--- a/crates/rustykrab-memory/src/chunking.rs
+++ b/crates/rustykrab-memory/src/chunking.rs
@@ -8,6 +8,15 @@ fn tokens_to_chars(tokens: usize) -> usize {
     (tokens as f64 * 3.5) as usize
 }
 
+/// Snap a byte offset forward to the nearest UTF-8 character boundary.
+fn snap_to_char_boundary(s: &str, offset: usize) -> usize {
+    let mut pos = offset.min(s.len());
+    while pos < s.len() && !s.is_char_boundary(pos) {
+        pos += 1;
+    }
+    pos
+}
+
 /// Split text into overlapping chunks of approximately `max_tokens` tokens
 /// with `overlap_ratio` fraction of overlap between consecutive chunks.
 ///
@@ -30,7 +39,7 @@ pub fn chunk_text(content: &str, max_tokens: usize, overlap_ratio: f64) -> Vec<S
     let mut start = 0;
 
     while start < content.len() {
-        let end = (start + max_chars).min(content.len());
+        let end = snap_to_char_boundary(content, (start + max_chars).min(content.len()));
 
         // Try to find a natural break point near the end boundary.
         let chunk_end = if end < content.len() {
@@ -47,7 +56,7 @@ pub fn chunk_text(content: &str, max_tokens: usize, overlap_ratio: f64) -> Vec<S
 
         // Advance by (chunk_size - overlap), but at least 1 char to avoid infinite loop.
         let advance = (chunk_end - start).saturating_sub(overlap_chars).max(1);
-        start += advance;
+        start = snap_to_char_boundary(content, start + advance);
     }
 
     chunks
@@ -56,7 +65,11 @@ pub fn chunk_text(content: &str, max_tokens: usize, overlap_ratio: f64) -> Vec<S
 /// Find the best break point near `target_end` by looking for sentence
 /// boundaries, then newlines, then word boundaries.
 fn find_break_point(content: &str, start: usize, target_end: usize) -> usize {
-    let search_start = start + (target_end - start) * 3 / 4; // Look in the last 25%
+    let search_start = snap_to_char_boundary(content, start + (target_end - start) * 3 / 4);
+    let target_end = snap_to_char_boundary(content, target_end);
+    if search_start >= target_end {
+        return target_end;
+    }
     let region = &content[search_start..target_end];
 
     // Prefer sentence boundaries (. ! ? followed by whitespace).

--- a/crates/rustykrab-providers/Cargo.toml
+++ b/crates/rustykrab-providers/Cargo.toml
@@ -14,3 +14,4 @@ serde_json.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+secrecy.workspace = true

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -6,6 +6,7 @@ use rustykrab_core::types::{
     Message, MessageContent, Role, ToolCall, ToolSchema,
 };
 use rustykrab_core::Error;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -16,7 +17,7 @@ use uuid::Uuid;
 /// agentic workloads due to superior prompt injection resistance.
 pub struct AnthropicProvider {
     client: reqwest::Client,
-    api_key: String,
+    api_key: SecretString,
     model: String,
     max_tokens: u32,
 }
@@ -25,7 +26,7 @@ impl AnthropicProvider {
     pub fn new(api_key: String) -> Self {
         Self {
             client: reqwest::Client::new(),
-            api_key,
+            api_key: SecretString::from(api_key),
             model: "claude-sonnet-4-20250514".to_string(),
             max_tokens: 4096,
         }
@@ -229,7 +230,7 @@ impl ModelProvider for AnthropicProvider {
         let resp = self
             .client
             .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &self.api_key)
+            .header("x-api-key", self.api_key.expose_secret())
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
             .json(&body)

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -70,7 +70,7 @@ impl Store {
 
     /// Return a handle for encrypted secret operations.
     pub fn secrets(&self) -> SecretStore {
-        SecretStore::new(self.secrets_tree.clone(), (*self.master_key).clone())
+        SecretStore::new(self.secrets_tree.clone(), self.master_key.clone())
     }
 
     /// Return a handle for conversation memory/RAG operations.

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -3,6 +3,8 @@ use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use argon2::Argon2;
 use rustykrab_core::Error;
 use rand::RngCore;
+use std::sync::Arc;
+use zeroize::Zeroizing;
 
 /// The salt length used for Argon2 key derivation.
 const SALT_LEN: usize = 16;
@@ -27,12 +29,12 @@ const NONCE_LEN: usize = 12;
 #[derive(Clone)]
 pub struct SecretStore {
     tree: sled::Tree,
-    master_key: Vec<u8>,
+    master_key: Arc<Zeroizing<Vec<u8>>>,
 }
 
 impl SecretStore {
-    pub(crate) fn new(tree: sled::Tree, master_key: Vec<u8>) -> Self {
-        Self { tree, master_key }
+    pub(crate) fn new(tree: sled::Tree, master_key: Zeroizing<Vec<u8>>) -> Self {
+        Self { tree, master_key: Arc::new(master_key) }
     }
 
     /// Store a secret value under the given name.

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -51,20 +51,6 @@ impl GmailTool {
         Ok((email, password))
     }
 
-    /// Connect to Gmail IMAP with TLS.
-    fn connect_imap(&self) -> Result<imap::Session<native_tls::TlsStream<std::net::TcpStream>>> {
-        let (email, password) = self.get_credentials()?;
-        let tls = native_tls::TlsConnector::builder()
-            .build()
-            .map_err(|e| Error::ToolExecution(format!("TLS setup failed: {e}").into()))?;
-        let client = imap::connect((IMAP_HOST, IMAP_PORT), IMAP_HOST, &tls)
-            .map_err(|e| Error::ToolExecution(format!("IMAP connect failed: {e}").into()))?;
-        let session = client
-            .login(&email, &password)
-            .map_err(|e| Error::ToolExecution(format!("IMAP login failed: {}", e.0).into()))?;
-        Ok(session)
-    }
-
     // -----------------------------------------------------------------------
     // Action: setup
     // -----------------------------------------------------------------------
@@ -85,8 +71,17 @@ impl GmailTool {
             .map_err(|e| Error::ToolExecution(format!("failed to store app password: {e}").into()))?;
 
         // Verify credentials by connecting to IMAP.
-        let mut session = self.connect_imap()?;
-        let _ = session.logout();
+        // IMAP is blocking — run in spawn_blocking to avoid blocking the tokio worker.
+        let email_owned = email.to_string();
+        let password_owned = app_password.to_string();
+        tokio::task::spawn_blocking(move || {
+            let mut session = connect_imap_blocking(&email_owned, &password_owned)?;
+            let _ = session.logout();
+            Ok::<(), Error>(())
+        })
+        .await
+        .map_err(|e| Error::ToolExecution(format!("spawn_blocking failed: {e}").into()))?
+        .map_err(|e: Error| e)?;
 
         Ok(json!({
             "status": "authenticated",

--- a/crates/rustykrab-tools/src/process.rs
+++ b/crates/rustykrab-tools/src/process.rs
@@ -1,7 +1,11 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Result, Tool};
 use serde_json::{json, Value};
+use tokio::sync::Mutex;
 
 /// Commands allowed to be started as background processes.
 const ALLOWED_PROCESS_COMMANDS: &[&str] = &[
@@ -15,11 +19,18 @@ const ALLOWED_PROCESS_COMMANDS: &[&str] = &[
 ///
 /// Security: Only allowlisted commands can be started as background
 /// processes. Shell metacharacters and command substitution are rejected.
-pub struct ProcessTool;
+///
+/// Spawned child handles are retained so they can be awaited/killed later,
+/// preventing zombie process leaks.
+pub struct ProcessTool {
+    children: Arc<Mutex<HashMap<u32, tokio::process::Child>>>,
+}
 
 impl ProcessTool {
     pub fn new() -> Self {
-        Self
+        Self {
+            children: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 }
 
@@ -133,6 +144,9 @@ impl Tool for ProcessTool {
                     )
                 })?;
 
+                // Retain the child handle to prevent zombie process leaks.
+                self.children.lock().await.insert(pid, child);
+
                 Ok(json!({
                     "action": "start",
                     "pid": pid,
@@ -152,6 +166,19 @@ impl Tool for ProcessTool {
                     ));
                 }
 
+                // Try to kill via the stored child handle first (cleans up zombie).
+                let pid_u32 = pid as u32;
+                if let Some(mut child) = self.children.lock().await.remove(&pid_u32) {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    return Ok(json!({
+                        "action": "stop",
+                        "pid": pid,
+                        "status": "terminated",
+                    }));
+                }
+
+                // Fallback to kill(1) for processes not tracked by us.
                 let output = tokio::process::Command::new("kill")
                     .arg(pid.to_string())
                     .output()

--- a/crates/rustykrab-tools/src/sessions_spawn.rs
+++ b/crates/rustykrab-tools/src/sessions_spawn.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -11,13 +12,20 @@ use super::session_manager::SessionManager;
 const MAX_SPAWN_DEPTH: u64 = 5;
 
 /// A tool that spawns a new sub-session with an optional system prompt.
+///
+/// Depth is tracked server-side via an atomic counter so clients cannot
+/// bypass the fork-bomb guard by omitting or resetting the `_depth` arg.
 pub struct SessionsSpawnTool {
     manager: Arc<dyn SessionManager>,
+    depth: Arc<AtomicU64>,
 }
 
 impl SessionsSpawnTool {
     pub fn new(manager: Arc<dyn SessionManager>) -> Self {
-        Self { manager }
+        Self {
+            manager,
+            depth: Arc::new(AtomicU64::new(0)),
+        }
     }
 }
 
@@ -54,23 +62,29 @@ impl Tool for SessionsSpawnTool {
     }
 
     async fn execute(&self, args: Value) -> Result<Value> {
-        // H7: Check current recursion depth before spawning
-        let current_depth = args["_depth"].as_u64().unwrap_or(0);
+        // H7: Server-side depth tracking — ignore client-provided _depth.
+        let current_depth = self.depth.load(Ordering::Acquire);
         if current_depth >= MAX_SPAWN_DEPTH {
             return Err(rustykrab_core::Error::ToolExecution(format!(
                 "maximum session spawn depth ({MAX_SPAWN_DEPTH}) exceeded"
             ).into()));
         }
 
-        let system_prompt = args["system_prompt"].as_str();
-        let capabilities = args["capabilities"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                    .collect::<Vec<String>>()
-            });
+        self.depth.fetch_add(1, Ordering::AcqRel);
+        let result = async {
+            let system_prompt = args["system_prompt"].as_str();
+            let capabilities = args["capabilities"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<String>>()
+                });
 
-        self.manager.spawn_session(system_prompt, capabilities).await
+            self.manager.spawn_session(system_prompt, capabilities).await
+        }.await;
+        self.depth.fetch_sub(1, Ordering::AcqRel);
+
+        result
     }
 }

--- a/crates/rustykrab-tools/src/subagents.rs
+++ b/crates/rustykrab-tools/src/subagents.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -11,13 +12,20 @@ use super::session_manager::SessionManager;
 const MAX_RECURSION_DEPTH: u64 = 5;
 
 /// A tool that runs a task using a specific sub-agent.
+///
+/// Depth is tracked server-side via an atomic counter so clients cannot
+/// bypass the fork-bomb guard by omitting or resetting the `_depth` arg.
 pub struct SubagentsTool {
     manager: Arc<dyn SessionManager>,
+    depth: Arc<AtomicU64>,
 }
 
 impl SubagentsTool {
     pub fn new(manager: Arc<dyn SessionManager>) -> Self {
-        Self { manager }
+        Self {
+            manager,
+            depth: Arc::new(AtomicU64::new(0)),
+        }
     }
 }
 
@@ -60,14 +68,18 @@ impl Tool for SubagentsTool {
             .as_str()
             .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing task".into()))?;
 
-        // H7: Check current recursion depth before spawning
-        let current_depth = args["_depth"].as_u64().unwrap_or(0);
+        // H7: Server-side depth tracking — ignore client-provided _depth.
+        let current_depth = self.depth.load(Ordering::Acquire);
         if current_depth >= MAX_RECURSION_DEPTH {
             return Err(rustykrab_core::Error::ToolExecution(format!(
                 "maximum agent recursion depth ({MAX_RECURSION_DEPTH}) exceeded"
             ).into()));
         }
 
-        self.manager.run_subagent(agent_id, task).await
+        self.depth.fetch_add(1, Ordering::AcqRel);
+        let result = self.manager.run_subagent(agent_id, task).await;
+        self.depth.fetch_sub(1, Ordering::AcqRel);
+
+        result
     }
 }


### PR DESCRIPTION
- #72: Replace unimplemented!() panic in WebChatChannel::receive() with proper error
- #73: Replace fragile last_err.unwrap() with unwrap_or_else in retry loops
- #91: Fix UTF-8 panics in chunk_text by snapping byte offsets to char boundaries
- #107: Retain spawned child handles in ProcessTool to prevent zombie process leaks
- #112: Track recursion depth server-side in sessions_spawn/subagents (ignore client _depth)
- #152: Keep master key in Zeroizing wrapper through SecretStore (Arc<Zeroizing<Vec<u8>>>)
- #172: Store API key as secrecy::SecretString instead of plain String
- #181: Wrap blocking IMAP connect in spawn_blocking in gmail action_setup

Closes #72, closes #73, closes #91, closes #107, closes #112, closes #152, closes #172, closes #181

https://claude.ai/code/session_019ugiQHRWcDxg7gsmn9Q3gs