### PR TITLE
Fix all 11 provider issues: streaming, error handling, serialization, and API compliance

### DIFF
--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -286,6 +286,7 @@ async fn execute_tool_for_subtask(
             return ToolResult {
                 call_id: call.id.clone(),
                 output: serde_json::json!({ "error": format!("unknown tool: {}", call.name) }),
+                is_error: true,
             };
         }
     };
@@ -309,6 +310,7 @@ async fn execute_tool_for_subtask(
         return ToolResult {
             call_id: call.id.clone(),
             output: serde_json::json!({ "error": format!("sandbox denied tool '{}': {e}", call.name) }),
+            is_error: true,
         };
     }
 
@@ -319,6 +321,7 @@ async fn execute_tool_for_subtask(
                 return ToolResult {
                     call_id: call.id.clone(),
                     output,
+                    is_error: false,
                 };
             }
             Err(e) => {
@@ -341,6 +344,7 @@ async fn execute_tool_for_subtask(
     ToolResult {
         call_id: call.id.clone(),
         output: serde_json::json!({ "error": last_err.unwrap_or_else(|| rustykrab_core::Error::ToolExecution("all retries exhausted".into())).to_string() }),
+        is_error: true,
     }
 }
 

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -183,6 +183,7 @@ impl AgentRunner {
                 message,
                 usage,
                 stop_reason,
+                ..
             } = self.provider.chat(&conv.messages, &schemas).await?;
             let llm_elapsed = llm_start.elapsed();
             tracing::info!(
@@ -265,6 +266,7 @@ impl AgentRunner {
                                 content: MessageContent::ToolResult(ToolResult {
                                     call_id,
                                     output: serde_json::json!({ "error": err_str }),
+                                    is_error: true,
                                 }),
                                 created_at: Utc::now(),
                             }
@@ -378,6 +380,7 @@ impl AgentRunner {
                 message,
                 usage,
                 stop_reason,
+                ..
             } = self
                 .provider
                 .chat_stream(&conv.messages, &schemas, &stream_callback)
@@ -466,6 +469,7 @@ impl AgentRunner {
                                 content: MessageContent::ToolResult(ToolResult {
                                     call_id: call_id.clone(),
                                     output: serde_json::json!({ "error": err_str }),
+                                    is_error: true,
                                 }),
                                 created_at: Utc::now(),
                             };
@@ -982,6 +986,7 @@ async fn execute_single_tool(
     Ok(ToolResult {
         call_id: call.id.clone(),
         output,
+        is_error: false,
     })
 }
 

--- a/crates/rustykrab-core/src/error.rs
+++ b/crates/rustykrab-core/src/error.rs
@@ -106,6 +106,18 @@ pub enum Error {
     #[error("model provider error: {0}")]
     ModelProvider(String),
 
+    #[error("model provider rate limited: {0}")]
+    ModelRateLimit(String),
+
+    #[error("model provider authentication failed: {0}")]
+    ModelAuthError(String),
+
+    #[error("model provider bad request: {0}")]
+    ModelBadRequest(String),
+
+    #[error("model provider overloaded: {0}")]
+    ModelOverloaded(String),
+
     #[error("tool execution error: {0}")]
     ToolExecution(ToolError),
 

--- a/crates/rustykrab-core/src/model.rs
+++ b/crates/rustykrab-core/src/model.rs
@@ -10,6 +10,10 @@ pub struct ModelResponse {
     pub usage: Usage,
     /// The stop reason from the model — tells us if there are more tool calls.
     pub stop_reason: StopReason,
+    /// Text content returned alongside tool calls in a mixed response.
+    /// When the model returns both reasoning text and tool_use blocks,
+    /// the tool calls go into `message.content` and the text is preserved here.
+    pub text: Option<String>,
 }
 
 /// Why the model stopped generating.
@@ -28,6 +32,10 @@ pub enum StopReason {
 pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
+    /// Tokens read from the prompt cache (Anthropic).
+    pub cache_read_tokens: u32,
+    /// Tokens written into the prompt cache (Anthropic).
+    pub cache_creation_tokens: u32,
 }
 
 /// A chunk of a streaming response.

--- a/crates/rustykrab-core/src/types.rs
+++ b/crates/rustykrab-core/src/types.rs
@@ -77,6 +77,10 @@ pub struct ToolCall {
 pub struct ToolResult {
     pub call_id: String,
     pub output: serde_json::Value,
+    /// Whether the tool execution failed. Sent as `is_error` to providers
+    /// so the model knows to interpret the output as an error message.
+    #[serde(default)]
+    pub is_error: bool,
 }
 
 /// A conversation is an ordered sequence of messages.

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use rustykrab_core::error::Result;
-use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, Usage};
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
 use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolSchema};
 use rustykrab_core::Error;
 use secrecy::{ExposeSecret, SecretString};
@@ -52,7 +52,9 @@ impl AnthropicProvider {
     }
 
     /// Convert our internal messages to Anthropic API format.
-    fn build_messages(messages: &[Message]) -> (Option<String>, Vec<ApiMessage>) {
+    ///
+    /// Returns an error if tool result serialization fails (#195).
+    fn build_messages(messages: &[Message]) -> Result<(Option<String>, Vec<ApiMessage>)> {
         let mut system_prompt = None;
         let mut api_messages = Vec::new();
 
@@ -67,7 +69,9 @@ impl AnthropicProvider {
                     if let MessageContent::Text(ref text) = msg.content {
                         api_messages.push(ApiMessage {
                             role: "user".to_string(),
-                            content: ApiContent::Text(text.clone()),
+                            content: ApiContent::Blocks(vec![ContentBlock::Text {
+                                text: text.clone(),
+                            }]),
                         });
                     }
                 }
@@ -75,7 +79,9 @@ impl AnthropicProvider {
                     MessageContent::Text(ref text) => {
                         api_messages.push(ApiMessage {
                             role: "assistant".to_string(),
-                            content: ApiContent::Text(text.clone()),
+                            content: ApiContent::Blocks(vec![ContentBlock::Text {
+                                text: text.clone(),
+                            }]),
                         });
                     }
                     MessageContent::ToolCall(ref call) => {
@@ -106,11 +112,19 @@ impl AnthropicProvider {
                 },
                 Role::Tool => {
                     if let MessageContent::ToolResult(ref result) = msg.content {
+                        // Fix #182: avoid double-serialization of string values.
+                        // Fix #195: propagate serialization errors instead of swallowing them.
+                        let content = match &result.output {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => serde_json::to_string(other).map_err(Error::Serialization)?,
+                        };
                         api_messages.push(ApiMessage {
                             role: "user".to_string(),
                             content: ApiContent::Blocks(vec![ContentBlock::ToolResult {
                                 tool_use_id: result.call_id.clone(),
-                                content: serde_json::to_string(&result.output).unwrap_or_default(),
+                                content,
+                                // Fix #207: pass is_error flag to model.
+                                is_error: result.is_error,
                             }]),
                         });
                     }
@@ -118,7 +132,7 @@ impl AnthropicProvider {
             }
         }
 
-        (system_prompt, api_messages)
+        Ok((system_prompt, api_messages))
     }
 
     /// Convert tool schemas to Anthropic's tool format.
@@ -135,10 +149,14 @@ impl AnthropicProvider {
 
     /// Parse the API response into our internal types.
     /// Supports multiple tool calls in a single response (parallel tool use).
+    /// Fix #190: preserves text content alongside tool calls.
     fn parse_response(resp: ApiResponse) -> Result<ModelResponse> {
         let usage = Usage {
             prompt_tokens: resp.usage.input_tokens,
             completion_tokens: resp.usage.output_tokens,
+            // Fix #203: capture cache token fields from Anthropic response.
+            cache_read_tokens: resp.usage.cache_read_input_tokens.unwrap_or(0),
+            cache_creation_tokens: resp.usage.cache_creation_input_tokens.unwrap_or(0),
         };
 
         let stop_reason = match resp.stop_reason.as_deref() {
@@ -161,7 +179,19 @@ impl AnthropicProvider {
             })
             .collect();
 
-        // If there are tool calls, return them (single or multi).
+        // Fix #190: always extract text blocks, even when tool calls are present.
+        let text: String = resp
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ResponseBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        // If there are tool calls, return them (single or multi),
+        // preserving any accompanying text in `response.text`.
         if !tool_calls.is_empty() {
             let content = if tool_calls.len() == 1 {
                 MessageContent::ToolCall(tool_calls.into_iter().next().unwrap())
@@ -178,19 +208,9 @@ impl AnthropicProvider {
                 },
                 usage,
                 stop_reason,
+                text: if text.is_empty() { None } else { Some(text) },
             });
         }
-
-        // Otherwise, extract text.
-        let text = resp
-            .content
-            .iter()
-            .filter_map(|b| match b {
-                ResponseBlock::Text { text } => Some(text.as_str()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("");
 
         Ok(ModelResponse {
             message: Message {
@@ -201,7 +221,19 @@ impl AnthropicProvider {
             },
             usage,
             stop_reason,
+            text: None,
         })
+    }
+
+    /// Map an HTTP status code to a specific error variant (#186).
+    fn map_status_error(status: reqwest::StatusCode, body: &str) -> Error {
+        match status.as_u16() {
+            400 => Error::ModelBadRequest(format!("Anthropic API: {body}")),
+            401 | 403 => Error::ModelAuthError(format!("Anthropic API: {body}")),
+            429 => Error::ModelRateLimit(format!("Anthropic API: {body}")),
+            529 => Error::ModelOverloaded(format!("Anthropic API: {body}")),
+            _ => Error::ModelProvider(format!("Anthropic API returned {status}: {body}")),
+        }
     }
 }
 
@@ -212,7 +244,15 @@ impl ModelProvider for AnthropicProvider {
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
-        let (system, api_messages) = Self::build_messages(messages);
+        let (system, api_messages) = Self::build_messages(messages)?;
+
+        // Fix #200: validate that the message list is not empty before calling the API.
+        if api_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call Anthropic API with an empty message list".into(),
+            ));
+        }
+
         let api_tools = Self::build_tools(tools);
 
         let mut body = serde_json::json!({
@@ -221,8 +261,9 @@ impl ModelProvider for AnthropicProvider {
             "messages": api_messages,
         });
 
+        // Fix #178: use array format for system parameter to enable prompt caching.
         if let Some(sys) = system {
-            body["system"] = serde_json::json!(sys);
+            body["system"] = serde_json::json!([{"type": "text", "text": sys}]);
         }
         if !api_tools.is_empty() {
             body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
@@ -266,9 +307,8 @@ impl ModelProvider for AnthropicProvider {
 
             let error_body = resp.text().await.unwrap_or_default();
             let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
-            last_err = Some(Error::ModelProvider(format!(
-                "Anthropic API returned {status}: {error_body}"
-            )));
+            // Fix #186: map status codes to specific error variants.
+            last_err = Some(Self::map_status_error(status, &error_body));
 
             if !is_retryable {
                 break;
@@ -276,6 +316,224 @@ impl ModelProvider for AnthropicProvider {
         }
 
         Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    }
+
+    /// Fix #175: streaming implementation using Anthropic SSE.
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        let (system, api_messages) = Self::build_messages(messages)?;
+
+        if api_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call Anthropic API with an empty message list".into(),
+            ));
+        }
+
+        let api_tools = Self::build_tools(tools);
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": api_messages,
+            "stream": true,
+        });
+
+        if let Some(sys) = system {
+            body["system"] = serde_json::json!([{"type": "text", "text": sys}]);
+        }
+        if !api_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
+        }
+
+        tracing::debug!(model = %self.model, "calling Anthropic Messages API (streaming)");
+
+        let resp = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", self.api_key.expose_secret())
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::ModelProvider(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(Self::map_status_error(status, &error_body));
+        }
+
+        // Parse SSE events from the response body.
+        let mut buffer = String::new();
+        let mut current_event_type = String::new();
+        let mut full_text = String::new();
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        // Per-block accumulators for tool input JSON (keyed by block index).
+        let mut tool_input_bufs: std::collections::HashMap<usize, String> =
+            std::collections::HashMap::new();
+        let mut tool_meta: std::collections::HashMap<usize, (String, String)> =
+            std::collections::HashMap::new();
+        let mut input_tokens: u32 = 0;
+        let mut output_tokens: u32 = 0;
+        let mut cache_read_tokens: u32 = 0;
+        let mut cache_creation_tokens: u32 = 0;
+        let mut stop_reason = StopReason::EndTurn;
+
+        let mut response = resp;
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
+        {
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(newline_pos) = buffer.find('\n') {
+                let line = buffer[..newline_pos].trim_end().to_string();
+                buffer = buffer[newline_pos + 1..].to_string();
+
+                if line.starts_with("event: ") {
+                    current_event_type = line[7..].to_string();
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    match current_event_type.as_str() {
+                        "message_start" => {
+                            if let Ok(evt) =
+                                serde_json::from_str::<SseMessageStart>(data)
+                            {
+                                input_tokens = evt.message.usage.input_tokens;
+                                cache_read_tokens = evt
+                                    .message
+                                    .usage
+                                    .cache_read_input_tokens
+                                    .unwrap_or(0);
+                                cache_creation_tokens = evt
+                                    .message
+                                    .usage
+                                    .cache_creation_input_tokens
+                                    .unwrap_or(0);
+                            }
+                        }
+                        "content_block_start" => {
+                            if let Ok(evt) =
+                                serde_json::from_str::<SseContentBlockStart>(data)
+                            {
+                                if let SseContentBlock::ToolUse { id, name } =
+                                    evt.content_block
+                                {
+                                    tool_meta.insert(evt.index, (id, name));
+                                    tool_input_bufs
+                                        .insert(evt.index, String::new());
+                                }
+                            }
+                        }
+                        "content_block_delta" => {
+                            if let Ok(evt) =
+                                serde_json::from_str::<SseContentBlockDelta>(data)
+                            {
+                                match evt.delta {
+                                    SseDelta::TextDelta { text } => {
+                                        full_text.push_str(&text);
+                                        on_event(StreamEvent::TextDelta(text));
+                                    }
+                                    SseDelta::InputJsonDelta { partial_json } => {
+                                        if let Some(buf) =
+                                            tool_input_bufs.get_mut(&evt.index)
+                                        {
+                                            buf.push_str(&partial_json);
+                                        }
+                                    }
+                                    SseDelta::Unknown => {}
+                                }
+                            }
+                        }
+                        "content_block_stop" => {
+                            // Finalize any tool call whose input is now complete.
+                            if let Ok(evt) =
+                                serde_json::from_str::<SseContentBlockStop>(data)
+                            {
+                                if let Some(json_buf) =
+                                    tool_input_bufs.remove(&evt.index)
+                                {
+                                    if let Some((id, name)) =
+                                        tool_meta.remove(&evt.index)
+                                    {
+                                        let input: serde_json::Value =
+                                            serde_json::from_str(&json_buf)
+                                                .unwrap_or(serde_json::Value::Object(
+                                                    Default::default(),
+                                                ));
+                                        tool_calls.push(ToolCall {
+                                            id,
+                                            name,
+                                            arguments: input,
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        "message_delta" => {
+                            if let Ok(evt) =
+                                serde_json::from_str::<SseMessageDelta>(data)
+                            {
+                                output_tokens = evt.usage.output_tokens;
+                                stop_reason = match evt.delta.stop_reason.as_deref()
+                                {
+                                    Some("tool_use") => StopReason::ToolUse,
+                                    Some("max_tokens") => StopReason::MaxTokens,
+                                    _ => StopReason::EndTurn,
+                                };
+                            }
+                        }
+                        _ => {} // message_stop, ping, etc.
+                    }
+                }
+                // Blank lines and other lines are ignored.
+            }
+        }
+
+        let usage = Usage {
+            prompt_tokens: input_tokens,
+            completion_tokens: output_tokens,
+            cache_read_tokens,
+            cache_creation_tokens,
+        };
+
+        let (content, text_field) = if !tool_calls.is_empty() {
+            let tc = if tool_calls.len() == 1 {
+                MessageContent::ToolCall(tool_calls.into_iter().next().unwrap())
+            } else {
+                MessageContent::MultiToolCall(tool_calls)
+            };
+            (
+                tc,
+                if full_text.is_empty() {
+                    None
+                } else {
+                    Some(full_text)
+                },
+            )
+        } else {
+            (MessageContent::Text(full_text), None)
+        };
+
+        let response = ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content,
+                created_at: Utc::now(),
+            },
+            usage,
+            stop_reason,
+            text: text_field,
+        };
+
+        on_event(StreamEvent::Done(response.clone()));
+        Ok(response)
     }
 }
 
@@ -290,13 +548,14 @@ struct ApiMessage {
 #[derive(Serialize)]
 #[serde(untagged)]
 enum ApiContent {
-    Text(String),
     Blocks(Vec<ContentBlock>),
 }
 
 #[derive(Serialize)]
 #[serde(tag = "type")]
 enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
     #[serde(rename = "tool_use")]
     ToolUse {
         id: String,
@@ -307,7 +566,14 @@ enum ContentBlock {
     ToolResult {
         tool_use_id: String,
         content: String,
+        /// Fix #207: signal tool execution errors to the model.
+        #[serde(skip_serializing_if = "is_false")]
+        is_error: bool,
     },
+}
+
+fn is_false(v: &bool) -> bool {
+    !v
 }
 
 #[derive(Serialize)]
@@ -325,6 +591,7 @@ struct ApiResponse {
     stop_reason: Option<String>,
 }
 
+/// Fix #206: added Unknown catch-all so new block types don't crash deserialization.
 #[derive(Deserialize)]
 #[serde(tag = "type")]
 enum ResponseBlock {
@@ -336,10 +603,86 @@ enum ResponseBlock {
         name: String,
         input: serde_json::Value,
     },
+    /// Catch-all for any block type not yet handled (e.g. future API additions).
+    #[serde(other)]
+    Unknown,
 }
 
+/// Fix #203: added cache token fields.
 #[derive(Deserialize)]
 struct ApiUsage {
     input_tokens: u32,
+    output_tokens: u32,
+    #[serde(default)]
+    cache_read_input_tokens: Option<u32>,
+    #[serde(default)]
+    cache_creation_input_tokens: Option<u32>,
+}
+
+// --- Streaming SSE types ---
+
+#[derive(Deserialize)]
+struct SseMessageStart {
+    message: SseMessageMeta,
+}
+
+#[derive(Deserialize)]
+struct SseMessageMeta {
+    usage: ApiUsage,
+}
+
+#[derive(Deserialize)]
+struct SseContentBlockStart {
+    index: usize,
+    content_block: SseContentBlock,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+#[allow(dead_code)]
+enum SseContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse { id: String, name: String },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct SseContentBlockDelta {
+    index: usize,
+    delta: SseDelta,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum SseDelta {
+    #[serde(rename = "text_delta")]
+    TextDelta { text: String },
+    #[serde(rename = "input_json_delta")]
+    InputJsonDelta { partial_json: String },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct SseContentBlockStop {
+    index: usize,
+}
+
+#[derive(Deserialize)]
+struct SseMessageDelta {
+    delta: SseMessageDeltaInfo,
+    usage: SseDeltaUsage,
+}
+
+#[derive(Deserialize)]
+struct SseMessageDeltaInfo {
+    stop_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SseDeltaUsage {
     output_tokens: u32,
 }

--- a/crates/rustykrab-providers/src/lib.rs
+++ b/crates/rustykrab-providers/src/lib.rs
@@ -2,4 +2,4 @@ mod anthropic;
 mod ollama;
 
 pub use anthropic::AnthropicProvider;
-pub use ollama::OllamaProvider;
+pub use ollama::{OllamaConfig, OllamaProvider};

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use rustykrab_core::error::Result;
-use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, Usage};
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
 use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolSchema};
 use rustykrab_core::Error;
 use serde::{Deserialize, Serialize};
@@ -107,7 +107,8 @@ impl OllamaProvider {
         &self.model
     }
 
-    fn build_messages(messages: &[Message]) -> Vec<OllamaMessage> {
+    /// Fix #195: returns Result to propagate serialization errors.
+    fn build_messages(messages: &[Message]) -> Result<Vec<OllamaMessage>> {
         messages
             .iter()
             .map(|msg| {
@@ -118,7 +119,7 @@ impl OllamaProvider {
                     Role::Tool => "tool",
                 };
 
-                match &msg.content {
+                Ok(match &msg.content {
                     MessageContent::Text(text) => OllamaMessage {
                         role: role.to_string(),
                         content: Some(text.clone()),
@@ -149,12 +150,22 @@ impl OllamaProvider {
                                 .collect(),
                         ),
                     },
-                    MessageContent::ToolResult(result) => OllamaMessage {
-                        role: role.to_string(),
-                        content: Some(serde_json::to_string(&result.output).unwrap_or_default()),
-                        tool_calls: None,
-                    },
-                }
+                    MessageContent::ToolResult(result) => {
+                        // Fix #182: avoid double-serialization of string values.
+                        // Fix #195: propagate serialization errors.
+                        let content = match &result.output {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => {
+                                serde_json::to_string(other).map_err(Error::Serialization)?
+                            }
+                        };
+                        OllamaMessage {
+                            role: role.to_string(),
+                            content: Some(content),
+                            tool_calls: None,
+                        }
+                    }
+                })
             })
             .collect()
     }
@@ -190,6 +201,12 @@ impl OllamaProvider {
     fn parse_response(resp: OllamaResponse) -> Result<ModelResponse> {
         let msg = resp.message;
 
+        // Fix #192: parse done_reason to detect truncation.
+        let stop_reason = match resp.done_reason.as_deref() {
+            Some("length") => StopReason::MaxTokens,
+            _ => StopReason::EndTurn, // "stop" or absent → normal end
+        };
+
         // Collect all tool calls.
         if let Some(tool_calls) = msg.tool_calls {
             if !tool_calls.is_empty() {
@@ -218,8 +235,10 @@ impl OllamaProvider {
                     usage: Usage {
                         prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
                         completion_tokens: resp.eval_count.unwrap_or(0),
+                        ..Default::default()
                     },
                     stop_reason: StopReason::ToolUse,
+                    text: None,
                 });
             }
         }
@@ -234,9 +253,21 @@ impl OllamaProvider {
             usage: Usage {
                 prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
                 completion_tokens: resp.eval_count.unwrap_or(0),
+                ..Default::default()
             },
-            stop_reason: StopReason::EndTurn,
+            stop_reason,
+            text: None,
         })
+    }
+
+    /// Map an HTTP status code to a specific error variant (#186).
+    fn map_status_error(status: reqwest::StatusCode, body: &str) -> Error {
+        match status.as_u16() {
+            400 => Error::ModelBadRequest(format!("Ollama API: {body}")),
+            401 | 403 => Error::ModelAuthError(format!("Ollama API: {body}")),
+            429 => Error::ModelRateLimit(format!("Ollama API: {body}")),
+            _ => Error::ModelProvider(format!("Ollama API returned {status}: {body}")),
+        }
     }
 }
 
@@ -247,7 +278,15 @@ impl ModelProvider for OllamaProvider {
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
-        let ollama_messages = Self::build_messages(messages);
+        let ollama_messages = Self::build_messages(messages)?;
+
+        // Fix #200: validate non-empty messages.
+        if ollama_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call Ollama API with an empty message list".into(),
+            ));
+        }
+
         let ollama_tools = Self::build_tools(tools);
 
         let mut body = serde_json::json!({
@@ -299,9 +338,8 @@ impl ModelProvider for OllamaProvider {
 
             let error_body = resp.text().await.unwrap_or_default();
             let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
-            last_err = Some(Error::ModelProvider(format!(
-                "Ollama API returned {status}: {error_body}"
-            )));
+            // Fix #186: map status codes to specific error variants.
+            last_err = Some(Self::map_status_error(status, &error_body));
 
             if !is_retryable {
                 break;
@@ -309,6 +347,158 @@ impl ModelProvider for OllamaProvider {
         }
 
         Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    }
+
+    /// Fix #175: streaming implementation using Ollama NDJSON.
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        let ollama_messages = Self::build_messages(messages)?;
+
+        if ollama_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call Ollama API with an empty message list".into(),
+            ));
+        }
+
+        let ollama_tools = Self::build_tools(tools);
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": ollama_messages,
+            "stream": true,
+            "options": {
+                "temperature": self.config.temperature,
+                "num_ctx": self.config.num_ctx,
+                "top_p": self.config.top_p,
+                "num_predict": self.config.num_predict,
+            },
+        });
+
+        if !ollama_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&ollama_tools).map_err(Error::Serialization)?;
+        }
+
+        tracing::debug!(model = %self.model, base_url = %self.base_url, "calling Ollama chat API (streaming)");
+
+        let url = format!("{}/api/chat", self.base_url);
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                Error::ModelProvider(format!(
+                    "failed to connect to Ollama at {}: {e}. Is Ollama running?",
+                    self.base_url
+                ))
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(Self::map_status_error(status, &error_body));
+        }
+
+        // Parse newline-delimited JSON chunks.
+        let mut buffer = String::new();
+        let mut full_text = String::new();
+        let mut tool_calls: Vec<ToolCall> = Vec::new();
+        let mut prompt_eval_count: u32 = 0;
+        let mut eval_count: u32 = 0;
+        let mut done_reason: Option<String> = None;
+
+        let mut response = resp;
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
+        {
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(newline_pos) = buffer.find('\n') {
+                let line = buffer[..newline_pos].trim().to_string();
+                buffer = buffer[newline_pos + 1..].to_string();
+
+                if line.is_empty() {
+                    continue;
+                }
+
+                let stream_chunk: OllamaStreamChunk =
+                    serde_json::from_str(&line).map_err(|e| {
+                        Error::ModelProvider(format!(
+                            "failed to parse Ollama stream chunk: {e}"
+                        ))
+                    })?;
+
+                if let Some(ref content) = stream_chunk.message.content {
+                    if !content.is_empty() {
+                        full_text.push_str(content);
+                        on_event(StreamEvent::TextDelta(content.clone()));
+                    }
+                }
+
+                // Collect tool calls from the final chunk.
+                if let Some(tcs) = stream_chunk.message.tool_calls {
+                    for tc in tcs {
+                        tool_calls.push(ToolCall {
+                            id: Uuid::new_v4().to_string(),
+                            name: tc.function.name,
+                            arguments: Self::normalize_arguments(tc.function.arguments),
+                        });
+                    }
+                }
+
+                if stream_chunk.done {
+                    prompt_eval_count = stream_chunk.prompt_eval_count.unwrap_or(0);
+                    eval_count = stream_chunk.eval_count.unwrap_or(0);
+                    done_reason = stream_chunk.done_reason;
+                }
+            }
+        }
+
+        let stop_reason = if !tool_calls.is_empty() {
+            StopReason::ToolUse
+        } else {
+            match done_reason.as_deref() {
+                Some("length") => StopReason::MaxTokens,
+                _ => StopReason::EndTurn,
+            }
+        };
+
+        let content = if !tool_calls.is_empty() {
+            if tool_calls.len() == 1 {
+                MessageContent::ToolCall(tool_calls.into_iter().next().unwrap())
+            } else {
+                MessageContent::MultiToolCall(tool_calls)
+            }
+        } else {
+            MessageContent::Text(full_text)
+        };
+
+        let response = ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content,
+                created_at: Utc::now(),
+            },
+            usage: Usage {
+                prompt_tokens: prompt_eval_count,
+                completion_tokens: eval_count,
+                ..Default::default()
+            },
+            stop_reason,
+            text: None,
+        };
+
+        on_event(StreamEvent::Done(response.clone()));
+        Ok(response)
     }
 }
 
@@ -352,10 +542,33 @@ struct OllamaResponse {
     message: OllamaResponseMessage,
     prompt_eval_count: Option<u32>,
     eval_count: Option<u32>,
+    /// Fix #192: parse done_reason to detect truncation.
+    #[serde(default)]
+    done_reason: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct OllamaResponseMessage {
     content: Option<String>,
+    tool_calls: Option<Vec<OllamaToolCall>>,
+}
+
+/// Streaming chunk from Ollama's NDJSON response.
+#[derive(Deserialize)]
+struct OllamaStreamChunk {
+    message: OllamaStreamMessage,
+    done: bool,
+    #[serde(default)]
+    done_reason: Option<String>,
+    #[serde(default)]
+    prompt_eval_count: Option<u32>,
+    #[serde(default)]
+    eval_count: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct OllamaStreamMessage {
+    content: Option<String>,
+    #[serde(default)]
     tool_calls: Option<Vec<OllamaToolCall>>,
 }


### PR DESCRIPTION
Resolves #175, #178, #182, #186, #190, #192, #195, #200, #203, #206, #207

HIGH priority fixes:
- #175 (H1): Implement SSE streaming for Anthropic and NDJSON streaming for Ollama
- #178 (H2): Use array format for Anthropic system parameter to enable prompt caching
- #182 (H3): Fix tool result double-serialization by handling string values directly
- #186 (H4): Differentiate API errors into ModelRateLimit, ModelAuthError,
  ModelBadRequest, ModelOverloaded instead of opaque ModelProvider
- #190 (H5): Preserve text content alongside tool calls in mixed responses
  via new ModelResponse.text field

MEDIUM priority fixes:
- #192 (M1): Parse Ollama done_reason field to detect truncation (MaxTokens)
- #195 (M2): Propagate serialization errors instead of silently swallowing
  them with unwrap_or_default()
- #200 (M3): Validate message list is non-empty before making API calls
- #203 (M4): Capture cache_read_input_tokens and cache_creation_input_tokens
  from Anthropic responses into Usage struct

LOW priority fixes:
- #206 (L1): Add #[serde(other)] catch-all variant to ResponseBlock so new
  Anthropic block types don't crash deserialization
- #207 (L2): Add is_error flag to ToolResult and pass it to Anthropic API
  in tool_result content blocks

https://claude.ai/code/session_016Yjr5oeM2smbpegjbpbyKv