### PR TITLE
Fix failing CI checks: formatting, clippy warnings, and add CI gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,25 @@ jobs:
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Gate job: add this as a required status check in branch protection
+  # to block merges when any CI job fails.
+  ci-pass:
+    name: CI Pass
+    if: always()
+    needs: [check, test, fmt, audit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all checks passed
+        run: |
+          if [[ "${{ needs.check.result }}" != "success" ||
+                "${{ needs.test.result }}" != "success" ||
+                "${{ needs.fmt.result }}" != "success" ||
+                "${{ needs.audit.result }}" != "success" ]]; then
+            echo "::error::One or more CI jobs failed"
+            echo "  check:  ${{ needs.check.result }}"
+            echo "  test:   ${{ needs.test.result }}"
+            echo "  fmt:    ${{ needs.fmt.result }}"
+            echo "  audit:  ${{ needs.audit.result }}"
+            exit 1
+          fi

--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -174,6 +174,7 @@ impl ParallelExecutor {
 }
 
 /// Execute a single sub-task with its own focused context.
+#[allow(clippy::too_many_arguments)]
 async fn execute_sub_task(
     task: &SubTask,
     dep_context: &[String],
@@ -266,8 +267,7 @@ async fn execute_sub_task(
             }
         };
 
-        total_tokens +=
-            (response.usage.prompt_tokens + response.usage.completion_tokens) as u64;
+        total_tokens += (response.usage.prompt_tokens + response.usage.completion_tokens) as u64;
 
         // If the model wants to use tools, execute them and continue.
         if response.message.content.has_tool_calls() {

--- a/crates/rustykrab-agent/src/orchestrator/pipeline.rs
+++ b/crates/rustykrab-agent/src/orchestrator/pipeline.rs
@@ -147,9 +147,7 @@ impl OrchestrationPipeline {
         )
         .await
         .map_err(|_| {
-            rustykrab_core::Error::Internal(format!(
-                "model call timed out after {timeout_secs}s"
-            ))
+            rustykrab_core::Error::Internal(format!("model call timed out after {timeout_secs}s"))
         })??;
         let text = match response.message.content.as_text() {
             Some(t) => t.to_string(),

--- a/crates/rustykrab-agent/src/orchestrator/verifier.rs
+++ b/crates/rustykrab-agent/src/orchestrator/verifier.rs
@@ -196,17 +196,15 @@ impl ConsistencyVoter {
         // Estimate agreement by similarity check, filtering out common stop
         // words that inflate overlap scores (fixes ORCH-M3).
         const STOP_WORDS: &[&str] = &[
-            "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
-            "have", "has", "had", "do", "does", "did", "will", "would", "shall",
-            "should", "may", "might", "can", "could", "must", "to", "of", "in",
-            "for", "on", "with", "at", "by", "from", "as", "into", "through",
-            "during", "before", "after", "then", "once", "here", "there", "when",
-            "where", "why", "how", "all", "both", "each", "few", "more", "most",
-            "other", "some", "such", "no", "nor", "not", "only", "own", "same",
-            "so", "than", "too", "very", "and", "but", "or", "if", "it", "its",
-            "this", "that", "these", "those", "i", "me", "my", "we", "our", "you",
-            "your", "he", "him", "his", "she", "her", "they", "them", "their",
-            "what", "which", "who", "whom",
+            "the", "a", "an", "is", "are", "was", "were", "be", "been", "being", "have", "has",
+            "had", "do", "does", "did", "will", "would", "shall", "should", "may", "might", "can",
+            "could", "must", "to", "of", "in", "for", "on", "with", "at", "by", "from", "as",
+            "into", "through", "during", "before", "after", "then", "once", "here", "there",
+            "when", "where", "why", "how", "all", "both", "each", "few", "more", "most", "other",
+            "some", "such", "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very",
+            "and", "but", "or", "if", "it", "its", "this", "that", "these", "those", "i", "me",
+            "my", "we", "our", "you", "your", "he", "him", "his", "she", "her", "they", "them",
+            "their", "what", "which", "who", "whom",
         ];
         let a_lower = answer.to_lowercase();
         let answer_words: std::collections::HashSet<&str> = a_lower

--- a/crates/rustykrab-channels/src/mcp.rs
+++ b/crates/rustykrab-channels/src/mcp.rs
@@ -117,11 +117,7 @@ impl McpClient {
     /// `command` is the program to run (e.g. "npx"), `args` are its arguments
     /// (e.g. `["hyperframes", "mcp"]`), and `env` provides additional
     /// environment variables for the child process.
-    pub async fn spawn(
-        command: &str,
-        args: &[&str],
-        env: &[(&str, &str)],
-    ) -> Result<Self, String> {
+    pub async fn spawn(command: &str, args: &[&str], env: &[(&str, &str)]) -> Result<Self, String> {
         let mut cmd = Command::new(command);
         cmd.args(args)
             .stdin(std::process::Stdio::piped())
@@ -136,14 +132,8 @@ impl McpClient {
             .spawn()
             .map_err(|e| format!("failed to spawn MCP server `{command}`: {e}"))?;
 
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or("MCP server has no stdout")?;
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or("MCP server has no stdin")?;
+        let stdout = child.stdout.take().ok_or("MCP server has no stdout")?;
+        let stdin = child.stdin.take().ok_or("MCP server has no stdin")?;
 
         let pending: Arc<Mutex<PendingMap>> = Arc::new(Mutex::new(HashMap::new()));
 
@@ -185,10 +175,7 @@ impl McpClient {
                                     let mut map = pending_reader.lock().await;
                                     if let Some(tx) = map.remove(&id) {
                                         let result = if let Some(err) = resp.error {
-                                            Err(format!(
-                                                "MCP error {}: {}",
-                                                err.code, err.message
-                                            ))
+                                            Err(format!("MCP error {}: {}", err.code, err.message))
                                         } else {
                                             Ok(resp.result.unwrap_or(Value::Null))
                                         };
@@ -198,9 +185,7 @@ impl McpClient {
                                 // Notifications (no id) are logged but not dispatched.
                             }
                             Err(e) => {
-                                tracing::trace!(
-                                    "MCP non-JSON line (parse error: {e}): {line}"
-                                );
+                                tracing::trace!("MCP non-JSON line (parse error: {e}): {line}");
                             }
                         }
                     }
@@ -247,11 +232,7 @@ impl McpClient {
     }
 
     /// Send a JSON-RPC request and wait for the response.
-    pub async fn request(
-        &self,
-        method: &str,
-        params: Option<Value>,
-    ) -> Result<Value, String> {
+    pub async fn request(&self, method: &str, params: Option<Value>) -> Result<Value, String> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
         let req = JsonRpcRequest {
@@ -261,8 +242,8 @@ impl McpClient {
             params,
         };
 
-        let line = serde_json::to_string(&req)
-            .map_err(|e| format!("failed to serialize request: {e}"))?;
+        let line =
+            serde_json::to_string(&req).map_err(|e| format!("failed to serialize request: {e}"))?;
 
         let (tx, rx) = oneshot::channel();
         {
@@ -288,11 +269,7 @@ impl McpClient {
     }
 
     /// Send a JSON-RPC notification (no id, no response expected).
-    pub async fn notify(
-        &self,
-        method: &str,
-        params: Option<Value>,
-    ) -> Result<(), String> {
+    pub async fn notify(&self, method: &str, params: Option<Value>) -> Result<(), String> {
         let notification = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,
@@ -330,11 +307,7 @@ impl McpClient {
     }
 
     /// Call a tool on the MCP server.
-    pub async fn call_tool(
-        &self,
-        name: &str,
-        arguments: Value,
-    ) -> Result<McpToolResult, String> {
+    pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<McpToolResult, String> {
         let params = serde_json::json!({
             "name": name,
             "arguments": arguments

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -639,5 +639,4 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].len(), 4096);
     }
-
 }

--- a/crates/rustykrab-channels/src/video.rs
+++ b/crates/rustykrab-channels/src/video.rs
@@ -157,9 +157,7 @@ impl VideoChannel {
 
     /// Run `hyperframes doctor` to verify the environment (Node >= 22, FFmpeg, Chrome).
     pub async fn check_environment(&self) -> Result<DoctorResult, String> {
-        let output = self
-            .run_npx(&["hyperframes", "doctor"], None)
-            .await?;
+        let output = self.run_npx(&["hyperframes", "doctor"], None).await?;
 
         let raw = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -212,9 +210,7 @@ impl VideoChannel {
         args.push("--template");
         args.push(template_val);
 
-        let init_result = self
-            .run_npx(&args, Some(&self.config.projects_dir))
-            .await;
+        let init_result = self.run_npx(&args, Some(&self.config.projects_dir)).await;
 
         match init_result {
             Ok(output) if output.status.success() => {
@@ -222,9 +218,8 @@ impl VideoChannel {
                 // Rename it to our UUID-based directory.
                 let created_dir = self.config.projects_dir.join(name);
                 if created_dir.exists() && created_dir != project_dir {
-                    std::fs::rename(&created_dir, &project_dir).map_err(|e| {
-                        format!("failed to rename project dir: {e}")
-                    })?;
+                    std::fs::rename(&created_dir, &project_dir)
+                        .map_err(|e| format!("failed to rename project dir: {e}"))?;
                 }
                 tracing::info!(
                     project_id = %project_id,
@@ -237,9 +232,7 @@ impl VideoChannel {
                 tracing::debug!("hyperframes CLI not available, creating project locally");
                 std::fs::create_dir_all(&project_dir)
                     .map_err(|e| format!("failed to create project dir: {e}"))?;
-                self.write_composition_html(
-                    &project_dir, name, width, height, duration, fps, &[],
-                )?;
+                self.write_composition_html(&project_dir, name, width, height, duration, fps, &[])?;
             }
         }
 
@@ -373,9 +366,7 @@ impl VideoChannel {
             }
         }
 
-        let render_output = self
-            .run_npx(&args, Some(&project.dir))
-            .await?;
+        let render_output = self.run_npx(&args, Some(&project.dir)).await?;
 
         if !render_output.status.success() {
             let stderr = String::from_utf8_lossy(&render_output.stderr);
@@ -530,11 +521,7 @@ impl VideoChannel {
     }
 
     /// Call an MCP tool (requires prior `connect_mcp`).
-    pub async fn call_mcp_tool(
-        &self,
-        name: &str,
-        arguments: Value,
-    ) -> Result<Value, String> {
+    pub async fn call_mcp_tool(&self, name: &str, arguments: Value) -> Result<Value, String> {
         let mcp_guard = self.mcp.lock().await;
         let client = mcp_guard
             .as_ref()
@@ -665,6 +652,7 @@ impl VideoChannel {
     }
 
     /// Generate an HTML composition file using hyperframes data attributes.
+    #[allow(clippy::too_many_arguments)]
     fn write_composition_html(
         &self,
         project_dir: &Path,

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -142,9 +142,8 @@ async fn main() -> anyhow::Result<()> {
     );
     let model_cache_dir = data_dir.join("models");
     std::fs::create_dir_all(&model_cache_dir)?;
-    let embedder = Arc::new(
-        FastEmbedder::new(model_cache_dir).expect("failed to initialize embedding model"),
-    );
+    let embedder =
+        Arc::new(FastEmbedder::new(model_cache_dir).expect("failed to initialize embedding model"));
     let memory_system = Arc::new(MemorySystem::new(
         MemoryConfig::default(),
         memory_storage,
@@ -156,13 +155,12 @@ async fn main() -> anyhow::Result<()> {
     let agent_id_path = data_dir.join("agent_id");
     let agent_id = if agent_id_path.exists() {
         let raw = std::fs::read_to_string(&agent_id_path)?;
-        Uuid::parse_str(raw.trim())
-            .unwrap_or_else(|_| {
-                tracing::warn!("corrupt agent_id file, generating new ID");
-                let id = Uuid::new_v4();
-                let _ = std::fs::write(&agent_id_path, id.to_string());
-                id
-            })
+        Uuid::parse_str(raw.trim()).unwrap_or_else(|_| {
+            tracing::warn!("corrupt agent_id file, generating new ID");
+            let id = Uuid::new_v4();
+            let _ = std::fs::write(&agent_id_path, id.to_string());
+            id
+        })
     } else {
         let id = Uuid::new_v4();
         std::fs::write(&agent_id_path, id.to_string())?;
@@ -204,9 +202,7 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("video communication channel enabled");
         Some(channel)
     } else {
-        tracing::info!(
-            "video channel disabled (set RUSTYKRAB_VIDEO=true to enable)"
-        );
+        tracing::info!("video channel disabled (set RUSTYKRAB_VIDEO=true to enable)");
         None
     };
 

--- a/crates/rustykrab-gateway/src/origin.rs
+++ b/crates/rustykrab-gateway/src/origin.rs
@@ -94,10 +94,7 @@ pub async fn origin_check_middleware(
     // Add CORS headers when the origin was validated.
     if let Some(origin) = allowed_origin {
         let headers = response.headers_mut();
-        headers.insert(
-            header::ACCESS_CONTROL_ALLOW_ORIGIN,
-            origin.parse().unwrap(),
-        );
+        headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin.parse().unwrap());
         headers.insert(
             header::ACCESS_CONTROL_ALLOW_METHODS,
             "GET, POST, PUT, DELETE, PATCH, OPTIONS".parse().unwrap(),

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -396,8 +396,8 @@ impl ModelProvider for AnthropicProvider {
                 let line = buffer[..newline_pos].trim_end().to_string();
                 buffer = buffer[newline_pos + 1..].to_string();
 
-                if line.starts_with("event: ") {
-                    current_event_type = line[7..].to_string();
+                if let Some(event_type) = line.strip_prefix("event: ") {
+                    current_event_type = event_type.to_string();
                 } else if let Some(data) = line.strip_prefix("data: ") {
                     match current_event_type.as_str() {
                         "message_start" => {

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -122,7 +122,7 @@ impl GmailTool {
             // Strip CRLF sequences to prevent IMAP command injection, then
             // escape inner double quotes so the IMAP command parses correctly
             // (e.g. query `from:"foo@bar.com"` becomes `X-GM-RAW "from:\"foo@bar.com\""`).
-            let sanitized_query = query.replace('\r', "").replace('\n', "").replace('\0', "");
+            let sanitized_query = query.replace(['\r', '\n', '\0'], "");
             let escaped_query = sanitized_query.replace('\\', "\\\\").replace('"', "\\\"");
             let uids = session
                 .uid_search(format!("X-GM-RAW \"{escaped_query}\""))

--- a/crates/rustykrab-tools/src/process.rs
+++ b/crates/rustykrab-tools/src/process.rs
@@ -243,10 +243,8 @@ impl Tool for ProcessTool {
                     }))
                 } else {
                     Err(rustykrab_core::Error::ToolExecution(
-                        format!(
-                            "process {pid} was not spawned by this tool and cannot be stopped"
-                        )
-                        .into(),
+                        format!("process {pid} was not spawned by this tool and cannot be stopped")
+                            .into(),
                     ))
                 }
             }

--- a/crates/rustykrab-tools/src/video.rs
+++ b/crates/rustykrab-tools/src/video.rs
@@ -56,10 +56,7 @@ pub trait VideoBackend: Send + Sync {
     ) -> std::result::Result<Value, String>;
 
     /// Lint a composition.
-    async fn lint(
-        &self,
-        project: &VideoProject,
-    ) -> std::result::Result<Value, String>;
+    async fn lint(&self, project: &VideoProject) -> std::result::Result<Value, String>;
 
     /// Render a project to video.
     async fn render(
@@ -71,10 +68,7 @@ pub trait VideoBackend: Send + Sync {
     ) -> std::result::Result<Value, String>;
 
     /// Get project info.
-    async fn project_info(
-        &self,
-        project: &VideoProject,
-    ) -> std::result::Result<Value, String>;
+    async fn project_info(&self, project: &VideoProject) -> std::result::Result<Value, String>;
 
     /// List projects.
     async fn list_projects(&self) -> std::result::Result<Vec<VideoProject>, String>;
@@ -143,10 +137,7 @@ impl VideoBackend for VideoChannelAdapter {
         self.channel.set_composition(project, html).await
     }
 
-    async fn lint(
-        &self,
-        project: &VideoProject,
-    ) -> std::result::Result<Value, String> {
+    async fn lint(&self, project: &VideoProject) -> std::result::Result<Value, String> {
         self.channel.lint(project).await
     }
 
@@ -170,10 +161,7 @@ impl VideoBackend for VideoChannelAdapter {
         }))
     }
 
-    async fn project_info(
-        &self,
-        project: &VideoProject,
-    ) -> std::result::Result<Value, String> {
+    async fn project_info(&self, project: &VideoProject) -> std::result::Result<Value, String> {
         self.channel.project_info(project).await
     }
 
@@ -430,22 +418,20 @@ impl Tool for VideoTool {
                 let project = self.get_project(project_id).await?;
 
                 let elem_val = &args["element"];
-                let element: CompositionElement =
-                    serde_json::from_value(elem_val.clone()).map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("invalid element: {e}").into(),
-                        )
+                let element: CompositionElement = serde_json::from_value(elem_val.clone())
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(format!("invalid element: {e}").into())
                     })?;
 
-                let result =
-                    self.backend
-                        .add_element(&project, &element)
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("failed to add element: {e}").into(),
-                            )
-                        })?;
+                let result = self
+                    .backend
+                    .add_element(&project, &element)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("failed to add element: {e}").into(),
+                        )
+                    })?;
 
                 Ok(json!({
                     "action": "add_element",
@@ -463,9 +449,7 @@ impl Tool for VideoTool {
                 let project = self.get_project(project_id).await?;
 
                 let html = args["html"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution(
-                        "missing html for set_composition".into(),
-                    )
+                    rustykrab_core::Error::ToolExecution("missing html for set_composition".into())
                 })?;
 
                 let result = self
@@ -495,9 +479,7 @@ impl Tool for VideoTool {
                 let project = self.get_project(project_id).await?;
 
                 let result = self.backend.lint(&project).await.map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(
-                        format!("lint failed: {e}").into(),
-                    )
+                    rustykrab_core::Error::ToolExecution(format!("lint failed: {e}").into())
                 })?;
 
                 Ok(json!({
@@ -523,9 +505,7 @@ impl Tool for VideoTool {
                     .render(&project, output_name, quality, format)
                     .await
                     .map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("render failed: {e}").into(),
-                        )
+                        rustykrab_core::Error::ToolExecution(format!("render failed: {e}").into())
                     })?;
 
                 Ok(json!({
@@ -601,15 +581,15 @@ impl Tool for VideoTool {
                     .map(|o| Value::Object(o.clone()))
                     .unwrap_or(json!({}));
 
-                let result =
-                    self.backend
-                        .call_mcp_tool(tool_name, arguments)
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("MCP tool call failed: {e}").into(),
-                            )
-                        })?;
+                let result = self
+                    .backend
+                    .call_mcp_tool(tool_name, arguments)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("MCP tool call failed: {e}").into(),
+                        )
+                    })?;
 
                 Ok(json!({
                     "action": "mcp_call",


### PR DESCRIPTION
- Run cargo fmt across 10 files with formatting drift from recent PRs
- Fix clippy::manual_strip in anthropic.rs (use strip_prefix)
- Fix clippy::collapsible_str_replace in gmail.rs (use array pattern)
- Suppress clippy::too_many_arguments on two internal functions
- Add CI Pass gate job that fails if any upstream job fails, suitable
  for use as a single required status check in branch protection

https://claude.ai/code/session_01N7Z9L7PAd7E1sBfK5Guh3u