### PR TITLE
Enforce sandbox policy and add OS-level code execution isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
  "imap",
  "imap-proto",
  "lettre",
+ "libc",
  "mail-parser",
  "reqwest 0.13.2",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ imap = "2"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls", "rustls-native-certs", "aws-lc-rs", "builder"] }
 mail-parser = "0.9"
 
+# System-level interfaces (resource limits, process isolation)
+libc = "0.2"
+
 # TLS (unified on rustls — no OpenSSL dependency)
 rustls = "0.23"
 rustls-native-certs = "0.8"

--- a/crates/rustykrab-agent/src/sandbox.rs
+++ b/crates/rustykrab-agent/src/sandbox.rs
@@ -62,10 +62,63 @@ pub trait Sandbox: Send + Sync {
     async fn execute(&self, tool_name: &str, args: Value, policy: &SandboxPolicy) -> Result<Value>;
 }
 
-/// Process-based sandbox using fork + resource limits.
+/// Validate that a tool's required capabilities are permitted by the policy.
 ///
-/// On Linux, this uses `setrlimit` and `unshare` for namespace isolation.
-/// On other platforms, it falls back to timeout-based process control.
+/// This is a defense-in-depth check that mirrors the runner's
+/// `enforce_sandbox_policy()`. Even if the runner check is bypassed,
+/// the sandbox itself rejects disallowed operations.
+fn validate_tool_policy(tool_name: &str, policy: &SandboxPolicy) -> Result<()> {
+    let needs_fs_read = matches!(tool_name, "read" | "pdf" | "image");
+    let needs_fs_write = matches!(
+        tool_name,
+        "write" | "edit" | "apply_patch" | "tts" | "image_generate" | "skill_create" | "canvas"
+    );
+    let needs_spawn = matches!(tool_name, "exec" | "process" | "code_execution");
+    let needs_net = matches!(
+        tool_name,
+        "http_request"
+            | "http_session"
+            | "web_fetch"
+            | "web_search"
+            | "x_search"
+            | "browser"
+            | "gmail"
+            | "image_generate"
+            | "tts"
+    );
+
+    if needs_fs_read && !policy.allow_fs_read {
+        return Err(Error::Auth(format!(
+            "sandbox denied tool '{tool_name}': filesystem read access not permitted"
+        )));
+    }
+    if needs_fs_write && !policy.allow_fs_write {
+        return Err(Error::Auth(format!(
+            "sandbox denied tool '{tool_name}': filesystem write access not permitted"
+        )));
+    }
+    if needs_spawn && !policy.allow_spawn {
+        return Err(Error::Auth(format!(
+            "sandbox denied tool '{tool_name}': process spawning not permitted"
+        )));
+    }
+    if needs_net && !policy.allow_net {
+        return Err(Error::Auth(format!(
+            "sandbox denied tool '{tool_name}': network access not permitted"
+        )));
+    }
+    Ok(())
+}
+
+/// Process-based sandbox using resource limits and policy enforcement.
+///
+/// Provides two layers of protection:
+/// 1. Policy validation: rejects tool calls that violate the `SandboxPolicy`
+/// 2. Timeout enforcement: kills long-running tool executions
+///
+/// Individual tools that spawn subprocesses (e.g. `CodeExecutionTool`)
+/// apply additional OS-level isolation (macOS Seatbelt, Linux namespaces)
+/// within their own execution.
 pub struct ProcessSandbox;
 
 impl ProcessSandbox {
@@ -85,22 +138,15 @@ impl Sandbox for ProcessSandbox {
     async fn execute(&self, tool_name: &str, args: Value, policy: &SandboxPolicy) -> Result<Value> {
         use tokio::time::{timeout, Duration};
 
+        // Enforce policy constraints: reject tool calls that require
+        // capabilities not granted by the policy.
+        validate_tool_policy(tool_name, policy)?;
+
         let timeout_duration = Duration::from_secs(policy.timeout_secs);
         let tool = tool_name.to_string();
 
-        // Execute the tool call in a blocking task with a timeout.
-        // The blocking task provides process-level isolation via tokio's
-        // thread pool, and the timeout prevents runaway execution.
         let result = timeout(timeout_duration, async move {
             tracing::info!(tool = %tool, "executing in sandbox with policy enforcement");
-
-            // Enforce policy constraints by rejecting disallowed operations.
-            // Tools that require capabilities not granted by the policy will
-            // be blocked before execution.
-            //
-            // NOTE: This is a policy-enforcement layer. Full process isolation
-            // (seccomp-bpf, namespaces) should be added for defense-in-depth
-            // in production deployments.
             Ok(args)
         })
         .await;
@@ -130,5 +176,121 @@ impl Sandbox for NoSandbox {
         _policy: &SandboxPolicy,
     ) -> Result<Value> {
         Ok(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn sandbox_denies_code_execution_without_spawn() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_spawn: false,
+            ..SandboxPolicy::default()
+        };
+        let result = sandbox
+            .execute("code_execution", json!({"code": "print(1)"}), &policy)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("process spawning not permitted"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn sandbox_allows_code_execution_with_spawn() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_spawn: true,
+            ..SandboxPolicy::default()
+        };
+        let args = json!({"code": "print(1)"});
+        let result = sandbox
+            .execute("code_execution", args.clone(), &policy)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), args);
+    }
+
+    #[tokio::test]
+    async fn sandbox_denies_read_without_fs_read() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy::default(); // all denied
+        let result = sandbox
+            .execute("read", json!({"path": "/etc/passwd"}), &policy)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("filesystem read access not permitted"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn sandbox_denies_write_without_fs_write() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_fs_read: true,
+            ..SandboxPolicy::default()
+        };
+        let result = sandbox
+            .execute("write", json!({"path": "/tmp/x", "content": "y"}), &policy)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("filesystem write access not permitted"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn sandbox_denies_network_without_allow_net() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy::default();
+        let result = sandbox
+            .execute("http_request", json!({"url": "http://example.com"}), &policy)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("network access not permitted"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn sandbox_allows_memory_tools_with_default_policy() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy::default();
+        // Memory tools don't require fs/net/spawn
+        let result = sandbox
+            .execute("memory_save", json!({"fact": "test"}), &policy)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sandbox_timeout_triggers_error() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_spawn: true,
+            timeout_secs: 0, // immediate timeout
+            ..SandboxPolicy::default()
+        };
+        // The async block should be interrupted by the zero timeout
+        let result = sandbox
+            .execute("code_execution", json!({"code": "x"}), &policy)
+            .await;
+        // With timeout_secs=0, this may or may not timeout depending on
+        // scheduling, so we just verify it doesn't panic. A real timeout
+        // test would use a longer-running operation.
+        assert!(result.is_ok() || result.unwrap_err().to_string().contains("timeout"));
+    }
+
+    #[tokio::test]
+    async fn sandbox_trusted_policy_allows_most_tools() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy::trusted();
+        // Trusted allows fs_read, fs_write, net but NOT spawn
+        assert!(sandbox.execute("read", json!({}), &policy).await.is_ok());
+        assert!(sandbox.execute("write", json!({}), &policy).await.is_ok());
+        assert!(sandbox.execute("http_request", json!({}), &policy).await.is_ok());
+        // Spawn is still denied in trusted policy
+        assert!(sandbox.execute("exec", json!({}), &policy).await.is_err());
     }
 }

--- a/crates/rustykrab-tools/Cargo.toml
+++ b/crates/rustykrab-tools/Cargo.toml
@@ -26,6 +26,7 @@ rustls.workspace = true
 rustls-native-certs.workspace = true
 lettre.workspace = true
 mail-parser.workspace = true
+libc.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rustykrab-tools/src/code_execution.rs
+++ b/crates/rustykrab-tools/src/code_execution.rs
@@ -5,6 +5,8 @@ use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::timeout;
 
+use crate::sandboxed_spawn;
+
 /// Resolve the full path to python3, checking common locations
 /// so that pyenv/Homebrew/conda installs are found even after env_clear().
 fn which_python() -> Option<std::path::PathBuf> {
@@ -26,10 +28,14 @@ fn which_python() -> Option<std::path::PathBuf> {
 
 /// A built-in tool that executes Python code in a sandboxed environment.
 ///
-/// Security improvements:
-/// - Uses unique temp files per invocation (UUID-based) to prevent race conditions
-/// - Cleans up temp files in all code paths
-/// - Enforces timeout limits
+/// Security layers:
+/// - macOS: Seatbelt profile via `sandbox-exec` denies network access and
+///   restricts filesystem writes to the sandbox temp directory.
+/// - Linux: PID/IPC/network namespace isolation via `unshare()`.
+/// - All platforms: POSIX resource limits (memory, CPU, nproc, file size).
+/// - UUID-based temp files prevent race conditions across concurrent sessions.
+/// - Temp files cleaned up in all code paths.
+/// - Timeout enforcement via tokio.
 pub struct CodeExecutionTool;
 
 impl CodeExecutionTool {
@@ -51,9 +57,9 @@ impl Tool for CodeExecutionTool {
     }
 
     fn description(&self) -> &str {
-        "Execute Python code and return stdout/stderr. Has access to the user's \
-         Python environment including installed packages. If a package is missing, \
-         install it with subprocess.check_call(['pip', 'install', 'package_name']). \
+        "Execute Python code and return stdout/stderr. Has read-only access to the \
+         user's Python environment including installed packages. Code runs in a \
+         sandbox with no network access and restricted filesystem writes. \
          Use this for data processing, file format conversion, calculations, \
          and any task that benefits from Python libraries."
     }
@@ -107,8 +113,7 @@ impl Tool for CodeExecutionTool {
         // rather than falling back to a system Python that may lack packages.
         let python_path = which_python().unwrap_or_else(|| "python3".into());
 
-        // Include the Python's bin directory in PATH so pip is also available.
-        // This allows the model to install packages if needed.
+        // Include the Python's bin directory in PATH so libraries are importable.
         let python_bin_dir = python_path
             .parent()
             .map(|p| p.to_string_lossy().to_string())
@@ -119,17 +124,119 @@ impl Tool for CodeExecutionTool {
             format!("{python_bin_dir}:/usr/local/bin:/usr/bin:/bin")
         };
 
-        let future = tokio::process::Command::new(&python_path)
-            .arg(&tmp_file)
-            .env_clear()
-            .env("PATH", &sandbox_path)
-            .env("HOME", std::env::temp_dir())
-            .env("LANG", "C.UTF-8")
-            .env("PYTHONDONTWRITEBYTECODE", "1")
-            .current_dir(&tmp_dir)
-            .output();
+        let result = {
+            // Build the sandboxed command based on the platform.
+            #[cfg(target_os = "macos")]
+            let future = {
+                let profile_file = tmp_dir.join(format!("sandbox_{}.sb", unique_id));
+                let profile =
+                    sandboxed_spawn::generate_seatbelt_profile(&tmp_dir, &python_path);
+                tokio::fs::write(&profile_file, &profile)
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(e.to_string().into())
+                    })?;
 
-        let result = timeout(Duration::from_secs(timeout_secs), future).await;
+                let max_mem = 256u64 * 1024 * 1024;
+                let max_cpu = timeout_secs;
+
+                let mut cmd = tokio::process::Command::new("sandbox-exec");
+                cmd.arg("-f")
+                    .arg(&profile_file)
+                    .arg(&python_path)
+                    .arg(&tmp_file)
+                    .env_clear()
+                    .env("PATH", &sandbox_path)
+                    .env("HOME", &tmp_dir)
+                    .env("TMPDIR", &tmp_dir)
+                    .env("LANG", "C.UTF-8")
+                    .env("PYTHONDONTWRITEBYTECODE", "1")
+                    .current_dir(&tmp_dir);
+
+                // Apply resource limits in the child process
+                unsafe {
+                    cmd.pre_exec(move || {
+                        sandboxed_spawn::apply_resource_limits(max_mem, max_cpu)
+                    });
+                }
+
+                let output_future = cmd.output();
+                let r = timeout(Duration::from_secs(timeout_secs), output_future).await;
+
+                // Clean up the seatbelt profile file
+                let _ = tokio::fs::remove_file(&profile_file).await;
+                r
+            };
+
+            #[cfg(target_os = "linux")]
+            let future = {
+                let max_mem = 256u64 * 1024 * 1024;
+                let max_cpu = timeout_secs;
+
+                let mut cmd = tokio::process::Command::new(&python_path);
+                cmd.arg(&tmp_file)
+                    .env_clear()
+                    .env("PATH", &sandbox_path)
+                    .env("HOME", &tmp_dir)
+                    .env("TMPDIR", &tmp_dir)
+                    .env("LANG", "C.UTF-8")
+                    .env("PYTHONDONTWRITEBYTECODE", "1")
+                    .current_dir(&tmp_dir);
+
+                // Apply resource limits and namespace isolation in the child
+                unsafe {
+                    cmd.pre_exec(move || {
+                        sandboxed_spawn::apply_resource_limits(max_mem, max_cpu)?;
+                        if let Err(e) = sandboxed_spawn::apply_linux_namespaces() {
+                            // Namespace isolation unavailable — rlimits still apply
+                            eprintln!(
+                                "rustykrab: namespace isolation unavailable: {e}, \
+                                 falling back to resource limits only"
+                            );
+                        }
+                        Ok(())
+                    });
+                }
+
+                timeout(
+                    Duration::from_secs(timeout_secs),
+                    cmd.output(),
+                )
+                .await
+            };
+
+            // Fallback for other Unix platforms: rlimits only
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            let future = {
+                let max_mem = 256u64 * 1024 * 1024;
+                let max_cpu = timeout_secs;
+
+                let mut cmd = tokio::process::Command::new(&python_path);
+                cmd.arg(&tmp_file)
+                    .env_clear()
+                    .env("PATH", &sandbox_path)
+                    .env("HOME", &tmp_dir)
+                    .env("TMPDIR", &tmp_dir)
+                    .env("LANG", "C.UTF-8")
+                    .env("PYTHONDONTWRITEBYTECODE", "1")
+                    .current_dir(&tmp_dir);
+
+                #[cfg(unix)]
+                unsafe {
+                    cmd.pre_exec(move || {
+                        sandboxed_spawn::apply_resource_limits(max_mem, max_cpu)
+                    });
+                }
+
+                timeout(
+                    Duration::from_secs(timeout_secs),
+                    cmd.output(),
+                )
+                .await
+            };
+
+            future
+        };
 
         // Clean up temp file regardless of outcome
         let _ = tokio::fs::remove_file(&tmp_file).await;
@@ -151,5 +258,62 @@ impl Tool for CodeExecutionTool {
             "stderr": stderr,
             "exit_code": exit_code,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn basic_python_execution() {
+        let tool = CodeExecutionTool::new();
+        let result = tool.execute(json!({"code": "print(2 + 2)"})).await;
+        assert!(result.is_ok(), "execution failed: {:?}", result.err());
+        let output = result.unwrap();
+        assert_eq!(output["stdout"].as_str().unwrap().trim(), "4");
+        assert_eq!(output["exit_code"], 0);
+    }
+
+    #[tokio::test]
+    async fn network_access_blocked() {
+        let tool = CodeExecutionTool::new();
+        let code = r#"
+import socket
+try:
+    s = socket.create_connection(("8.8.8.8", 53), timeout=3)
+    s.close()
+    print("CONNECTED")
+except Exception as e:
+    print(f"BLOCKED: {e}")
+"#;
+        let result = tool.execute(json!({"code": code})).await;
+        assert!(result.is_ok(), "execution failed: {:?}", result.err());
+        let output = result.unwrap();
+        let stdout = output["stdout"].as_str().unwrap();
+        assert!(
+            stdout.contains("BLOCKED"),
+            "network should be blocked, got stdout: {stdout}"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_enforced() {
+        let tool = CodeExecutionTool::new();
+        let code = "import time; time.sleep(60)";
+        let result = tool
+            .execute(json!({"code": code, "timeout_secs": 2}))
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("timed out"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn missing_code_parameter() {
+        let tool = CodeExecutionTool::new();
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("missing code"));
     }
 }

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -2,6 +2,9 @@
 pub mod sanitize;
 pub mod security;
 
+// Sandboxed subprocess execution
+mod sandboxed_spawn;
+
 // Filesystem tools
 mod apply_patch;
 mod edit;

--- a/crates/rustykrab-tools/src/sandboxed_spawn.rs
+++ b/crates/rustykrab-tools/src/sandboxed_spawn.rs
@@ -1,0 +1,227 @@
+//! Cross-platform sandboxed subprocess execution.
+//!
+//! Provides OS-level process isolation for tools that spawn subprocesses
+//! (primarily `CodeExecutionTool`). Two layers of protection:
+//!
+//! 1. **POSIX resource limits** (`setrlimit`): memory, CPU, file size, and
+//!    process count limits. Works on macOS and Linux.
+//!
+//! 2. **Platform-specific isolation**:
+//!    - **macOS**: Seatbelt (`sandbox-exec`) profiles that restrict filesystem
+//!      writes and deny network access at the kernel level.
+//!    - **Linux**: Namespace isolation (`unshare`) for PID, IPC, and network,
+//!      plus `PR_SET_NO_NEW_PRIVS` to prevent privilege escalation.
+
+use std::io;
+
+/// Apply POSIX resource limits to the current process.
+///
+/// Intended to be called from a `pre_exec` hook so that limits are applied
+/// to the child process before it execs the target binary.
+///
+/// # Safety
+///
+/// Must be called in a `pre_exec` context (post-fork, pre-exec). Uses only
+/// async-signal-safe libc calls (`setrlimit`).
+#[cfg(unix)]
+pub fn apply_resource_limits(max_memory_bytes: u64, max_cpu_secs: u64) -> io::Result<()> {
+    unsafe {
+        // Memory limit (virtual address space)
+        if max_memory_bytes > 0 {
+            let limit = libc::rlimit {
+                rlim_cur: max_memory_bytes,
+                rlim_max: max_memory_bytes,
+            };
+            if libc::setrlimit(libc::RLIMIT_AS, &limit) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        // CPU time limit
+        if max_cpu_secs > 0 {
+            let limit = libc::rlimit {
+                rlim_cur: max_cpu_secs,
+                rlim_max: max_cpu_secs,
+            };
+            if libc::setrlimit(libc::RLIMIT_CPU, &limit) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        // File size limit (10 MB)
+        let fsize_limit = libc::rlimit {
+            rlim_cur: 10 * 1024 * 1024,
+            rlim_max: 10 * 1024 * 1024,
+        };
+        if libc::setrlimit(libc::RLIMIT_FSIZE, &fsize_limit) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Process count limit — prevent fork bombs.
+        // Set to 1 so the Python process itself can run but cannot spawn children.
+        let nproc_limit = libc::rlimit {
+            rlim_cur: 1,
+            rlim_max: 1,
+        };
+        if libc::setrlimit(libc::RLIMIT_NPROC, &nproc_limit) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+/// Generate a macOS Seatbelt sandbox profile for code execution.
+///
+/// The profile denies all operations by default, then selectively allows:
+/// - Reading system libraries, Python installation, and the sandbox directory
+/// - Writing only to the sandbox temporary directory
+/// - Basic process operations needed by the Python runtime
+/// - Network access is always denied
+#[cfg(target_os = "macos")]
+pub fn generate_seatbelt_profile(sandbox_dir: &Path, python_path: &Path) -> String {
+    let sandbox_dir = sandbox_dir.to_string_lossy();
+
+    // Resolve the Python installation's lib directory for read access.
+    // e.g., /opt/homebrew/Cellar/python@3.12/3.12.x/Frameworks/...
+    let python_parent = python_path
+        .parent()
+        .and_then(|p| p.parent()) // go up from bin/ to the install root
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let mut profile = String::from(
+        r#"(version 1)
+(deny default)
+
+;; Allow the Python process to execute
+(allow process-exec)
+
+;; Allow reading system libraries and frameworks
+(allow file-read*
+    (subpath "/usr/")
+    (subpath "/Library/")
+    (subpath "/System/")
+    (subpath "/private/var/")
+    (subpath "/opt/homebrew/")
+    (subpath "/usr/local/")
+    (subpath "/dev/")
+    (subpath "/private/tmp/")
+    (subpath "/tmp/")
+"#,
+    );
+
+    // Allow reading the Python installation directory (for pyenv, conda, etc.)
+    if !python_parent.is_empty()
+        && !python_parent.starts_with("/usr/")
+        && !python_parent.starts_with("/opt/homebrew/")
+        && !python_parent.starts_with("/usr/local/")
+    {
+        profile.push_str(&format!("    (subpath \"{}\")\n", python_parent));
+    }
+
+    profile.push_str(&format!(
+        r#"    (subpath "{sandbox_dir}"))
+
+;; Allow writing ONLY to the sandbox temp directory
+(allow file-write*
+    (subpath "{sandbox_dir}")
+    (subpath "/dev/null"))
+
+;; Allow basic process operations needed by Python runtime
+(allow process-fork)
+(allow signal (target self))
+(allow sysctl-read)
+
+;; Allow mach IPC (required for basic process operation on macOS)
+(allow mach-lookup)
+(allow mach-register)
+
+;; DENY all network access
+(deny network*)
+"#
+    ));
+
+    profile
+}
+
+/// Apply Linux namespace isolation to the current process.
+///
+/// Called from `pre_exec` to isolate the child process. Falls back
+/// gracefully if namespaces are unavailable (rlimits still apply).
+///
+/// # Safety
+///
+/// Must be called in a `pre_exec` context. Uses only libc syscalls.
+#[cfg(target_os = "linux")]
+pub fn apply_linux_namespaces() -> io::Result<()> {
+    unsafe {
+        // Prevent privilege escalation via setuid binaries
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+            // Non-fatal: log and continue
+            let _ = io::Error::last_os_error();
+        }
+
+        // Create new namespaces: PID, IPC, and network
+        let flags = libc::CLONE_NEWPID | libc::CLONE_NEWIPC | libc::CLONE_NEWNET;
+        if libc::unshare(flags) != 0 {
+            // Namespace isolation unavailable (e.g., user namespaces disabled).
+            // Fall back to rlimits-only protection. This is logged as a warning
+            // by the caller.
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "macos")]
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    use std::path::Path;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_profile_denies_network() {
+        let profile = generate_seatbelt_profile(
+            Path::new("/tmp/rustykrab_sandbox"),
+            Path::new("/usr/bin/python3"),
+        );
+        assert!(profile.contains("(deny network*)"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_profile_allows_sandbox_dir_write() {
+        let profile = generate_seatbelt_profile(
+            Path::new("/tmp/rustykrab_sandbox"),
+            Path::new("/usr/bin/python3"),
+        );
+        assert!(profile.contains("(subpath \"/tmp/rustykrab_sandbox\")"));
+        assert!(profile.contains("(allow file-write*"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_profile_includes_custom_python_path() {
+        let profile = generate_seatbelt_profile(
+            Path::new("/tmp/rustykrab_sandbox"),
+            Path::new("/Users/dev/.pyenv/versions/3.12.0/bin/python3"),
+        );
+        // Should include the pyenv install root for read access
+        assert!(profile.contains("/Users/dev/.pyenv/versions/3.12.0"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_profile_no_duplicate_for_system_python() {
+        let profile = generate_seatbelt_profile(
+            Path::new("/tmp/rustykrab_sandbox"),
+            Path::new("/usr/bin/python3"),
+        );
+        // /usr/ is already in the default paths, so no extra subpath needed
+        let count = profile.matches("(subpath \"/usr/\")").count();
+        assert_eq!(count, 1);
+    }
+}


### PR DESCRIPTION
Fixes #67 (SEC-C2) and #68 (SEC-C3):

- ProcessSandbox now validates SandboxPolicy fields (fs_read, fs_write,
  net, spawn) against tool requirements before execution, providing
  defense-in-depth alongside runner's enforce_sandbox_policy().

- CodeExecutionTool applies OS-level process isolation:
  - macOS: Seatbelt profile via sandbox-exec denies network access and
    restricts filesystem writes to /tmp/rustykrab_sandbox/ only.
  - Linux: PID/IPC/network namespace isolation via unshare() with
    graceful fallback to rlimits if namespaces unavailable.
  - All platforms: POSIX resource limits (RLIMIT_AS, RLIMIT_CPU,
    RLIMIT_NPROC, RLIMIT_FSIZE) via setrlimit.

Closes #67
Closes #68

https://claude.ai/code/session_01R82XUBac4SD51bhaqZgwX7