### PR TITLE
Add network reconnaissance tools and skill (net_scan, net_admin, net_audit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "0.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -63,6 +63,11 @@ mod canvas;
 // Device tools
 mod nodes;
 
+// Network tools
+mod net_admin;
+mod net_audit;
+mod net_scan;
+
 // HTTP
 mod http_request;
 mod http_session;
@@ -140,6 +145,11 @@ pub use canvas::CanvasTool;
 // Devices
 pub use nodes::NodesTool;
 
+// Network
+pub use net_admin::NetAdminTool;
+pub use net_audit::NetAuditTool;
+pub use net_scan::NetScanTool;
+
 // HTTP
 pub use http_request::HttpRequestTool;
 pub use http_session::HttpSessionTool;
@@ -191,6 +201,10 @@ pub fn builtin_tools(
         std::sync::Arc::new(CanvasTool::new()),
         // Devices
         std::sync::Arc::new(NodesTool::new()),
+        // Network
+        std::sync::Arc::new(NetScanTool::new()),
+        std::sync::Arc::new(NetAdminTool::new()),
+        std::sync::Arc::new(NetAuditTool::new()),
         // Email
         std::sync::Arc::new(GmailTool::new(secrets.clone())),
         // Notion

--- a/crates/rustykrab-tools/src/net_admin.rs
+++ b/crates/rustykrab-tools/src/net_admin.rs
@@ -1,0 +1,294 @@
+use async_trait::async_trait;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Result, Tool};
+use serde_json::{json, Value};
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+use tokio::time::timeout;
+
+/// Remote administration tool for machines the user owns.
+///
+/// Supported actions:
+/// - **ssh_exec**: Run a command on a remote host via SSH (requires `ssh` binary).
+/// - **wake_on_lan**: Send a WoL magic packet to wake a machine by MAC address.
+/// - **ssh_copy_id**: Copy the local public key to a remote host for key-based auth.
+///
+/// All targets must be in private/link-local IP ranges.
+pub struct NetAdminTool;
+
+impl NetAdminTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NetAdminTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Return `true` if the IP is in a private / link-local range.
+fn is_local_network(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+/// Validate that `host` is a local-network IP.
+fn require_local(host: &str) -> std::result::Result<IpAddr, String> {
+    let ip: IpAddr = host
+        .parse()
+        .map_err(|e| format!("invalid IP address: {e}"))?;
+    if !is_local_network(&ip) {
+        return Err(format!(
+            "{ip} is not in a private/local range — only local-network targets are allowed"
+        ));
+    }
+    Ok(ip)
+}
+
+/// Build a Wake-on-LAN magic packet for the given MAC address.
+fn build_wol_packet(mac: &str) -> std::result::Result<Vec<u8>, String> {
+    let mac_bytes: Vec<u8> = mac
+        .split([':', '-'])
+        .map(|octet| u8::from_str_radix(octet, 16).map_err(|e| format!("bad MAC octet: {e}")))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if mac_bytes.len() != 6 {
+        return Err("MAC address must have exactly 6 octets".into());
+    }
+    // Magic packet: 6 x 0xFF followed by the MAC repeated 16 times.
+    let mut packet = vec![0xFFu8; 6];
+    for _ in 0..16 {
+        packet.extend_from_slice(&mac_bytes);
+    }
+    Ok(packet)
+}
+
+/// Execute an SSH command on a remote host.
+async fn ssh_exec(
+    host: &str,
+    user: &str,
+    command: &str,
+    port: u16,
+    timeout_secs: u64,
+) -> Result<Value> {
+    let path = std::env::var("PATH")
+        .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".to_string());
+
+    let future = tokio::process::Command::new("ssh")
+        .args([
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            &format!("ConnectTimeout={}", timeout_secs.min(30)),
+            "-o",
+            "BatchMode=yes",
+            "-p",
+            &port.to_string(),
+            &format!("{user}@{host}"),
+            command,
+        ])
+        .env("PATH", &path)
+        .output();
+
+    let output = timeout(Duration::from_secs(timeout_secs), future)
+        .await
+        .map_err(|_| {
+            rustykrab_core::Error::ToolExecution(
+                format!("SSH command timed out after {timeout_secs}s").into(),
+            )
+        })?
+        .map_err(|e| {
+            rustykrab_core::Error::ToolExecution(format!("failed to execute ssh: {e}").into())
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    Ok(json!({
+        "action": "ssh_exec",
+        "host": host,
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr,
+    }))
+}
+
+#[async_trait]
+impl Tool for NetAdminTool {
+    fn name(&self) -> &str {
+        "net_admin"
+    }
+
+    fn description(&self) -> &str {
+        "Remote administration for machines you own on the local network. Supports SSH command execution and Wake-on-LAN."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["ssh_exec", "wake_on_lan", "ssh_copy_id"],
+                        "description": "ssh_exec: run a command via SSH. wake_on_lan: send a WoL magic packet. ssh_copy_id: install your public key on a remote host."
+                    },
+                    "host": {
+                        "type": "string",
+                        "description": "Target IP address (must be a private/link-local address)"
+                    },
+                    "user": {
+                        "type": "string",
+                        "description": "SSH username (default: current user)"
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "Command to execute on the remote host (required for ssh_exec)"
+                    },
+                    "port": {
+                        "type": "integer",
+                        "description": "SSH port (default: 22)"
+                    },
+                    "mac_address": {
+                        "type": "string",
+                        "description": "MAC address for Wake-on-LAN (e.g. AA:BB:CC:DD:EE:FF)"
+                    },
+                    "broadcast_ip": {
+                        "type": "string",
+                        "description": "Broadcast IP for WoL (default: 255.255.255.255)"
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "description": "Timeout in seconds (default: 30, max: 120)"
+                    }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+
+        let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(30).min(120);
+
+        match action {
+            "ssh_exec" => {
+                let host = args["host"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("host is required for ssh_exec".into())
+                })?;
+                require_local(host).map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+                let user = args["user"].as_str().unwrap_or("root");
+                let command = args["command"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("command is required for ssh_exec".into())
+                })?;
+                let port = args["port"].as_u64().unwrap_or(22) as u16;
+
+                ssh_exec(host, user, command, port, timeout_secs).await
+            }
+
+            "ssh_copy_id" => {
+                let host = args["host"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("host is required for ssh_copy_id".into())
+                })?;
+                require_local(host).map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+                let user = args["user"].as_str().unwrap_or("root");
+                let port = args["port"].as_u64().unwrap_or(22) as u16;
+
+                let path = std::env::var("PATH")
+                    .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
+
+                let output = timeout(
+                    Duration::from_secs(timeout_secs),
+                    tokio::process::Command::new("ssh-copy-id")
+                        .args(["-p", &port.to_string(), &format!("{user}@{host}")])
+                        .env("PATH", &path)
+                        .output(),
+                )
+                .await
+                .map_err(|_| rustykrab_core::Error::ToolExecution("ssh-copy-id timed out".into()))?
+                .map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to run ssh-copy-id: {e}").into(),
+                    )
+                })?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+                Ok(json!({
+                    "action": "ssh_copy_id",
+                    "host": host,
+                    "success": output.status.success(),
+                    "stdout": stdout,
+                    "stderr": stderr,
+                }))
+            }
+
+            "wake_on_lan" => {
+                let mac = args["mac_address"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(
+                        "mac_address is required for wake_on_lan".into(),
+                    )
+                })?;
+                let broadcast_str = args["broadcast_ip"].as_str().unwrap_or("255.255.255.255");
+                let broadcast_ip: Ipv4Addr = broadcast_str.parse().map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("invalid broadcast IP: {e}").into(),
+                    )
+                })?;
+
+                let packet = build_wol_packet(mac)
+                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+                let socket = tokio::net::UdpSocket::bind("0.0.0.0:0")
+                    .await
+                    .map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(
+                            format!("failed to bind UDP socket: {e}").into(),
+                        )
+                    })?;
+                socket.set_broadcast(true).map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to enable broadcast: {e}").into(),
+                    )
+                })?;
+
+                let dest = std::net::SocketAddr::new(
+                    IpAddr::V4(broadcast_ip),
+                    9, // WoL standard port
+                );
+                socket.send_to(&packet, dest).await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to send WoL packet: {e}").into(),
+                    )
+                })?;
+
+                Ok(json!({
+                    "action": "wake_on_lan",
+                    "mac_address": mac,
+                    "broadcast_ip": broadcast_str,
+                    "sent": true,
+                }))
+            }
+
+            _ => Err(rustykrab_core::Error::ToolExecution(
+                format!("unknown net_admin action: {action}").into(),
+            )),
+        }
+    }
+}

--- a/crates/rustykrab-tools/src/net_audit.rs
+++ b/crates/rustykrab-tools/src/net_audit.rs
@@ -1,0 +1,363 @@
+use async_trait::async_trait;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Result, Tool};
+use serde_json::{json, Value};
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+/// Security auditing tool for the local network.
+///
+/// Supported actions:
+/// - **banner_grab**: Connects to a port and reads the service banner
+///   to identify software versions.
+/// - **ssl_check**: Tests TLS configuration on a host+port, reporting
+///   certificate info and protocol version.
+/// - **ssh_auth_methods**: Queries an SSH server for supported
+///   authentication methods.
+/// - **service_info**: Performs banner grab on all open ports of a host
+///   to produce a comprehensive service inventory.
+///
+/// All targets must be in private/link-local IP ranges.
+pub struct NetAuditTool;
+
+impl NetAuditTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NetAuditTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Return `true` if the IP is in a private / link-local range.
+fn is_local_network(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+/// Validate that `host` is a local-network IP.
+fn require_local(host: &str) -> std::result::Result<IpAddr, String> {
+    let ip: IpAddr = host
+        .parse()
+        .map_err(|e| format!("invalid IP address: {e}"))?;
+    if !is_local_network(&ip) {
+        return Err(format!(
+            "{ip} is not in a private/local range — only local-network auditing is allowed"
+        ));
+    }
+    Ok(ip)
+}
+
+/// Connect to a TCP port and read the initial service banner.
+async fn banner_grab(ip: IpAddr, port: u16, timeout_ms: u64) -> Option<String> {
+    let addr = SocketAddr::new(ip, port);
+    let connect = timeout(Duration::from_millis(timeout_ms), TcpStream::connect(addr));
+    let mut stream = match connect.await {
+        Ok(Ok(s)) => s,
+        _ => return None,
+    };
+
+    // Some services (HTTP) need a small nudge to send a banner.
+    if port == 80 || port == 8080 || port == 8443 {
+        let _ = stream
+            .write_all(b"HEAD / HTTP/1.0\r\nHost: check\r\n\r\n")
+            .await;
+    }
+
+    let mut buf = vec![0u8; 2048];
+    let read = timeout(Duration::from_millis(timeout_ms), stream.read(&mut buf));
+    match read.await {
+        Ok(Ok(n)) if n > 0 => {
+            let banner = String::from_utf8_lossy(&buf[..n]).to_string();
+            Some(banner.trim().to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Query SSH authentication methods by connecting and performing a partial
+/// handshake (reading the server ident string).
+async fn ssh_auth_probe(ip: IpAddr, port: u16, timeout_ms: u64) -> Value {
+    let addr = SocketAddr::new(ip, port);
+    let connect = timeout(Duration::from_millis(timeout_ms), TcpStream::connect(addr));
+    let mut stream = match connect.await {
+        Ok(Ok(s)) => s,
+        _ => {
+            return json!({
+                "reachable": false,
+                "error": "connection failed or timed out",
+            })
+        }
+    };
+
+    // Read server identification string (e.g. "SSH-2.0-OpenSSH_9.6").
+    let mut buf = vec![0u8; 512];
+    let read = timeout(Duration::from_millis(timeout_ms), stream.read(&mut buf));
+    let server_ident = match read.await {
+        Ok(Ok(n)) if n > 0 => String::from_utf8_lossy(&buf[..n]).trim().to_string(),
+        _ => String::new(),
+    };
+
+    // Try ssh-keyscan to discover host key types.
+    let path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
+
+    let keyscan = timeout(
+        Duration::from_secs(10),
+        tokio::process::Command::new("ssh-keyscan")
+            .args(["-p", &port.to_string(), &ip.to_string()])
+            .env("PATH", &path)
+            .output(),
+    )
+    .await;
+
+    let mut key_types = Vec::new();
+    if let Ok(Ok(output)) = keyscan {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            // Lines look like: "192.168.1.1 ssh-ed25519 AAAA..."
+            if let Some(key_type) = line.split_whitespace().nth(1) {
+                if key_type.starts_with("ssh-") || key_type.starts_with("ecdsa-") {
+                    key_types.push(key_type.to_string());
+                }
+            }
+        }
+    }
+
+    json!({
+        "reachable": true,
+        "server_ident": server_ident,
+        "host_key_types": key_types,
+    })
+}
+
+/// Check TLS/SSL configuration on a host+port.
+async fn ssl_check(ip: IpAddr, port: u16, timeout_ms: u64) -> Value {
+    let path = std::env::var("PATH").unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string());
+
+    // Try openssl s_client for certificate details.
+    let result = timeout(
+        Duration::from_millis(timeout_ms.max(5_000)),
+        tokio::process::Command::new("openssl")
+            .args([
+                "s_client",
+                "-connect",
+                &format!("{ip}:{port}"),
+                "-servername",
+                &ip.to_string(),
+                "-brief",
+            ])
+            .stdin(std::process::Stdio::null())
+            .env("PATH", &path)
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            // Parse out useful fields.
+            let combined = format!("{stdout}\n{stderr}");
+            let mut protocol = String::new();
+            let mut cipher = String::new();
+            let mut subject = String::new();
+            let mut issuer = String::new();
+            let mut not_after = String::new();
+
+            for line in combined.lines() {
+                let line = line.trim();
+                if line.starts_with("Protocol version:") || line.starts_with("Protocol  :") {
+                    protocol = line
+                        .split_once(':')
+                        .map(|(_, v)| v)
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                } else if line.starts_with("Ciphersuite:") || line.starts_with("Cipher    :") {
+                    cipher = line
+                        .split_once(':')
+                        .map(|(_, v)| v)
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                } else if line.starts_with("subject=") {
+                    subject = line.trim_start_matches("subject=").trim().to_string();
+                } else if line.starts_with("issuer=") {
+                    issuer = line.trim_start_matches("issuer=").trim().to_string();
+                } else if line.starts_with("notAfter=") || line.contains("Not After") {
+                    not_after = line
+                        .split_once('=')
+                        .map(|(_, v)| v)
+                        .or_else(|| line.split_once(':').map(|(_, v)| v))
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                }
+            }
+
+            json!({
+                "tls_available": true,
+                "protocol": protocol,
+                "cipher": cipher,
+                "subject": subject,
+                "issuer": issuer,
+                "not_after": not_after,
+            })
+        }
+        Ok(Err(e)) => json!({
+            "tls_available": false,
+            "error": format!("openssl not available: {e}"),
+        }),
+        Err(_) => json!({
+            "tls_available": false,
+            "error": "TLS check timed out",
+        }),
+    }
+}
+
+#[async_trait]
+impl Tool for NetAuditTool {
+    fn name(&self) -> &str {
+        "net_audit"
+    }
+
+    fn description(&self) -> &str {
+        "Security auditing for local network services. Grab banners, check TLS/SSL, and probe SSH configurations."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["banner_grab", "ssl_check", "ssh_auth_methods", "service_info"],
+                        "description": "banner_grab: read a service banner. ssl_check: test TLS config. ssh_auth_methods: probe SSH auth. service_info: banner grab on multiple ports."
+                    },
+                    "host": {
+                        "type": "string",
+                        "description": "Target IP address (must be private/link-local)"
+                    },
+                    "port": {
+                        "type": "integer",
+                        "description": "Port to probe (default varies by action)"
+                    },
+                    "ports": {
+                        "type": "array",
+                        "items": { "type": "integer" },
+                        "description": "List of ports for service_info (default: common ports)"
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "description": "Per-probe timeout in milliseconds (default: 3000, max: 15000)"
+                    }
+                },
+                "required": ["action", "host"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+
+        let host_str = args["host"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing host".into()))?;
+
+        let ip =
+            require_local(host_str).map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+        let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(3_000).min(15_000);
+
+        match action {
+            "banner_grab" => {
+                let port = args["port"].as_u64().unwrap_or(80) as u16;
+                let banner = banner_grab(ip, port, timeout_ms).await;
+
+                Ok(json!({
+                    "action": "banner_grab",
+                    "host": host_str,
+                    "port": port,
+                    "banner": banner,
+                }))
+            }
+
+            "ssl_check" => {
+                let port = args["port"].as_u64().unwrap_or(443) as u16;
+                let result = ssl_check(ip, port, timeout_ms).await;
+
+                Ok(json!({
+                    "action": "ssl_check",
+                    "host": host_str,
+                    "port": port,
+                    "result": result,
+                }))
+            }
+
+            "ssh_auth_methods" => {
+                let port = args["port"].as_u64().unwrap_or(22) as u16;
+                let result = ssh_auth_probe(ip, port, timeout_ms).await;
+
+                Ok(json!({
+                    "action": "ssh_auth_methods",
+                    "host": host_str,
+                    "port": port,
+                    "result": result,
+                }))
+            }
+
+            "service_info" => {
+                let default_ports: Vec<u16> = vec![
+                    21, 22, 23, 25, 53, 80, 110, 143, 443, 445, 993, 995, 3306, 3389, 5432, 5900,
+                    8080, 8443,
+                ];
+                let ports: Vec<u16> = args["ports"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_u64().map(|n| n as u16))
+                            .collect()
+                    })
+                    .unwrap_or(default_ports);
+
+                let mut services = Vec::new();
+                for &port in &ports {
+                    if let Some(banner) = banner_grab(ip, port, timeout_ms).await {
+                        services.push(json!({
+                            "port": port,
+                            "banner": banner,
+                        }));
+                    }
+                }
+
+                Ok(json!({
+                    "action": "service_info",
+                    "host": host_str,
+                    "services": services,
+                    "ports_scanned": ports.len(),
+                }))
+            }
+
+            _ => Err(rustykrab_core::Error::ToolExecution(
+                format!("unknown net_audit action: {action}").into(),
+            )),
+        }
+    }
+}

--- a/crates/rustykrab-tools/src/net_scan.rs
+++ b/crates/rustykrab-tools/src/net_scan.rs
@@ -1,0 +1,329 @@
+use async_trait::async_trait;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Result, Tool};
+use serde_json::{json, Value};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+/// Well-known ports to scan by default when no explicit list is provided.
+const DEFAULT_PORTS: &[u16] = &[
+    22, 80, 443, 445, 3389, 5900, 8080, 8443, // SSH, HTTP, HTTPS, SMB, RDP, VNC, alt-HTTP
+    21, 23, 25, 53, 110, 143, 993, 995, // FTP, Telnet, SMTP, DNS, POP3, IMAP
+    3306, 5432, 6379, 27017, // MySQL, PostgreSQL, Redis, MongoDB
+    1883, 8883, 5353, 9100, // MQTT, mDNS, printers
+];
+
+/// Human-readable labels for common services.
+fn service_label(port: u16) -> &'static str {
+    match port {
+        21 => "ftp",
+        22 => "ssh",
+        23 => "telnet",
+        25 => "smtp",
+        53 => "dns",
+        80 => "http",
+        110 => "pop3",
+        143 => "imap",
+        443 => "https",
+        445 => "smb",
+        993 => "imaps",
+        995 => "pop3s",
+        1883 => "mqtt",
+        3306 => "mysql",
+        3389 => "rdp",
+        5353 => "mdns",
+        5432 => "postgresql",
+        5900 => "vnc",
+        6379 => "redis",
+        8080 => "http-alt",
+        8443 => "https-alt",
+        8883 => "mqtt-tls",
+        9100 => "printer",
+        27017 => "mongodb",
+        _ => "unknown",
+    }
+}
+
+/// Network discovery and port-scanning tool.
+///
+/// Provides three actions:
+/// - **ping_sweep**: Probes a subnet to find live hosts (TCP connect on port 80/443).
+/// - **port_scan**: Scans a list of ports on a single host.
+/// - **scan_subnet**: Combines sweep + port scan for every live host found.
+///
+/// All operations are restricted to RFC-1918 / link-local addresses so the
+/// tool cannot be used for external reconnaissance.
+pub struct NetScanTool;
+
+impl NetScanTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NetScanTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Return `true` if the IP is in a private / link-local range.
+fn is_local_network(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || v4.is_link_local() || v4.is_loopback(),
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || (v6.segments()[0] & 0xfe00) == 0xfc00  // unique-local
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link-local
+        }
+    }
+}
+
+/// Try a TCP connect to `addr` within `timeout_ms` milliseconds.
+async fn tcp_probe(addr: SocketAddr, timeout_ms: u64) -> bool {
+    timeout(Duration::from_millis(timeout_ms), TcpStream::connect(addr))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false)
+}
+
+/// Expand a CIDR-style subnet (e.g. `192.168.1.0/24`) into individual IPv4
+/// host addresses, excluding the network and broadcast addresses.
+fn expand_subnet(cidr: &str) -> std::result::Result<Vec<Ipv4Addr>, String> {
+    let parts: Vec<&str> = cidr.split('/').collect();
+    if parts.len() != 2 {
+        return Err("expected CIDR notation, e.g. 192.168.1.0/24".into());
+    }
+    let base: Ipv4Addr = parts[0].parse().map_err(|e| format!("invalid IP: {e}"))?;
+    let prefix_len: u32 = parts[1]
+        .parse()
+        .map_err(|e| format!("invalid prefix length: {e}"))?;
+    if prefix_len > 32 {
+        return Err("prefix length must be <= 32".into());
+    }
+    // Limit to /20 (4094 hosts) to avoid accidental DoS.
+    if prefix_len < 20 {
+        return Err(
+            "prefix length must be >= 20 (max 4094 hosts) to prevent accidental DoS".into(),
+        );
+    }
+
+    let base_u32 = u32::from(base);
+    let mask = if prefix_len == 0 {
+        0u32
+    } else {
+        !0u32 << (32 - prefix_len)
+    };
+    let network = base_u32 & mask;
+    let host_count = 1u32 << (32 - prefix_len);
+
+    let mut addrs = Vec::new();
+    // Skip network address (i=0) and broadcast (i=host_count-1).
+    for i in 1..host_count.saturating_sub(1) {
+        addrs.push(Ipv4Addr::from(network + i));
+    }
+    Ok(addrs)
+}
+
+/// Perform a ping sweep by attempting a TCP connect on probe ports.
+async fn ping_sweep(cidr: &str, timeout_ms: u64) -> std::result::Result<Vec<Value>, String> {
+    let hosts = expand_subnet(cidr)?;
+    let probe_ports: &[u16] = &[80, 443, 22, 445];
+
+    // Verify all hosts are in local network ranges.
+    for h in &hosts {
+        if !is_local_network(&IpAddr::V4(*h)) {
+            return Err(format!(
+                "host {h} is not in a private/local range — only local-network scanning is allowed"
+            ));
+        }
+    }
+
+    let mut handles = Vec::new();
+    for host in hosts {
+        let handle = tokio::spawn(async move {
+            for &port in probe_ports {
+                let addr = SocketAddr::new(IpAddr::V4(host), port);
+                if tcp_probe(addr, timeout_ms).await {
+                    return Some(host);
+                }
+            }
+            None
+        });
+        handles.push(handle);
+    }
+
+    let mut live = Vec::new();
+    for h in handles {
+        if let Ok(Some(ip)) = h.await {
+            live.push(json!(ip.to_string()));
+        }
+    }
+
+    Ok(live)
+}
+
+/// Scan a list of ports on a single host.
+async fn port_scan(ip: IpAddr, ports: &[u16], timeout_ms: u64) -> Vec<Value> {
+    let mut handles = Vec::new();
+    for &port in ports {
+        let addr = SocketAddr::new(ip, port);
+        let handle = tokio::spawn(async move {
+            if tcp_probe(addr, timeout_ms).await {
+                Some(port)
+            } else {
+                None
+            }
+        });
+        handles.push(handle);
+    }
+
+    let mut open = Vec::new();
+    for h in handles {
+        if let Ok(Some(port)) = h.await {
+            open.push(json!({
+                "port": port,
+                "service": service_label(port),
+            }));
+        }
+    }
+    open
+}
+
+#[async_trait]
+impl Tool for NetScanTool {
+    fn name(&self) -> &str {
+        "net_scan"
+    }
+
+    fn description(&self) -> &str {
+        "Discover devices and open ports on the local network. Restricted to private/link-local IP ranges."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["ping_sweep", "port_scan", "scan_subnet"],
+                        "description": "ping_sweep: find live hosts in a subnet. port_scan: scan ports on a single host. scan_subnet: sweep + port scan all live hosts."
+                    },
+                    "subnet": {
+                        "type": "string",
+                        "description": "CIDR subnet to scan, e.g. 192.168.1.0/24 (required for ping_sweep and scan_subnet)"
+                    },
+                    "host": {
+                        "type": "string",
+                        "description": "IP address to scan (required for port_scan)"
+                    },
+                    "ports": {
+                        "type": "array",
+                        "items": { "type": "integer" },
+                        "description": "List of ports to scan (default: common well-known ports)"
+                    },
+                    "timeout_ms": {
+                        "type": "integer",
+                        "description": "Per-probe timeout in milliseconds (default: 1500, max: 10000)"
+                    }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+
+        let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(1500).min(10_000);
+
+        let ports: Vec<u16> = args["ports"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_u64().map(|n| n as u16))
+                    .collect()
+            })
+            .unwrap_or_else(|| DEFAULT_PORTS.to_vec());
+
+        match action {
+            "ping_sweep" => {
+                let subnet = args["subnet"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("subnet is required for ping_sweep".into())
+                })?;
+
+                let live = ping_sweep(subnet, timeout_ms)
+                    .await
+                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+                Ok(json!({
+                    "action": "ping_sweep",
+                    "subnet": subnet,
+                    "live_hosts": live,
+                    "count": live.len(),
+                }))
+            }
+            "port_scan" => {
+                let host_str = args["host"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution("host is required for port_scan".into())
+                })?;
+                let ip: IpAddr = host_str.parse().map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(format!("invalid IP address: {e}").into())
+                })?;
+                if !is_local_network(&ip) {
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        format!("{ip} is not in a private/local range — only local-network scanning is allowed").into(),
+                    ));
+                }
+
+                let open = port_scan(ip, &ports, timeout_ms).await;
+                Ok(json!({
+                    "action": "port_scan",
+                    "host": host_str,
+                    "open_ports": open,
+                    "scanned_count": ports.len(),
+                }))
+            }
+            "scan_subnet" => {
+                let subnet = args["subnet"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(
+                        "subnet is required for scan_subnet".into(),
+                    )
+                })?;
+
+                let live = ping_sweep(subnet, timeout_ms)
+                    .await
+                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+
+                let mut results = Vec::new();
+                for host_val in &live {
+                    let host_str = host_val.as_str().unwrap_or_default();
+                    if let Ok(ip) = host_str.parse::<IpAddr>() {
+                        let open = port_scan(ip, &ports, timeout_ms).await;
+                        results.push(json!({
+                            "host": host_str,
+                            "open_ports": open,
+                        }));
+                    }
+                }
+
+                Ok(json!({
+                    "action": "scan_subnet",
+                    "subnet": subnet,
+                    "hosts": results,
+                    "live_count": live.len(),
+                }))
+            }
+            _ => Err(rustykrab_core::Error::ToolExecution(
+                format!("unknown net_scan action: {action}").into(),
+            )),
+        }
+    }
+}

--- a/skills/network-recon/SKILL.md
+++ b/skills/network-recon/SKILL.md
@@ -1,0 +1,69 @@
+---
+name = "network-recon"
+description = "Discover, administer, and audit machines on your local network"
+version = "1.0"
+user_invocable = true
+emoji = "N"
+
+[requires]
+bins = ["ssh", "openssl"]
+---
+You are a network reconnaissance and administration assistant. You help the
+user discover, manage, and secure machines on their **local** network.
+
+You have three tools at your disposal:
+
+## net_scan — Network Discovery
+
+Use `net_scan` to find devices and open ports on the local network.
+
+| Action | Description |
+|---|---|
+| `ping_sweep` | Probe a CIDR subnet (e.g. `192.168.1.0/24`) to find live hosts via TCP connect probes. |
+| `port_scan` | Scan a list of ports on a single host to find open services. |
+| `scan_subnet` | Combine sweep + port scan: discover live hosts then scan each one for open ports. |
+
+Start with `ping_sweep` or `scan_subnet` to get a picture of the network,
+then drill into specific hosts with `port_scan`.
+
+## net_admin — Remote Administration
+
+Use `net_admin` to manage machines you own.
+
+| Action | Description |
+|---|---|
+| `ssh_exec` | Run a shell command on a remote host via SSH. Requires the user to have SSH access (key-based auth recommended). |
+| `ssh_copy_id` | Install the local SSH public key on a remote host so future connections are passwordless. |
+| `wake_on_lan` | Send a WoL magic packet to power on a machine by its MAC address. |
+
+Always confirm with the user before running destructive commands via `ssh_exec`.
+Prefer key-based authentication; suggest `ssh_copy_id` when password auth is the
+only option.
+
+## net_audit — Security Auditing
+
+Use `net_audit` to assess the security posture of local services.
+
+| Action | Description |
+|---|---|
+| `banner_grab` | Connect to a port and read the service banner to identify software and versions. |
+| `ssl_check` | Test TLS/SSL configuration on a host+port — shows protocol, cipher, certificate info, and expiry. |
+| `ssh_auth_methods` | Query an SSH server for its identification string and host key types. |
+| `service_info` | Banner-grab across multiple ports on a single host for a full service inventory. |
+
+## Workflow
+
+A typical session follows this pattern:
+
+1. **Discover** — Run `net_scan.scan_subnet` to find all live hosts and their open ports.
+2. **Identify** — Run `net_audit.service_info` on interesting hosts to fingerprint services.
+3. **Assess** — Check TLS with `net_audit.ssl_check` and SSH with `net_audit.ssh_auth_methods`.
+4. **Administer** — Use `net_admin.ssh_exec` to apply fixes, update software, or configure services.
+5. **Report** — Summarize findings: list each host, its services, and any security concerns.
+
+## Safety
+
+- All three tools are restricted to **private/link-local IP ranges** (RFC 1918, link-local, loopback). Attempts to target public IPs will be rejected.
+- Subnet scans are capped at /20 (4094 hosts) to prevent accidental resource exhaustion.
+- SSH commands use `BatchMode=yes` and `StrictHostKeyChecking=accept-new` — they will fail rather than hang waiting for interactive input.
+- Always confirm with the user before taking administrative actions on remote machines.


### PR DESCRIPTION
Three new tools for local network discovery, administration, and security
auditing, restricted to private/link-local IP ranges. Bundled as a
user-invocable "network-recon" skill with workflow guidance.

https://claude.ai/code/session_01MZd9X55xwxhmWEENCwWnbk