### PR TITLE
Fix 11 security issues across gateway, store, and tools crates

### DIFF
--- a/crates/rustykrab-gateway/src/auth.rs
+++ b/crates/rustykrab-gateway/src/auth.rs
@@ -77,8 +77,10 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
 
 /// Generate a cryptographically random 32-byte hex token.
 pub fn generate_token() -> String {
-    use rand::RngCore;
+    use rand::TryRngCore;
     let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
+    rand::rngs::OsRng
+        .try_fill_bytes(&mut bytes)
+        .expect("OS RNG failed");
     hex::encode(bytes)
 }

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -31,7 +31,7 @@ async fn add_security_headers(mut response: Response) -> Response {
     );
     headers.insert(
         header::CONTENT_SECURITY_POLICY,
-        "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self' data:"
+        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:"
             .parse()
             .unwrap(),
     );

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -256,25 +256,26 @@ pub async fn run_agent_streaming(
         // The pipeline runs synchronously and can take many minutes.
         // Emit periodic heartbeat events so the SSE timeout doesn't
         // kill the connection while the pipeline is working.
-        let heartbeat_event = on_event as &(dyn Fn(AgentEvent) + Send + Sync);
-        let keepalive = tokio::spawn({
-            // Safety: on_event lives for the duration of run_agent_streaming
-            // which is awaited below, so it outlives this spawned task.
-            let event_fn: &'static (dyn Fn(AgentEvent) + Send + Sync) =
-                unsafe { std::mem::transmute(heartbeat_event) };
-            async move {
-                loop {
-                    tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
-                    event_fn(AgentEvent::Compressing); // reuse existing event as heartbeat
+        // Uses tokio::select! with an interval instead of unsafe transmute,
+        // avoiding a potential use-after-free if the pipeline future is
+        // cancelled before the heartbeat task is aborted.
+        let result = {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
+            interval.tick().await; // first tick is immediate, consume it
+
+            let pipeline_future =
+                pipeline.run(user_content, TaskComplexity::Complex, context.as_deref());
+            tokio::pin!(pipeline_future);
+
+            loop {
+                tokio::select! {
+                    result = &mut pipeline_future => break result,
+                    _ = interval.tick() => {
+                        on_event(AgentEvent::Compressing); // heartbeat
+                    }
                 }
             }
-        });
-
-        let result = pipeline
-            .run(user_content, TaskComplexity::Complex, context.as_deref())
-            .await;
-
-        keepalive.abort(); // stop the heartbeat once pipeline finishes
+        };
 
         let result = result.map_err(|e| {
             tracing::error!("orchestration pipeline error: {e}");

--- a/crates/rustykrab-gateway/src/origin.rs
+++ b/crates/rustykrab-gateway/src/origin.rs
@@ -43,23 +43,36 @@ impl Default for OriginPolicy {
 
 /// Axum middleware that validates the Origin header.
 ///
-/// Non-browser clients (curl, SDKs) typically don't send an Origin header,
-/// so a missing header is allowed. But if an Origin header IS present,
-/// it must match the policy — this is what blocks browser-based attacks.
+/// For sensitive endpoints (/api/ and /webhook/), the Origin header is
+/// mandatory. This prevents non-browser tools from bypassing origin
+/// protection by simply omitting the header.
 pub async fn origin_check_middleware(
     state: axum::extract::State<crate::AppState>,
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    if let Some(origin) = request.headers().get(header::ORIGIN) {
-        let origin_str = origin.to_str().unwrap_or("");
-        if !state.origin_policy.is_allowed(origin_str) {
+    let path = request.uri().path().to_string();
+    let is_sensitive = path.starts_with("/api/") || path.starts_with("/webhook/");
+
+    match request.headers().get(header::ORIGIN) {
+        Some(origin) => {
+            let origin_str = origin.to_str().unwrap_or("");
+            if !state.origin_policy.is_allowed(origin_str) {
+                tracing::warn!(
+                    origin = origin_str,
+                    "rejected request from disallowed origin"
+                );
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+        None if is_sensitive => {
             tracing::warn!(
-                origin = origin_str,
-                "rejected request from disallowed origin"
+                path = %path,
+                "rejected request without Origin header on sensitive endpoint"
             );
             return Err(StatusCode::FORBIDDEN);
         }
+        None => {} // non-sensitive endpoints don't require Origin
     }
 
     Ok(next.run(request).await)

--- a/crates/rustykrab-gateway/src/rate_limit.rs
+++ b/crates/rustykrab-gateway/src/rate_limit.rs
@@ -115,6 +115,28 @@ impl RateLimiter {
     }
 }
 
+/// Extract the client IP address, preferring the X-Forwarded-For header
+/// when the request arrives through a reverse proxy.
+fn extract_client_ip(request: &Request, socket_addr: IpAddr) -> IpAddr {
+    // Only trust X-Forwarded-For when the direct connection is from
+    // loopback (i.e. a local reverse proxy). This prevents spoofing
+    // by external clients injecting the header directly.
+    if socket_addr.is_loopback() {
+        if let Some(forwarded) = request.headers().get("x-forwarded-for") {
+            if let Ok(value) = forwarded.to_str() {
+                // X-Forwarded-For: client, proxy1, proxy2
+                // The leftmost entry is the original client IP.
+                if let Some(client_ip) = value.split(',').next() {
+                    if let Ok(ip) = client_ip.trim().parse::<IpAddr>() {
+                        return ip;
+                    }
+                }
+            }
+        }
+    }
+    socket_addr
+}
+
 /// Axum middleware that enforces rate limiting on API endpoints.
 pub async fn rate_limit_middleware(
     ConnectInfo(addr): ConnectInfo<std::net::SocketAddr>,
@@ -129,8 +151,10 @@ pub async fn rate_limit_middleware(
         return Ok(next.run(request).await);
     }
 
-    if !state.rate_limiter.check(addr.ip()) {
-        tracing::warn!(ip = %addr.ip(), path = %path, "rate limited");
+    let client_ip = extract_client_ip(&request, addr.ip());
+
+    if !state.rate_limiter.check(client_ip) {
+        tracing::warn!(ip = %client_ip, path = %path, "rate limited");
         return Err(StatusCode::TOO_MANY_REQUESTS);
     }
 

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -1,7 +1,7 @@
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use argon2::Argon2;
-use rand::RngCore;
+use rand::TryRngCore;
 use rustykrab_core::Error;
 use std::sync::Arc;
 use zeroize::Zeroizing;
@@ -112,11 +112,16 @@ impl SecretStore {
     /// ciphertext to its key name — moving a ciphertext to a different
     /// key name will fail authentication.
     fn encrypt(&self, key_name: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
-        // Generate random salt and nonce.
+        // Generate random salt and nonce using OsRng for explicit
+        // cryptographic intent.
         let mut salt = [0u8; SALT_LEN];
         let mut nonce_bytes = [0u8; NONCE_LEN];
-        rand::rng().fill_bytes(&mut salt);
-        rand::rng().fill_bytes(&mut nonce_bytes);
+        rand::rngs::OsRng
+            .try_fill_bytes(&mut salt)
+            .expect("OS RNG failed");
+        rand::rngs::OsRng
+            .try_fill_bytes(&mut nonce_bytes)
+            .expect("OS RNG failed");
 
         // Derive a per-secret encryption key via Argon2id.
         let derived_key = self.derive_key(&salt)?;

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -90,13 +90,13 @@ fn truncate_utf8(s: &str, max_bytes: usize) -> (&str, bool) {
     (&s[..end], true)
 }
 
-/// Mask a cookie value for security: show first 8 chars + "..."
+/// Mask a cookie value for security: hide the entire value to prevent
+/// exposure of predictable session token prefixes.
 fn mask_cookie_value(value: &str) -> String {
-    if value.len() <= 8 {
-        value.to_string()
-    } else {
-        format!("{}...", &value[..8])
+    if value.is_empty() {
+        return String::new();
     }
+    format!("***({} chars)", value.len())
 }
 
 #[async_trait]

--- a/crates/rustykrab-tools/src/exec.rs
+++ b/crates/rustykrab-tools/src/exec.rs
@@ -119,7 +119,10 @@ impl Default for ExecTool {
 
 fn truncate_output(s: String) -> String {
     if s.len() > MAX_OUTPUT_BYTES {
-        let mut truncated = s[..MAX_OUTPUT_BYTES].to_string();
+        // Use floor_char_boundary to avoid panicking when the truncation
+        // point falls within a multi-byte UTF-8 character.
+        let end = s.floor_char_boundary(MAX_OUTPUT_BYTES);
+        let mut truncated = s[..end].to_string();
         truncated.push_str("\n... [truncated]");
         truncated
     } else {
@@ -249,7 +252,7 @@ impl Tool for ExecTool {
             .arg(command)
             .env_clear()
             .env("PATH", &path)
-            .env("HOME", std::env::var("HOME").unwrap_or_default())
+            .env("HOME", "/tmp/rustykrab-home")
             .env("LANG", "C.UTF-8")
             .output();
 

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -119,9 +119,11 @@ impl GmailTool {
 
             // Use Gmail's X-GM-RAW extension for full search syntax,
             // falling back to standard IMAP SEARCH.
-            // Escape inner double quotes so the IMAP command parses correctly
+            // Strip CRLF sequences to prevent IMAP command injection, then
+            // escape inner double quotes so the IMAP command parses correctly
             // (e.g. query `from:"foo@bar.com"` becomes `X-GM-RAW "from:\"foo@bar.com\""`).
-            let escaped_query = query.replace('\\', "\\\\").replace('"', "\\\"");
+            let sanitized_query = query.replace('\r', "").replace('\n', "").replace('\0', "");
+            let escaped_query = sanitized_query.replace('\\', "\\\\").replace('"', "\\\"");
             let uids = session
                 .uid_search(format!("X-GM-RAW \"{escaped_query}\""))
                 .or_else(|_| session.uid_search(&query))

--- a/crates/rustykrab-tools/src/process.rs
+++ b/crates/rustykrab-tools/src/process.rs
@@ -229,35 +229,24 @@ impl Tool for ProcessTool {
                     ));
                 }
 
-                // Try to kill via the stored child handle first (cleans up zombie).
+                // Only allow killing processes that were spawned by this tool.
+                // This prevents arbitrary PID termination of system or
+                // third-party processes.
                 let pid_u32 = pid as u32;
                 if let Some(mut child) = self.children.lock().await.remove(&pid_u32) {
                     let _ = child.kill().await;
                     let _ = child.wait().await;
-                    return Ok(json!({
-                        "action": "stop",
-                        "pid": pid,
-                        "status": "terminated",
-                    }));
-                }
-
-                // Fallback to kill(1) for processes not tracked by us.
-                let output = tokio::process::Command::new("kill")
-                    .arg(pid.to_string())
-                    .output()
-                    .await
-                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.to_string().into()))?;
-
-                if output.status.success() {
                     Ok(json!({
                         "action": "stop",
                         "pid": pid,
                         "status": "terminated",
                     }))
                 } else {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
                     Err(rustykrab_core::Error::ToolExecution(
-                        format!("failed to stop process {pid}: {stderr}").into(),
+                        format!(
+                            "process {pid} was not spawned by this tool and cannot be stopped"
+                        )
+                        .into(),
                     ))
                 }
             }

--- a/crates/rustykrab-tools/src/security.rs
+++ b/crates/rustykrab-tools/src/security.rs
@@ -178,6 +178,10 @@ fn is_private_ip(ip: &IpAddr) -> bool {
         IpAddr::V6(v6) => {
             v6.is_loopback()       // ::1
                 || v6.is_unspecified() // ::
+                // Unique local addresses (fc00::/7)
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                // Link-local addresses (fe80::/10)
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
                 // IPv4-mapped addresses
                 || v6.to_ipv4_mapped().map(|v4| {
                     v4.is_loopback() || v4.is_private() || v4.is_link_local()


### PR DESCRIPTION
Closes #81, #84, #86, #88, #93, #97, #100, #103, #105, #109, #113

High:
- SEC-H7: Replace unsafe transmute lifetime extension with tokio::select!
  heartbeat loop in orchestrate.rs, eliminating use-after-free risk

Medium:
- SEC-M1: Require Origin header on sensitive endpoints (/api/, /webhook/)
- SEC-M2: Extract client IP from X-Forwarded-For when behind reverse proxy
- SEC-M3: Replace CSP unsafe-inline with 'self' for script-src/style-src
- SEC-M5: Replace rand::rng() with OsRng for cryptographic key generation
- SEC-M6: Sandbox HOME to /tmp/rustykrab-home in exec tool
- SEC-M7: Restrict process stop to only tool-spawned PIDs

Low:
- SEC-L1: Use floor_char_boundary() to prevent UTF-8 truncation panics
- SEC-L2: Add unique-local (fc00::/7) and link-local (fe80::/10) IPv6 checks
- SEC-L3: Fully mask cookie values instead of exposing first 8 chars
- SEC-L4: Strip CRLF and null bytes from IMAP X-GM-RAW queries

https://claude.ai/code/session_01LBuKPQCrntUZRqd5H8dfjJ