### PR TITLE
fix: use RELEASE_TOKEN so semver action can push to protected main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
The default GITHUB_TOKEN cannot push to branches with protection rules.
Switch to a PAT-based secret (RELEASE_TOKEN) that bypasses branch protection.

https://claude.ai/code/session_01R49RqGf2m6JNkcTrEbUvUX