### PR TITLE
Fix 10 tools issues: security, performance, and correctness

### DIFF
--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -401,48 +401,31 @@ impl ModelProvider for AnthropicProvider {
                 } else if let Some(data) = line.strip_prefix("data: ") {
                     match current_event_type.as_str() {
                         "message_start" => {
-                            if let Ok(evt) =
-                                serde_json::from_str::<SseMessageStart>(data)
-                            {
+                            if let Ok(evt) = serde_json::from_str::<SseMessageStart>(data) {
                                 input_tokens = evt.message.usage.input_tokens;
-                                cache_read_tokens = evt
-                                    .message
-                                    .usage
-                                    .cache_read_input_tokens
-                                    .unwrap_or(0);
-                                cache_creation_tokens = evt
-                                    .message
-                                    .usage
-                                    .cache_creation_input_tokens
-                                    .unwrap_or(0);
+                                cache_read_tokens =
+                                    evt.message.usage.cache_read_input_tokens.unwrap_or(0);
+                                cache_creation_tokens =
+                                    evt.message.usage.cache_creation_input_tokens.unwrap_or(0);
                             }
                         }
                         "content_block_start" => {
-                            if let Ok(evt) =
-                                serde_json::from_str::<SseContentBlockStart>(data)
-                            {
-                                if let SseContentBlock::ToolUse { id, name } =
-                                    evt.content_block
-                                {
+                            if let Ok(evt) = serde_json::from_str::<SseContentBlockStart>(data) {
+                                if let SseContentBlock::ToolUse { id, name } = evt.content_block {
                                     tool_meta.insert(evt.index, (id, name));
-                                    tool_input_bufs
-                                        .insert(evt.index, String::new());
+                                    tool_input_bufs.insert(evt.index, String::new());
                                 }
                             }
                         }
                         "content_block_delta" => {
-                            if let Ok(evt) =
-                                serde_json::from_str::<SseContentBlockDelta>(data)
-                            {
+                            if let Ok(evt) = serde_json::from_str::<SseContentBlockDelta>(data) {
                                 match evt.delta {
                                     SseDelta::TextDelta { text } => {
                                         full_text.push_str(&text);
                                         on_event(StreamEvent::TextDelta(text));
                                     }
                                     SseDelta::InputJsonDelta { partial_json } => {
-                                        if let Some(buf) =
-                                            tool_input_bufs.get_mut(&evt.index)
-                                        {
+                                        if let Some(buf) = tool_input_bufs.get_mut(&evt.index) {
                                             buf.push_str(&partial_json);
                                         }
                                     }
@@ -452,20 +435,13 @@ impl ModelProvider for AnthropicProvider {
                         }
                         "content_block_stop" => {
                             // Finalize any tool call whose input is now complete.
-                            if let Ok(evt) =
-                                serde_json::from_str::<SseContentBlockStop>(data)
-                            {
-                                if let Some(json_buf) =
-                                    tool_input_bufs.remove(&evt.index)
-                                {
-                                    if let Some((id, name)) =
-                                        tool_meta.remove(&evt.index)
-                                    {
-                                        let input: serde_json::Value =
-                                            serde_json::from_str(&json_buf)
-                                                .unwrap_or(serde_json::Value::Object(
-                                                    Default::default(),
-                                                ));
+                            if let Ok(evt) = serde_json::from_str::<SseContentBlockStop>(data) {
+                                if let Some(json_buf) = tool_input_bufs.remove(&evt.index) {
+                                    if let Some((id, name)) = tool_meta.remove(&evt.index) {
+                                        let input: serde_json::Value = serde_json::from_str(
+                                            &json_buf,
+                                        )
+                                        .unwrap_or(serde_json::Value::Object(Default::default()));
                                         tool_calls.push(ToolCall {
                                             id,
                                             name,
@@ -476,12 +452,9 @@ impl ModelProvider for AnthropicProvider {
                             }
                         }
                         "message_delta" => {
-                            if let Ok(evt) =
-                                serde_json::from_str::<SseMessageDelta>(data)
-                            {
+                            if let Ok(evt) = serde_json::from_str::<SseMessageDelta>(data) {
                                 output_tokens = evt.usage.output_tokens;
-                                stop_reason = match evt.delta.stop_reason.as_deref()
-                                {
+                                stop_reason = match evt.delta.stop_reason.as_deref() {
                                     Some("tool_use") => StopReason::ToolUse,
                                     Some("max_tokens") => StopReason::MaxTokens,
                                     _ => StopReason::EndTurn,

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -155,9 +155,7 @@ impl OllamaProvider {
                         // Fix #195: propagate serialization errors.
                         let content = match &result.output {
                             serde_json::Value::String(s) => s.clone(),
-                            other => {
-                                serde_json::to_string(other).map_err(Error::Serialization)?
-                            }
+                            other => serde_json::to_string(other).map_err(Error::Serialization)?,
                         };
                         OllamaMessage {
                             role: role.to_string(),
@@ -429,12 +427,9 @@ impl ModelProvider for OllamaProvider {
                     continue;
                 }
 
-                let stream_chunk: OllamaStreamChunk =
-                    serde_json::from_str(&line).map_err(|e| {
-                        Error::ModelProvider(format!(
-                            "failed to parse Ollama stream chunk: {e}"
-                        ))
-                    })?;
+                let stream_chunk: OllamaStreamChunk = serde_json::from_str(&line).map_err(|e| {
+                    Error::ModelProvider(format!("failed to parse Ollama stream chunk: {e}"))
+                })?;
 
                 if let Some(ref content) = stream_chunk.message.content {
                     if !content.is_empty() {

--- a/crates/rustykrab-tools/src/canvas.rs
+++ b/crates/rustykrab-tools/src/canvas.rs
@@ -11,7 +11,10 @@ pub struct CanvasTool {
 impl CanvasTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 }

--- a/crates/rustykrab-tools/src/gateway.rs
+++ b/crates/rustykrab-tools/src/gateway.rs
@@ -87,28 +87,32 @@ impl Tool for GatewayTool {
                 let key = args["key"].as_str();
                 let value = args["value"].as_str();
 
-                if let (Some(k), Some(v)) = (key, value) {
-                    let result =
-                        self.backend.set_config(k, v).await.map_err(|e| {
+                match (key, value) {
+                    (Some(k), Some(v)) => {
+                        let result = self.backend.set_config(k, v).await.map_err(|e| {
                             rustykrab_core::Error::ToolExecution(e.to_string().into())
                         })?;
 
-                    Ok(json!({
-                        "action": "config",
-                        "operation": "set",
-                        "result": result,
-                    }))
-                } else {
-                    let config =
-                        self.backend.get_config(key).await.map_err(|e| {
+                        Ok(json!({
+                            "action": "config",
+                            "operation": "set",
+                            "result": result,
+                        }))
+                    }
+                    (None, Some(_)) => Err(rustykrab_core::Error::ToolExecution(
+                        "config value provided without a key".into(),
+                    )),
+                    (key, None) => {
+                        let config = self.backend.get_config(key).await.map_err(|e| {
                             rustykrab_core::Error::ToolExecution(e.to_string().into())
                         })?;
 
-                    Ok(json!({
-                        "action": "config",
-                        "operation": "get",
-                        "config": config,
-                    }))
+                        Ok(json!({
+                            "action": "config",
+                            "operation": "get",
+                            "config": config,
+                        }))
+                    }
                 }
             }
             _ => Err(rustykrab_core::Error::ToolExecution(

--- a/crates/rustykrab-tools/src/image.rs
+++ b/crates/rustykrab-tools/src/image.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use base64::Engine;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Result, Tool};
 use serde_json::{json, Value};
+
+/// Maximum image download size (50 MB).
+const MAX_IMAGE_DOWNLOAD_SIZE: usize = 50 * 1024 * 1024;
 
 /// A built-in tool that analyzes images from URLs or file paths.
 pub struct ImageTool {
@@ -12,7 +14,10 @@ pub struct ImageTool {
 impl ImageTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 }
@@ -65,23 +70,41 @@ impl Tool for ImageTool {
                 rustykrab_core::Error::ToolExecution(format!("URL validation failed: {e}").into())
             })?;
 
-            self.client
-                .get(source)
-                .send()
-                .await
-                .map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(
-                        format!("failed to download image: {e}").into(),
-                    )
-                })?
-                .bytes()
-                .await
-                .map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(
-                        format!("failed to read image bytes: {e}").into(),
-                    )
-                })?
-                .to_vec()
+            let resp = self.client.get(source).send().await.map_err(|e| {
+                rustykrab_core::Error::ToolExecution(
+                    format!("failed to download image: {e}").into(),
+                )
+            })?;
+
+            // Check content-length header for early rejection
+            if let Some(len) = resp.content_length() {
+                if len > MAX_IMAGE_DOWNLOAD_SIZE as u64 {
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        format!("image too large: {len} bytes (max {MAX_IMAGE_DOWNLOAD_SIZE})")
+                            .into(),
+                    ));
+                }
+            }
+
+            // Read body with size limit via chunked reading
+            let mut bytes = Vec::new();
+            let mut resp = resp;
+            while let Some(chunk) = resp.chunk().await.map_err(|e| {
+                rustykrab_core::Error::ToolExecution(
+                    format!("failed to read image bytes: {e}").into(),
+                )
+            })? {
+                bytes.extend_from_slice(&chunk);
+                if bytes.len() > MAX_IMAGE_DOWNLOAD_SIZE {
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        format!(
+                            "image download exceeded size limit ({MAX_IMAGE_DOWNLOAD_SIZE} bytes)"
+                        )
+                        .into(),
+                    ));
+                }
+            }
+            bytes
         } else {
             // Path traversal protection: validate path before reading
             let safe_path = crate::security::validate_path(source).map_err(|e| {
@@ -95,12 +118,16 @@ impl Tool for ImageTool {
             })?
         };
 
-        let b64 = base64::engine::general_purpose::STANDARD.encode(&image_bytes);
-        let b64_len = b64.len();
+        // Compute base64 length without allocating the encoded string.
+        let b64_len = image_bytes.len().div_ceil(3) * 4;
+
+        let prompt = args["prompt"].as_str().unwrap_or("");
 
         Ok(json!({
             "source": source,
+            "size_bytes": image_bytes.len(),
             "base64_length": b64_len,
+            "prompt": prompt,
             "analysis": "Image loaded successfully. Pass to model for analysis."
         }))
     }

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -11,7 +11,10 @@ pub struct NodesTool {
 impl NodesTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 }

--- a/crates/rustykrab-tools/src/notion.rs
+++ b/crates/rustykrab-tools/src/notion.rs
@@ -53,7 +53,11 @@ impl NotionTool {
     }
 
     /// Build an authorized request to the Notion API.
-    fn notion_request(&self, method: reqwest::Method, path: &str) -> Result<reqwest::RequestBuilder> {
+    fn notion_request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+    ) -> Result<reqwest::RequestBuilder> {
         let token = self.get_token()?;
         let url = format!("{NOTION_API_BASE}{path}");
         Ok(self
@@ -66,9 +70,10 @@ impl NotionTool {
 
     /// Send a request and parse the JSON response, returning a friendly error on failure.
     async fn send_and_parse(&self, req: reqwest::RequestBuilder) -> Result<Value> {
-        let resp = req.send().await.map_err(|e| {
-            Error::ToolExecution(format!("Notion API request failed: {e}").into())
-        })?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("Notion API request failed: {e}").into()))?;
 
         let status = resp.status();
         let body = resp.text().await.map_err(|e| {
@@ -104,9 +109,7 @@ impl NotionTool {
             self.secrets
                 .set(KEY_DEFAULT_PARENT, parent_id)
                 .map_err(|e| {
-                    Error::ToolExecution(
-                        format!("failed to store default parent: {e}").into(),
-                    )
+                    Error::ToolExecution(format!("failed to store default parent: {e}").into())
                 })?;
         }
 
@@ -565,7 +568,10 @@ impl NotionTool {
                 "children": chunk,
             });
             let req = self
-                .notion_request(reqwest::Method::PATCH, &format!("/blocks/{page_id}/children"))?
+                .notion_request(
+                    reqwest::Method::PATCH,
+                    &format!("/blocks/{page_id}/children"),
+                )?
                 .json(&body);
             self.send_and_parse(req).await?;
         }
@@ -918,7 +924,10 @@ fn markdown_to_blocks(md: &str) -> Vec<Value> {
         }
 
         // Checklist items.
-        if let Some(rest) = trimmed.strip_prefix("- [x] ").or_else(|| trimmed.strip_prefix("- [X] ")) {
+        if let Some(rest) = trimmed
+            .strip_prefix("- [x] ")
+            .or_else(|| trimmed.strip_prefix("- [X] "))
+        {
             blocks.push(json!({
                 "type": "to_do",
                 "to_do": {
@@ -942,7 +951,10 @@ fn markdown_to_blocks(md: &str) -> Vec<Value> {
         }
 
         // Bulleted list items.
-        if let Some(rest) = trimmed.strip_prefix("- ").or_else(|| trimmed.strip_prefix("* ")) {
+        if let Some(rest) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+        {
             blocks.push(json!({
                 "type": "bulleted_list_item",
                 "bulleted_list_item": { "rich_text": rich_text_from_inline(rest) }

--- a/crates/rustykrab-tools/src/process.rs
+++ b/crates/rustykrab-tools/src/process.rs
@@ -73,12 +73,17 @@ fn validate_process_command(command: &str) -> std::result::Result<(), String> {
     }
 
     let base_cmd = command.split_whitespace().next().unwrap_or("");
-    let cmd_name = base_cmd.rsplit('/').next().unwrap_or(base_cmd);
 
-    if !ALLOWED_PROCESS_COMMANDS.contains(&cmd_name) {
+    // Reject absolute or relative paths to prevent allowlist bypass —
+    // e.g. /tmp/python would match "python" but execute a malicious binary.
+    if base_cmd.contains('/') {
+        return Err("absolute or relative paths are not allowed; use command names only".into());
+    }
+
+    if !ALLOWED_PROCESS_COMMANDS.contains(&base_cmd) {
         return Err(format!(
             "command '{}' is not allowed as a background process. Allowed: {}",
-            cmd_name,
+            base_cmd,
             ALLOWED_PROCESS_COMMANDS.join(", ")
         ));
     }
@@ -146,15 +151,53 @@ impl Tool for ProcessTool {
                     .split_first()
                     .ok_or_else(|| rustykrab_core::Error::ToolExecution("empty command".into()))?;
 
-                let child = tokio::process::Command::new(program)
-                    .args(cmd_args)
+                let mut cmd = tokio::process::Command::new(program);
+                cmd.args(cmd_args)
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())
-                    .env_clear()
-                    .env("PATH", "/usr/local/bin:/usr/bin:/bin")
-                    .env("HOME", std::env::var("HOME").unwrap_or_default())
-                    .env("LANG", "C.UTF-8")
+                    .env_clear();
+
+                // Forward safe environment variables needed by common tools
+                // (docker, kubectl, npm, ssh, etc.) while keeping secrets out.
+                const SAFE_ENV_VARS: &[&str] = &[
+                    "PATH",
+                    "HOME",
+                    "USER",
+                    "LOGNAME",
+                    "SHELL",
+                    "TERM",
+                    "LANG",
+                    "LC_ALL",
+                    "LC_CTYPE",
+                    "TMPDIR",
+                    "XDG_RUNTIME_DIR",
+                    "XDG_CONFIG_HOME",
+                    "XDG_DATA_HOME",
+                    "DOCKER_HOST",
+                    "DOCKER_CONFIG",
+                    "KUBECONFIG",
+                    "NODE_PATH",
+                    "NPM_CONFIG_PREFIX",
+                    "SSH_AUTH_SOCK",
+                    "CARGO_HOME",
+                    "RUSTUP_HOME",
+                    "GOPATH",
+                ];
+                for var_name in SAFE_ENV_VARS {
+                    if let Ok(val) = std::env::var(var_name) {
+                        cmd.env(var_name, val);
+                    }
+                }
+                // Ensure PATH and LANG always have sensible defaults
+                if std::env::var("PATH").is_err() {
+                    cmd.env("PATH", "/usr/local/bin:/usr/bin:/bin");
+                }
+                if std::env::var("LANG").is_err() {
+                    cmd.env("LANG", "C.UTF-8");
+                }
+
+                let child = cmd
                     .spawn()
                     .map_err(|e| rustykrab_core::Error::ToolExecution(e.to_string().into()))?;
 
@@ -219,34 +262,14 @@ impl Tool for ProcessTool {
                 }
             }
             "list" => {
-                let output = tokio::process::Command::new("ps")
-                    .args(["aux", "--no-headers"])
-                    .output()
-                    .await
-                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.to_string().into()))?;
-
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let processes: Vec<Value> = stdout
-                    .lines()
-                    .filter(|line| !line.is_empty())
-                    .map(|line| {
-                        let parts: Vec<&str> = line.split_whitespace().collect();
-                        if parts.len() >= 11 {
-                            json!({
-                                "user": parts[0],
-                                "pid": parts[1],
-                                "cpu": parts[2],
-                                "mem": parts[3],
-                                "command": parts[10..].join(" "),
-                            })
-                        } else {
-                            json!({ "raw": line })
-                        }
-                    })
-                    .collect();
+                // Only list processes managed by this tool, not all system processes.
+                let children = self.children.lock().await;
+                let processes: Vec<Value> =
+                    children.keys().map(|pid| json!({ "pid": pid })).collect();
 
                 Ok(json!({
                     "action": "list",
+                    "count": processes.len(),
                     "processes": processes,
                 }))
             }

--- a/crates/rustykrab-tools/src/sanitize.rs
+++ b/crates/rustykrab-tools/src/sanitize.rs
@@ -18,18 +18,20 @@ pub fn html_to_text(html: &str, include_links: bool) -> String {
     let mut in_anchor = false;
     let mut anchor_text = String::new();
 
-    let chars: Vec<char> = html.chars().collect();
-    let len = chars.len();
+    // Iterate directly over the str using byte offsets instead of collecting
+    // all chars into a Vec (which would use 4 bytes per char — ~4x memory).
+    let len = html.len();
     let mut i = 0;
 
     while i < len {
-        let ch = chars[i];
+        let ch = html[i..].chars().next().unwrap();
+        let ch_len = ch.len_utf8();
 
         if ch == '<' {
             in_tag = true;
             collecting_tag = true;
             tag_name.clear();
-            i += 1;
+            i += ch_len;
             continue;
         }
 
@@ -128,29 +130,28 @@ pub fn html_to_text(html: &str, include_links: bool) -> String {
                     _ => {}
                 }
 
-                i += 1;
+                i += ch_len;
                 continue;
             }
 
             if collecting_tag {
                 tag_name.push(ch);
             }
-            i += 1;
+            i += ch_len;
             continue;
         }
 
         // Not in a tag — this is text content
         if in_script_or_style {
-            i += 1;
+            i += ch_len;
             continue;
         }
 
         // Handle HTML entities
         if ch == '&' {
-            let entity_end = chars[i..].iter().position(|&c| c == ';');
-            if let Some(end) = entity_end {
-                let entity: String = chars[i..i + end + 1].iter().collect();
-                let decoded = decode_entity(&entity);
+            if let Some(end) = html[i..].find(';') {
+                let entity = &html[i..i + end + 1];
+                let decoded = decode_entity(entity);
                 if in_anchor {
                     anchor_text.push_str(&decoded);
                 } else {
@@ -166,7 +167,7 @@ pub fn html_to_text(html: &str, include_links: bool) -> String {
         } else {
             result.push(ch);
         }
-        i += 1;
+        i += ch_len;
     }
 
     // Collapse excessive whitespace but preserve paragraph breaks
@@ -175,7 +176,9 @@ pub fn html_to_text(html: &str, include_links: bool) -> String {
 
 /// Extract href attribute value from a tag string like `a href="..."`
 fn extract_href(tag_content: &str) -> String {
-    let lower = tag_content.to_lowercase();
+    // Use to_ascii_lowercase() to preserve byte positions — to_lowercase()
+    // can shift byte offsets when multi-byte chars change length.
+    let lower = tag_content.to_ascii_lowercase();
     if let Some(pos) = lower.find("href=") {
         let after_href = &tag_content[pos + 5..];
         let trimmed = after_href.trim_start();

--- a/crates/rustykrab-tools/src/security.rs
+++ b/crates/rustykrab-tools/src/security.rs
@@ -172,7 +172,7 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || v4.is_link_local()                // 169.254.0.0/16
                 || v4.is_broadcast()                 // 255.255.255.255
                 || v4.is_unspecified()               // 0.0.0.0
-                || v4.octets()[0] == 100 && v4.octets()[1] >= 64 && v4.octets()[1] <= 127
+                || (v4.octets()[0] == 100 && v4.octets()[1] >= 64 && v4.octets()[1] <= 127)
             // 100.64.0.0/10 (CGNAT)
         }
         IpAddr::V6(v6) => {

--- a/crates/rustykrab-tools/src/tts.rs
+++ b/crates/rustykrab-tools/src/tts.rs
@@ -3,6 +3,9 @@ use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Result, Tool};
 use serde_json::{json, Value};
 
+/// Maximum TTS response size (100 MB).
+const MAX_TTS_RESPONSE_SIZE: usize = 100 * 1024 * 1024;
+
 /// A built-in tool that converts text to speech audio using a configured TTS API.
 pub struct TtsTool {
     client: reqwest::Client,
@@ -11,7 +14,10 @@ pub struct TtsTool {
 impl TtsTool {
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 }
@@ -92,7 +98,7 @@ impl Tool for TtsTool {
             req = req.header("Authorization", format!("Bearer {api_key}"));
         }
 
-        let resp = req.send().await.map_err(|e| {
+        let mut resp = req.send().await.map_err(|e| {
             rustykrab_core::Error::ToolExecution(format!("TTS request failed: {e}").into())
         })?;
 
@@ -104,9 +110,29 @@ impl Tool for TtsTool {
             ));
         }
 
-        let audio_bytes = resp.bytes().await.map_err(|e| {
+        // Check content-length header for early rejection
+        if let Some(len) = resp.content_length() {
+            if len > MAX_TTS_RESPONSE_SIZE as u64 {
+                return Err(rustykrab_core::Error::ToolExecution(
+                    format!("TTS response too large: {len} bytes (max {MAX_TTS_RESPONSE_SIZE})")
+                        .into(),
+                ));
+            }
+        }
+
+        // Read body with size limit via chunked reading
+        let mut audio_bytes = Vec::new();
+        while let Some(chunk) = resp.chunk().await.map_err(|e| {
             rustykrab_core::Error::ToolExecution(format!("failed to read TTS response: {e}").into())
-        })?;
+        })? {
+            audio_bytes.extend_from_slice(&chunk);
+            if audio_bytes.len() > MAX_TTS_RESPONSE_SIZE {
+                return Err(rustykrab_core::Error::ToolExecution(
+                    format!("TTS response exceeded size limit ({MAX_TTS_RESPONSE_SIZE} bytes)")
+                        .into(),
+                ));
+            }
+        }
 
         tokio::fs::write(&safe_output_path, &audio_bytes)
             .await


### PR DESCRIPTION
Closes #142 - Add parentheses to CGNAT range check for explicit operator precedence
Closes #139 - Use to_ascii_lowercase() in extract_href to preserve byte positions
Closes #137 - Eliminate Vec<char> allocation in html_to_text (4x memory savings)
Closes #135 - Return error when gateway config value is provided without a key
Closes #132 - Compute base64 length mathematically instead of encoding then discarding
Closes #129 - Forward broader set of safe env vars in process spawn (env_clear fix)
Closes #126 - Add 30s timeout to reqwest::Client in nodes, canvas, tts, and image tools
Closes #123 - Restrict process list to managed processes only (no longer leaks ps aux)
Closes #120 - Reject path-based commands to prevent allowlist bypass (/tmp/python)
Closes #115 - Add size limits on image download (50MB) and TTS response (100MB)

Note: #118 (SSRF DNS blocking) was already fixed — code uses tokio::net::lookup_host.

https://claude.ai/code/session_01PoYPsi2h2eRxbwgX29Rvox