### PR TITLE
Add task scheduling with SQLite job store and executor loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -199,9 +199,8 @@ impl JobStore {
 
 /// Parse a schedule string, returning `(is_one_shot, next_run_at)`.
 fn parse_schedule(schedule: &str, now: DateTime<Utc>) -> Result<(bool, DateTime<Utc>), Error> {
-    // Try ISO 8601 timestamp first (one-shot).
-    if let Ok(ts) = DateTime::parse_from_rfc3339(schedule) {
-        let ts = ts.with_timezone(&Utc);
+    // Try ISO 8601 / RFC 3339 timestamp first (one-shot).
+    if let Some(ts) = try_parse_datetime(schedule) {
         if ts <= now {
             return Err(Error::Config(
                 "one-shot schedule must be in the future".to_string(),
@@ -215,14 +214,58 @@ fn parse_schedule(schedule: &str, now: DateTime<Utc>) -> Result<(bool, DateTime<
     Ok((false, next))
 }
 
+/// Try to parse a datetime string in multiple common formats.
+///
+/// Accepts RFC 3339 (`2025-04-12T14:30:00Z`), with offset
+/// (`2025-04-12T14:30:00+02:00`), or naive datetime assumed as UTC
+/// (`2025-04-12T14:30:00`, `2025-04-12 14:30:00`).
+fn try_parse_datetime(s: &str) -> Option<DateTime<Utc>> {
+    // RFC 3339 with timezone
+    if let Ok(ts) = DateTime::parse_from_rfc3339(s) {
+        return Some(ts.with_timezone(&Utc));
+    }
+    // Naive datetime (no timezone) — assume UTC
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(naive.and_utc());
+    }
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Some(naive.and_utc());
+    }
+    // Date + time without seconds
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M") {
+        return Some(naive.and_utc());
+    }
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M") {
+        return Some(naive.and_utc());
+    }
+    None
+}
+
 /// Compute the next occurrence of a cron expression after `after`.
+///
+/// Handles both standard 5-field cron (`minute hour dom month dow`) and
+/// 6-field cron with seconds (`second minute hour dom month dow`).
 fn compute_next_cron_run(expression: &str, after: DateTime<Utc>) -> Result<DateTime<Utc>, Error> {
-    let cron: Cron = expression
+    let normalized = normalize_cron_expression(expression);
+    let cron: Cron = normalized
         .parse()
-        .map_err(|e| Error::Config(format!("invalid cron expression: {e}")))?;
+        .map_err(|e| Error::Config(format!("invalid cron expression '{expression}': {e}")))?;
 
     cron.find_next_occurrence(&after, false)
         .map_err(|e| Error::Config(format!("could not compute next cron occurrence: {e}")))
+}
+
+/// Normalize a cron expression for `croner` which requires 6 fields
+/// (seconds minutes hours day-of-month month day-of-week).
+///
+/// If the input has 5 fields (standard cron), prepend `0` for seconds.
+fn normalize_cron_expression(expr: &str) -> String {
+    let fields: Vec<&str> = expr.split_whitespace().collect();
+    if fields.len() == 5 {
+        format!("0 {expr}")
+    } else {
+        expr.to_string()
+    }
 }
 
 /// Parse an RFC 3339 timestamp stored in SQLite.


### PR DESCRIPTION
## Summary

- Implement a complete task scheduling system so users can conversationally ask the agent to run tasks at specific times or on recurring cron schedules
- Add `croner` crate for cron expression parsing, with automatic normalization of standard 5-field cron to the 6-field format croner expects
- Create `JobStore` in `rustykrab-store` backed by a `scheduled_jobs` SQLite table, supporting both cron expressions (recurring) and ISO 8601 / naive datetime timestamps (one-shot)
- Extend `CronBackend` trait and `CronTool` schema with channel/chat_id params so scheduled job results route back to the originating channel
- Wire the cron tool into `main.rs` and spawn a background job executor loop (30s poll) that runs due jobs through the agent pipeline and delivers responses to Telegram or Signal

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets` passes
- [ ] `cargo test --workspace` passes
- [ ] Manual: send "remind me in 2 minutes to check the weather" via Telegram, verify cron tool is invoked, job appears in SQLite, executor fires and delivers response
- [ ] Manual: send "every day at 9am, give me a morning briefing", verify recurring job is created with correct `next_run_at`
- [ ] Manual: list and delete jobs via conversation

https://claude.ai/code/session_019ggNJeZB7Tkv3oqbqckQ2L