### PR TITLE
[fix] restore 'unsafe-inline' in CSP to unbreak hosted UI

### DIFF
--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -34,7 +34,7 @@ async fn security_headers_middleware(request: Request, next: Next) -> Response {
     );
     headers.insert(
         header::CONTENT_SECURITY_POLICY,
-        "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:"
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
             .parse()
             .unwrap(),
     );


### PR DESCRIPTION
The security hardening in #230 tightened the Content-Security-Policy
from script-src 'unsafe-inline' to script-src 'self', which blocks
all inline <script> and <style> tags. Since the webchat UI is a
single-file SPA with all CSS and JS embedded inline via rust_embed,
this made the entire UI non-functional in the browser.

https://claude.ai/code/session_01MCmSkhGJ7nsYuxp2RBBrPY