### PR TITLE
Fix 17 error-handling issues across channels, gateway, agent, and tools

### DIFF
--- a/crates/rustykrab-agent/src/orchestrator/decomposer.rs
+++ b/crates/rustykrab-agent/src/orchestrator/decomposer.rs
@@ -114,8 +114,12 @@ impl Decomposer {
                 );
                 Ok(tasks)
             }
-            Ok(_) | Err(_) => {
-                tracing::debug!("decomposition failed or empty, wrapping as single task");
+            Ok(_) => {
+                tracing::warn!("decomposition returned empty task list, wrapping as single task");
+                Ok(vec![SubTask::new(user_request)])
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "decomposition failed, wrapping as single task");
                 Ok(vec![SubTask::new(user_request)])
             }
         }

--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -78,9 +78,9 @@ impl ParallelExecutor {
 
             // Execute all ready tasks concurrently, bounded by a semaphore
             // to prevent pathological workloads from spawning unbounded
-            // concurrent LLM calls (fixes ASYNC-M1).
+            // concurrent LLM calls.
             let semaphore = Arc::new(Semaphore::new(self.config.max_concurrent_tasks));
-            let mut handles = Vec::new();
+            let mut handles: Vec<(Uuid, _)> = Vec::new();
             for task in &ready {
                 // Gather dependency results as context.
                 let dep_context: Vec<String> = task
@@ -91,6 +91,7 @@ impl ParallelExecutor {
                     .map(|r| r.output.clone())
                     .collect();
 
+                let task_id = task.id;
                 let task = (*task).clone();
                 let provider = self.provider.clone();
                 let tools = self.tools.clone();
@@ -99,29 +100,45 @@ impl ParallelExecutor {
                 let sys_ctx = system_context.map(|s| s.to_string());
                 let sem = semaphore.clone();
 
-                handles.push(tokio::spawn(async move {
-                    let _permit = sem.acquire().await.expect("semaphore closed");
-                    execute_sub_task(
-                        &task,
-                        &dep_context,
-                        sys_ctx.as_deref(),
-                        &provider,
-                        &tools,
-                        &sandbox,
-                        &config,
-                    )
-                    .await
-                }));
+                handles.push((
+                    task_id,
+                    tokio::spawn(async move {
+                        let _permit = sem.acquire().await.expect("semaphore closed");
+                        execute_sub_task(
+                            &task,
+                            &dep_context,
+                            sys_ctx.as_deref(),
+                            &provider,
+                            &tools,
+                            &sandbox,
+                            &config,
+                        )
+                        .await
+                    }),
+                ));
             }
 
-            for handle in handles {
+            for (task_id, handle) in handles {
                 match handle.await {
                     Ok(result) => {
                         completed.insert(result.task_id);
                         results.insert(result.task_id, result);
                     }
                     Err(e) => {
-                        tracing::error!("sub-task panicked: {e}");
+                        tracing::error!(task_id = %task_id, "sub-task panicked: {e}");
+                        // Insert a failure result so downstream consumers know the
+                        // task failed rather than silently receiving incomplete results.
+                        completed.insert(task_id);
+                        results.insert(
+                            task_id,
+                            SubTaskResult {
+                                task_id,
+                                output: String::new(),
+                                success: false,
+                                error: Some(format!("task panicked: {e}")),
+                                tokens_used: 0,
+                            },
+                        );
                     }
                 }
             }

--- a/crates/rustykrab-agent/src/orchestrator/pipeline.rs
+++ b/crates/rustykrab-agent/src/orchestrator/pipeline.rs
@@ -107,7 +107,15 @@ impl OrchestrationPipeline {
 
         let schemas: Vec<_> = self.tools.iter().map(|t| t.schema()).collect();
         let response = self.provider.chat(&messages, &schemas).await?;
-        let text = response.message.content.as_text().unwrap_or("").to_string();
+        let text = match response.message.content.as_text() {
+            Some(t) => t.to_string(),
+            None => {
+                tracing::warn!(
+                    "model returned non-text response in direct pipeline, using empty string"
+                );
+                String::new()
+            }
+        };
 
         Ok(PipelineResult {
             response: text,
@@ -211,8 +219,10 @@ impl OrchestrationPipeline {
         for (i, r) in results.iter().enumerate() {
             if r.success {
                 // Truncate long outputs to keep the completion check cheap.
+                // Use floor_char_boundary to avoid splitting multi-byte UTF-8.
                 let output = if r.output.len() > 500 {
-                    format!("{}...", &r.output[..500])
+                    let end = r.output.floor_char_boundary(500);
+                    format!("{}...", &r.output[..end])
                 } else {
                     r.output.clone()
                 };
@@ -248,12 +258,15 @@ impl OrchestrationPipeline {
         });
 
         let response = self.provider.chat(&messages, &[]).await?;
-        let text = response
-            .message
-            .content
-            .as_text()
-            .unwrap_or("")
-            .to_uppercase();
+        let text = match response.message.content.as_text() {
+            Some(t) => t.to_uppercase(),
+            None => {
+                tracing::warn!(
+                    "model returned non-text response in completion check, assuming incomplete"
+                );
+                return Ok(false);
+            }
+        };
 
         Ok(text.contains("COMPLETE") && !text.contains("INCOMPLETE"))
     }

--- a/crates/rustykrab-agent/src/router.rs
+++ b/crates/rustykrab-agent/src/router.rs
@@ -133,15 +133,11 @@ impl HarnessRouter {
     }
 }
 
-/// Truncate a message for classification (first ~200 chars).
+/// Truncate a message for classification (first ~200 bytes, respecting
+/// UTF-8 char boundaries via `floor_char_boundary`).
 fn truncate_for_classification(text: &str) -> &str {
     if text.len() > 200 {
-        &text[..text
-            .char_indices()
-            .take_while(|(i, _)| *i < 200)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(200)]
+        &text[..text.floor_char_boundary(200)]
     } else {
         text
     }

--- a/crates/rustykrab-channels/src/signal.rs
+++ b/crates/rustykrab-channels/src/signal.rs
@@ -3,6 +3,9 @@ use rustykrab_core::types::{Message, MessageContent, Role};
 use rustykrab_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -34,6 +37,8 @@ pub struct SignalChannel {
     inbound_tx: mpsc::Sender<Message>,
     /// Receiver for inbound messages (consumed by the agent loop).
     inbound_rx: Option<mpsc::Receiver<Message>>,
+    /// Graceful shutdown flag.
+    shutdown_flag: Arc<AtomicBool>,
 }
 
 impl SignalChannel {
@@ -44,14 +49,20 @@ impl SignalChannel {
     /// - `allowed_numbers`: set of phone numbers allowed to message the bot
     pub fn new(base_url: String, account_number: String, allowed_numbers: HashSet<String>) -> Self {
         let (tx, rx) = mpsc::channel(256);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("failed to build HTTP client");
         Self {
-            client: reqwest::Client::new(),
+            client,
             base_url,
             account_number,
             allowed_numbers,
             webhook_secret: None,
             inbound_tx: tx,
             inbound_rx: Some(rx),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -64,6 +75,11 @@ impl SignalChannel {
     /// Take the inbound receiver (can only be called once).
     pub fn take_inbound_rx(&mut self) -> Option<mpsc::Receiver<Message>> {
         self.inbound_rx.take()
+    }
+
+    /// Request graceful shutdown of the polling loop.
+    pub fn shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::Relaxed);
     }
 
     /// Send a text message to a Signal recipient.
@@ -122,7 +138,7 @@ impl SignalChannel {
         Ok(())
     }
 
-    /// Start polling for incoming messages. Runs forever — spawn as a task.
+    /// Start polling for incoming messages. Runs until `shutdown()` is called.
     ///
     /// Uses the signal-cli-rest-api `/v1/receive` endpoint which returns
     /// pending messages and marks them as read.
@@ -134,6 +150,11 @@ impl SignalChannel {
         );
 
         loop {
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                tracing::info!("Signal polling shutdown requested");
+                return Ok(());
+            }
+
             match self.poll_once().await {
                 Ok(count) => {
                     if count > 0 {
@@ -142,12 +163,12 @@ impl SignalChannel {
                 }
                 Err(e) => {
                     tracing::error!("Signal polling error: {e}");
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
 
             // signal-cli-rest-api doesn't support long-polling, so we poll on an interval.
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -5,6 +5,9 @@ use rustykrab_core::{Error, Result};
 use serde::Deserialize;
 use sha2::Sha256;
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -44,6 +47,8 @@ pub struct TelegramChannel {
     inbound_tx: mpsc::Sender<ChannelMessage>,
     /// Receiver for inbound messages (consumed by the agent loop).
     inbound_rx: Option<mpsc::Receiver<ChannelMessage>>,
+    /// Graceful shutdown flag.
+    shutdown_flag: Arc<AtomicBool>,
 }
 
 impl TelegramChannel {
@@ -53,14 +58,20 @@ impl TelegramChannel {
     /// `allowed_chats` restricts which Telegram chats can use the bot.
     pub fn new(bot_token: String, allowed_chats: HashSet<i64>) -> Self {
         let (tx, rx) = mpsc::channel(256);
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("failed to build HTTP client");
         Self {
-            client: reqwest::Client::new(),
+            client,
             api_base: format!("https://api.telegram.org/bot{bot_token}"),
             bot_token,
             allowed_chats,
             webhook_secret: None,
             inbound_tx: tx,
             inbound_rx: Some(rx),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -74,6 +85,11 @@ impl TelegramChannel {
     /// The agent loop reads from this to get user messages.
     pub fn take_inbound_rx(&mut self) -> Option<mpsc::Receiver<ChannelMessage>> {
         self.inbound_rx.take()
+    }
+
+    /// Request graceful shutdown of the polling loop.
+    pub fn shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::Relaxed);
     }
 
     /// Send a "typing" chat action so the user sees the bot is working.
@@ -215,6 +231,11 @@ impl TelegramChannel {
         tracing::info!("Telegram long-polling started");
 
         loop {
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                tracing::info!("Telegram polling shutdown requested");
+                return Ok(());
+            }
+
             let url = format!("{}/getUpdates", self.api_base);
             let mut params = vec![("timeout", "30".to_string())];
             if let Some(off) = offset {
@@ -436,8 +457,8 @@ impl TelegramChannel {
             Error::Config("no webhook secret configured for HMAC verification".into())
         })?;
 
-        let mut mac =
-            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key size");
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+            .map_err(|e| Error::Config(format!("invalid HMAC key: {e}")))?;
         mac.update(payload);
 
         let expected = hex::decode(signature_hex)
@@ -476,8 +497,18 @@ fn split_message(text: &str, max_len: usize) -> Vec<String> {
             break;
         }
 
+        // Find the nearest char boundary at or before max_len to avoid
+        // panicking on multi-byte UTF-8 characters.
+        let safe_end = remaining.floor_char_boundary(max_len);
+        if safe_end == 0 {
+            // Single character larger than max_len (shouldn't happen with
+            // reasonable limits, but handle gracefully).
+            chunks.push(remaining.to_string());
+            break;
+        }
+
         // Find the best split point within the limit.
-        let window = &remaining[..max_len];
+        let window = &remaining[..safe_end];
         let split_at = find_split_point(window);
 
         chunks.push(remaining[..split_at].trim_end().to_string());

--- a/crates/rustykrab-gateway/src/rate_limit.rs
+++ b/crates/rustykrab-gateway/src/rate_limit.rs
@@ -85,14 +85,17 @@ impl RateLimiter {
         record.attempts.push(now);
 
         // Prune stale entries to prevent unbounded memory growth.
-        // Only evict a limited batch per call to avoid iterating the
-        // entire HashMap under the lock (fixes ASYNC-M2).
-        if records.len() > 10_000 {
-            let stale_cutoff = now - (self.config.lockout * 2);
+        // Use a lower threshold (1000) to keep memory usage reasonable,
+        // and only evict a limited batch per call to avoid iterating the
+        // entire HashMap under the lock.
+        if records.len() > 1_000 {
+            let stale_cutoff = now - self.config.window * 2;
             let stale_keys: Vec<IpAddr> = records
                 .iter()
                 .filter(|(_, rec)| {
+                    // Stale if lockout expired (or never locked).
                     let locked_expired = rec.locked_until.map(|l| l <= now).unwrap_or(true);
+                    // Stale if no recent activity.
                     let no_recent = rec
                         .attempts
                         .last()

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -191,6 +191,7 @@ async fn send_message_stream(
     // streaming agent are surfaced instead of silently swallowed when
     // the JoinHandle is dropped (fixes ASYNC-H4).
     let agent_state = state.clone();
+    let panic_tx = tx.clone();
     let agent_handle = tokio::spawn(async move {
         let heartbeat = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
             std::time::SystemTime::now()
@@ -210,7 +211,9 @@ async fn send_message_stream(
                     .as_millis() as u64,
                 std::sync::atomic::Ordering::Relaxed,
             );
-            let _ = event_tx.try_send(SsePayload::Event(event));
+            if let Err(e) = event_tx.try_send(SsePayload::Event(event)) {
+                tracing::warn!("SSE event dropped (channel full): {e}");
+            }
         };
 
         // Heartbeat monitor: checks every 30s if we've gone 5 minutes without an event.
@@ -253,18 +256,22 @@ async fn send_message_stream(
             // Agent completed normally; monitor task will be dropped.
         }
 
-        // Persist conversation on success.
-        if result.is_ok() {
-            conv.updated_at = Utc::now();
-            let _ = agent_state.store.conversations().save(&conv);
+        // Persist conversation regardless of outcome to preserve the user message.
+        conv.updated_at = Utc::now();
+        if let Err(e) = agent_state.store.conversations().save(&conv) {
+            tracing::error!("failed to save conversation: {e}");
         }
 
         let _ = tx.send(SsePayload::Done(result)).await;
     });
-    // Spawn a lightweight watcher that logs if the agent task panics.
+    // Spawn a lightweight watcher that logs if the agent task panics
+    // and sends an error event to the client so the result is not silently lost.
     tokio::spawn(async move {
         if let Err(e) = agent_handle.await {
             tracing::error!("streaming agent task panicked: {e}");
+            let _ = panic_tx
+                .send(SsePayload::Done(Err(StatusCode::INTERNAL_SERVER_ERROR)))
+                .await;
         }
     });
 

--- a/crates/rustykrab-tools/src/canvas.rs
+++ b/crates/rustykrab-tools/src/canvas.rs
@@ -86,6 +86,14 @@ impl Tool for CanvasTool {
                             )
                         })?;
 
+                    if !resp.status().is_success() {
+                        let status = resp.status();
+                        let err = resp.text().await.unwrap_or_default();
+                        return Err(rustykrab_core::Error::ToolExecution(
+                            format!("canvas present API returned {status}: {err}").into(),
+                        ));
+                    }
+
                     let body = resp.text().await.map_err(|e| {
                         rustykrab_core::Error::ToolExecution(
                             format!("failed to read response: {e}").into(),
@@ -133,6 +141,14 @@ impl Tool for CanvasTool {
                         )
                     })?;
 
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let err = resp.text().await.unwrap_or_default();
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        format!("canvas evaluate API returned {status}: {err}").into(),
+                    ));
+                }
+
                 let body = resp.text().await.map_err(|e| {
                     rustykrab_core::Error::ToolExecution(
                         format!("failed to read response: {e}").into(),
@@ -163,6 +179,14 @@ impl Tool for CanvasTool {
                             format!("canvas snapshot failed: {e}").into(),
                         )
                     })?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let err = resp.text().await.unwrap_or_default();
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        format!("canvas snapshot API returned {status}: {err}").into(),
+                    ));
+                }
 
                 let body = resp.text().await.map_err(|e| {
                     rustykrab_core::Error::ToolExecution(

--- a/crates/rustykrab-tools/src/tts.rs
+++ b/crates/rustykrab-tools/src/tts.rs
@@ -96,6 +96,14 @@ impl Tool for TtsTool {
             rustykrab_core::Error::ToolExecution(format!("TTS request failed: {e}").into())
         })?;
 
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_default();
+            return Err(rustykrab_core::Error::ToolExecution(
+                format!("TTS API returned {status}: {err}").into(),
+            ));
+        }
+
         let audio_bytes = resp.bytes().await.map_err(|e| {
             rustykrab_core::Error::ToolExecution(format!("failed to read TTS response: {e}").into())
         })?;


### PR DESCRIPTION
## Summary

Fixes all 17 open issues labeled `error-handling`, spanning 10 files across 5 crates. Changes are grouped by severity.

### High Priority (8 issues)

| Issue | ID | Fix |
|-------|-----|-----|
| #75 | ERR-H1 | **Verified**: Anthropic provider already has 300s request + 10s connect timeout |
| #77 | ERR-H2 | **Verified**: Ollama provider already has 300s request + 10s connect timeout |
| #78 | ERR-H3 | Add 30s request timeout + 10s connect timeout to Signal channel `reqwest::Client` |
| #80 | ERR-H4 | Add 60s request timeout + 10s connect timeout to Telegram channel `reqwest::Client` |
| #82 | ERR-H5 | Insert failure `SubTaskResult` for panicked tasks in executor + monitor spawned SSE agent task for panics |
| #83 | ERR-H6 | Add `shutdown()` method + `AtomicBool` flag to Signal polling loop for graceful stop |
| #85 | ERR-H7 | Add `shutdown()` method + `AtomicBool` flag to Telegram polling loop for graceful stop |
| #87 | ERR-H8 | Replace `expect("HMAC accepts any key size")` with `map_err(...)` in `verify_hmac()` |

### Medium Priority (8 issues)

| Issue | ID | Fix |
|-------|-----|-----|
| #89 | ERR-M1 | Log decomposer errors at `warn` level with error details instead of silent `debug` fallback |
| #92 | ERR-M2 | Warn when model returns non-text response instead of hiding with `unwrap_or("")` |
| #95 | ERR-M3 | Save conversation regardless of agent outcome (was only saved on success, losing user messages on error) |
| #98 | ERR-M4 | Log warning when SSE events are dropped due to channel overflow (was `let _ = try_send`) |
| #101 | ERR-M5 | Lower rate limiter pruning threshold from 10,000 to 1,000 entries; tighten stale-entry logic |
| #104 | ERR-M6 | Use `floor_char_boundary()` in `truncate_for_classification` to avoid splitting UTF-8 |
| #108 | ERR-M7 | Use `floor_char_boundary()` in Telegram `split_message` to prevent panic on multi-byte chars |
| #111 | ERR-M8 | Use `floor_char_boundary()` in pipeline `check_completion` truncation |

### Low Priority (1 issue)

| Issue | ID | Fix |
|-------|-----|-----|
| #116 | ERR-L1 | Add HTTP status checks to all 3 canvas actions (`present`, `evaluate`, `snapshot`) and TTS tool |

## Files Changed (10 files, 5 crates)

- `crates/rustykrab-channels/src/signal.rs` — timeout, graceful shutdown
- `crates/rustykrab-channels/src/telegram.rs` — timeout, graceful shutdown, HMAC fix, UTF-8 split
- `crates/rustykrab-gateway/src/routes.rs` — panic monitoring, conversation save, SSE overflow logging
- `crates/rustykrab-gateway/src/rate_limit.rs` — lower pruning threshold
- `crates/rustykrab-agent/src/orchestrator/decomposer.rs` — error logging
- `crates/rustykrab-agent/src/orchestrator/pipeline.rs` — non-text response handling, UTF-8 truncation
- `crates/rustykrab-agent/src/orchestrator/executor.rs` — insert failure result for panicked sub-tasks
- `crates/rustykrab-agent/src/router.rs` — UTF-8 safe truncation
- `crates/rustykrab-tools/src/canvas.rs` — HTTP status checks
- `crates/rustykrab-tools/src/tts.rs` — HTTP status check

## Test plan

- [x] `cargo check` passes
- [x] All 53 existing tests pass (`cargo test`)
- [ ] Manual: verify Signal/Telegram channel timeout behavior with a slow/unreachable endpoint
- [ ] Manual: verify graceful shutdown via `channel.shutdown()` stops polling loops
- [ ] Manual: verify SSE stream receives error event when agent task panics
- [ ] Manual: send multi-byte UTF-8 message exceeding 4096 chars through Telegram to confirm no panic
- [ ] Manual: verify panicked sub-task produces a failure SubTaskResult visible in pipeline output

Closes #75, #77, #78, #80, #82, #83, #85, #87, #89, #92, #95, #98, #101, #104, #108, #111, #116

https://claude.ai/code/session_014EonxjLiZnbqbr3QBvhG3n