### PR TITLE
Add semantic versioning, changelog, and automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,67 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
 
 jobs:
+  # ── Version bump, commit, tag ──────────────────────────────────────
+  bump:
+    name: Bump Version & Tag
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine bump type from PR labels
+        id: bump-type
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"semver:major"'; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+          elif echo "$LABELS" | grep -q '"semver:minor"'; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version
+        id: bump
+        run: |
+          ./scripts/release.sh "${{ steps.bump-type.outputs.bump }}" \
+            --ci \
+            --pr-title "${{ github.event.pull_request.title }}" \
+            --pr-number "${{ github.event.pull_request.number }}"
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Push version commit and tag
+        run: |
+          git push origin main --tags
+
+  # ── Build release binaries ─────────────────────────────────────────
   build:
     name: Build (${{ matrix.target }})
+    needs: bump
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,6 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -55,12 +104,15 @@ jobs:
           name: rustykrab-${{ matrix.target }}
           path: dist/rustykrab-${{ matrix.target }}.tar.gz
 
+  # ── Create GitHub Release ──────────────────────────────────────────
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [bump, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.tag }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -68,18 +120,15 @@ jobs:
           merge-multiple: true
 
       - name: Extract changelog for this version
-        id: changelog
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-          # Extract the section for this version from CHANGELOG.md
-          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found" CHANGELOG.md)
-          # Write to file for the release body
-          echo "$NOTES" > release_notes.md
+          VERSION="${{ needs.bump.outputs.version }}"
+          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found" \
+            CHANGELOG.md > release_notes.md
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.bump.outputs.tag }}
           body_path: release_notes.md
           files: artifacts/*
           generate_release_notes: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+## Project overview
+
+RustyKrab is a multi-crate Rust workspace — an AI agent runtime with HTTP gateway, model providers, tools, communication channels, and a memory system.
+
+## Workspace layout
+
+```
+crates/
+  rustykrab-core        # Shared types, error types, traits
+  rustykrab-store       # SQLite persistent storage + encrypted credentials
+  rustykrab-gateway     # Axum HTTP gateway
+  rustykrab-agent       # Agent orchestration loop
+  rustykrab-providers   # Model providers (Anthropic, Ollama)
+  rustykrab-tools       # Built-in tools (browser, email, Notion, etc.)
+  rustykrab-channels    # Communication channels (WebChat, Telegram, Signal, Video)
+  rustykrab-skills      # Composable skill definitions
+  rustykrab-cli         # CLI entrypoint and daemon (the binary crate)
+  rustykrab-memory      # Hybrid memory system (vector + BM25 + temporal + graph)
+```
+
+All crates inherit version from `[workspace.package]` in the root `Cargo.toml`.
+
+## Build commands
+
+```bash
+make build          # release build (+ codesign on macOS)
+make debug          # debug build
+make clean          # cargo clean
+make version        # print current version
+cargo test --workspace   # run all tests
+cargo clippy --workspace --all-targets   # lint
+cargo fmt --all -- --check               # format check
+```
+
+## Versioning and releases
+
+This project uses **semantic versioning**. The single source of truth for the version is `version` in the root `Cargo.toml` `[workspace.package]`.
+
+### Automated releases (on every PR merge)
+
+Every PR merged to `main` automatically triggers a release via `.github/workflows/release.yml`:
+
+1. **Version bump** is determined by PR labels:
+   - `semver:major` — breaking change (1.0.0 → 2.0.0)
+   - `semver:minor` — new feature (0.1.0 → 0.2.0)
+   - No label — patch (default) (0.1.0 → 0.1.1)
+2. The workflow runs `scripts/release.sh --ci` which updates `Cargo.toml` and `CHANGELOG.md`
+3. A `release: vX.Y.Z` commit and `vX.Y.Z` tag are pushed to `main`
+4. Release binaries are built for linux-x86_64, macOS-arm64, macOS-x86_64
+5. A GitHub Release is created with changelog notes and attached tarballs
+
+### PR titles become changelog entries
+
+The merged PR title is written into `CHANGELOG.md` under the new version heading. Write clear, descriptive PR titles.
+
+For richer changelogs, manually add entries under `## [Unreleased]` in `CHANGELOG.md` before merging — they will be promoted to the new version section automatically.
+
+### Manual / local releases
+
+```bash
+./scripts/release.sh patch    # 0.1.0 → 0.1.1
+./scripts/release.sh minor    # 0.1.0 → 0.2.0
+./scripts/release.sh major    # 0.1.0 → 1.0.0
+./scripts/release.sh 2.0.0    # explicit version
+git push origin main --tags
+```
+
+### Version at runtime
+
+- `rustykrab-cli --version` / `-V` prints version with git hash and build date
+- Version banner is logged at startup via `tracing::info!`
+- `build.rs` in `rustykrab-cli` embeds git hash, dirty flag, and build date at compile time
+
+## CI
+
+`.github/workflows/ci.yml` runs on every push/PR to `main`:
+- `cargo check` + `cargo clippy` (warnings are errors via `-Dwarnings`)
+- `cargo test --workspace`
+- `cargo fmt --all -- --check`
+- Security audit via `rustsec/audit-check`
+
+## Code conventions
+
+- Rust edition 2021, MSRV 1.88
+- All dependencies go in `[workspace.dependencies]` and crates use `.workspace = true`
+- Error handling: `thiserror` for library crates, `anyhow` for the CLI
+- Async runtime: `tokio`; HTTP: `axum`; TLS: `rustls` (no OpenSSL)
+- Tracing for logging (not `println!` or `log`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,18 @@ git push origin main --tags
 - `cargo fmt --all -- --check`
 - Security audit via `rustsec/audit-check`
 
+### Pre-push: run CI checks locally
+
+Before pushing a PR, run the same checks that CI enforces to avoid round-tripping on failures:
+
+```bash
+cargo fmt --all -- --check    # formatting
+cargo clippy --workspace --all-targets -- -D warnings   # lint (warnings = errors)
+cargo test --workspace        # tests
+```
+
+All three must pass — CI will block the merge otherwise.
+
 ## Code conventions
 
 - Rust edition 2021, MSRV 1.88

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,19 +2,24 @@
 #
 # release.sh — Bump the workspace version, update CHANGELOG.md, commit, and tag.
 #
-# Usage:
-#   ./scripts/release.sh <major|minor|patch>
-#   ./scripts/release.sh 1.2.3          # explicit version
+# Usage (local):
+#   ./scripts/release.sh patch
+#   ./scripts/release.sh minor
+#   ./scripts/release.sh major
+#   ./scripts/release.sh 1.2.3
+#
+# Usage (CI — called by GitHub Actions on PR merge):
+#   ./scripts/release.sh patch --ci --pr-title "Add foo" --pr-number 42
 #
 # What it does:
-#   1. Validates the working tree is clean
+#   1. Validates the working tree is clean (skipped in --ci mode)
 #   2. Computes the next version (or uses the one you gave)
 #   3. Updates workspace version in Cargo.toml
 #   4. Moves "Unreleased" entries in CHANGELOG.md under a new version heading
-#   5. Runs `cargo check` to regenerate Cargo.lock
+#   5. Runs `cargo check` to regenerate Cargo.lock (skipped in --ci mode)
 #   6. Commits and tags as v<version>
 #
-# After running this script, push with:
+# After running locally, push with:
 #   git push origin main --tags
 #
 set -euo pipefail
@@ -25,8 +30,26 @@ CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 
 die() { echo "error: $*" >&2; exit 1; }
 
-# --- Ensure clean working tree ---
-if [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
+# --- Parse arguments ---
+BUMP=""
+CI_MODE=false
+PR_TITLE=""
+PR_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ci)       CI_MODE=true; shift ;;
+        --pr-title) PR_TITLE="$2"; shift 2 ;;
+        --pr-number) PR_NUMBER="$2"; shift 2 ;;
+        -*)         die "unknown flag: $1" ;;
+        *)          BUMP="$1"; shift ;;
+    esac
+done
+
+[ -n "$BUMP" ] || die "Usage: release.sh <major|minor|patch|X.Y.Z> [--ci --pr-title '...' --pr-number N]"
+
+# --- Ensure clean working tree (local only) ---
+if [ "$CI_MODE" = false ] && [ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]; then
     die "working tree is dirty — commit or stash changes first"
 fi
 
@@ -37,8 +60,6 @@ CURRENT=$(sed -n 's/^version = "\(.*\)"/\1/p' "$CARGO_TOML" | head -1)
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
 # --- Compute next version ---
-BUMP="${1:?Usage: release.sh <major|minor|patch|X.Y.Z>}"
-
 case "$BUMP" in
     major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
     minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
@@ -58,21 +79,41 @@ echo "  Updated $CARGO_TOML"
 
 # --- Update CHANGELOG.md ---
 DATE=$(date -u +%Y-%m-%d)
-# Replace the "## [Unreleased]" line, keeping a fresh Unreleased section above
-sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE/" "$CHANGELOG"
+
+if [ "$CI_MODE" = true ] && [ -n "$PR_TITLE" ]; then
+    # In CI: add PR as a changelog entry under the new version heading.
+    # The [Unreleased] section keeps any manually-written entries and gets
+    # promoted to the new version heading.
+    PR_REF=""
+    if [ -n "$PR_NUMBER" ]; then
+        PR_REF=" (#$PR_NUMBER)"
+    fi
+
+    # Insert the new version heading after [Unreleased], and append the PR entry
+    sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE\n\n- ${PR_TITLE}${PR_REF}/" "$CHANGELOG"
+else
+    # Local: just promote the [Unreleased] section to the new version heading
+    sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE/" "$CHANGELOG"
+fi
 echo "  Updated $CHANGELOG"
 
-# --- Regenerate Cargo.lock ---
-(cd "$REPO_ROOT" && cargo check --quiet 2>/dev/null) || true
-echo "  Cargo.lock updated"
+# --- Regenerate Cargo.lock (local only — CI may not have all native deps) ---
+if [ "$CI_MODE" = false ]; then
+    (cd "$REPO_ROOT" && cargo check --quiet 2>/dev/null) || true
+    echo "  Cargo.lock updated"
+fi
 
 # --- Commit and tag ---
-git -C "$REPO_ROOT" add Cargo.toml Cargo.lock CHANGELOG.md
-git -C "$REPO_ROOT" commit -m "release: v$NEXT"
-git -C "$REPO_ROOT" tag -a "v$NEXT" -m "v$NEXT"
+cd "$REPO_ROOT"
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "release: v$NEXT"
+git tag -a "v$NEXT" -m "v$NEXT"
 
 echo ""
 echo "Done! Tagged v$NEXT"
-echo ""
-echo "Next steps:"
-echo "  git push origin main --tags"
+
+if [ "$CI_MODE" = false ]; then
+    echo ""
+    echo "Next steps:"
+    echo "  git push origin main --tags"
+fi


### PR DESCRIPTION
## Summary

- **build.rs** embeds git commit hash, dirty flag, and build date at compile time
- **`--version` / `-V` CLI flag** and startup banner print version info (e.g. `rustykrab 0.1.0 (abc1234, 2026-04-11)`)
- **CHANGELOG.md** following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
- **Automated release on every PR merge**: version bump (controlled via `semver:major` / `semver:minor` labels, default patch), changelog update with PR title, tag, binary builds (linux-x86_64, macOS-arm64, macOS-x86_64), and GitHub Release creation
- **`scripts/release.sh`** for manual local releases with `--ci` mode for GitHub Actions
- **CLAUDE.md** documenting project conventions, release workflow, and local CI check instructions

## Test plan

- [ ] Verify `cargo check -p rustykrab-cli` passes (build.rs compiles)
- [ ] Verify `rustykrab-cli --version` prints version string with git hash
- [ ] Verify `scripts/release.sh patch --ci --pr-title "Test" --pr-number 1` bumps version and updates CHANGELOG.md correctly
- [ ] Merge this PR and confirm the release workflow triggers, bumps version, and creates a GitHub Release
- [ ] Add `semver:major` / `semver:minor` labels to the repo for future use

https://claude.ai/code/session_01Fu5ZP2AJN88b7yny5v3r3S