### PR TITLE
Add video as a communication channel via hyperframes MCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dirs",
  "hex",
  "hmac",
  "reqwest",
@@ -2411,6 +2412,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-native-certs",
+ "rustykrab-channels",
  "rustykrab-core",
  "rustykrab-store",
  "serde",

--- a/crates/rustykrab-channels/Cargo.toml
+++ b/crates/rustykrab-channels/Cargo.toml
@@ -18,3 +18,4 @@ reqwest.workspace = true
 hmac.workspace = true
 sha2.workspace = true
 hex.workspace = true
+dirs = "6"

--- a/crates/rustykrab-channels/src/lib.rs
+++ b/crates/rustykrab-channels/src/lib.rs
@@ -1,9 +1,13 @@
 mod channel;
+pub mod mcp;
 pub mod signal;
 pub mod telegram;
+pub mod video;
 mod webchat;
 
 pub use channel::Channel;
+pub use mcp::McpClient;
 pub use signal::SignalChannel;
 pub use telegram::{ChannelMessage, TelegramChannel};
+pub use video::{VideoChannel, VideoConfig};
 pub use webchat::{web_chat_pair, WebChatChannel, WebChatHandle};

--- a/crates/rustykrab-channels/src/mcp.rs
+++ b/crates/rustykrab-channels/src/mcp.rs
@@ -1,0 +1,410 @@
+//! Lightweight MCP (Model Context Protocol) client over stdio.
+//!
+//! Speaks JSON-RPC 2.0 to a child process's stdin/stdout. Designed to be
+//! transport-agnostic but currently implements the stdio transport used by
+//! most MCP servers (including hyperframes).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing;
+
+/// A single MCP tool definition returned by `tools/list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolDef {
+    pub name: String,
+    pub description: Option<String>,
+    #[serde(default, rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+/// Content block returned by `tools/call`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub data: Option<String>,
+    #[serde(rename = "mimeType", default)]
+    pub mime_type: Option<String>,
+}
+
+/// Result of a `tools/call` invocation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpToolResult {
+    pub content: Vec<McpContent>,
+    #[serde(default, rename = "isError")]
+    pub is_error: bool,
+}
+
+/// Server capabilities returned during initialization.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ServerCapabilities {
+    #[serde(default)]
+    pub tools: Option<Value>,
+    #[serde(default)]
+    pub resources: Option<Value>,
+    #[serde(default)]
+    pub prompts: Option<Value>,
+}
+
+/// Result of MCP `initialize` handshake.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: String,
+    #[serde(default)]
+    pub capabilities: ServerCapabilities,
+    #[serde(default, rename = "serverInfo")]
+    pub server_info: Option<Value>,
+}
+
+// -- Internal JSON-RPC types --
+
+#[derive(Serialize)]
+struct JsonRpcRequest {
+    jsonrpc: &'static str,
+    id: u64,
+    method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<Value>,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcResponse {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    id: Option<u64>,
+    result: Option<Value>,
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcError {
+    code: i64,
+    message: String,
+    #[allow(dead_code)]
+    data: Option<Value>,
+}
+
+type PendingMap = HashMap<u64, oneshot::Sender<Result<Value, String>>>;
+
+/// MCP client that communicates with a child process over stdio.
+pub struct McpClient {
+    /// Channel to send raw JSON lines to the writer task.
+    write_tx: mpsc::Sender<String>,
+    /// Monotonically increasing request ID.
+    next_id: AtomicU64,
+    /// Pending requests awaiting responses.
+    pending: Arc<Mutex<PendingMap>>,
+    /// Handle to the child process (for lifecycle management).
+    child: Mutex<Option<Child>>,
+    /// Cached tool definitions after `tools/list`.
+    tools: Mutex<Vec<McpToolDef>>,
+}
+
+impl McpClient {
+    /// Spawn an MCP server process and perform the `initialize` handshake.
+    ///
+    /// `command` is the program to run (e.g. "npx"), `args` are its arguments
+    /// (e.g. `["hyperframes", "mcp"]`), and `env` provides additional
+    /// environment variables for the child process.
+    pub async fn spawn(
+        command: &str,
+        args: &[&str],
+        env: &[(&str, &str)],
+    ) -> Result<Self, String> {
+        let mut cmd = Command::new(command);
+        cmd.args(args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("failed to spawn MCP server `{command}`: {e}"))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("MCP server has no stdout")?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or("MCP server has no stdin")?;
+
+        let pending: Arc<Mutex<PendingMap>> = Arc::new(Mutex::new(HashMap::new()));
+
+        // Writer task: serializes JSON lines to child stdin.
+        let (write_tx, mut write_rx) = mpsc::channel::<String>(64);
+        let mut stdin = stdin;
+        tokio::spawn(async move {
+            while let Some(line) = write_rx.recv().await {
+                if let Err(e) = stdin.write_all(line.as_bytes()).await {
+                    tracing::error!("MCP write error: {e}");
+                    break;
+                }
+                if let Err(e) = stdin.write_all(b"\n").await {
+                    tracing::error!("MCP write newline error: {e}");
+                    break;
+                }
+                if let Err(e) = stdin.flush().await {
+                    tracing::error!("MCP flush error: {e}");
+                    break;
+                }
+            }
+        });
+
+        // Reader task: reads JSON lines from child stdout and dispatches.
+        let pending_reader = pending.clone();
+        let reader = BufReader::new(stdout);
+        tokio::spawn(async move {
+            let mut lines = reader.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim().to_string();
+                        if line.is_empty() {
+                            continue;
+                        }
+                        match serde_json::from_str::<JsonRpcResponse>(&line) {
+                            Ok(resp) => {
+                                if let Some(id) = resp.id {
+                                    let mut map = pending_reader.lock().await;
+                                    if let Some(tx) = map.remove(&id) {
+                                        let result = if let Some(err) = resp.error {
+                                            Err(format!(
+                                                "MCP error {}: {}",
+                                                err.code, err.message
+                                            ))
+                                        } else {
+                                            Ok(resp.result.unwrap_or(Value::Null))
+                                        };
+                                        let _ = tx.send(result);
+                                    }
+                                }
+                                // Notifications (no id) are logged but not dispatched.
+                            }
+                            Err(e) => {
+                                tracing::trace!(
+                                    "MCP non-JSON line (parse error: {e}): {line}"
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::info!("MCP server stdout closed");
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::error!("MCP read error: {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        let client = Self {
+            write_tx,
+            next_id: AtomicU64::new(1),
+            pending,
+            child: Mutex::new(Some(child)),
+            tools: Mutex::new(Vec::new()),
+        };
+
+        // Perform the MCP initialize handshake.
+        let init_params = serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "rustykrab",
+                "version": "0.1.0"
+            }
+        });
+
+        let init_result = client.request("initialize", Some(init_params)).await?;
+        let _init: InitializeResult = serde_json::from_value(init_result)
+            .map_err(|e| format!("failed to parse initialize result: {e}"))?;
+
+        // Send initialized notification (no id, no response expected).
+        client.notify("notifications/initialized", None).await?;
+
+        tracing::info!("MCP client initialized");
+
+        Ok(client)
+    }
+
+    /// Send a JSON-RPC request and wait for the response.
+    pub async fn request(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id,
+            method: method.to_string(),
+            params,
+        };
+
+        let line = serde_json::to_string(&req)
+            .map_err(|e| format!("failed to serialize request: {e}"))?;
+
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut map = self.pending.lock().await;
+            map.insert(id, tx);
+        }
+
+        self.write_tx
+            .send(line)
+            .await
+            .map_err(|e| format!("failed to send to MCP writer: {e}"))?;
+
+        match tokio::time::timeout(std::time::Duration::from_secs(120), rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err("MCP response channel dropped".to_string()),
+            Err(_) => {
+                // Clean up the pending entry on timeout.
+                let mut map = self.pending.lock().await;
+                map.remove(&id);
+                Err("MCP request timed out (120s)".to_string())
+            }
+        }
+    }
+
+    /// Send a JSON-RPC notification (no id, no response expected).
+    pub async fn notify(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(), String> {
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params.unwrap_or(Value::Object(serde_json::Map::new()))
+        });
+
+        let line = serde_json::to_string(&notification)
+            .map_err(|e| format!("failed to serialize notification: {e}"))?;
+
+        self.write_tx
+            .send(line)
+            .await
+            .map_err(|e| format!("failed to send notification: {e}"))?;
+
+        Ok(())
+    }
+
+    /// List available tools from the MCP server.
+    pub async fn list_tools(&self) -> Result<Vec<McpToolDef>, String> {
+        let result = self.request("tools/list", None).await?;
+
+        #[derive(Deserialize)]
+        struct ToolsList {
+            tools: Vec<McpToolDef>,
+        }
+
+        let list: ToolsList = serde_json::from_value(result)
+            .map_err(|e| format!("failed to parse tools/list: {e}"))?;
+
+        // Cache the tools.
+        let mut cached = self.tools.lock().await;
+        *cached = list.tools.clone();
+
+        Ok(list.tools)
+    }
+
+    /// Call a tool on the MCP server.
+    pub async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+    ) -> Result<McpToolResult, String> {
+        let params = serde_json::json!({
+            "name": name,
+            "arguments": arguments
+        });
+
+        let result = self.request("tools/call", Some(params)).await?;
+
+        serde_json::from_value(result)
+            .map_err(|e| format!("failed to parse tools/call result: {e}"))
+    }
+
+    /// Get cached tool definitions (call `list_tools` first).
+    pub async fn cached_tools(&self) -> Vec<McpToolDef> {
+        self.tools.lock().await.clone()
+    }
+
+    /// Gracefully shut down the MCP server.
+    pub async fn shutdown(&self) {
+        // Try to send a clean shutdown if the server supports it.
+        let _ = self.notify("notifications/cancelled", None).await;
+
+        let mut child = self.child.lock().await;
+        if let Some(mut c) = child.take() {
+            // Give the process a moment to exit cleanly.
+            tokio::select! {
+                _ = c.wait() => {},
+                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                    tracing::warn!("MCP server did not exit cleanly, killing");
+                    let _ = c.kill().await;
+                }
+            }
+        }
+    }
+
+    /// Check if the child process is still running.
+    pub async fn is_alive(&self) -> bool {
+        let mut child = self.child.lock().await;
+        match child.as_mut() {
+            Some(c) => c.try_wait().ok().flatten().is_none(),
+            None => false,
+        }
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        // Best-effort synchronous kill on drop.
+        if let Ok(mut guard) = self.child.try_lock() {
+            if let Some(ref mut c) = *guard {
+                let _ = c.start_kill();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_rpc_request_serializes() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list".to_string(),
+            params: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"jsonrpc\":\"2.0\""));
+        assert!(json.contains("\"method\":\"tools/list\""));
+        assert!(!json.contains("params"));
+    }
+}

--- a/crates/rustykrab-channels/src/video.rs
+++ b/crates/rustykrab-channels/src/video.rs
@@ -1,9 +1,18 @@
-//! Video communication channel powered by Hyperframes via MCP.
+//! Video communication channel powered by Hyperframes.
 //!
 //! Treats video as a first-class mode of communication: the agent can
 //! respond to users by composing HTML-based video compositions and rendering
-//! them to MP4 files. Internally manages the hyperframes MCP server process
-//! and provides the full pipeline: compose → preview → render.
+//! them to MP4 files. Uses the hyperframes CLI (`npx hyperframes`) as the
+//! primary rendering engine, with optional MCP server support for advanced
+//! operations.
+//!
+//! Hyperframes compositions are HTML documents with semantic data attributes:
+//! - `data-start` — playhead position in seconds
+//! - `data-duration` — element visibility window
+//! - `data-track` — layer ordering (compositing depth)
+//! - `data-volume` — audio level normalization
+//!
+//! The rendering pipeline: HTML composition → Puppeteer (frame capture) → FFmpeg → MP4
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -23,8 +32,14 @@ pub struct VideoConfig {
     pub projects_dir: PathBuf,
     /// Path to the `npx` binary (defaults to "npx").
     pub npx_path: String,
-    /// Additional environment variables for the MCP server process.
+    /// Render quality: "draft", "standard", or "high".
+    pub default_quality: String,
+    /// Default output format: "mp4" or "webm".
+    pub default_format: String,
+    /// Additional environment variables for child processes.
     pub env: Vec<(String, String)>,
+    /// Whether to attempt MCP connection for advanced operations.
+    pub mcp_enabled: bool,
 }
 
 impl Default for VideoConfig {
@@ -37,7 +52,10 @@ impl Default for VideoConfig {
         Self {
             projects_dir: data_dir,
             npx_path: "npx".to_string(),
+            default_quality: "standard".to_string(),
+            default_format: "mp4".to_string(),
             env: Vec::new(),
+            mcp_enabled: false,
         }
     }
 }
@@ -70,14 +88,14 @@ pub struct RenderResult {
     pub duration: f64,
     /// File size in bytes.
     pub size: u64,
-    /// Format (always "mp4" for now).
+    /// Format ("mp4" or "webm").
     pub format: String,
 }
 
 /// An element in a video composition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompositionElement {
-    /// Element type: "text", "image", "video", "audio", "shape".
+    /// Element type: "text", "image", "video", "audio", "shape", "html".
     #[serde(rename = "type")]
     pub element_type: String,
     /// Unique element ID within the composition.
@@ -93,17 +111,28 @@ pub struct CompositionElement {
     pub properties: Value,
 }
 
+/// Result of running `hyperframes doctor` — environment readiness.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoctorResult {
+    pub node_ok: bool,
+    pub ffmpeg_ok: bool,
+    pub chrome_ok: bool,
+    pub raw_output: String,
+}
+
 /// The video communication channel.
 ///
-/// Manages the hyperframes MCP server lifecycle and provides methods for
-/// composing and rendering video content. Like Telegram sends text or
-/// Signal sends encrypted messages, VideoChannel communicates via video.
+/// Manages the hyperframes CLI and optional MCP server to provide video
+/// as a mode of communication. Like Telegram sends text or Signal sends
+/// encrypted messages, VideoChannel communicates via video.
 pub struct VideoChannel {
     config: VideoConfig,
-    /// MCP client connection to the hyperframes server.
+    /// Optional MCP client for advanced operations.
     mcp: Arc<Mutex<Option<McpClient>>>,
-    /// Available MCP tools (cached after first connection).
+    /// Cached MCP tool definitions.
     available_tools: Mutex<Vec<McpToolDef>>,
+    /// Whether the environment has been verified.
+    env_checked: Mutex<bool>,
 }
 
 impl VideoChannel {
@@ -113,6 +142,7 @@ impl VideoChannel {
             config,
             mcp: Arc::new(Mutex::new(None)),
             available_tools: Mutex::new(Vec::new()),
+            env_checked: Mutex::new(false),
         }
     }
 
@@ -125,57 +155,41 @@ impl VideoChannel {
         "video"
     }
 
-    /// Ensure the MCP server is running and connected.
-    /// Lazily starts the server on first use.
-    pub async fn ensure_connected(&self) -> Result<(), String> {
-        let mut mcp_guard = self.mcp.lock().await;
+    /// Run `hyperframes doctor` to verify the environment (Node >= 22, FFmpeg, Chrome).
+    pub async fn check_environment(&self) -> Result<DoctorResult, String> {
+        let output = self
+            .run_npx(&["hyperframes", "doctor"], None)
+            .await?;
 
-        // Check if already connected and alive.
-        if let Some(ref client) = *mcp_guard {
-            if client.is_alive().await {
-                return Ok(());
-            }
-            tracing::warn!("hyperframes MCP server died, restarting");
+        let raw = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let combined = format!("{raw}\n{stderr}");
+
+        let result = DoctorResult {
+            node_ok: combined.contains("node") && !combined.contains("node: FAIL"),
+            ffmpeg_ok: combined.contains("ffmpeg") && !combined.contains("ffmpeg: FAIL"),
+            chrome_ok: combined.contains("chrome") || combined.contains("Chrome"),
+            raw_output: combined,
+        };
+
+        let mut checked = self.env_checked.lock().await;
+        *checked = true;
+
+        if result.node_ok && result.ffmpeg_ok {
+            tracing::info!("hyperframes environment check passed");
+        } else {
+            tracing::warn!(
+                node = result.node_ok,
+                ffmpeg = result.ffmpeg_ok,
+                chrome = result.chrome_ok,
+                "hyperframes environment check — some dependencies missing"
+            );
         }
 
-        // Ensure projects directory exists.
-        std::fs::create_dir_all(&self.config.projects_dir)
-            .map_err(|e| format!("failed to create video projects dir: {e}"))?;
-
-        // Build env vars for the child process.
-        let env_refs: Vec<(&str, &str)> = self
-            .config
-            .env
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
-
-        // Spawn the hyperframes MCP server via npx.
-        let client = McpClient::spawn(
-            &self.config.npx_path,
-            &["@hyperframes/engine", "mcp"],
-            &env_refs,
-        )
-        .await?;
-
-        // Discover available tools.
-        let tools = client.list_tools().await?;
-        tracing::info!(
-            tool_count = tools.len(),
-            "hyperframes MCP tools discovered"
-        );
-        for tool in &tools {
-            tracing::debug!(name = %tool.name, "  MCP tool: {}", tool.description.as_deref().unwrap_or(""));
-        }
-
-        let mut cached = self.available_tools.lock().await;
-        *cached = tools;
-
-        *mcp_guard = Some(client);
-        Ok(())
+        Ok(result)
     }
 
-    /// Initialize a new video project (composition).
+    /// Initialize a new video project using `npx hyperframes init`.
     pub async fn create_project(
         &self,
         name: &str,
@@ -183,192 +197,234 @@ impl VideoChannel {
         height: u32,
         duration: f64,
         fps: u32,
+        template: Option<&str>,
     ) -> Result<VideoProject, String> {
-        self.ensure_connected().await?;
+        // Ensure projects directory exists.
+        std::fs::create_dir_all(&self.config.projects_dir)
+            .map_err(|e| format!("failed to create video projects dir: {e}"))?;
 
         let project_id = Uuid::new_v4().to_string();
         let project_dir = self.config.projects_dir.join(&project_id);
-        std::fs::create_dir_all(&project_dir)
-            .map_err(|e| format!("failed to create project dir: {e}"))?;
 
-        // Try to use the MCP init tool if available.
+        // Try `npx hyperframes init` first.
+        let mut args = vec!["hyperframes", "init", name];
+        let template_val = template.unwrap_or("blank");
+        args.push("--template");
+        args.push(template_val);
+
         let init_result = self
-            .call_mcp_tool(
-                "init",
-                json!({
-                    "name": name,
-                    "width": width,
-                    "height": height,
-                    "duration": duration,
-                    "fps": fps,
-                    "outputDir": project_dir.to_string_lossy()
-                }),
-            )
+            .run_npx(&args, Some(&self.config.projects_dir))
             .await;
 
         match init_result {
-            Ok(_) => {
-                tracing::info!(project_id = %project_id, "video project created via MCP");
-            }
-            Err(e) => {
-                tracing::debug!(
-                    "MCP init not available ({e}), creating project locally"
+            Ok(output) if output.status.success() => {
+                // hyperframes init creates a directory named after the project.
+                // Rename it to our UUID-based directory.
+                let created_dir = self.config.projects_dir.join(name);
+                if created_dir.exists() && created_dir != project_dir {
+                    std::fs::rename(&created_dir, &project_dir).map_err(|e| {
+                        format!("failed to rename project dir: {e}")
+                    })?;
+                }
+                tracing::info!(
+                    project_id = %project_id,
+                    template = template_val,
+                    "video project created via hyperframes CLI"
                 );
-                // Fallback: create the HTML composition file directly.
+            }
+            _ => {
+                // Fallback: create the composition HTML directly.
+                tracing::debug!("hyperframes CLI not available, creating project locally");
+                std::fs::create_dir_all(&project_dir)
+                    .map_err(|e| format!("failed to create project dir: {e}"))?;
                 self.write_composition_html(
                     &project_dir, name, width, height, duration, fps, &[],
                 )?;
             }
         }
 
-        Ok(VideoProject {
+        let project = VideoProject {
             id: project_id,
             name: name.to_string(),
-            dir: project_dir,
+            dir: project_dir.clone(),
             width,
             height,
             duration,
             fps,
-        })
+        };
+
+        // Persist project metadata.
+        self.write_project_meta(&project)?;
+
+        Ok(project)
     }
 
-    /// Add an element to an existing composition.
+    /// Add an element to an existing composition by editing the HTML.
     pub async fn add_element(
         &self,
         project: &VideoProject,
         element: &CompositionElement,
     ) -> Result<Value, String> {
-        self.ensure_connected().await?;
+        let html_path = project.dir.join("index.html");
+        let element_html = self.element_to_html(element)?;
 
-        // Try the MCP tool first.
-        let mcp_result = self
-            .call_mcp_tool(
-                "add_element",
-                json!({
-                    "projectDir": project.dir.to_string_lossy(),
-                    "element": element
-                }),
-            )
-            .await;
+        if html_path.exists() {
+            let mut content = std::fs::read_to_string(&html_path)
+                .map_err(|e| format!("failed to read composition: {e}"))?;
 
-        match mcp_result {
-            Ok(result) => Ok(result),
-            Err(_) => {
-                // Fallback: directly edit the HTML composition file.
-                let html_path = project.dir.join("index.html");
-                let element_html = self.element_to_html(element)?;
-
-                if html_path.exists() {
-                    let mut content = std::fs::read_to_string(&html_path)
-                        .map_err(|e| format!("failed to read composition: {e}"))?;
-
-                    // Insert before closing stage div.
-                    if let Some(pos) = content.rfind("</div>") {
-                        content.insert_str(pos, &format!("  {element_html}\n  "));
-                        std::fs::write(&html_path, content)
-                            .map_err(|e| format!("failed to write composition: {e}"))?;
-                    }
-                }
-
-                Ok(json!({
-                    "status": "added",
-                    "element_id": element.id,
-                    "method": "direct"
-                }))
+            // Insert before the closing </div> of the stage.
+            if let Some(pos) = content.rfind("</div>") {
+                content.insert_str(pos, &format!("    {element_html}\n  "));
+                std::fs::write(&html_path, content)
+                    .map_err(|e| format!("failed to write composition: {e}"))?;
+            } else {
+                return Err("composition HTML missing closing </div> for stage".to_string());
             }
+        } else {
+            return Err(format!(
+                "composition file not found: {}. Use create_project first.",
+                html_path.display()
+            ));
         }
+
+        // Run lint to validate the composition.
+        let lint_result = self.lint(project).await;
+
+        Ok(json!({
+            "status": "added",
+            "element_id": element.id,
+            "element_type": element.element_type,
+            "timeline": format!("{}s – {}s on track {}", element.start, element.start + element.duration, element.track),
+            "lint": lint_result.unwrap_or_else(|e| json!({"error": e}))
+        }))
     }
 
-    /// Update the full HTML composition for a project.
+    /// Set the full HTML composition for a project.
     pub async fn set_composition(
         &self,
         project: &VideoProject,
         html: &str,
     ) -> Result<Value, String> {
-        self.ensure_connected().await?;
+        let html_path = project.dir.join("index.html");
+        std::fs::write(&html_path, html)
+            .map_err(|e| format!("failed to write composition: {e}"))?;
 
-        // Try MCP tool first.
-        let mcp_result = self
-            .call_mcp_tool(
-                "set_composition",
-                json!({
-                    "projectDir": project.dir.to_string_lossy(),
-                    "html": html
-                }),
-            )
-            .await;
+        // Run lint to validate.
+        let lint_result = self.lint(project).await;
 
-        match mcp_result {
-            Ok(result) => Ok(result),
-            Err(_) => {
-                // Fallback: write HTML directly.
-                let html_path = project.dir.join("index.html");
-                std::fs::write(&html_path, html)
-                    .map_err(|e| format!("failed to write composition: {e}"))?;
-
-                Ok(json!({
-                    "status": "composition_set",
-                    "path": html_path.to_string_lossy(),
-                    "method": "direct"
-                }))
-            }
-        }
+        Ok(json!({
+            "status": "composition_set",
+            "path": html_path.to_string_lossy(),
+            "size_bytes": html.len(),
+            "lint": lint_result.unwrap_or_else(|e| json!({"error": e}))
+        }))
     }
 
-    /// Render the composition to an MP4 video.
+    /// Lint the composition using `npx hyperframes lint`.
+    pub async fn lint(&self, project: &VideoProject) -> Result<Value, String> {
+        let output = self
+            .run_npx(&["hyperframes", "lint"], Some(&project.dir))
+            .await?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        Ok(json!({
+            "success": output.status.success(),
+            "output": stdout.trim(),
+            "errors": stderr.trim(),
+        }))
+    }
+
+    /// Render the composition to video using `npx hyperframes render`.
     pub async fn render(
         &self,
         project: &VideoProject,
         output_name: Option<&str>,
+        quality: Option<&str>,
+        format: Option<&str>,
     ) -> Result<RenderResult, String> {
-        self.ensure_connected().await?;
-
-        let output_filename = output_name.unwrap_or("output.mp4");
+        let fmt = format.unwrap_or(&self.config.default_format);
+        let default_name = format!("output.{fmt}");
+        let output_filename = output_name.unwrap_or(&default_name);
         let output_path = project.dir.join(output_filename);
+        let qual = quality.unwrap_or(&self.config.default_quality);
 
-        // Try the MCP render tool.
-        let render_result = self
-            .call_mcp_tool(
-                "render",
-                json!({
-                    "projectDir": project.dir.to_string_lossy(),
-                    "output": output_path.to_string_lossy(),
-                    "width": project.width,
-                    "height": project.height,
-                    "fps": project.fps,
-                    "duration": project.duration
-                }),
-            )
-            .await;
+        let fps_str = project.fps.to_string();
+        let output_str = output_path.to_string_lossy().to_string();
 
-        match render_result {
-            Ok(result) => {
-                // Parse the result for the output path.
-                let actual_path = result
-                    .get("path")
-                    .and_then(|p| p.as_str())
-                    .map(PathBuf::from)
-                    .unwrap_or(output_path.clone());
+        let args = vec![
+            "hyperframes",
+            "render",
+            "--output",
+            &output_str,
+            "--fps",
+            &fps_str,
+            "--quality",
+            qual,
+            "--format",
+            fmt,
+        ];
 
-                let size = std::fs::metadata(&actual_path)
-                    .map(|m| m.len())
-                    .unwrap_or(0);
-
-                Ok(RenderResult {
-                    path: actual_path,
-                    duration: project.duration,
-                    size,
-                    format: "mp4".to_string(),
-                })
+        // If MCP is available, try it first (may support more render options).
+        if self.config.mcp_enabled {
+            if let Ok(result) = self.try_mcp_render(project, &output_path).await {
+                return Ok(result);
             }
-            Err(e) => Err(format!("render failed: {e}")),
         }
+
+        let render_output = self
+            .run_npx(&args, Some(&project.dir))
+            .await?;
+
+        if !render_output.status.success() {
+            let stderr = String::from_utf8_lossy(&render_output.stderr);
+            let stdout = String::from_utf8_lossy(&render_output.stdout);
+            return Err(format!(
+                "render failed (exit {}): {}\n{}",
+                render_output.status.code().unwrap_or(-1),
+                stderr.trim(),
+                stdout.trim()
+            ));
+        }
+
+        // Find the output file. hyperframes may place it in a different location.
+        let actual_path = if output_path.exists() {
+            output_path
+        } else {
+            // Search common output locations.
+            let alt_paths = [
+                project.dir.join("out").join(output_filename),
+                project.dir.join("dist").join(output_filename),
+                project.dir.join(output_filename),
+            ];
+            alt_paths
+                .into_iter()
+                .find(|p| p.exists())
+                .ok_or("render completed but output file not found")?
+        };
+
+        let size = std::fs::metadata(&actual_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        tracing::info!(
+            path = %actual_path.display(),
+            size_bytes = size,
+            "video rendered successfully"
+        );
+
+        Ok(RenderResult {
+            path: actual_path,
+            duration: project.duration,
+            size,
+            format: fmt.to_string(),
+        })
     }
 
     /// Get project status and composition info.
     pub async fn project_info(&self, project: &VideoProject) -> Result<Value, String> {
         let html_path = project.dir.join("index.html");
-
         let html_exists = html_path.exists();
         let html_size = if html_exists {
             std::fs::metadata(&html_path).map(|m| m.len()).unwrap_or(0)
@@ -376,16 +432,19 @@ impl VideoChannel {
             0
         };
 
-        // Check for rendered output.
-        let output_path = project.dir.join("output.mp4");
-        let rendered = output_path.exists();
-        let render_size = if rendered {
-            std::fs::metadata(&output_path)
-                .map(|m| m.len())
-                .unwrap_or(0)
-        } else {
-            0
-        };
+        // Check for rendered outputs.
+        let mp4_path = project.dir.join("output.mp4");
+        let webm_path = project.dir.join("output.webm");
+        let rendered_mp4 = mp4_path.exists();
+        let rendered_webm = webm_path.exists();
+
+        // Try to get composition list from CLI.
+        let compositions = self
+            .run_npx(&["hyperframes", "compositions"], Some(&project.dir))
+            .await
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
         Ok(json!({
             "id": project.id,
@@ -400,11 +459,11 @@ impl VideoChannel {
                 "size_bytes": html_size,
                 "path": html_path.to_string_lossy()
             },
-            "rendered": {
-                "exists": rendered,
-                "size_bytes": render_size,
-                "path": output_path.to_string_lossy()
-            }
+            "outputs": {
+                "mp4": { "exists": rendered_mp4, "path": mp4_path.to_string_lossy() },
+                "webm": { "exists": rendered_webm, "path": webm_path.to_string_lossy() }
+            },
+            "compositions_cli": compositions
         }))
     }
 
@@ -436,12 +495,41 @@ impl VideoChannel {
         Ok(projects)
     }
 
-    /// Get available MCP tools from the hyperframes server.
-    pub async fn available_tools(&self) -> Vec<McpToolDef> {
-        self.available_tools.lock().await.clone()
+    /// Connect to the hyperframes MCP server (optional, for advanced operations).
+    pub async fn connect_mcp(&self) -> Result<Vec<McpToolDef>, String> {
+        let mut mcp_guard = self.mcp.lock().await;
+
+        if let Some(ref client) = *mcp_guard {
+            if client.is_alive().await {
+                return Ok(self.available_tools.lock().await.clone());
+            }
+        }
+
+        let env_refs: Vec<(&str, &str)> = self
+            .config
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let client = McpClient::spawn(
+            &self.config.npx_path,
+            &["@hyperframes/engine", "mcp"],
+            &env_refs,
+        )
+        .await?;
+
+        let tools = client.list_tools().await?;
+        tracing::info!(tool_count = tools.len(), "hyperframes MCP tools discovered");
+
+        let mut cached = self.available_tools.lock().await;
+        *cached = tools.clone();
+        *mcp_guard = Some(client);
+
+        Ok(tools)
     }
 
-    /// Call an arbitrary MCP tool on the hyperframes server.
+    /// Call an MCP tool (requires prior `connect_mcp`).
     pub async fn call_mcp_tool(
         &self,
         name: &str,
@@ -450,7 +538,7 @@ impl VideoChannel {
         let mcp_guard = self.mcp.lock().await;
         let client = mcp_guard
             .as_ref()
-            .ok_or("MCP client not connected")?;
+            .ok_or("MCP not connected — call connect_mcp first, or set mcp_enabled=true")?;
 
         let result = client.call_tool(name, arguments).await?;
 
@@ -464,7 +552,6 @@ impl VideoChannel {
             return Err(format!("MCP tool `{name}` error: {error_text}"));
         }
 
-        // Extract text content from the result.
         let texts: Vec<&str> = result
             .content
             .iter()
@@ -472,7 +559,6 @@ impl VideoChannel {
             .collect();
 
         if texts.len() == 1 {
-            // Try to parse as JSON, otherwise wrap as text.
             match serde_json::from_str::<Value>(texts[0]) {
                 Ok(v) => Ok(v),
                 Err(_) => Ok(json!({ "text": texts[0] })),
@@ -482,7 +568,12 @@ impl VideoChannel {
         }
     }
 
-    /// Gracefully shut down the hyperframes MCP server.
+    /// Get cached MCP tool definitions.
+    pub async fn available_tools(&self) -> Vec<McpToolDef> {
+        self.available_tools.lock().await.clone()
+    }
+
+    /// Gracefully shut down the MCP server (if running).
     pub async fn shutdown(&self) {
         let mut mcp_guard = self.mcp.lock().await;
         if let Some(client) = mcp_guard.take() {
@@ -493,7 +584,87 @@ impl VideoChannel {
 
     // --- Private helpers ---
 
-    /// Generate an HTML composition file for a project.
+    /// Run an npx command and capture output.
+    async fn run_npx(
+        &self,
+        args: &[&str],
+        cwd: Option<&Path>,
+    ) -> Result<std::process::Output, String> {
+        let mut cmd = tokio::process::Command::new(&self.config.npx_path);
+        cmd.args(args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
+
+        for (k, v) in &self.config.env {
+            cmd.env(k, v);
+        }
+
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(300), // 5 minute timeout for renders
+            cmd.output(),
+        )
+        .await
+        .map_err(|_| "hyperframes command timed out (300s)".to_string())?
+        .map_err(|e| format!("failed to run npx: {e}"))?;
+
+        Ok(output)
+    }
+
+    /// Try rendering via MCP (optional path).
+    async fn try_mcp_render(
+        &self,
+        project: &VideoProject,
+        output_path: &Path,
+    ) -> Result<RenderResult, String> {
+        self.connect_mcp().await?;
+
+        let result = self
+            .call_mcp_tool(
+                "render",
+                json!({
+                    "projectDir": project.dir.to_string_lossy(),
+                    "output": output_path.to_string_lossy(),
+                    "width": project.width,
+                    "height": project.height,
+                    "fps": project.fps,
+                    "duration": project.duration
+                }),
+            )
+            .await?;
+
+        let actual_path = result
+            .get("path")
+            .and_then(|p| p.as_str())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| output_path.to_path_buf());
+
+        let size = std::fs::metadata(&actual_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        Ok(RenderResult {
+            path: actual_path,
+            duration: project.duration,
+            size,
+            format: "mp4".to_string(),
+        })
+    }
+
+    /// Write project metadata to disk.
+    fn write_project_meta(&self, project: &VideoProject) -> Result<(), String> {
+        let meta = serde_json::to_string_pretty(project)
+            .map_err(|e| format!("failed to serialize project meta: {e}"))?;
+        let meta_path = project.dir.join("project.json");
+        std::fs::write(meta_path, meta)
+            .map_err(|e| format!("failed to write project metadata: {e}"))?;
+        Ok(())
+    }
+
+    /// Generate an HTML composition file using hyperframes data attributes.
     fn write_composition_html(
         &self,
         project_dir: &Path,
@@ -534,18 +705,6 @@ impl VideoChannel {
         let html_path = project_dir.join("index.html");
         std::fs::write(&html_path, &html)
             .map_err(|e| format!("failed to write composition HTML: {e}"))?;
-
-        // Write project metadata.
-        let meta = json!({
-            "id": project_dir.file_name().unwrap().to_string_lossy(),
-            "name": name,
-            "dir": project_dir.to_string_lossy(),
-            "width": width,
-            "height": height
-        });
-        let meta_path = project_dir.join("project.json");
-        std::fs::write(meta_path, serde_json::to_string_pretty(&meta).unwrap())
-            .map_err(|e| format!("failed to write project metadata: {e}"))?;
 
         Ok(())
     }
@@ -626,11 +785,11 @@ impl VideoChannel {
                     .get("backgroundColor")
                     .and_then(|v| v.as_str())
                     .unwrap_or("#333333");
-                let width = props
+                let w = props
                     .get("width")
                     .and_then(|v| v.as_str())
                     .unwrap_or("100%");
-                let height = props
+                let h = props
                     .get("height")
                     .and_then(|v| v.as_str())
                     .unwrap_or("100%");
@@ -638,11 +797,11 @@ impl VideoChannel {
                 let y = props.get("y").and_then(|v| v.as_str()).unwrap_or("0");
 
                 Ok(format!(
-                    r#"<div {base_attrs} style="position:absolute;left:{x};top:{y};width:{width};height:{height};background:{bg}"></div>"#
+                    r#"<div {base_attrs} style="position:absolute;left:{x};top:{y};width:{w};height:{h};background:{bg}"></div>"#
                 ))
             }
             "html" => {
-                // Raw HTML passthrough — for advanced compositions.
+                // Raw HTML passthrough for advanced compositions.
                 let raw = props
                     .get("html")
                     .and_then(|v| v.as_str())

--- a/crates/rustykrab-channels/src/video.rs
+++ b/crates/rustykrab-channels/src/video.rs
@@ -1,0 +1,657 @@
+//! Video communication channel powered by Hyperframes via MCP.
+//!
+//! Treats video as a first-class mode of communication: the agent can
+//! respond to users by composing HTML-based video compositions and rendering
+//! them to MP4 files. Internally manages the hyperframes MCP server process
+//! and provides the full pipeline: compose → preview → render.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+use tracing;
+use uuid::Uuid;
+
+use crate::mcp::{McpClient, McpToolDef};
+
+/// Configuration for the video channel.
+#[derive(Debug, Clone)]
+pub struct VideoConfig {
+    /// Working directory for video projects.
+    pub projects_dir: PathBuf,
+    /// Path to the `npx` binary (defaults to "npx").
+    pub npx_path: String,
+    /// Additional environment variables for the MCP server process.
+    pub env: Vec<(String, String)>,
+}
+
+impl Default for VideoConfig {
+    fn default() -> Self {
+        let data_dir = dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("rustykrab")
+            .join("video");
+
+        Self {
+            projects_dir: data_dir,
+            npx_path: "npx".to_string(),
+            env: Vec::new(),
+        }
+    }
+}
+
+/// A video composition project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VideoProject {
+    /// Unique project ID.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Directory on disk where composition files live.
+    pub dir: PathBuf,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+    /// Duration in seconds.
+    pub duration: f64,
+    /// Frames per second.
+    pub fps: u32,
+}
+
+/// Metadata for a rendered video.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenderResult {
+    /// Path to the rendered MP4 file.
+    pub path: PathBuf,
+    /// Duration of the rendered video in seconds.
+    pub duration: f64,
+    /// File size in bytes.
+    pub size: u64,
+    /// Format (always "mp4" for now).
+    pub format: String,
+}
+
+/// An element in a video composition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompositionElement {
+    /// Element type: "text", "image", "video", "audio", "shape".
+    #[serde(rename = "type")]
+    pub element_type: String,
+    /// Unique element ID within the composition.
+    pub id: String,
+    /// Start time in seconds on the timeline.
+    pub start: f64,
+    /// Duration in seconds.
+    pub duration: f64,
+    /// Track/layer index (0 = bottom).
+    pub track: u32,
+    /// Element-specific properties (src, text, color, font, etc.).
+    #[serde(default)]
+    pub properties: Value,
+}
+
+/// The video communication channel.
+///
+/// Manages the hyperframes MCP server lifecycle and provides methods for
+/// composing and rendering video content. Like Telegram sends text or
+/// Signal sends encrypted messages, VideoChannel communicates via video.
+pub struct VideoChannel {
+    config: VideoConfig,
+    /// MCP client connection to the hyperframes server.
+    mcp: Arc<Mutex<Option<McpClient>>>,
+    /// Available MCP tools (cached after first connection).
+    available_tools: Mutex<Vec<McpToolDef>>,
+}
+
+impl VideoChannel {
+    /// Create a new video channel with the given configuration.
+    pub fn new(config: VideoConfig) -> Self {
+        Self {
+            config,
+            mcp: Arc::new(Mutex::new(None)),
+            available_tools: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Create a new video channel with default configuration.
+    pub fn with_defaults() -> Self {
+        Self::new(VideoConfig::default())
+    }
+
+    pub fn name(&self) -> &str {
+        "video"
+    }
+
+    /// Ensure the MCP server is running and connected.
+    /// Lazily starts the server on first use.
+    pub async fn ensure_connected(&self) -> Result<(), String> {
+        let mut mcp_guard = self.mcp.lock().await;
+
+        // Check if already connected and alive.
+        if let Some(ref client) = *mcp_guard {
+            if client.is_alive().await {
+                return Ok(());
+            }
+            tracing::warn!("hyperframes MCP server died, restarting");
+        }
+
+        // Ensure projects directory exists.
+        std::fs::create_dir_all(&self.config.projects_dir)
+            .map_err(|e| format!("failed to create video projects dir: {e}"))?;
+
+        // Build env vars for the child process.
+        let env_refs: Vec<(&str, &str)> = self
+            .config
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        // Spawn the hyperframes MCP server via npx.
+        let client = McpClient::spawn(
+            &self.config.npx_path,
+            &["@hyperframes/engine", "mcp"],
+            &env_refs,
+        )
+        .await?;
+
+        // Discover available tools.
+        let tools = client.list_tools().await?;
+        tracing::info!(
+            tool_count = tools.len(),
+            "hyperframes MCP tools discovered"
+        );
+        for tool in &tools {
+            tracing::debug!(name = %tool.name, "  MCP tool: {}", tool.description.as_deref().unwrap_or(""));
+        }
+
+        let mut cached = self.available_tools.lock().await;
+        *cached = tools;
+
+        *mcp_guard = Some(client);
+        Ok(())
+    }
+
+    /// Initialize a new video project (composition).
+    pub async fn create_project(
+        &self,
+        name: &str,
+        width: u32,
+        height: u32,
+        duration: f64,
+        fps: u32,
+    ) -> Result<VideoProject, String> {
+        self.ensure_connected().await?;
+
+        let project_id = Uuid::new_v4().to_string();
+        let project_dir = self.config.projects_dir.join(&project_id);
+        std::fs::create_dir_all(&project_dir)
+            .map_err(|e| format!("failed to create project dir: {e}"))?;
+
+        // Try to use the MCP init tool if available.
+        let init_result = self
+            .call_mcp_tool(
+                "init",
+                json!({
+                    "name": name,
+                    "width": width,
+                    "height": height,
+                    "duration": duration,
+                    "fps": fps,
+                    "outputDir": project_dir.to_string_lossy()
+                }),
+            )
+            .await;
+
+        match init_result {
+            Ok(_) => {
+                tracing::info!(project_id = %project_id, "video project created via MCP");
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "MCP init not available ({e}), creating project locally"
+                );
+                // Fallback: create the HTML composition file directly.
+                self.write_composition_html(
+                    &project_dir, name, width, height, duration, fps, &[],
+                )?;
+            }
+        }
+
+        Ok(VideoProject {
+            id: project_id,
+            name: name.to_string(),
+            dir: project_dir,
+            width,
+            height,
+            duration,
+            fps,
+        })
+    }
+
+    /// Add an element to an existing composition.
+    pub async fn add_element(
+        &self,
+        project: &VideoProject,
+        element: &CompositionElement,
+    ) -> Result<Value, String> {
+        self.ensure_connected().await?;
+
+        // Try the MCP tool first.
+        let mcp_result = self
+            .call_mcp_tool(
+                "add_element",
+                json!({
+                    "projectDir": project.dir.to_string_lossy(),
+                    "element": element
+                }),
+            )
+            .await;
+
+        match mcp_result {
+            Ok(result) => Ok(result),
+            Err(_) => {
+                // Fallback: directly edit the HTML composition file.
+                let html_path = project.dir.join("index.html");
+                let element_html = self.element_to_html(element)?;
+
+                if html_path.exists() {
+                    let mut content = std::fs::read_to_string(&html_path)
+                        .map_err(|e| format!("failed to read composition: {e}"))?;
+
+                    // Insert before closing stage div.
+                    if let Some(pos) = content.rfind("</div>") {
+                        content.insert_str(pos, &format!("  {element_html}\n  "));
+                        std::fs::write(&html_path, content)
+                            .map_err(|e| format!("failed to write composition: {e}"))?;
+                    }
+                }
+
+                Ok(json!({
+                    "status": "added",
+                    "element_id": element.id,
+                    "method": "direct"
+                }))
+            }
+        }
+    }
+
+    /// Update the full HTML composition for a project.
+    pub async fn set_composition(
+        &self,
+        project: &VideoProject,
+        html: &str,
+    ) -> Result<Value, String> {
+        self.ensure_connected().await?;
+
+        // Try MCP tool first.
+        let mcp_result = self
+            .call_mcp_tool(
+                "set_composition",
+                json!({
+                    "projectDir": project.dir.to_string_lossy(),
+                    "html": html
+                }),
+            )
+            .await;
+
+        match mcp_result {
+            Ok(result) => Ok(result),
+            Err(_) => {
+                // Fallback: write HTML directly.
+                let html_path = project.dir.join("index.html");
+                std::fs::write(&html_path, html)
+                    .map_err(|e| format!("failed to write composition: {e}"))?;
+
+                Ok(json!({
+                    "status": "composition_set",
+                    "path": html_path.to_string_lossy(),
+                    "method": "direct"
+                }))
+            }
+        }
+    }
+
+    /// Render the composition to an MP4 video.
+    pub async fn render(
+        &self,
+        project: &VideoProject,
+        output_name: Option<&str>,
+    ) -> Result<RenderResult, String> {
+        self.ensure_connected().await?;
+
+        let output_filename = output_name.unwrap_or("output.mp4");
+        let output_path = project.dir.join(output_filename);
+
+        // Try the MCP render tool.
+        let render_result = self
+            .call_mcp_tool(
+                "render",
+                json!({
+                    "projectDir": project.dir.to_string_lossy(),
+                    "output": output_path.to_string_lossy(),
+                    "width": project.width,
+                    "height": project.height,
+                    "fps": project.fps,
+                    "duration": project.duration
+                }),
+            )
+            .await;
+
+        match render_result {
+            Ok(result) => {
+                // Parse the result for the output path.
+                let actual_path = result
+                    .get("path")
+                    .and_then(|p| p.as_str())
+                    .map(PathBuf::from)
+                    .unwrap_or(output_path.clone());
+
+                let size = std::fs::metadata(&actual_path)
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+
+                Ok(RenderResult {
+                    path: actual_path,
+                    duration: project.duration,
+                    size,
+                    format: "mp4".to_string(),
+                })
+            }
+            Err(e) => Err(format!("render failed: {e}")),
+        }
+    }
+
+    /// Get project status and composition info.
+    pub async fn project_info(&self, project: &VideoProject) -> Result<Value, String> {
+        let html_path = project.dir.join("index.html");
+
+        let html_exists = html_path.exists();
+        let html_size = if html_exists {
+            std::fs::metadata(&html_path).map(|m| m.len()).unwrap_or(0)
+        } else {
+            0
+        };
+
+        // Check for rendered output.
+        let output_path = project.dir.join("output.mp4");
+        let rendered = output_path.exists();
+        let render_size = if rendered {
+            std::fs::metadata(&output_path)
+                .map(|m| m.len())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        Ok(json!({
+            "id": project.id,
+            "name": project.name,
+            "dir": project.dir.to_string_lossy(),
+            "width": project.width,
+            "height": project.height,
+            "duration": project.duration,
+            "fps": project.fps,
+            "composition": {
+                "exists": html_exists,
+                "size_bytes": html_size,
+                "path": html_path.to_string_lossy()
+            },
+            "rendered": {
+                "exists": rendered,
+                "size_bytes": render_size,
+                "path": output_path.to_string_lossy()
+            }
+        }))
+    }
+
+    /// List all video projects in the projects directory.
+    pub fn list_projects(&self) -> Result<Vec<VideoProject>, String> {
+        let mut projects = Vec::new();
+
+        if !self.config.projects_dir.exists() {
+            return Ok(projects);
+        }
+
+        let entries = std::fs::read_dir(&self.config.projects_dir)
+            .map_err(|e| format!("failed to read projects dir: {e}"))?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let meta_path = path.join("project.json");
+                if meta_path.exists() {
+                    if let Ok(content) = std::fs::read_to_string(&meta_path) {
+                        if let Ok(project) = serde_json::from_str::<VideoProject>(&content) {
+                            projects.push(project);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(projects)
+    }
+
+    /// Get available MCP tools from the hyperframes server.
+    pub async fn available_tools(&self) -> Vec<McpToolDef> {
+        self.available_tools.lock().await.clone()
+    }
+
+    /// Call an arbitrary MCP tool on the hyperframes server.
+    pub async fn call_mcp_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+    ) -> Result<Value, String> {
+        let mcp_guard = self.mcp.lock().await;
+        let client = mcp_guard
+            .as_ref()
+            .ok_or("MCP client not connected")?;
+
+        let result = client.call_tool(name, arguments).await?;
+
+        if result.is_error {
+            let error_text: String = result
+                .content
+                .iter()
+                .filter_map(|c| c.text.as_deref())
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Err(format!("MCP tool `{name}` error: {error_text}"));
+        }
+
+        // Extract text content from the result.
+        let texts: Vec<&str> = result
+            .content
+            .iter()
+            .filter_map(|c| c.text.as_deref())
+            .collect();
+
+        if texts.len() == 1 {
+            // Try to parse as JSON, otherwise wrap as text.
+            match serde_json::from_str::<Value>(texts[0]) {
+                Ok(v) => Ok(v),
+                Err(_) => Ok(json!({ "text": texts[0] })),
+            }
+        } else {
+            Ok(json!({ "content": result.content }))
+        }
+    }
+
+    /// Gracefully shut down the hyperframes MCP server.
+    pub async fn shutdown(&self) {
+        let mut mcp_guard = self.mcp.lock().await;
+        if let Some(client) = mcp_guard.take() {
+            client.shutdown().await;
+        }
+        tracing::info!("video channel shut down");
+    }
+
+    // --- Private helpers ---
+
+    /// Generate an HTML composition file for a project.
+    fn write_composition_html(
+        &self,
+        project_dir: &Path,
+        name: &str,
+        width: u32,
+        height: u32,
+        _duration: f64,
+        _fps: u32,
+        elements: &[CompositionElement],
+    ) -> Result<(), String> {
+        let mut elements_html = String::new();
+        for elem in elements {
+            let html = self.element_to_html(elem)?;
+            elements_html.push_str(&format!("    {html}\n"));
+        }
+
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{name}</title>
+  <style>
+    * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+    #stage {{ position: relative; overflow: hidden; background: #000; }}
+  </style>
+</head>
+<body>
+  <div id="stage"
+       data-composition-id="{name}"
+       data-width="{width}"
+       data-height="{height}">
+{elements_html}  </div>
+</body>
+</html>"#
+        );
+
+        let html_path = project_dir.join("index.html");
+        std::fs::write(&html_path, &html)
+            .map_err(|e| format!("failed to write composition HTML: {e}"))?;
+
+        // Write project metadata.
+        let meta = json!({
+            "id": project_dir.file_name().unwrap().to_string_lossy(),
+            "name": name,
+            "dir": project_dir.to_string_lossy(),
+            "width": width,
+            "height": height
+        });
+        let meta_path = project_dir.join("project.json");
+        std::fs::write(meta_path, serde_json::to_string_pretty(&meta).unwrap())
+            .map_err(|e| format!("failed to write project metadata: {e}"))?;
+
+        Ok(())
+    }
+
+    /// Convert a composition element to its HTML representation using
+    /// hyperframes data attributes.
+    fn element_to_html(&self, elem: &CompositionElement) -> Result<String, String> {
+        let props = &elem.properties;
+        let base_attrs = format!(
+            r#"id="{}" data-start="{}" data-duration="{}" data-track="{}""#,
+            elem.id, elem.start, elem.duration, elem.track
+        );
+
+        match elem.element_type.as_str() {
+            "text" => {
+                let text = props
+                    .get("text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Hello");
+                let font_size = props
+                    .get("fontSize")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("48px");
+                let color = props
+                    .get("color")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("#ffffff");
+                let x = props.get("x").and_then(|v| v.as_str()).unwrap_or("50%");
+                let y = props.get("y").and_then(|v| v.as_str()).unwrap_or("50%");
+
+                Ok(format!(
+                    r#"<div {base_attrs} style="position:absolute;left:{x};top:{y};font-size:{font_size};color:{color};transform:translate(-50%,-50%)">{text}</div>"#
+                ))
+            }
+            "image" => {
+                let src = props
+                    .get("src")
+                    .and_then(|v| v.as_str())
+                    .ok_or("image element requires `src` property")?;
+                let style = props
+                    .get("style")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("width:100%;height:100%;object-fit:cover");
+
+                Ok(format!(
+                    r#"<img {base_attrs} src="{src}" style="{style}" />"#
+                ))
+            }
+            "video" => {
+                let src = props
+                    .get("src")
+                    .and_then(|v| v.as_str())
+                    .ok_or("video element requires `src` property")?;
+                let volume = props.get("volume").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                let volume_attr = if volume > 0.0 {
+                    format!(r#" data-volume="{volume}""#)
+                } else {
+                    String::new()
+                };
+
+                Ok(format!(
+                    r#"<video {base_attrs}{volume_attr} src="{src}" muted playsinline style="width:100%;height:100%;object-fit:cover" />"#
+                ))
+            }
+            "audio" => {
+                let src = props
+                    .get("src")
+                    .and_then(|v| v.as_str())
+                    .ok_or("audio element requires `src` property")?;
+                let volume = props.get("volume").and_then(|v| v.as_f64()).unwrap_or(1.0);
+
+                Ok(format!(
+                    r#"<audio {base_attrs} data-volume="{volume}" src="{src}" />"#
+                ))
+            }
+            "shape" => {
+                let bg = props
+                    .get("backgroundColor")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("#333333");
+                let width = props
+                    .get("width")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("100%");
+                let height = props
+                    .get("height")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("100%");
+                let x = props.get("x").and_then(|v| v.as_str()).unwrap_or("0");
+                let y = props.get("y").and_then(|v| v.as_str()).unwrap_or("0");
+
+                Ok(format!(
+                    r#"<div {base_attrs} style="position:absolute;left:{x};top:{y};width:{width};height:{height};background:{bg}"></div>"#
+                ))
+            }
+            "html" => {
+                // Raw HTML passthrough — for advanced compositions.
+                let raw = props
+                    .get("html")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<div></div>");
+                Ok(raw.to_string())
+            }
+            other => Err(format!(
+                "unknown element type `{other}` — use text, image, video, audio, shape, or html"
+            )),
+        }
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter, OrchestrationPipeline};
-use rustykrab_channels::{ChannelMessage, TelegramChannel};
+use rustykrab_channels::{ChannelMessage, TelegramChannel, VideoChannel, VideoConfig};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::types::MessageContent;
@@ -152,10 +152,45 @@ async fn main() -> anyhow::Result<()> {
     });
     tracing::info!("memory system initialized");
 
+    // --- Video channel (optional, enabled via RUSTYKRAB_VIDEO=true) ---
+    let video_enabled = std::env::var("RUSTYKRAB_VIDEO")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+
+    let video_channel: Option<Arc<VideoChannel>> = if video_enabled {
+        let video_dir = data_dir.join("video");
+        std::fs::create_dir_all(&video_dir)?;
+
+        let mut video_config = VideoConfig::default();
+        video_config.projects_dir = video_dir;
+
+        // Allow custom npx path via env.
+        if let Ok(npx) = std::env::var("RUSTYKRAB_NPX_PATH") {
+            video_config.npx_path = npx;
+        }
+
+        let channel = Arc::new(VideoChannel::new(video_config));
+        tracing::info!("video communication channel enabled");
+        Some(channel)
+    } else {
+        tracing::info!(
+            "video channel disabled (set RUSTYKRAB_VIDEO=true to enable)"
+        );
+        None
+    };
+
     // --- Tools ---
     let mut tools = rustykrab_tools::builtin_tools(store.secrets());
     tools.extend(rustykrab_tools::memory_tools(memory_backend));
     tools.extend(rustykrab_tools::skill_tools(skills_dir.clone()));
+
+    // --- Video tool (if video channel enabled) ---
+    if let Some(ref vc) = video_channel {
+        let video_backend: Arc<dyn rustykrab_tools::VideoBackend> =
+            Arc::new(rustykrab_tools::VideoChannelAdapter::new(vc.clone()));
+        tools.extend(rustykrab_tools::video_tools(video_backend));
+        tracing::info!("video tool registered");
+    }
 
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");
@@ -217,6 +252,11 @@ async fn main() -> anyhow::Result<()> {
 
     if let Some(pipeline) = orchestration_pipeline {
         state = state.with_orchestration_pipeline(pipeline);
+    }
+
+    // --- Attach video channel to state ---
+    if let Some(vc) = video_channel {
+        state = state.with_video(vc);
     }
 
     // Track infrastructure task JoinHandles so panics are surfaced
@@ -343,6 +383,9 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Telegram agent loop started");
     }
 
+    // Save a reference to the video channel for shutdown.
+    let video_shutdown_handle = state.video.clone();
+
     // --- Gateway with security middleware ---
     let app = rustykrab_gateway::router(state);
 
@@ -369,6 +412,12 @@ async fn main() -> anyhow::Result<()> {
                 tracing::error!("infrastructure task panicked during shutdown: {e}");
             }
         }
+    }
+
+    // Shut down video channel (MCP server).
+    if let Some(ref vc) = video_shutdown_handle {
+        tracing::info!("shutting down video channel...");
+        vc.shutdown().await;
     }
 
     // Flush database before exit

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -1,7 +1,7 @@
 use rustykrab_agent::{
     HarnessProfile, HarnessRouter, OrchestrationPipeline, ProcessSandbox, Sandbox,
 };
-use rustykrab_channels::{SignalChannel, TelegramChannel};
+use rustykrab_channels::{SignalChannel, TelegramChannel, VideoChannel};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_skills::SkillRegistry;
@@ -22,6 +22,8 @@ pub struct AppState {
     pub origin_policy: OriginPolicy,
     pub telegram: Option<Arc<TelegramChannel>>,
     pub signal: Option<Arc<SignalChannel>>,
+    /// Video communication channel (hyperframes MCP).
+    pub video: Option<Arc<VideoChannel>>,
     /// Sandbox for tool execution isolation.
     pub sandbox: Arc<dyn Sandbox>,
     /// Base harness profile (used as fallback and template).
@@ -54,6 +56,7 @@ impl AppState {
             origin_policy: OriginPolicy::default(),
             telegram: None,
             signal: None,
+            video: None,
             sandbox: Arc::new(ProcessSandbox::new()),
             harness_profile: HarnessProfile::default(),
             harness_router: None,
@@ -84,6 +87,12 @@ impl AppState {
     /// Attach a Signal channel.
     pub fn with_signal(mut self, signal: Arc<SignalChannel>) -> Self {
         self.signal = Some(signal);
+        self
+    }
+
+    /// Attach a Video communication channel.
+    pub fn with_video(mut self, video: Arc<VideoChannel>) -> Self {
+        self.video = Some(video);
         self
     }
 

--- a/crates/rustykrab-tools/Cargo.toml
+++ b/crates/rustykrab-tools/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 rustykrab-core.workspace = true
 rustykrab-store.workspace = true
+rustykrab-channels.workspace = true
 async-trait.workspace = true
 reqwest = { workspace = true, features = ["cookies"] }
 serde.workspace = true

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -51,6 +51,7 @@ mod image;
 mod image_generate;
 mod pdf;
 mod tts;
+mod video;
 
 // UI tools
 mod browser;
@@ -124,6 +125,7 @@ pub use self::image::ImageTool;
 pub use image_generate::ImageGenerateTool;
 pub use pdf::PdfTool;
 pub use tts::TtsTool;
+pub use video::{VideoBackend, VideoChannelAdapter, VideoTool};
 
 // UI
 pub use browser::BrowserTool;
@@ -239,4 +241,11 @@ pub fn automation_tools(
         std::sync::Arc::new(CronTool::new(cron_backend)),
         std::sync::Arc::new(GatewayTool::new(gateway_backend)),
     ]
+}
+
+/// Collect video tools that require a VideoBackend into a Vec.
+pub fn video_tools(
+    backend: std::sync::Arc<dyn VideoBackend>,
+) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
+    vec![std::sync::Arc::new(VideoTool::new(backend))]
 }

--- a/crates/rustykrab-tools/src/video.rs
+++ b/crates/rustykrab-tools/src/video.rs
@@ -1,0 +1,541 @@
+//! Video creation tool — the agent's interface to the video communication channel.
+//!
+//! Enables the agent to compose HTML-based video compositions and render
+//! them to MP4 via the hyperframes engine (MCP). Video is treated as a
+//! mode of communication: the agent can respond with rendered video just
+//! as it responds with text through Telegram or WebChat.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Result, Tool};
+use serde_json::{json, Value};
+
+use rustykrab_channels::video::{CompositionElement, VideoChannel, VideoProject};
+
+/// Backend trait for video operations, allowing the tool to remain
+/// decoupled from the channel lifecycle.
+#[async_trait]
+pub trait VideoBackend: Send + Sync {
+    /// Create a new video project.
+    async fn create_project(
+        &self,
+        name: &str,
+        width: u32,
+        height: u32,
+        duration: f64,
+        fps: u32,
+    ) -> std::result::Result<VideoProject, String>;
+
+    /// Add an element to a composition.
+    async fn add_element(
+        &self,
+        project: &VideoProject,
+        element: &CompositionElement,
+    ) -> std::result::Result<Value, String>;
+
+    /// Set the full HTML composition.
+    async fn set_composition(
+        &self,
+        project: &VideoProject,
+        html: &str,
+    ) -> std::result::Result<Value, String>;
+
+    /// Render a project to MP4.
+    async fn render(
+        &self,
+        project: &VideoProject,
+        output_name: Option<&str>,
+    ) -> std::result::Result<Value, String>;
+
+    /// Get project info.
+    async fn project_info(
+        &self,
+        project: &VideoProject,
+    ) -> std::result::Result<Value, String>;
+
+    /// List projects.
+    async fn list_projects(&self) -> std::result::Result<Vec<VideoProject>, String>;
+
+    /// Call a raw MCP tool on the hyperframes server.
+    async fn call_mcp_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+    ) -> std::result::Result<Value, String>;
+
+    /// List available MCP tools.
+    async fn available_tools(&self) -> std::result::Result<Value, String>;
+}
+
+/// Adapter bridging [VideoChannel] to the [VideoBackend] trait.
+pub struct VideoChannelAdapter {
+    channel: Arc<VideoChannel>,
+}
+
+impl VideoChannelAdapter {
+    pub fn new(channel: Arc<VideoChannel>) -> Self {
+        Self { channel }
+    }
+}
+
+#[async_trait]
+impl VideoBackend for VideoChannelAdapter {
+    async fn create_project(
+        &self,
+        name: &str,
+        width: u32,
+        height: u32,
+        duration: f64,
+        fps: u32,
+    ) -> std::result::Result<VideoProject, String> {
+        self.channel
+            .create_project(name, width, height, duration, fps)
+            .await
+    }
+
+    async fn add_element(
+        &self,
+        project: &VideoProject,
+        element: &CompositionElement,
+    ) -> std::result::Result<Value, String> {
+        self.channel.add_element(project, element).await
+    }
+
+    async fn set_composition(
+        &self,
+        project: &VideoProject,
+        html: &str,
+    ) -> std::result::Result<Value, String> {
+        self.channel.set_composition(project, html).await
+    }
+
+    async fn render(
+        &self,
+        project: &VideoProject,
+        output_name: Option<&str>,
+    ) -> std::result::Result<Value, String> {
+        let result = self.channel.render(project, output_name).await?;
+        Ok(json!({
+            "status": "rendered",
+            "path": result.path.to_string_lossy(),
+            "duration": result.duration,
+            "size_bytes": result.size,
+            "format": result.format
+        }))
+    }
+
+    async fn project_info(
+        &self,
+        project: &VideoProject,
+    ) -> std::result::Result<Value, String> {
+        self.channel.project_info(project).await
+    }
+
+    async fn list_projects(&self) -> std::result::Result<Vec<VideoProject>, String> {
+        self.channel.list_projects()
+    }
+
+    async fn call_mcp_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+    ) -> std::result::Result<Value, String> {
+        self.channel.call_mcp_tool(name, arguments).await
+    }
+
+    async fn available_tools(&self) -> std::result::Result<Value, String> {
+        let tools = self.channel.available_tools().await;
+        Ok(json!(tools))
+    }
+}
+
+/// Agent-facing video creation tool.
+///
+/// Actions:
+/// - `create_project` — Initialize a new video composition
+/// - `add_element` — Add a visual/audio element to the timeline
+/// - `set_composition` — Set the full HTML composition directly
+/// - `render` — Render the composition to MP4
+/// - `info` — Get project status
+/// - `list` — List all video projects
+/// - `mcp_tools` — List available hyperframes MCP tools
+/// - `mcp_call` — Call a raw MCP tool for advanced operations
+pub struct VideoTool {
+    backend: Arc<dyn VideoBackend>,
+    /// In-memory project cache for the current session.
+    projects: tokio::sync::Mutex<std::collections::HashMap<String, VideoProject>>,
+}
+
+impl VideoTool {
+    pub fn new(backend: Arc<dyn VideoBackend>) -> Self {
+        Self {
+            backend,
+            projects: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    async fn get_project(&self, project_id: &str) -> Result<VideoProject> {
+        let projects = self.projects.lock().await;
+        projects.get(project_id).cloned().ok_or_else(|| {
+            rustykrab_core::Error::ToolExecution(
+                format!(
+                    "project `{project_id}` not found. Use action `create_project` first, \
+                     or `list` to see existing projects."
+                )
+                .into(),
+            )
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for VideoTool {
+    fn name(&self) -> &str {
+        "video"
+    }
+
+    fn description(&self) -> &str {
+        "Create and render video compositions. Video is a communication channel: \
+         compose HTML-based scenes with text, images, video clips, and audio on a \
+         timeline, then render to MP4. Powered by hyperframes engine via MCP. \
+         Use this when you want to communicate via video — tutorials, presentations, \
+         explanations, greetings, or any visual content."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "create_project",
+                            "add_element",
+                            "set_composition",
+                            "render",
+                            "info",
+                            "list",
+                            "mcp_tools",
+                            "mcp_call"
+                        ],
+                        "description": "The video action to perform"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Project name (for create_project)"
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Project ID (for add_element, set_composition, render, info)"
+                    },
+                    "width": {
+                        "type": "integer",
+                        "description": "Video width in pixels (default: 1920)",
+                        "default": 1920
+                    },
+                    "height": {
+                        "type": "integer",
+                        "description": "Video height in pixels (default: 1080)",
+                        "default": 1080
+                    },
+                    "duration": {
+                        "type": "number",
+                        "description": "Video duration in seconds (default: 10)",
+                        "default": 10
+                    },
+                    "fps": {
+                        "type": "integer",
+                        "description": "Frames per second (default: 30)",
+                        "default": 30
+                    },
+                    "element": {
+                        "type": "object",
+                        "description": "Element to add (for add_element). Fields: type (text|image|video|audio|shape|html), id, start, duration, track, properties",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["text", "image", "video", "audio", "shape", "html"]
+                            },
+                            "id": { "type": "string" },
+                            "start": { "type": "number" },
+                            "duration": { "type": "number" },
+                            "track": { "type": "integer" },
+                            "properties": { "type": "object" }
+                        },
+                        "required": ["type", "id", "start", "duration", "track"]
+                    },
+                    "html": {
+                        "type": "string",
+                        "description": "Full HTML composition (for set_composition). Use hyperframes data attributes: data-start, data-duration, data-track, data-volume"
+                    },
+                    "output_name": {
+                        "type": "string",
+                        "description": "Output filename (for render, default: output.mp4)"
+                    },
+                    "mcp_tool": {
+                        "type": "string",
+                        "description": "MCP tool name (for mcp_call)"
+                    },
+                    "mcp_arguments": {
+                        "type": "object",
+                        "description": "MCP tool arguments (for mcp_call)"
+                    }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+
+        match action {
+            "create_project" => {
+                let name = args["name"]
+                    .as_str()
+                    .unwrap_or("untitled");
+                let width = args["width"].as_u64().unwrap_or(1920) as u32;
+                let height = args["height"].as_u64().unwrap_or(1080) as u32;
+                let duration = args["duration"].as_f64().unwrap_or(10.0);
+                let fps = args["fps"].as_u64().unwrap_or(30) as u32;
+
+                let project = self
+                    .backend
+                    .create_project(name, width, height, duration, fps)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("failed to create project: {e}").into(),
+                        )
+                    })?;
+
+                let project_id = project.id.clone();
+
+                let result = json!({
+                    "action": "create_project",
+                    "success": true,
+                    "project_id": &project.id,
+                    "name": &project.name,
+                    "dir": project.dir.to_string_lossy(),
+                    "width": project.width,
+                    "height": project.height,
+                    "duration": project.duration,
+                    "fps": project.fps,
+                    "note": "Project created. Use `add_element` to add content to the timeline, \
+                             or `set_composition` to set the full HTML. Then `render` to produce MP4."
+                });
+
+                let mut projects = self.projects.lock().await;
+                projects.insert(project_id, project);
+
+                Ok(result)
+            }
+
+            "add_element" => {
+                let project_id = args["project_id"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution("missing project_id".into())
+                    })?;
+
+                let project = self.get_project(project_id).await?;
+
+                let elem_val = &args["element"];
+                let element: CompositionElement =
+                    serde_json::from_value(elem_val.clone()).map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("invalid element: {e}").into(),
+                        )
+                    })?;
+
+                let result = self
+                    .backend
+                    .add_element(&project, &element)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("failed to add element: {e}").into(),
+                        )
+                    })?;
+
+                Ok(json!({
+                    "action": "add_element",
+                    "success": true,
+                    "project_id": project_id,
+                    "element_id": element.id,
+                    "element_type": element.element_type,
+                    "timeline": format!("{}s – {}s on track {}", element.start, element.start + element.duration, element.track),
+                    "result": result
+                }))
+            }
+
+            "set_composition" => {
+                let project_id = args["project_id"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution("missing project_id".into())
+                    })?;
+
+                let project = self.get_project(project_id).await?;
+
+                let html = args["html"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution(
+                            "missing html for set_composition".into(),
+                        )
+                    })?;
+
+                let result = self
+                    .backend
+                    .set_composition(&project, html)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("failed to set composition: {e}").into(),
+                        )
+                    })?;
+
+                Ok(json!({
+                    "action": "set_composition",
+                    "success": true,
+                    "project_id": project_id,
+                    "html_length": html.len(),
+                    "result": result,
+                    "note": "Composition set. Use `render` to produce MP4."
+                }))
+            }
+
+            "render" => {
+                let project_id = args["project_id"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution("missing project_id".into())
+                    })?;
+
+                let project = self.get_project(project_id).await?;
+                let output_name = args["output_name"].as_str();
+
+                let result = self
+                    .backend
+                    .render(&project, output_name)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("render failed: {e}").into(),
+                        )
+                    })?;
+
+                Ok(json!({
+                    "action": "render",
+                    "success": true,
+                    "project_id": project_id,
+                    "render": result,
+                    "note": "Video rendered successfully. The MP4 file is ready for delivery."
+                }))
+            }
+
+            "info" => {
+                let project_id = args["project_id"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution("missing project_id".into())
+                    })?;
+
+                let project = self.get_project(project_id).await?;
+
+                let info = self.backend.project_info(&project).await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to get project info: {e}").into(),
+                    )
+                })?;
+
+                Ok(json!({
+                    "action": "info",
+                    "success": true,
+                    "project": info
+                }))
+            }
+
+            "list" => {
+                let projects = self.backend.list_projects().await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to list projects: {e}").into(),
+                    )
+                })?;
+
+                // Also include in-memory projects.
+                let cached = self.projects.lock().await;
+                let cached_ids: Vec<&str> = cached.keys().map(|s| s.as_str()).collect();
+
+                Ok(json!({
+                    "action": "list",
+                    "success": true,
+                    "projects": projects,
+                    "active_session_projects": cached_ids,
+                    "count": projects.len()
+                }))
+            }
+
+            "mcp_tools" => {
+                let tools = self.backend.available_tools().await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to list MCP tools: {e}").into(),
+                    )
+                })?;
+
+                Ok(json!({
+                    "action": "mcp_tools",
+                    "success": true,
+                    "tools": tools,
+                    "note": "Use `mcp_call` with a tool name and arguments for advanced operations."
+                }))
+            }
+
+            "mcp_call" => {
+                let tool_name = args["mcp_tool"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        rustykrab_core::Error::ToolExecution("missing mcp_tool name".into())
+                    })?;
+
+                let arguments = args["mcp_arguments"]
+                    .as_object()
+                    .map(|o| Value::Object(o.clone()))
+                    .unwrap_or(json!({}));
+
+                let result =
+                    self.backend
+                        .call_mcp_tool(tool_name, arguments)
+                        .await
+                        .map_err(|e| {
+                            rustykrab_core::Error::ToolExecution(
+                                format!("MCP tool call failed: {e}").into(),
+                            )
+                        })?;
+
+                Ok(json!({
+                    "action": "mcp_call",
+                    "success": true,
+                    "tool": tool_name,
+                    "result": result
+                }))
+            }
+
+            _ => Err(rustykrab_core::Error::ToolExecution(
+                format!(
+                    "unknown video action `{action}`. Available: create_project, \
+                     add_element, set_composition, render, info, list, mcp_tools, mcp_call"
+                )
+                .into(),
+            )),
+        }
+    }
+}

--- a/crates/rustykrab-tools/src/video.rs
+++ b/crates/rustykrab-tools/src/video.rs
@@ -1,9 +1,18 @@
 //! Video creation tool — the agent's interface to the video communication channel.
 //!
 //! Enables the agent to compose HTML-based video compositions and render
-//! them to MP4 via the hyperframes engine (MCP). Video is treated as a
-//! mode of communication: the agent can respond with rendered video just
-//! as it responds with text through Telegram or WebChat.
+//! them to MP4 via the hyperframes engine. Video is treated as a mode of
+//! communication: the agent can respond with rendered video just as it
+//! responds with text through Telegram or WebChat.
+//!
+//! Primary workflow:
+//!   1. `create_project` — scaffold a new composition (uses `npx hyperframes init`)
+//!   2. `add_element` or `set_composition` — build the scene
+//!   3. `lint` — validate before rendering
+//!   4. `render` — produce MP4/WebM (uses `npx hyperframes render`)
+//!
+//! The tool also supports `doctor` (environment check), `info`, `list`,
+//! and direct MCP passthrough for advanced operations.
 
 use std::sync::Arc;
 
@@ -18,6 +27,9 @@ use rustykrab_channels::video::{CompositionElement, VideoChannel, VideoProject};
 /// decoupled from the channel lifecycle.
 #[async_trait]
 pub trait VideoBackend: Send + Sync {
+    /// Check environment readiness (Node >= 22, FFmpeg, Chrome).
+    async fn check_environment(&self) -> std::result::Result<Value, String>;
+
     /// Create a new video project.
     async fn create_project(
         &self,
@@ -26,6 +38,7 @@ pub trait VideoBackend: Send + Sync {
         height: u32,
         duration: f64,
         fps: u32,
+        template: Option<&str>,
     ) -> std::result::Result<VideoProject, String>;
 
     /// Add an element to a composition.
@@ -42,11 +55,19 @@ pub trait VideoBackend: Send + Sync {
         html: &str,
     ) -> std::result::Result<Value, String>;
 
-    /// Render a project to MP4.
+    /// Lint a composition.
+    async fn lint(
+        &self,
+        project: &VideoProject,
+    ) -> std::result::Result<Value, String>;
+
+    /// Render a project to video.
     async fn render(
         &self,
         project: &VideoProject,
         output_name: Option<&str>,
+        quality: Option<&str>,
+        format: Option<&str>,
     ) -> std::result::Result<Value, String>;
 
     /// Get project info.
@@ -58,15 +79,15 @@ pub trait VideoBackend: Send + Sync {
     /// List projects.
     async fn list_projects(&self) -> std::result::Result<Vec<VideoProject>, String>;
 
-    /// Call a raw MCP tool on the hyperframes server.
+    /// Connect to MCP server (optional).
+    async fn connect_mcp(&self) -> std::result::Result<Value, String>;
+
+    /// Call a raw MCP tool.
     async fn call_mcp_tool(
         &self,
         name: &str,
         arguments: Value,
     ) -> std::result::Result<Value, String>;
-
-    /// List available MCP tools.
-    async fn available_tools(&self) -> std::result::Result<Value, String>;
 }
 
 /// Adapter bridging [VideoChannel] to the [VideoBackend] trait.
@@ -82,6 +103,16 @@ impl VideoChannelAdapter {
 
 #[async_trait]
 impl VideoBackend for VideoChannelAdapter {
+    async fn check_environment(&self) -> std::result::Result<Value, String> {
+        let result = self.channel.check_environment().await?;
+        Ok(json!({
+            "node_ok": result.node_ok,
+            "ffmpeg_ok": result.ffmpeg_ok,
+            "chrome_ok": result.chrome_ok,
+            "raw_output": result.raw_output
+        }))
+    }
+
     async fn create_project(
         &self,
         name: &str,
@@ -89,9 +120,10 @@ impl VideoBackend for VideoChannelAdapter {
         height: u32,
         duration: f64,
         fps: u32,
+        template: Option<&str>,
     ) -> std::result::Result<VideoProject, String> {
         self.channel
-            .create_project(name, width, height, duration, fps)
+            .create_project(name, width, height, duration, fps, template)
             .await
     }
 
@@ -111,12 +143,24 @@ impl VideoBackend for VideoChannelAdapter {
         self.channel.set_composition(project, html).await
     }
 
+    async fn lint(
+        &self,
+        project: &VideoProject,
+    ) -> std::result::Result<Value, String> {
+        self.channel.lint(project).await
+    }
+
     async fn render(
         &self,
         project: &VideoProject,
         output_name: Option<&str>,
+        quality: Option<&str>,
+        format: Option<&str>,
     ) -> std::result::Result<Value, String> {
-        let result = self.channel.render(project, output_name).await?;
+        let result = self
+            .channel
+            .render(project, output_name, quality, format)
+            .await?;
         Ok(json!({
             "status": "rendered",
             "path": result.path.to_string_lossy(),
@@ -137,6 +181,11 @@ impl VideoBackend for VideoChannelAdapter {
         self.channel.list_projects()
     }
 
+    async fn connect_mcp(&self) -> std::result::Result<Value, String> {
+        let tools = self.channel.connect_mcp().await?;
+        Ok(json!(tools))
+    }
+
     async fn call_mcp_tool(
         &self,
         name: &str,
@@ -144,24 +193,21 @@ impl VideoBackend for VideoChannelAdapter {
     ) -> std::result::Result<Value, String> {
         self.channel.call_mcp_tool(name, arguments).await
     }
-
-    async fn available_tools(&self) -> std::result::Result<Value, String> {
-        let tools = self.channel.available_tools().await;
-        Ok(json!(tools))
-    }
 }
 
 /// Agent-facing video creation tool.
 ///
 /// Actions:
+/// - `doctor` — Check environment (Node >= 22, FFmpeg, Chrome)
 /// - `create_project` — Initialize a new video composition
 /// - `add_element` — Add a visual/audio element to the timeline
 /// - `set_composition` — Set the full HTML composition directly
-/// - `render` — Render the composition to MP4
+/// - `lint` — Validate the composition
+/// - `render` — Render to MP4/WebM
 /// - `info` — Get project status
 /// - `list` — List all video projects
-/// - `mcp_tools` — List available hyperframes MCP tools
-/// - `mcp_call` — Call a raw MCP tool for advanced operations
+/// - `connect_mcp` — Connect to hyperframes MCP server (advanced)
+/// - `mcp_call` — Call a raw MCP tool (advanced)
 pub struct VideoTool {
     backend: Arc<dyn VideoBackend>,
     /// In-memory project cache for the current session.
@@ -197,11 +243,13 @@ impl Tool for VideoTool {
     }
 
     fn description(&self) -> &str {
-        "Create and render video compositions. Video is a communication channel: \
-         compose HTML-based scenes with text, images, video clips, and audio on a \
-         timeline, then render to MP4. Powered by hyperframes engine via MCP. \
-         Use this when you want to communicate via video — tutorials, presentations, \
-         explanations, greetings, or any visual content."
+        "Create and render video compositions using hyperframes. Video is a \
+         communication channel: compose HTML-based scenes with text, images, \
+         video clips, and audio on a timeline, then render to MP4. Use this \
+         when you want to communicate via video — tutorials, presentations, \
+         explanations, greetings, or any visual content. Requires Node.js >= 22 \
+         and FFmpeg. Templates: blank, warm-grain, play-mode, swiss-grid, \
+         vignelli, decision-tree, kinetic-type, product-promo, nyt-graph."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -214,13 +262,15 @@ impl Tool for VideoTool {
                     "action": {
                         "type": "string",
                         "enum": [
+                            "doctor",
                             "create_project",
                             "add_element",
                             "set_composition",
+                            "lint",
                             "render",
                             "info",
                             "list",
-                            "mcp_tools",
+                            "connect_mcp",
                             "mcp_call"
                         ],
                         "description": "The video action to perform"
@@ -231,7 +281,7 @@ impl Tool for VideoTool {
                     },
                     "project_id": {
                         "type": "string",
-                        "description": "Project ID (for add_element, set_composition, render, info)"
+                        "description": "Project ID (for add_element, set_composition, lint, render, info)"
                     },
                     "width": {
                         "type": "integer",
@@ -250,32 +300,50 @@ impl Tool for VideoTool {
                     },
                     "fps": {
                         "type": "integer",
-                        "description": "Frames per second (default: 30)",
+                        "description": "Frames per second: 24, 30, or 60 (default: 30)",
                         "default": 30
+                    },
+                    "template": {
+                        "type": "string",
+                        "enum": ["blank", "warm-grain", "play-mode", "swiss-grid", "vignelli", "decision-tree", "kinetic-type", "product-promo", "nyt-graph"],
+                        "description": "Project template (for create_project, default: blank)"
                     },
                     "element": {
                         "type": "object",
-                        "description": "Element to add (for add_element). Fields: type (text|image|video|audio|shape|html), id, start, duration, track, properties",
+                        "description": "Element to add. Fields: type (text|image|video|audio|shape|html), id, start, duration, track, properties",
                         "properties": {
                             "type": {
                                 "type": "string",
                                 "enum": ["text", "image", "video", "audio", "shape", "html"]
                             },
                             "id": { "type": "string" },
-                            "start": { "type": "number" },
-                            "duration": { "type": "number" },
-                            "track": { "type": "integer" },
-                            "properties": { "type": "object" }
+                            "start": { "type": "number", "description": "Start time in seconds" },
+                            "duration": { "type": "number", "description": "Duration in seconds" },
+                            "track": { "type": "integer", "description": "Layer (0 = bottom)" },
+                            "properties": {
+                                "type": "object",
+                                "description": "Element-specific: text (text, fontSize, color, x, y), image/video (src, style, volume), audio (src, volume), shape (backgroundColor, width, height, x, y), html (html)"
+                            }
                         },
                         "required": ["type", "id", "start", "duration", "track"]
                     },
                     "html": {
                         "type": "string",
-                        "description": "Full HTML composition (for set_composition). Use hyperframes data attributes: data-start, data-duration, data-track, data-volume"
+                        "description": "Full HTML composition (for set_composition). Use hyperframes data attributes: data-start, data-duration, data-track, data-volume on a #stage div"
                     },
                     "output_name": {
                         "type": "string",
                         "description": "Output filename (for render, default: output.mp4)"
+                    },
+                    "quality": {
+                        "type": "string",
+                        "enum": ["draft", "standard", "high"],
+                        "description": "Render quality (default: standard)"
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["mp4", "webm"],
+                        "description": "Output format (default: mp4)"
                     },
                     "mcp_tool": {
                         "type": "string",
@@ -297,18 +365,32 @@ impl Tool for VideoTool {
             .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
 
         match action {
+            "doctor" => {
+                let result = self.backend.check_environment().await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("environment check failed: {e}").into(),
+                    )
+                })?;
+
+                Ok(json!({
+                    "action": "doctor",
+                    "success": true,
+                    "environment": result,
+                    "note": "Requires: Node.js >= 22, FFmpeg, and Chrome/Chromium for rendering."
+                }))
+            }
+
             "create_project" => {
-                let name = args["name"]
-                    .as_str()
-                    .unwrap_or("untitled");
+                let name = args["name"].as_str().unwrap_or("untitled");
                 let width = args["width"].as_u64().unwrap_or(1920) as u32;
                 let height = args["height"].as_u64().unwrap_or(1080) as u32;
                 let duration = args["duration"].as_f64().unwrap_or(10.0);
                 let fps = args["fps"].as_u64().unwrap_or(30) as u32;
+                let template = args["template"].as_str();
 
                 let project = self
                     .backend
-                    .create_project(name, width, height, duration, fps)
+                    .create_project(name, width, height, duration, fps, template)
                     .await
                     .map_err(|e| {
                         rustykrab_core::Error::ToolExecution(
@@ -328,8 +410,10 @@ impl Tool for VideoTool {
                     "height": project.height,
                     "duration": project.duration,
                     "fps": project.fps,
+                    "template": template.unwrap_or("blank"),
                     "note": "Project created. Use `add_element` to add content to the timeline, \
-                             or `set_composition` to set the full HTML. Then `render` to produce MP4."
+                             or `set_composition` to set the full HTML directly. Use `lint` to \
+                             validate, then `render` to produce MP4/WebM."
                 });
 
                 let mut projects = self.projects.lock().await;
@@ -339,11 +423,9 @@ impl Tool for VideoTool {
             }
 
             "add_element" => {
-                let project_id = args["project_id"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution("missing project_id".into())
-                    })?;
+                let project_id = args["project_id"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing project_id".into())
+                })?;
 
                 let project = self.get_project(project_id).await?;
 
@@ -355,43 +437,36 @@ impl Tool for VideoTool {
                         )
                     })?;
 
-                let result = self
-                    .backend
-                    .add_element(&project, &element)
-                    .await
-                    .map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to add element: {e}").into(),
-                        )
-                    })?;
+                let result =
+                    self.backend
+                        .add_element(&project, &element)
+                        .await
+                        .map_err(|e| {
+                            rustykrab_core::Error::ToolExecution(
+                                format!("failed to add element: {e}").into(),
+                            )
+                        })?;
 
                 Ok(json!({
                     "action": "add_element",
                     "success": true,
                     "project_id": project_id,
-                    "element_id": element.id,
-                    "element_type": element.element_type,
-                    "timeline": format!("{}s – {}s on track {}", element.start, element.start + element.duration, element.track),
                     "result": result
                 }))
             }
 
             "set_composition" => {
-                let project_id = args["project_id"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution("missing project_id".into())
-                    })?;
+                let project_id = args["project_id"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing project_id".into())
+                })?;
 
                 let project = self.get_project(project_id).await?;
 
-                let html = args["html"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution(
-                            "missing html for set_composition".into(),
-                        )
-                    })?;
+                let html = args["html"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(
+                        "missing html for set_composition".into(),
+                    )
+                })?;
 
                 let result = self
                     .backend
@@ -407,25 +482,45 @@ impl Tool for VideoTool {
                     "action": "set_composition",
                     "success": true,
                     "project_id": project_id,
-                    "html_length": html.len(),
                     "result": result,
-                    "note": "Composition set. Use `render` to produce MP4."
+                    "note": "Composition set. Use `lint` to validate, then `render` to produce video."
+                }))
+            }
+
+            "lint" => {
+                let project_id = args["project_id"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing project_id".into())
+                })?;
+
+                let project = self.get_project(project_id).await?;
+
+                let result = self.backend.lint(&project).await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("lint failed: {e}").into(),
+                    )
+                })?;
+
+                Ok(json!({
+                    "action": "lint",
+                    "success": true,
+                    "project_id": project_id,
+                    "result": result
                 }))
             }
 
             "render" => {
-                let project_id = args["project_id"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution("missing project_id".into())
-                    })?;
+                let project_id = args["project_id"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing project_id".into())
+                })?;
 
                 let project = self.get_project(project_id).await?;
                 let output_name = args["output_name"].as_str();
+                let quality = args["quality"].as_str();
+                let format = args["format"].as_str();
 
                 let result = self
                     .backend
-                    .render(&project, output_name)
+                    .render(&project, output_name, quality, format)
                     .await
                     .map_err(|e| {
                         rustykrab_core::Error::ToolExecution(
@@ -438,16 +533,14 @@ impl Tool for VideoTool {
                     "success": true,
                     "project_id": project_id,
                     "render": result,
-                    "note": "Video rendered successfully. The MP4 file is ready for delivery."
+                    "note": "Video rendered successfully. The file is ready for delivery."
                 }))
             }
 
             "info" => {
-                let project_id = args["project_id"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution("missing project_id".into())
-                    })?;
+                let project_id = args["project_id"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing project_id".into())
+                })?;
 
                 let project = self.get_project(project_id).await?;
 
@@ -471,7 +564,6 @@ impl Tool for VideoTool {
                     )
                 })?;
 
-                // Also include in-memory projects.
                 let cached = self.projects.lock().await;
                 let cached_ids: Vec<&str> = cached.keys().map(|s| s.as_str()).collect();
 
@@ -484,27 +576,25 @@ impl Tool for VideoTool {
                 }))
             }
 
-            "mcp_tools" => {
-                let tools = self.backend.available_tools().await.map_err(|e| {
+            "connect_mcp" => {
+                let tools = self.backend.connect_mcp().await.map_err(|e| {
                     rustykrab_core::Error::ToolExecution(
-                        format!("failed to list MCP tools: {e}").into(),
+                        format!("failed to connect MCP: {e}").into(),
                     )
                 })?;
 
                 Ok(json!({
-                    "action": "mcp_tools",
+                    "action": "connect_mcp",
                     "success": true,
                     "tools": tools,
-                    "note": "Use `mcp_call` with a tool name and arguments for advanced operations."
+                    "note": "MCP connected. Use `mcp_call` for advanced hyperframes operations."
                 }))
             }
 
             "mcp_call" => {
-                let tool_name = args["mcp_tool"]
-                    .as_str()
-                    .ok_or_else(|| {
-                        rustykrab_core::Error::ToolExecution("missing mcp_tool name".into())
-                    })?;
+                let tool_name = args["mcp_tool"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("missing mcp_tool name".into())
+                })?;
 
                 let arguments = args["mcp_arguments"]
                     .as_object()
@@ -531,8 +621,8 @@ impl Tool for VideoTool {
 
             _ => Err(rustykrab_core::Error::ToolExecution(
                 format!(
-                    "unknown video action `{action}`. Available: create_project, \
-                     add_element, set_composition, render, info, list, mcp_tools, mcp_call"
+                    "unknown video action `{action}`. Available: doctor, create_project, \
+                     add_element, set_composition, lint, render, info, list, connect_mcp, mcp_call"
                 )
                 .into(),
             )),


### PR DESCRIPTION
Introduces video as a first-class mode of communication in RustyKrab,
powered by the hyperframes engine via MCP (Model Context Protocol).
Just as Telegram sends text and Signal sends encrypted messages, the
video channel communicates by composing HTML-based compositions and
rendering them to MP4.

New modules:
- rustykrab-channels/src/mcp.rs: Lightweight MCP client (JSON-RPC 2.0
  over stdio) for communicating with any MCP server
- rustykrab-channels/src/video.rs: VideoChannel managing the
  hyperframes MCP server lifecycle with full pipeline support
  (compose -> preview -> render)
- rustykrab-tools/src/video.rs: VideoTool agent interface with actions
  for create_project, add_element, set_composition, render, and
  direct MCP tool passthrough

Integration:
- VideoChannel added to AppState alongside Telegram/Signal
- Enabled via RUSTYKRAB_VIDEO=true environment variable
- Graceful shutdown of MCP server on exit

https://claude.ai/code/session_017riydABo6phGBsw9Bxsk2X