### PR TITLE
Fix macOS release builds: pin runners to correct architectures, add manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -15,7 +26,9 @@ jobs:
   # ── Version bump, commit, tag ──────────────────────────────────────
   bump:
     name: Bump Version & Tag
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}
@@ -38,25 +51,31 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Determine bump type from PR labels
+      - name: Determine bump type
         id: bump-type
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-          if echo "$LABELS" | grep -q '"semver:major"'; then
-            echo "bump=major" >> "$GITHUB_OUTPUT"
-          elif echo "$LABELS" | grep -q '"semver:minor"'; then
-            echo "bump=minor" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump=${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
           else
-            echo "bump=patch" >> "$GITHUB_OUTPUT"
+            LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+            if echo "$LABELS" | grep -q '"semver:major"'; then
+              echo "bump=major" >> "$GITHUB_OUTPUT"
+            elif echo "$LABELS" | grep -q '"semver:minor"'; then
+              echo "bump=minor" >> "$GITHUB_OUTPUT"
+            else
+              echo "bump=patch" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Bump version
         id: bump
         run: |
+          PR_TITLE="${{ github.event.pull_request.title || 'Manual release' }}"
+          PR_NUMBER="${{ github.event.pull_request.number || '0' }}"
           ./scripts/release.sh "${{ steps.bump-type.outputs.bump }}" \
             --ci \
-            --pr-title "${{ github.event.pull_request.title }}" \
-            --pr-number "${{ github.event.pull_request.number }}"
+            --pr-title "$PR_TITLE" \
+            --pr-number "$PR_NUMBER"
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
@@ -80,10 +99,10 @@ jobs:
             os: ubuntu-latest
             artifact: rustykrab-cli
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             artifact: rustykrab-cli
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             artifact: rustykrab-cli
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,7 +3244,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.2.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",


### PR DESCRIPTION
- Use macos-14 (ARM) for aarch64-apple-darwin and macos-13 (Intel) for
  x86_64-apple-darwin instead of macos-latest for both, which avoids
  cross-compilation failures from system library dependencies.
- Add workflow_dispatch trigger so releases can be tested manually
  without merging a PR.

https://claude.ai/code/session_014LDNyH3tBL6cuFqx3sqUs4