### PR TITLE
Fix 6 store issues: atomicity, performance, security, correctness

### DIFF
--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -29,13 +29,13 @@ impl ConversationStore {
     }
 
     /// Persist a conversation (insert or update).
+    ///
+    /// Does not force an fsync — sled flushes according to its own policy.
+    /// Call `Store::flush()` when an explicit durability barrier is needed.
     pub fn save(&self, conv: &Conversation) -> Result<(), Error> {
         let bytes = serde_json::to_vec(conv)?;
         self.tree
             .insert(conv.id.as_bytes(), bytes)
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        self.tree
-            .flush()
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(())
     }

--- a/crates/rustykrab-store/src/knowledge_graph.rs
+++ b/crates/rustykrab-store/src/knowledge_graph.rs
@@ -10,6 +10,7 @@
 use rustykrab_core::orchestration::{EntityType, KnowledgeEntity, KnowledgeRelation, RelationType};
 use rustykrab_core::Error;
 use serde::{Deserialize, Serialize};
+use sled::Transactional;
 use uuid::Uuid;
 
 /// Persistent knowledge graph backed by sled trees.
@@ -43,6 +44,24 @@ impl KnowledgeGraph {
     /// Add or update an entity in the graph.
     pub fn upsert_entity(&self, entity: &KnowledgeEntity) -> Result<(), Error> {
         let key = entity.id.as_bytes().to_vec();
+
+        // If the entity already exists with a different name, remove the stale
+        // name index entry so it doesn't accumulate over renames.
+        if let Some(old_bytes) = self
+            .entities
+            .get(&key)
+            .map_err(|e| Error::Storage(e.to_string()))?
+        {
+            let old_entity: KnowledgeEntity = serde_json::from_slice(&old_bytes)?;
+            let old_name_key = old_entity.name.to_lowercase();
+            let new_name_key = entity.name.to_lowercase();
+            if old_name_key != new_name_key {
+                self.entity_names
+                    .remove(old_name_key.as_bytes())
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            }
+        }
+
         let bytes = serde_json::to_vec(entity)?;
         self.entities
             .insert(key, bytes)
@@ -122,24 +141,22 @@ impl KnowledgeGraph {
         Ok(results)
     }
 
-    /// Delete an entity and all its relations.
+    /// Delete an entity and all its relations atomically.
+    ///
+    /// Uses a sled transaction across all three trees so a crash cannot
+    /// leave orphaned relations or a dangling name index entry.
     pub fn delete_entity(&self, id: Uuid) -> Result<(), Error> {
-        // Remove the entity.
-        if let Some(bytes) = self
+        // Fetch the entity name for the name-index cleanup.
+        let name_key = self
             .entities
-            .remove(id.as_bytes())
+            .get(id.as_bytes())
             .map_err(|e| Error::Storage(e.to_string()))?
-        {
-            // Remove name index.
-            let entity: KnowledgeEntity = serde_json::from_slice(&bytes)?;
-            let name_key = entity.name.to_lowercase();
-            self.entity_names
-                .remove(name_key.as_bytes())
-                .map_err(|e| Error::Storage(e.to_string()))?;
-        }
+            .and_then(|bytes| serde_json::from_slice::<KnowledgeEntity>(&bytes).ok())
+            .map(|e| e.name.to_lowercase());
 
-        // Remove all relations involving this entity.
-        let to_remove: Vec<Vec<u8>> = self
+        // Collect relation keys to remove (iteration not available inside
+        // sled transactions, so we scan first).
+        let relation_keys: Vec<Vec<u8>> = self
             .relations
             .iter()
             .filter_map(|entry| {
@@ -153,11 +170,21 @@ impl KnowledgeGraph {
             })
             .collect();
 
-        for key in to_remove {
-            self.relations
-                .remove(key)
-                .map_err(|e| Error::Storage(e.to_string()))?;
-        }
+        // Atomically remove entity, name index, and all relations.
+        (&self.entities, &self.relations, &self.entity_names)
+            .transaction(|(entities_tx, relations_tx, names_tx)| {
+                entities_tx.remove(id.as_bytes())?;
+                if let Some(ref nk) = name_key {
+                    names_tx.remove(nk.as_bytes())?;
+                }
+                for key in &relation_keys {
+                    relations_tx.remove(key.as_slice())?;
+                }
+                Ok(())
+            })
+            .map_err(|e: sled::transaction::TransactionError| {
+                Error::Storage(format!("transaction failed: {e}"))
+            })?;
 
         Ok(())
     }
@@ -182,6 +209,11 @@ impl KnowledgeGraph {
         for entry in self.relations.scan_prefix(&prefix) {
             let (_, value) = entry.map_err(|e| Error::Storage(e.to_string()))?;
             let rel: KnowledgeRelation = serde_json::from_slice(&value)?;
+            debug_assert_eq!(
+                rel.from_id, entity_id,
+                "prefix scan returned relation with from_id {} but expected {}",
+                rel.from_id, entity_id
+            );
             results.push(rel);
         }
         Ok(results)

--- a/crates/rustykrab-store/src/memory.rs
+++ b/crates/rustykrab-store/src/memory.rs
@@ -44,9 +44,20 @@ impl MemoryStore {
         Self { tree }
     }
 
+    /// Build a composite key: `conversation_id (16 bytes) || entry_id (16 bytes)`.
+    ///
+    /// This layout lets us `scan_prefix(conversation_id)` to retrieve only
+    /// the entries belonging to a single conversation, avoiding full-table scans.
+    fn composite_key(conversation_id: &Uuid, entry_id: &Uuid) -> Vec<u8> {
+        let mut key = Vec::with_capacity(32);
+        key.extend_from_slice(conversation_id.as_bytes());
+        key.extend_from_slice(entry_id.as_bytes());
+        key
+    }
+
     /// Store a memory entry.
     pub fn save(&self, entry: &MemoryEntry) -> Result<(), Error> {
-        let key = entry.id.as_bytes().to_vec();
+        let key = Self::composite_key(&entry.conversation_id, &entry.id);
         let bytes = serde_json::to_vec(entry)?;
         self.tree
             .insert(key, bytes)
@@ -54,11 +65,12 @@ impl MemoryStore {
         Ok(())
     }
 
-    /// Retrieve a memory by its unique ID.
-    pub fn get(&self, id: Uuid) -> Result<MemoryEntry, Error> {
+    /// Retrieve a memory by its unique ID and conversation ID.
+    pub fn get(&self, id: Uuid, conversation_id: Uuid) -> Result<MemoryEntry, Error> {
+        let key = Self::composite_key(&conversation_id, &id);
         let bytes = self
             .tree
-            .get(id.as_bytes())
+            .get(key)
             .map_err(|e| Error::Storage(e.to_string()))?
             .ok_or_else(|| Error::NotFound(format!("memory {id}")))?;
         let entry: MemoryEntry = serde_json::from_slice(&bytes)?;
@@ -69,6 +81,9 @@ impl MemoryStore {
     /// given keywords. This is the associative retrieval mechanism:
     /// keywords from the user's message are matched against stored
     /// tags to surface relevant memories automatically.
+    ///
+    /// Uses a prefix scan on `conversation_id` so only entries for the
+    /// target conversation are visited.
     ///
     /// Updates `last_accessed` and `access_count` on matched entries
     /// (reconsolidation — retrieval strengthens the memory).
@@ -83,13 +98,9 @@ impl MemoryStore {
         let keywords_lower: Vec<String> = keywords.iter().map(|k| k.to_lowercase()).collect();
         let mut results = Vec::new();
 
-        for item in self.tree.iter() {
+        for item in self.tree.scan_prefix(conversation_id.as_bytes()) {
             let (key, value) = item.map_err(|e| Error::Storage(e.to_string()))?;
             let mut entry: MemoryEntry = serde_json::from_slice(&value)?;
-
-            if entry.conversation_id != conversation_id {
-                continue;
-            }
 
             let matches = entry.tags.iter().any(|tag| {
                 let tag_lower = tag.to_lowercase();
@@ -118,32 +129,35 @@ impl MemoryStore {
     /// List all memories for a conversation.
     pub fn list_for_conversation(&self, conversation_id: Uuid) -> Result<Vec<MemoryEntry>, Error> {
         let mut entries = Vec::new();
-        for item in self.tree.iter() {
+        for item in self.tree.scan_prefix(conversation_id.as_bytes()) {
             let (_, value) = item.map_err(|e| Error::Storage(e.to_string()))?;
             let entry: MemoryEntry = serde_json::from_slice(&value)?;
-            if entry.conversation_id == conversation_id {
-                entries.push(entry);
-            }
+            entries.push(entry);
         }
         entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
         Ok(entries)
     }
 
     /// Delete a specific memory entry.
-    pub fn delete(&self, id: Uuid) -> Result<(), Error> {
+    pub fn delete(&self, id: Uuid, conversation_id: Uuid) -> Result<(), Error> {
+        let key = Self::composite_key(&conversation_id, &id);
         self.tree
-            .remove(id.as_bytes())
+            .remove(key)
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(())
     }
 
     /// Delete all memories for a conversation.
     pub fn delete_for_conversation(&self, conversation_id: Uuid) -> Result<u32, Error> {
-        let entries = self.list_for_conversation(conversation_id)?;
-        let count = entries.len() as u32;
-        for entry in entries {
+        let keys: Vec<Vec<u8>> = self
+            .tree
+            .scan_prefix(conversation_id.as_bytes())
+            .filter_map(|item| item.ok().map(|(key, _)| key.to_vec()))
+            .collect();
+        let count = keys.len() as u32;
+        for key in keys {
             self.tree
-                .remove(entry.id.as_bytes())
+                .remove(key)
                 .map_err(|e| Error::Storage(e.to_string()))?;
         }
         Ok(count)

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -125,7 +125,7 @@ impl SecretStore {
 
         // Derive a per-secret encryption key via Argon2id.
         let derived_key = self.derive_key(&salt)?;
-        let cipher = Aes256Gcm::new_from_slice(&derived_key)
+        let cipher = Aes256Gcm::new_from_slice(&*derived_key)
             .map_err(|e| Error::Storage(format!("cipher init: {e}")))?;
 
         let nonce = Nonce::from_slice(&nonce_bytes);
@@ -160,7 +160,7 @@ impl SecretStore {
         let ciphertext = &data[SALT_LEN + NONCE_LEN..];
 
         let derived_key = self.derive_key(salt)?;
-        let cipher = Aes256Gcm::new_from_slice(&derived_key)
+        let cipher = Aes256Gcm::new_from_slice(&*derived_key)
             .map_err(|e| Error::Storage(format!("cipher init: {e}")))?;
 
         let nonce = Nonce::from_slice(nonce_bytes);
@@ -185,10 +185,14 @@ impl SecretStore {
     /// Argon2id is resistant to both side-channel and GPU/ASIC brute-force
     /// attacks. Even if the database is stolen, the attacker must spend
     /// significant time/memory per guess of the master key.
-    fn derive_key(&self, salt: &[u8]) -> Result<[u8; 32], Error> {
-        let mut key = [0u8; 32];
+    ///
+    /// The returned key is wrapped in `Zeroizing` so it is securely erased
+    /// from memory when dropped, preventing key material from lingering
+    /// on the stack.
+    fn derive_key(&self, salt: &[u8]) -> Result<Zeroizing<[u8; 32]>, Error> {
+        let mut key = Zeroizing::new([0u8; 32]);
         Argon2::default()
-            .hash_password_into(&self.master_key, salt, &mut key)
+            .hash_password_into(&self.master_key, salt, &mut *key)
             .map_err(|e| Error::Storage(format!("key derivation failed: {e}")))?;
         Ok(key)
     }


### PR DESCRIPTION
## Summary

Fixes all 6 open issues labeled `store` in `rustykrab-store`:

### Fixes

- **#162 (HIGH) — Name index inconsistency on entity rename**: `upsert_entity` now fetches the existing entity before updating; if the name changed, the old lowercase name index entry is removed before inserting the new one. Prevents stale index accumulation across renames.

- **#168 (MEDIUM) — Entity deletion not atomic**: `delete_entity` now uses `sled::Transactional` across entities, relations, and entity_names trees. Relation keys are collected first (iteration isn't available inside sled transactions), then all removals happen atomically — a crash can no longer leave orphaned relations or dangling name index entries.

- **#171 (MEDIUM) — Memory store recall does full-table scan**: Changed `MemoryStore` key structure from `entry_id` to composite `conversation_id || entry_id`. `recall`, `list_for_conversation`, `delete`, and `delete_for_conversation` now use `scan_prefix(conversation_id)` instead of iterating the entire tree.

- **#176 (MEDIUM) — Derived keys not zeroized**: `SecretStore::derive_key` now returns `Zeroizing<[u8; 32]>` instead of a bare `[u8; 32]`, ensuring derived encryption key material is securely erased from memory when dropped rather than lingering on the stack.

- **#184 (MEDIUM) — ConversationStore::save flushes on every write**: Removed the synchronous `self.tree.flush()` call from `save()`. Sled manages its own flush policy; callers needing an explicit durability barrier can use `Store::flush()`.

- **#189 (MEDIUM) — relations_from prefix scan has no defensive assertion**: Added `debug_assert_eq!(rel.from_id, entity_id)` after deserialization in `relations_from` to catch prefix scan mismatches during development/testing.

## Test plan

- [x] `cargo check -p rustykrab-store` passes
- [x] `cargo check -p rustykrab-gateway` passes (downstream consumer of `MemoryStore::recall`)
- [x] `cargo check -p rustykrab-tools -p rustykrab-memory` passes
- [ ] Run `cargo test -p rustykrab-store` once CI environment can build

Closes #162, closes #168, closes #171, closes #176, closes #184, closes #189

https://claude.ai/code/session_01HpDSyUk2mrZ6wV51KxntxE