### PR TITLE
Add Telegram forum topic (thread) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -23,6 +23,9 @@ const SEND_MAX_RETRIES: u32 = 3;
 /// An inbound message with channel-specific routing metadata.
 pub struct ChannelMessage {
     pub chat_id: i64,
+    /// Telegram forum topic thread ID. `0` means no thread (non-forum chat
+    /// or the implicit "General" topic).
+    pub thread_id: i64,
     pub message: Message,
     /// If true, the conversation for this chat should be reset.
     pub reset: bool,
@@ -96,12 +99,18 @@ impl TelegramChannel {
     }
 
     /// Send a "typing" chat action so the user sees the bot is working.
-    pub async fn send_typing(&self, chat_id: i64) -> Result<()> {
+    ///
+    /// When `thread_id > 0`, the typing indicator is scoped to that forum
+    /// topic so it appears in the correct thread.
+    pub async fn send_typing(&self, chat_id: i64, thread_id: i64) -> Result<()> {
         let url = format!("{}/sendChatAction", self.api_base);
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "chat_id": chat_id,
             "action": "typing",
         });
+        if thread_id > 0 {
+            body["message_thread_id"] = serde_json::json!(thread_id);
+        }
 
         let resp = self
             .client
@@ -122,21 +131,22 @@ impl TelegramChannel {
     /// Send a text message to a Telegram chat, automatically splitting
     /// messages that exceed Telegram's 4096 character limit.
     ///
+    /// When `thread_id > 0`, the message is posted inside that forum topic.
     /// Uses Markdown parse mode with automatic plain-text fallback if
     /// Telegram rejects the formatting.
-    pub async fn send_text(&self, chat_id: i64, text: &str) -> Result<()> {
+    pub async fn send_text(&self, chat_id: i64, text: &str, thread_id: i64) -> Result<()> {
         let chunks = split_message(text, TELEGRAM_MAX_LENGTH);
         for chunk in &chunks {
-            self.send_single_message(chat_id, chunk).await?;
+            self.send_single_message(chat_id, chunk, thread_id).await?;
         }
         Ok(())
     }
 
     /// Send a single message chunk with retry and Markdown fallback.
-    async fn send_single_message(&self, chat_id: i64, text: &str) -> Result<()> {
+    async fn send_single_message(&self, chat_id: i64, text: &str, thread_id: i64) -> Result<()> {
         // First attempt: with Markdown.
         match self
-            .try_send(chat_id, text, Some("Markdown"), SEND_MAX_RETRIES)
+            .try_send(chat_id, text, Some("Markdown"), SEND_MAX_RETRIES, thread_id)
             .await
         {
             Ok(()) => Ok(()),
@@ -146,7 +156,8 @@ impl TelegramChannel {
                 if err_str.contains("400") || err_str.contains("parse") || err_str.contains("can't")
                 {
                     tracing::debug!("Markdown rejected by Telegram, retrying as plain text");
-                    self.try_send(chat_id, text, None, SEND_MAX_RETRIES).await
+                    self.try_send(chat_id, text, None, SEND_MAX_RETRIES, thread_id)
+                        .await
                 } else {
                     Err(e)
                 }
@@ -161,6 +172,7 @@ impl TelegramChannel {
         text: &str,
         parse_mode: Option<&str>,
         max_retries: u32,
+        thread_id: i64,
     ) -> Result<()> {
         let url = format!("{}/sendMessage", self.api_base);
         let mut body = serde_json::json!({
@@ -169,6 +181,9 @@ impl TelegramChannel {
         });
         if let Some(mode) = parse_mode {
             body["parse_mode"] = serde_json::json!(mode);
+        }
+        if thread_id > 0 {
+            body["message_thread_id"] = serde_json::json!(thread_id);
         }
 
         let mut last_err = None;
@@ -371,6 +386,7 @@ impl TelegramChannel {
         };
 
         let chat_id = msg.chat.id;
+        let thread_id = msg.message_thread_id.unwrap_or(0);
 
         // Chat allowlist check.
         if !self.allowed_chats.is_empty() && !self.allowed_chats.contains(&chat_id) {
@@ -392,7 +408,7 @@ impl TelegramChannel {
 
         // Handle bot commands before forwarding to the agent.
         if let Some(reply) = self.handle_command(&text, chat_id).await {
-            let _ = self.send_text(chat_id, &reply).await;
+            let _ = self.send_text(chat_id, &reply, thread_id).await;
             return Ok(());
         }
 
@@ -402,7 +418,7 @@ impl TelegramChannel {
             .and_then(|u| u.username.as_deref())
             .unwrap_or("unknown");
 
-        tracing::info!(chat_id, %from, "received Telegram message");
+        tracing::info!(chat_id, thread_id, %from, "received Telegram message");
 
         let message = Message {
             id: Uuid::new_v4(),
@@ -414,6 +430,7 @@ impl TelegramChannel {
         self.inbound_tx
             .send(ChannelMessage {
                 chat_id,
+                thread_id,
                 message,
                 reset: false,
             })
@@ -579,6 +596,12 @@ pub struct TelegramMessage {
     pub from: Option<User>,
     pub text: Option<String>,
     pub date: i64,
+    /// Forum topic thread ID. Present when the message belongs to a forum topic.
+    #[serde(default)]
+    pub message_thread_id: Option<i64>,
+    /// Whether this message was sent inside a forum topic.
+    #[serde(default)]
+    pub is_topic_message: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -574,42 +574,48 @@ fn epoch_millis() -> u64 {
         .as_millis() as u64
 }
 
-/// Per-chat state for tracking conversations and preventing concurrent runs.
+/// Per-chat (or per-thread in forum groups) state for tracking conversations
+/// and preventing concurrent runs. Keyed by `(chat_id, thread_id)` where
+/// `thread_id == 0` means a non-forum chat or the implicit "General" topic.
 struct ChatState {
     conv_id: Uuid,
-    /// True while an agent run is in progress for this chat.
+    /// True while an agent run is in progress for this chat/thread.
     busy: bool,
 }
 
 /// Background task: consume inbound Telegram messages and run the agent.
 ///
-/// Each Telegram chat_id gets its own persistent conversation. Messages
-/// for different chats are processed concurrently so one slow agent run
-/// doesn't block other users. Within a single chat, messages are serialized.
+/// Each `(chat_id, thread_id)` pair gets its own persistent conversation.
+/// Messages for different chats/threads are processed concurrently so one
+/// slow agent run doesn't block other users or topics. Within a single
+/// chat+thread, messages are serialized.
 async fn telegram_agent_loop(
     mut rx: mpsc::Receiver<ChannelMessage>,
     tg: Arc<TelegramChannel>,
     state: AppState,
 ) {
-    let chat_states: Arc<tokio::sync::Mutex<HashMap<i64, ChatState>>> =
+    let chat_states: Arc<tokio::sync::Mutex<HashMap<(i64, i64), ChatState>>> =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
     while let Some(channel_msg) = rx.recv().await {
         let chat_id = channel_msg.chat_id;
+        let thread_id = channel_msg.thread_id;
+        let key = (chat_id, thread_id);
         let tg = tg.clone();
         let state = state.clone();
         let chat_states = chat_states.clone();
 
         tokio::spawn(async move {
-            // Check if this chat already has an agent run in progress.
+            // Check if this chat/thread already has an agent run in progress.
             {
                 let states = chat_states.lock().await;
-                if let Some(cs) = states.get(&chat_id) {
+                if let Some(cs) = states.get(&key) {
                     if cs.busy {
                         let _ = tg
                             .send_text(
                                 chat_id,
                                 "I'm still working on your previous message. Please wait.",
+                                thread_id,
                             )
                             .await;
                         return;
@@ -621,7 +627,11 @@ async fn telegram_agent_loop(
             if channel_msg.reset {
                 {
                     let mut states = chat_states.lock().await;
-                    states.remove(&chat_id);
+                    states.remove(&key);
+                }
+                // Also clear the persisted mapping.
+                if let Err(e) = state.store.chat_map().remove(chat_id, thread_id) {
+                    tracing::warn!(chat_id, thread_id, "failed to remove chat map entry: {e}");
                 }
                 return;
             }
@@ -631,39 +641,87 @@ async fn telegram_agent_loop(
                 _ => return,
             };
 
-            // Get or create conversation.
+            // Get or create conversation. Check in-memory first, then DB,
+            // then create a brand new one.
             let conv_id = {
                 let mut states = chat_states.lock().await;
-                match states.get(&chat_id) {
+                match states.get(&key) {
                     Some(cs) => cs.conv_id,
-                    None => match state.store.conversations().create() {
-                        Ok(conv) => {
-                            let id = conv.id;
-                            states.insert(
-                                chat_id,
-                                ChatState {
-                                    conv_id: id,
-                                    busy: false,
-                                },
-                            );
-                            tracing::info!(chat_id, conv_id = %id, "created new conversation for Telegram chat");
-                            id
+                    None => {
+                        // Try the database (survives restarts).
+                        let db_id = state
+                            .store
+                            .chat_map()
+                            .lookup(chat_id, thread_id)
+                            .ok()
+                            .flatten();
+
+                        match db_id {
+                            Some(id) => {
+                                states.insert(
+                                    key,
+                                    ChatState {
+                                        conv_id: id,
+                                        busy: false,
+                                    },
+                                );
+                                tracing::info!(
+                                    chat_id, thread_id, conv_id = %id,
+                                    "restored conversation from database"
+                                );
+                                id
+                            }
+                            None => match state.store.conversations().create() {
+                                Ok(conv) => {
+                                    let id = conv.id;
+                                    states.insert(
+                                        key,
+                                        ChatState {
+                                            conv_id: id,
+                                            busy: false,
+                                        },
+                                    );
+                                    // Persist the mapping so it survives restarts.
+                                    if let Err(e) =
+                                        state.store.chat_map().upsert(chat_id, thread_id, id)
+                                    {
+                                        tracing::warn!(
+                                            chat_id,
+                                            thread_id,
+                                            "failed to persist chat map: {e}"
+                                        );
+                                    }
+                                    tracing::info!(
+                                        chat_id, thread_id, conv_id = %id,
+                                        "created new conversation for Telegram chat/thread"
+                                    );
+                                    id
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        chat_id,
+                                        thread_id,
+                                        "failed to create conversation: {e}"
+                                    );
+                                    let _ = tg
+                                        .send_text(
+                                            chat_id,
+                                            "Internal error — please try again.",
+                                            thread_id,
+                                        )
+                                        .await;
+                                    return;
+                                }
+                            },
                         }
-                        Err(e) => {
-                            tracing::error!(chat_id, "failed to create conversation: {e}");
-                            let _ = tg
-                                .send_text(chat_id, "Internal error — please try again.")
-                                .await;
-                            return;
-                        }
-                    },
+                    }
                 }
             };
 
-            // Mark chat as busy.
+            // Mark chat/thread as busy.
             {
                 let mut states = chat_states.lock().await;
-                if let Some(cs) = states.get_mut(&chat_id) {
+                if let Some(cs) = states.get_mut(&key) {
                     cs.busy = true;
                 }
             }
@@ -672,23 +730,24 @@ async fn telegram_agent_loop(
                 &state,
                 &tg,
                 chat_id,
+                thread_id,
                 conv_id,
                 channel_msg.message,
                 &user_text,
             )
             .await;
 
-            // Mark chat as no longer busy.
+            // Mark chat/thread as no longer busy.
             {
                 let mut states = chat_states.lock().await;
-                if let Some(cs) = states.get_mut(&chat_id) {
+                if let Some(cs) = states.get_mut(&key) {
                     cs.busy = false;
                 }
             }
 
-            // Send response back to Telegram.
-            if let Err(e) = tg.send_text(chat_id, &reply).await {
-                tracing::error!(chat_id, "failed to send Telegram reply: {e}");
+            // Send response back to Telegram (in the correct thread).
+            if let Err(e) = tg.send_text(chat_id, &reply, thread_id).await {
+                tracing::error!(chat_id, thread_id, "failed to send Telegram reply: {e}");
             }
         });
     }
@@ -701,6 +760,7 @@ async fn process_telegram_message(
     state: &AppState,
     tg: &Arc<TelegramChannel>,
     chat_id: i64,
+    thread_id: i64,
     conv_id: Uuid,
     message: rustykrab_core::types::Message,
     user_text: &str,
@@ -709,7 +769,7 @@ async fn process_telegram_message(
     let mut conv = match state.store.conversations().get(conv_id) {
         Ok(c) => c,
         Err(e) => {
-            tracing::error!(chat_id, %conv_id, "failed to load conversation: {e}");
+            tracing::error!(chat_id, thread_id, %conv_id, "failed to load conversation: {e}");
             return "Internal error — please try again.".to_string();
         }
     };
@@ -718,8 +778,8 @@ async fn process_telegram_message(
     conv.messages.push(message);
     conv.updated_at = Utc::now();
 
-    // Send initial typing indicator.
-    let _ = tg.send_typing(chat_id).await;
+    // Send initial typing indicator (scoped to forum thread if applicable).
+    let _ = tg.send_typing(chat_id, thread_id).await;
 
     // Spawn a background task to keep re-sending typing indicators
     // while the agent is working.
@@ -732,7 +792,7 @@ async fn process_telegram_message(
             if !typing_flag.load(std::sync::atomic::Ordering::Relaxed) {
                 break;
             }
-            let _ = tg_typing.send_typing(chat_id).await;
+            let _ = tg_typing.send_typing(chat_id, thread_id).await;
         }
     });
 
@@ -878,7 +938,9 @@ async fn job_executor_loop(store: rustykrab_store::Store, state: AppState) {
                     Some("telegram") => {
                         if let (Some(tg), Some(cid)) = (&state.telegram, &chat_id) {
                             if let Ok(chat_id_num) = cid.parse::<i64>() {
-                                if let Err(e) = tg.send_text(chat_id_num, &response_text).await {
+                                // Scheduled jobs don't have thread context;
+                                // messages go to the "General" topic in forum groups.
+                                if let Err(e) = tg.send_text(chat_id_num, &response_text, 0).await {
                                     tracing::error!(job_id = %job_id, "failed to send scheduled job result to Telegram: {e}");
                                 }
                             } else {

--- a/crates/rustykrab-store/src/chat_map.rs
+++ b/crates/rustykrab-store/src/chat_map.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use rusqlite::params;
+use rustykrab_core::Error;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// Maps Telegram `(chat_id, thread_id)` pairs to conversation UUIDs.
+///
+/// The `thread_id` column uses `0` for non-forum chats (or the implicit
+/// "General" topic). The `UNIQUE(chat_id, thread_id)` constraint doubles
+/// as a composite index, so lookups by both columns are fast.
+#[derive(Clone)]
+pub struct ChatMapStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl ChatMapStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Look up the conversation UUID for a `(chat_id, thread_id)` pair.
+    /// Returns `None` if no mapping exists yet.
+    pub fn lookup(&self, chat_id: i64, thread_id: i64) -> Result<Option<Uuid>, Error> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT conv_id FROM telegram_chat_map
+                 WHERE chat_id = ?1 AND thread_id = ?2",
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        match stmt.query_row(params![chat_id, thread_id], |row| {
+            let id_str: String = row.get(0)?;
+            Ok(id_str)
+        }) {
+            Ok(id_str) => {
+                let id = Uuid::parse_str(&id_str)
+                    .map_err(|e| Error::Storage(format!("invalid conv_id UUID: {e}")))?;
+                Ok(Some(id))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(Error::Storage(e.to_string())),
+        }
+    }
+
+    /// Insert or update the mapping for a `(chat_id, thread_id)` pair.
+    pub fn upsert(&self, chat_id: i64, thread_id: i64, conv_id: Uuid) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO telegram_chat_map (chat_id, thread_id, conv_id)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(chat_id, thread_id) DO UPDATE SET conv_id = excluded.conv_id",
+            params![chat_id, thread_id, conv_id.to_string()],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Remove the mapping for a `(chat_id, thread_id)` pair (e.g. on `/reset`).
+    pub fn remove(&self, chat_id: i64, thread_id: i64) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM telegram_chat_map WHERE chat_id = ?1 AND thread_id = ?2",
+            params![chat_id, thread_id],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -1,3 +1,4 @@
+mod chat_map;
 mod conversation;
 mod jobs;
 pub mod keychain;
@@ -10,6 +11,7 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use zeroize::Zeroizing;
 
+pub use chat_map::ChatMapStore;
 pub use conversation::ConversationStore;
 pub use jobs::{JobStore, ScheduledJob};
 pub use secret::SecretStore;
@@ -80,6 +82,14 @@ impl Store {
             CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_due
                 ON scheduled_jobs (next_run_at)
                 WHERE enabled = 1;
+
+            CREATE TABLE IF NOT EXISTS telegram_chat_map (
+                chat_id    INTEGER NOT NULL,
+                thread_id  INTEGER NOT NULL DEFAULT 0,
+                conv_id    TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(chat_id, thread_id)
+            );
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -99,6 +109,11 @@ impl Store {
     /// Return a handle for scheduled-job operations.
     pub fn jobs(&self) -> JobStore {
         JobStore::new(Arc::clone(&self.conn))
+    }
+
+    /// Return a handle for Telegram chat/thread → conversation mapping.
+    pub fn chat_map(&self) -> ChatMapStore {
+        ChatMapStore::new(Arc::clone(&self.conn))
     }
 
     /// Flush all pending writes to disk.


### PR DESCRIPTION
Each forum topic now gets its own independent conversation, keyed by
(chat_id, thread_id). Bot replies, typing indicators, and busy-locks
are all scoped to the originating thread so multiple topics can be
served concurrently.

Changes:
- Parse `message_thread_id` / `is_topic_message` from inbound updates
- Pass `message_thread_id` in sendMessage and sendChatAction calls
- Key conversation state by (chat_id, thread_id) instead of chat_id
- Add `telegram_chat_map` table with UNIQUE(chat_id, thread_id) index
  for persistent conversation mapping across restarts
- Add ChatMapStore for DB-backed lookup/upsert/remove operations

https://claude.ai/code/session_01DdroSkqN6qpsGd6mVduos6