### PR TITLE
Fix semver release action: use GitHub App token to push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,14 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Push version commit and tag
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error::RELEASE_TOKEN secret is not set — cannot push to main"
+            exit 1
+          fi
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin main --tags
 
   # ── Build release binaries ─────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,17 @@ jobs:
       version: ${{ steps.bump.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |
@@ -56,13 +63,9 @@ jobs:
 
       - name: Push version commit and tag
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          if [ -z "$RELEASE_TOKEN" ]; then
-            echo "::error::RELEASE_TOKEN secret is not set — cannot push to main"
-            exit 1
-          fi
-          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin main --tags
 
   # ── Build release binaries ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- The release workflow was unable to push version bump commits and tags to `main` because the default `GITHUB_TOKEN` (attributed to `github-actions[bot]`) lacks permission to push to a branch protected by a ruleset
- Replace `GITHUB_TOKEN` / PAT with a short-lived token minted from a GitHub App via `actions/create-github-app-token@v1`
- Explicitly set the git remote URL with the app token so `git push` authenticates as the app, not `github-actions[bot]`

## Setup required

After merging, complete these steps to activate the fix:

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps) with **Contents: Read & write** permission, installed on this repo
2. **Add repo secrets**: `APP_ID` (numeric app ID) and `APP_PRIVATE_KEY` (the `.pem` contents)
3. **Add the app to the ruleset bypass list**: Settings → Rules → Rulesets → `main` ruleset → Bypass list → add the app → set to "Always"

## Test plan

- [ ] Create the GitHub App and add secrets as described above
- [ ] Add the app as a bypass actor in the `main` ruleset
- [ ] Merge a PR with a `semver:patch` / `semver:minor` label and verify the release workflow pushes the version commit and tag to `main`
- [ ] Verify the GitHub Release is created with correct changelog and artifacts

https://claude.ai/code/session_01R49RqGf2m6JNkcTrEbUvUX