### PR TITLE
Add semantic versioning, changelog, and version printing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: rustykrab-cli
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: rustykrab-cli
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: rustykrab-cli
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p rustykrab-cli
+
+      - name: Package artifact
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/
+          cd dist
+          tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rustykrab-${{ matrix.target }}
+          path: dist/rustykrab-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found" CHANGELOG.md)
+          # Write to file for the release body
+          echo "$NOTES" > release_notes.md
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          files: artifacts/*
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Semantic versioning with git metadata embedded at build time
+- `--version` / `-V` CLI flag prints version, git hash, and build date
+- Version banner logged at startup
+- CHANGELOG.md following Keep a Changelog format
+- Release script (`scripts/release.sh`) for automated version bumps
+- GitHub Actions release workflow for tag-triggered builds
+
+## [0.1.0] - 2026-04-11
+
+### Added
+- Initial release
+- Multi-crate workspace: core, store, gateway, agent, providers, tools, channels, skills, cli, memory
+- Anthropic Claude and Ollama model providers
+- Axum-based HTTP gateway with authentication
+- SQLite-based persistent storage with encrypted credentials
+- Communication channels: WebChat, Telegram, Signal, Video
+- Hybrid memory system with fastembed embeddings, BM25, temporal, and knowledge graph retrieval
+- Built-in tools: browser automation, email, Notion, file operations
+- Composable skill system with YAML definitions
+- OS-level sandbox and code execution isolation
+- macOS Keychain integration for credential management
+- CI pipeline: check, clippy, test, fmt, security audit

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release debug codesign codesign-debug clean
+.PHONY: build release debug codesign codesign-debug clean version
 
 # Default: release build + codesign
 build: release
@@ -23,3 +23,6 @@ codesign-debug:
 
 clean:
 	cargo clean
+
+version:
+	@cargo run -p rustykrab-cli --quiet -- --version

--- a/crates/rustykrab-cli/build.rs
+++ b/crates/rustykrab-cli/build.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+fn main() {
+    // Re-run if git HEAD changes (new commit, checkout, etc.)
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/");
+
+    // Git commit hash (short)
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=RUSTYKRAB_GIT_HASH={git_hash}");
+
+    // Whether the working tree is dirty
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+    let dirty_suffix = if dirty { "-dirty" } else { "" };
+    println!("cargo:rustc-env=RUSTYKRAB_GIT_DIRTY={dirty_suffix}");
+
+    // Build timestamp (UTC) via `date` command
+    let build_date = Command::new("date")
+        .args(["-u", "+%Y-%m-%d"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=RUSTYKRAB_BUILD_DATE={build_date}");
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -4,6 +4,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use chrono::Utc;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_HASH: &str = env!("RUSTYKRAB_GIT_HASH");
+const GIT_DIRTY: &str = env!("RUSTYKRAB_GIT_DIRTY");
+const BUILD_DATE: &str = env!("RUSTYKRAB_BUILD_DATE");
+
+fn version_string() -> String {
+    format!("{VERSION} ({GIT_HASH}{GIT_DIRTY}, {BUILD_DATE})")
+}
 use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter, OrchestrationPipeline};
 use rustykrab_channels::telegram::ChannelMessage;
 use rustykrab_channels::{TelegramChannel, VideoChannel, VideoConfig};
@@ -78,8 +87,14 @@ async fn main() -> anyhow::Result<()> {
         .with(fmt::layer().with_writer(non_blocking).with_ansi(false))
         .init();
 
+    tracing::info!("rustykrab {}", version_string());
+
     // --- CLI subcommands ---
     let args: Vec<String> = std::env::args().collect();
+    if args.len() >= 2 && (args[1] == "--version" || args[1] == "-V") {
+        println!("rustykrab {}", version_string());
+        return Ok(());
+    }
     if args.len() >= 2 && args[1] == "skill" {
         return handle_skill_subcommand(&data_dir, &args[2..]);
     }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# release.sh — Bump the workspace version, update CHANGELOG.md, commit, and tag.
+#
+# Usage:
+#   ./scripts/release.sh <major|minor|patch>
+#   ./scripts/release.sh 1.2.3          # explicit version
+#
+# What it does:
+#   1. Validates the working tree is clean
+#   2. Computes the next version (or uses the one you gave)
+#   3. Updates workspace version in Cargo.toml
+#   4. Moves "Unreleased" entries in CHANGELOG.md under a new version heading
+#   5. Runs `cargo check` to regenerate Cargo.lock
+#   6. Commits and tags as v<version>
+#
+# After running this script, push with:
+#   git push origin main --tags
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# --- Ensure clean working tree ---
+if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+    die "working tree is dirty — commit or stash changes first"
+fi
+
+# --- Read current version ---
+CURRENT=$(sed -n 's/^version = "\(.*\)"/\1/p' "$CARGO_TOML" | head -1)
+[ -n "$CURRENT" ] || die "could not read current version from $CARGO_TOML"
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+# --- Compute next version ---
+BUMP="${1:?Usage: release.sh <major|minor|patch|X.Y.Z>}"
+
+case "$BUMP" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+    [0-9]*.[0-9]*.[0-9]*)
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$BUMP" ;;
+    *)
+        die "unknown bump type: $BUMP (use major, minor, patch, or X.Y.Z)" ;;
+esac
+
+NEXT="${MAJOR}.${MINOR}.${PATCH}"
+echo "Bumping version: $CURRENT -> $NEXT"
+
+# --- Update Cargo.toml workspace version ---
+sed -i "s/^version = \"$CURRENT\"/version = \"$NEXT\"/" "$CARGO_TOML"
+echo "  Updated $CARGO_TOML"
+
+# --- Update CHANGELOG.md ---
+DATE=$(date -u +%Y-%m-%d)
+# Replace the "## [Unreleased]" line, keeping a fresh Unreleased section above
+sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE/" "$CHANGELOG"
+echo "  Updated $CHANGELOG"
+
+# --- Regenerate Cargo.lock ---
+(cd "$REPO_ROOT" && cargo check --quiet 2>/dev/null) || true
+echo "  Cargo.lock updated"
+
+# --- Commit and tag ---
+git -C "$REPO_ROOT" add Cargo.toml Cargo.lock CHANGELOG.md
+git -C "$REPO_ROOT" commit -m "release: v$NEXT"
+git -C "$REPO_ROOT" tag -a "v$NEXT" -m "v$NEXT"
+
+echo ""
+echo "Done! Tagged v$NEXT"
+echo ""
+echo "Next steps:"
+echo "  git push origin main --tags"


### PR DESCRIPTION
- build.rs embeds git hash, dirty flag, and build date at compile time
- Startup logs version banner via tracing::info
- --version / -V CLI flag prints version string and exits
- CHANGELOG.md following Keep a Changelog format
- scripts/release.sh for automated version bumps, commits, and tags
- GitHub Actions release workflow builds binaries on tag push
- Makefile `version` target for quick version check

https://claude.ai/code/session_01Fu5ZP2AJN88b7yny5v3r3S