### PR TITLE
Add central secret registry and cross-platform OS keychain support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "linux-keyutils",
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2053,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -3244,7 +3265,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3258,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3277,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3305,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3317,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3340,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3361,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3377,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3393,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3401,6 +3422,7 @@ dependencies = [
  "croner",
  "hex",
  "hmac",
+ "keyring",
  "rand",
  "rusqlite",
  "rustykrab-core",
@@ -3416,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ argon2 = "0.5"
 security-framework = { version = "3", features = ["OSX_10_15"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 secrecy = "0.10"
+keyring = { version = "3", default-features = false, features = ["linux-native"] }
 
 # Browser automation (Chrome DevTools Protocol)
 chromiumoxide = "0.9"

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -148,10 +148,50 @@ async fn main() -> anyhow::Result<()> {
 
     let store = rustykrab_store::Store::open(data_dir.join("db"), master_key)?;
 
+    // --- Validate required secrets (central registry) ---
+    // Every credential the app needs is declared in `registry::REGISTRY`.
+    // Required secrets that cannot be resolved from any source (env var,
+    // OS keychain, or encrypted store) cause a hard startup failure.
+    {
+        let missing = rustykrab_store::registry::validate(&store.secrets());
+        let required_missing: Vec<_> = missing.iter().filter(|m| m.spec.required).collect();
+
+        if !required_missing.is_empty() {
+            eprintln!();
+            eprintln!("ERROR: required secrets are missing — the application cannot start.");
+            eprintln!();
+            for m in &required_missing {
+                eprintln!("  {} ({})", m.spec.description, m.spec.store_name);
+                eprintln!("    Set via one of:");
+                eprintln!("      env var:    export {}=<value>", m.spec.env_var);
+                eprintln!(
+                    "      keychain:   rustykrab-cli keychain set {} <value>",
+                    m.spec.keychain_account
+                );
+                eprintln!(
+                    "      store:      credential_write(action='set', name='{}', value='...')",
+                    m.spec.store_name
+                );
+                eprintln!();
+            }
+            eprintln!("Tip: run `scripts/setup-secrets.sh` to store all required secrets at once.");
+            std::process::exit(1);
+        }
+
+        // Warn about optional secrets that are absent.
+        for m in missing.iter().filter(|m| !m.spec.required) {
+            tracing::warn!(
+                secret = m.spec.store_name,
+                "optional secret '{}' not found — some features may be unavailable",
+                m.spec.description,
+            );
+        }
+    }
+
     // --- Auth token ---
-    // Resolution order:
-    // 1. RUSTYKRAB_AUTH_TOKEN env var (CI, Docker, explicit override)
-    // 2. macOS Keychain (persists across restarts without env var)
+    // Resolution order (via registry):
+    // 1. Environment variable (CI, Docker, explicit override)
+    // 2. OS credential store (persists across restarts without env var)
     // 3. Encrypted local SecretStore
     // 4. Generate a new token and persist it in Keychain + SecretStore
     let auth_token = resolve_auth_token(&store);
@@ -1111,134 +1151,53 @@ fn handle_skill_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyho
 }
 
 // --- Credential resolution helpers ---
-// These functions implement a multi-source lookup chain:
-//   env var → macOS Keychain → SecretStore → generate/error
-// When a credential is found or generated, it is persisted to the sources
-// below so it survives future restarts without the env var.
-
-/// Keychain service names for RustyKrab credentials.
-const KEYCHAIN_SERVICE: &str = "com.rustykrab.credentials";
-const KEYCHAIN_ACCOUNT_AUTH_TOKEN: &str = "auth-token";
-const KEYCHAIN_ACCOUNT_API_KEY: &str = "anthropic-api-key";
+// These use the central registry (rustykrab_store::registry) for the
+// env-var → OS-keychain → SecretStore lookup chain.
 
 /// Resolve the bearer auth token for the gateway.
 ///
-/// Lookup chain: env var → Keychain → SecretStore → generate new.
-/// A newly generated token is persisted to Keychain and SecretStore so
-/// subsequent restarts pick it up automatically.
+/// Uses the registry to check env / keychain / store, then generates
+/// a new token if none exists.
 fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
-    // 1. Environment variable (highest priority — explicit override).
-    if let Ok(token) = std::env::var("RUSTYKRAB_AUTH_TOKEN") {
-        tracing::info!("auth token loaded from RUSTYKRAB_AUTH_TOKEN env var");
-        // Persist downward so removing the env var still works next time.
-        persist_credential(
-            store,
-            KEYCHAIN_ACCOUNT_AUTH_TOKEN,
-            "rustykrab_auth_token",
-            &token,
-        );
+    let spec = rustykrab_store::registry::lookup("rustykrab_auth_token")
+        .expect("rustykrab_auth_token must be in the registry");
+
+    if let Some(token) = rustykrab_store::registry::resolve(spec, &store.secrets()) {
+        tracing::info!("auth token resolved via registry");
         return token;
     }
 
-    // 2. macOS Keychain.
-    if rustykrab_store::keychain::keychain_available() {
-        if let Ok(Some(cred)) =
-            rustykrab_store::keychain::get_credential(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN)
-        {
-            tracing::info!("auth token loaded from macOS Keychain");
-            // Also ensure it's in the SecretStore.
-            let _ = store.secrets().set("rustykrab_auth_token", &cred.value);
-            return cred.value;
-        }
-    }
-
-    // 3. Encrypted SecretStore.
-    if let Ok(token) = store.secrets().get("rustykrab_auth_token") {
-        tracing::info!("auth token loaded from encrypted store");
-        // Back-fill into Keychain if available.
-        if rustykrab_store::keychain::keychain_available() {
-            let _ = rustykrab_store::keychain::set_credential(
-                KEYCHAIN_SERVICE,
-                KEYCHAIN_ACCOUNT_AUTH_TOKEN,
-                &token,
-            );
-        }
-        return token;
-    }
-
-    // 4. Generate a new token and persist everywhere.
+    // Not found anywhere — generate a new token and persist it.
     let token = rustykrab_gateway::generate_token();
     tracing::info!("generated new auth token — persisting for future restarts");
-    println!("\n  Auth token (also saved to Keychain/store): {token}\n");
-    persist_credential(
-        store,
-        KEYCHAIN_ACCOUNT_AUTH_TOKEN,
-        "rustykrab_auth_token",
-        &token,
-    );
+    println!("\n  Auth token (also saved to credential store): {token}\n");
+
+    let svc = rustykrab_store::registry::keychain_service();
+    if rustykrab_store::keychain::keychain_available() {
+        let _ = rustykrab_store::keychain::set_credential(svc, spec.keychain_account, &token);
+    }
+    let _ = store.secrets().set(spec.store_name, &token);
     token
 }
 
 /// Resolve the Anthropic API key.
 ///
-/// Lookup chain: env var → Keychain → SecretStore → empty (with error log).
+/// Uses the registry to check env / keychain / store.
 fn resolve_api_key(store: &rustykrab_store::Store) -> String {
-    // 1. Environment variable.
-    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
-        tracing::info!("API key loaded from ANTHROPIC_API_KEY env var");
-        persist_credential(store, KEYCHAIN_ACCOUNT_API_KEY, "anthropic_api_key", &key);
-        return key;
-    }
+    let spec = rustykrab_store::registry::lookup("anthropic_api_key")
+        .expect("anthropic_api_key must be in the registry");
 
-    // 2. macOS Keychain.
-    if rustykrab_store::keychain::keychain_available() {
-        if let Ok(Some(cred)) =
-            rustykrab_store::keychain::get_credential(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY)
-        {
-            tracing::info!("API key loaded from macOS Keychain");
-            let _ = store.secrets().set("anthropic_api_key", &cred.value);
-            return cred.value;
-        }
-    }
-
-    // 3. SecretStore.
-    if let Ok(key) = store.secrets().get("anthropic_api_key") {
-        tracing::info!("API key loaded from encrypted store");
-        if rustykrab_store::keychain::keychain_available() {
-            let _ = rustykrab_store::keychain::set_credential(
-                KEYCHAIN_SERVICE,
-                KEYCHAIN_ACCOUNT_API_KEY,
-                &key,
-            );
-        }
+    if let Some(key) = rustykrab_store::registry::resolve(spec, &store.secrets()) {
+        tracing::info!("API key resolved via registry");
         return key;
     }
 
     tracing::error!(
         "ANTHROPIC_API_KEY not set. Set the env var, store it via the secrets API, \
-         or add it to macOS Keychain (service: {KEYCHAIN_SERVICE}, account: {KEYCHAIN_ACCOUNT_API_KEY})."
+         or add it to the OS credential store (rustykrab-cli keychain set {}).",
+        spec.keychain_account,
     );
     String::new()
-}
-
-/// Persist a credential to both the macOS Keychain and the encrypted
-/// SecretStore. Errors are logged but not fatal — best-effort persistence.
-fn persist_credential(
-    store: &rustykrab_store::Store,
-    keychain_account: &str,
-    store_name: &str,
-    value: &str,
-) {
-    if rustykrab_store::keychain::keychain_available() {
-        if let Err(e) =
-            rustykrab_store::keychain::set_credential(KEYCHAIN_SERVICE, keychain_account, value)
-        {
-            tracing::warn!("failed to persist credential to Keychain: {e}");
-        }
-    }
-    if let Err(e) = store.secrets().set(store_name, value) {
-        tracing::warn!("failed to persist credential to store: {e}");
-    }
 }
 
 /// Handle `keychain status`, `keychain migrate`, and `keychain set` subcommands.
@@ -1250,56 +1209,78 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
 
     match sub {
         "status" => {
+            let available = rustykrab_store::keychain::keychain_available();
             println!(
-                "macOS Keychain support: {}",
-                if rustykrab_store::keychain::keychain_available() {
-                    "available (Data Protection Keychain)"
+                "OS credential store: {}",
+                if available {
+                    if cfg!(target_os = "macos") {
+                        "available (macOS Data Protection Keychain)"
+                    } else {
+                        "available (Secret Service)"
+                    }
                 } else {
-                    "not available (this platform does not support macOS Keychain)"
+                    "not available"
                 }
             );
 
-            if !rustykrab_store::keychain::keychain_available() {
+            if !available {
                 println!(
-                    "\nOn non-macOS platforms, use environment variables or the encrypted store."
+                    "\nNo OS credential store detected. Use environment variables \
+                     or the encrypted store instead."
                 );
                 return Ok(());
             }
 
-            // Check each known credential.
-            let checks = [
-                (
-                    "Master key",
-                    "com.rustykrab.master-key",
-                    "rustykrab-encryption-key",
-                ),
-                ("Auth token", KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN),
-                (
-                    "Anthropic API key",
-                    KEYCHAIN_SERVICE,
-                    KEYCHAIN_ACCOUNT_API_KEY,
-                ),
-            ];
+            // Master key (separate service).
+            let master_status = match rustykrab_store::keychain::get_credential(
+                "com.rustykrab.master-key",
+                "rustykrab-encryption-key",
+            ) {
+                Ok(Some(_)) => "present",
+                Ok(None) => "not set",
+                Err(_) => "error",
+            };
 
-            println!("\n{:<25} {:<40} STATUS", "CREDENTIAL", "SERVICE/ACCOUNT");
-            println!("{}", "-".repeat(80));
-            for (label, service, account) in &checks {
-                let status = match rustykrab_store::keychain::get_credential(service, account) {
-                    Ok(Some(_)) => "present",
-                    Ok(None) => "not set",
-                    Err(_) => "error",
-                };
-                println!("{:<25} {}/{:<14} {}", label, service, account, status);
+            let svc = rustykrab_store::registry::keychain_service();
+            println!(
+                "\n{:<25} {:<25} {:<10} STATUS",
+                "CREDENTIAL", "ACCOUNT", "REQUIRED"
+            );
+            println!("{}", "-".repeat(75));
+            println!(
+                "{:<25} {:<25} {:<10} {}",
+                "Master key", "rustykrab-encryption-key", "-", master_status
+            );
+
+            // All registry entries.
+            for spec in rustykrab_store::registry::REGISTRY {
+                let status =
+                    match rustykrab_store::keychain::get_credential(svc, spec.keychain_account) {
+                        Ok(Some(_)) => "present",
+                        Ok(None) => "not set",
+                        Err(_) => "error",
+                    };
+                let req = if spec.required { "yes" } else { "no" };
+                println!(
+                    "{:<25} {:<25} {:<10} {}",
+                    spec.description, spec.keychain_account, req, status
+                );
             }
             println!();
-            println!("All items use the Data Protection Keychain (no password prompts).");
         }
 
         "set" => {
+            // Build the list of accepted names from the registry.
+            let known_names: Vec<&str> = rustykrab_store::registry::REGISTRY
+                .iter()
+                .map(|s| s.keychain_account)
+                .collect();
+            let names_list = known_names.join(", ");
+
             let name = args.get(1).ok_or_else(|| {
                 anyhow::anyhow!(
                     "usage: rustykrab-cli keychain set <name> <value>\n  \
-                 names: auth-token, api-key"
+                     names: {names_list}, or <service>:<account>"
                 )
             })?;
             let value = args.get(2).ok_or_else(|| {
@@ -1307,41 +1288,38 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
             })?;
 
             if !rustykrab_store::keychain::keychain_available() {
-                anyhow::bail!("macOS Keychain is not available on this platform");
+                anyhow::bail!("OS credential store is not available on this platform");
             }
 
-            let (service, account) = match name.as_str() {
-                "auth-token" => (KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_AUTH_TOKEN),
-                "api-key" => (KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT_API_KEY),
-                other => {
-                    // Allow arbitrary service/account if specified as service:account
-                    if let Some((s, a)) = other.split_once(':') {
-                        (s, a)
-                    } else {
-                        anyhow::bail!(
-                            "unknown credential name '{other}'. \
-                             Use: auth-token, api-key, or service:account"
-                        );
-                    }
-                }
-            };
+            let svc = rustykrab_store::registry::keychain_service();
+
+            // Look up the name in the registry first, then fall back to
+            // arbitrary service:account pairs.
+            let (service, account, store_name) =
+                if let Some(spec) = rustykrab_store::registry::lookup_by_account(name) {
+                    (svc, spec.keychain_account, Some(spec.store_name))
+                } else if let Some((s, a)) = name.split_once(':') {
+                    (s, a, None)
+                } else {
+                    anyhow::bail!(
+                        "unknown credential name '{name}'. \
+                         Use: {names_list}, or <service>:<account>"
+                    );
+                };
 
             rustykrab_store::keychain::set_credential(service, account, value)
                 .map_err(|e| anyhow::anyhow!("failed to store: {e}"))?;
-            println!("Stored in Keychain: {service}/{account}");
+            println!("Stored in credential store: {service}/{account}");
 
             // Also persist to the encrypted store if the DB exists.
-            let db_path = data_dir.join("db");
-            if db_path.exists() {
-                if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
-                    if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
-                        let store_name = match name.as_str() {
-                            "auth-token" => "rustykrab_auth_token",
-                            "api-key" => "anthropic_api_key",
-                            _ => name.as_str(),
-                        };
-                        let _ = store.secrets().set(store_name, value);
-                        println!("Also stored in encrypted store as '{store_name}'");
+            if let Some(sn) = store_name {
+                let db_path = data_dir.join("db");
+                if db_path.exists() {
+                    if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
+                        if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
+                            let _ = store.secrets().set(sn, value);
+                            println!("Also stored in encrypted store as '{sn}'");
+                        }
                     }
                 }
             }
@@ -1349,53 +1327,39 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
 
         "migrate" => {
             if !rustykrab_store::keychain::keychain_available() {
-                anyhow::bail!("macOS Keychain is not available on this platform");
+                anyhow::bail!("OS credential store is not available on this platform");
             }
 
-            println!("Migrating credentials to Data Protection Keychain...");
-            println!(
-                "(This re-creates items without per-app ACLs so no password prompts occur.)\n"
-            );
+            println!("Migrating credentials to OS credential store...\n");
 
-            // Re-resolve master key — this migrates it to the DP keychain.
+            // Re-resolve master key — this ensures it is stored in the credential store.
             match rustykrab_store::keychain::resolve_master_key() {
                 Ok(_) => println!("  master key: OK"),
                 Err(e) => println!("  master key: FAILED ({e})"),
             }
 
-            // Migrate auth token and API key from env vars or existing store.
+            // Migrate all registry secrets from the encrypted store.
             let db_path = data_dir.join("db");
             if db_path.exists() {
                 if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
                     if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
-                        // Auth token
-                        if let Ok(token) = store.secrets().get("rustykrab_auth_token") {
-                            match rustykrab_store::keychain::set_credential(
-                                KEYCHAIN_SERVICE,
-                                KEYCHAIN_ACCOUNT_AUTH_TOKEN,
-                                &token,
-                            ) {
-                                Ok(()) => println!("  auth token: migrated to DP Keychain"),
-                                Err(e) => println!("  auth token: FAILED ({e})"),
+                        let svc = rustykrab_store::registry::keychain_service();
+                        for spec in rustykrab_store::registry::REGISTRY {
+                            if let Ok(val) = store.secrets().get(spec.store_name) {
+                                match rustykrab_store::keychain::set_credential(
+                                    svc,
+                                    spec.keychain_account,
+                                    &val,
+                                ) {
+                                    Ok(()) => println!("  {}: migrated", spec.description),
+                                    Err(e) => println!("  {}: FAILED ({e})", spec.description),
+                                }
+                            } else {
+                                println!(
+                                    "  {}: not in store (set via 'keychain set {}')",
+                                    spec.description, spec.keychain_account
+                                );
                             }
-                        } else {
-                            println!(
-                                "  auth token: not in store (will be generated on next start)"
-                            );
-                        }
-
-                        // API key
-                        if let Ok(key) = store.secrets().get("anthropic_api_key") {
-                            match rustykrab_store::keychain::set_credential(
-                                KEYCHAIN_SERVICE,
-                                KEYCHAIN_ACCOUNT_API_KEY,
-                                &key,
-                            ) {
-                                Ok(()) => println!("  API key: migrated to DP Keychain"),
-                                Err(e) => println!("  API key: FAILED ({e})"),
-                            }
-                        } else {
-                            println!("  API key: not in store (set via env var or 'keychain set api-key')");
                         }
                     }
                 }
@@ -1412,15 +1376,18 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
         _ => {
             eprintln!("Unknown keychain subcommand: {sub}");
             eprintln!("Usage:");
-            eprintln!(
-                "  rustykrab-cli keychain status              Show Keychain credential status"
-            );
+            eprintln!("  rustykrab-cli keychain status              Show credential store status");
             eprintln!("  rustykrab-cli keychain set <name> <value>  Store a credential");
             eprintln!(
-                "  rustykrab-cli keychain migrate             Migrate to Data Protection Keychain"
+                "  rustykrab-cli keychain migrate             Migrate store to OS credential store"
             );
             eprintln!();
-            eprintln!("Credential names: auth-token, api-key, or <service>:<account>");
+            eprint!("Credential names: ");
+            let names: Vec<&str> = rustykrab_store::registry::REGISTRY
+                .iter()
+                .map(|s| s.keychain_account)
+                .collect();
+            eprintln!("{}, or <service>:<account>", names.join(", "));
             std::process::exit(1);
         }
     }

--- a/crates/rustykrab-store/Cargo.toml
+++ b/crates/rustykrab-store/Cargo.toml
@@ -25,3 +25,6 @@ zeroize.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework.workspace = true
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+keyring.workspace = true

--- a/crates/rustykrab-store/src/keychain.rs
+++ b/crates/rustykrab-store/src/keychain.rs
@@ -16,9 +16,7 @@
 
 use rustykrab_core::Error;
 
-#[cfg(target_os = "macos")]
 const SERVICE_NAME: &str = "com.rustykrab.master-key";
-#[cfg(target_os = "macos")]
 const ACCOUNT_NAME: &str = "rustykrab-encryption-key";
 
 // ---------------------------------------------------------------------------
@@ -213,9 +211,11 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     Ok(key.to_vec())
 }
 
-/// Non-macOS fallback: use env var or generate an ephemeral key.
+/// Non-macOS: use env var, then OS credential store (Secret Service on Linux),
+/// then generate an ephemeral key as a last resort.
 #[cfg(not(target_os = "macos"))]
 pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
+    // Priority 1: environment variable (for CI, Docker, explicit override).
     if let Ok(env_key) = std::env::var("RUSTYKRAB_MASTER_KEY") {
         tracing::info!("using master key from RUSTYKRAB_MASTER_KEY env var");
         return hex::decode(env_key.trim()).map_err(|e| {
@@ -225,13 +225,71 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
         });
     }
 
+    // Priority 2: OS credential store (Secret Service on Linux).
+    if keychain_available() {
+        if let Some(key) = get_master_key()? {
+            tracing::info!("master key loaded from OS credential store");
+            return Ok(key);
+        }
+
+        // Generate a new key and persist it in the credential store.
+        tracing::info!("no master key found — generating and storing in OS credential store");
+        let mut key = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rng(), &mut key);
+        set_master_key(&key)?;
+        tracing::info!("master key stored in OS credential store");
+        return Ok(key.to_vec());
+    }
+
+    // Priority 3: ephemeral key (no credential store available).
     tracing::warn!(
-        "RUSTYKRAB_MASTER_KEY not set and macOS Keychain not available — \
+        "RUSTYKRAB_MASTER_KEY not set and OS credential store not available — \
          generating ephemeral key. Secrets will not survive restart."
     );
     let mut key = [0u8; 32];
     rand::RngCore::fill_bytes(&mut rand::rng(), &mut key);
     Ok(key.to_vec())
+}
+
+/// Retrieve the master key from the OS credential store.
+#[cfg(not(target_os = "macos"))]
+pub fn get_master_key() -> Result<Option<Vec<u8>>, Error> {
+    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    match entry.get_password() {
+        Ok(hex_str) => {
+            let key = hex::decode(hex_str.trim())
+                .map_err(|e| Error::Storage(format!("keyring: invalid hex: {e}")))?;
+            Ok(Some(key))
+        }
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => {
+            tracing::debug!("keyring read failed (Secret Service may not be available): {e}");
+            Ok(None)
+        }
+    }
+}
+
+/// Store the master key in the OS credential store (as hex).
+#[cfg(not(target_os = "macos"))]
+pub fn set_master_key(key: &[u8]) -> Result<(), Error> {
+    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    entry
+        .set_password(&hex::encode(key))
+        .map_err(|e| Error::Storage(format!("keyring write failed: {e}")))
+}
+
+/// Delete the master key from the OS credential store.
+#[cfg(not(target_os = "macos"))]
+pub fn delete_master_key() -> Result<(), Error> {
+    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(Error::Storage(format!("keyring delete failed: {e}"))),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -248,10 +306,26 @@ pub struct KeychainCredential {
     pub value: String,
 }
 
-/// Returns `true` when the current platform supports Keychain credential
-/// lookups (i.e. the binary was compiled for macOS).
+/// Returns `true` when the current platform has a working OS credential
+/// store (macOS Keychain, Linux Secret Service, etc.).
+#[cfg(target_os = "macos")]
 pub fn keychain_available() -> bool {
-    cfg!(target_os = "macos")
+    true
+}
+
+/// Probe the OS credential store (Secret Service on Linux).
+///
+/// Returns `true` if the backend responds, `false` otherwise (e.g. no
+/// D-Bus session, no Secret Service daemon running).
+#[cfg(not(target_os = "macos"))]
+pub fn keychain_available() -> bool {
+    keyring::Entry::new("com.rustykrab.probe", "availability-check")
+        .and_then(|entry| match entry.get_password() {
+            Ok(_) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e),
+        })
+        .is_ok()
 }
 
 /// Retrieve a credential from the macOS Keychain by service and account.
@@ -279,10 +353,20 @@ pub fn get_credential(service: &str, account: &str) -> Result<Option<KeychainCre
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn get_credential(_service: &str, _account: &str) -> Result<Option<KeychainCredential>, Error> {
-    Err(Error::Storage(
-        "macOS Keychain is not available on this platform".into(),
-    ))
+pub fn get_credential(service: &str, account: &str) -> Result<Option<KeychainCredential>, Error> {
+    let entry = keyring::Entry::new(service, account)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    match entry.get_password() {
+        Ok(value) => Ok(Some(KeychainCredential {
+            service: service.to_string(),
+            account: account.to_string(),
+            value,
+        })),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(Error::Storage(format!(
+            "keyring read failed for {service}/{account}: {e}"
+        ))),
+    }
 }
 
 /// Store a credential in the macOS Keychain under the given service/account.
@@ -296,10 +380,12 @@ pub fn set_credential(service: &str, account: &str, value: &str) -> Result<(), E
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn set_credential(_service: &str, _account: &str, _value: &str) -> Result<(), Error> {
-    Err(Error::Storage(
-        "macOS Keychain is not available on this platform".into(),
-    ))
+pub fn set_credential(service: &str, account: &str, value: &str) -> Result<(), Error> {
+    let entry = keyring::Entry::new(service, account)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    entry
+        .set_password(value)
+        .map_err(|e| Error::Storage(format!("keyring write failed for {service}/{account}: {e}")))
 }
 
 /// Delete a credential from the macOS Keychain.
@@ -309,8 +395,14 @@ pub fn delete_credential(service: &str, account: &str) -> Result<(), Error> {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn delete_credential(_service: &str, _account: &str) -> Result<(), Error> {
-    Err(Error::Storage(
-        "macOS Keychain is not available on this platform".into(),
-    ))
+pub fn delete_credential(service: &str, account: &str) -> Result<(), Error> {
+    let entry = keyring::Entry::new(service, account)
+        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(Error::Storage(format!(
+            "keyring delete failed for {service}/{account}: {e}"
+        ))),
+    }
 }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -2,6 +2,7 @@ mod chat_map;
 mod conversation;
 mod jobs;
 pub mod keychain;
+pub mod registry;
 mod secret;
 
 use std::path::Path;

--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -1,0 +1,161 @@
+//! Central secret registry — the single source of truth for every credential
+//! the application requires or can use.
+//!
+//! Each secret has three resolution sources checked in priority order:
+//! 1. Environment variable (highest priority — explicit override)
+//! 2. OS credential store (macOS Keychain / Linux Secret Service)
+//! 3. Encrypted local SecretStore (SQLite + AES-256-GCM)
+//!
+//! Required secrets are validated at startup. If any required secret is missing
+//! from *all* sources the application refuses to start.
+
+use crate::keychain;
+use crate::SecretStore;
+
+/// The keychain service name shared across all RustyKrab credentials.
+const KEYCHAIN_SERVICE: &str = "com.rustykrab.credentials";
+
+/// Describes a single credential the application knows about.
+#[derive(Debug, Clone, Copy)]
+pub struct SecretSpec {
+    /// Key in the encrypted `SecretStore` (e.g. `"notion_api_token"`).
+    pub store_name: &'static str,
+    /// Environment variable override (e.g. `"NOTION_API_TOKEN"`).
+    pub env_var: &'static str,
+    /// Account name under the shared keychain service.
+    pub keychain_account: &'static str,
+    /// Human-readable label for error / status output.
+    pub description: &'static str,
+    /// When `true`, the application **must** refuse to start if this secret
+    /// cannot be resolved from any source.
+    pub required: bool,
+}
+
+/// The authoritative list of every credential the application uses.
+///
+/// Add new entries here — tools, CLI startup, and the `keychain` subcommand
+/// all derive their behaviour from this list.
+pub static REGISTRY: &[SecretSpec] = &[
+    SecretSpec {
+        store_name: "anthropic_api_key",
+        env_var: "ANTHROPIC_API_KEY",
+        keychain_account: "anthropic-api-key",
+        description: "Anthropic Claude API key",
+        required: false, // not needed when provider is Ollama
+    },
+    SecretSpec {
+        store_name: "notion_api_token",
+        env_var: "NOTION_API_TOKEN",
+        keychain_account: "notion-api-token",
+        description: "Notion integration API token",
+        required: true,
+    },
+    SecretSpec {
+        store_name: "obsidian_api_key",
+        env_var: "OBSIDIAN_API_KEY",
+        keychain_account: "obsidian-api-key",
+        description: "Obsidian Local REST API key",
+        required: true,
+    },
+    SecretSpec {
+        store_name: "rustykrab_auth_token",
+        env_var: "RUSTYKRAB_AUTH_TOKEN",
+        keychain_account: "auth-token",
+        description: "Gateway bearer auth token",
+        required: false, // auto-generated when absent
+    },
+];
+
+/// A secret that could not be found in any resolution source.
+#[derive(Debug)]
+pub struct MissingSecret {
+    pub spec: &'static SecretSpec,
+}
+
+/// Validate every secret in [`REGISTRY`] and return those that are absent.
+///
+/// This does **not** mutate any store — it is a read-only check suitable for
+/// startup validation.
+pub fn validate(secrets: &SecretStore) -> Vec<MissingSecret> {
+    REGISTRY
+        .iter()
+        .filter(|spec| !is_present(spec, secrets))
+        .map(|spec| MissingSecret { spec })
+        .collect()
+}
+
+/// Resolve a secret from all sources in priority order.
+///
+/// When found in a higher-priority source the value is persisted downward
+/// so future runs can find it without the env var.
+///
+/// Returns `None` only when the secret is absent from every source.
+pub fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String> {
+    // 1. Environment variable (highest priority).
+    if let Ok(val) = std::env::var(spec.env_var) {
+        let val = val.trim().to_string();
+        if !val.is_empty() {
+            // Persist downward.
+            if keychain::keychain_available() {
+                let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
+            }
+            let _ = secrets.set(spec.store_name, &val);
+            return Some(val);
+        }
+    }
+
+    // 2. OS credential store.
+    if keychain::keychain_available() {
+        if let Ok(Some(cred)) = keychain::get_credential(KEYCHAIN_SERVICE, spec.keychain_account) {
+            let _ = secrets.set(spec.store_name, &cred.value);
+            return Some(cred.value);
+        }
+    }
+
+    // 3. Encrypted local store.
+    if let Ok(val) = secrets.get(spec.store_name) {
+        // Back-fill into keychain if available.
+        if keychain::keychain_available() {
+            let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
+        }
+        return Some(val);
+    }
+
+    None
+}
+
+/// Look up a [`SecretSpec`] by its store name.
+pub fn lookup(store_name: &str) -> Option<&'static SecretSpec> {
+    REGISTRY.iter().find(|s| s.store_name == store_name)
+}
+
+/// Look up a [`SecretSpec`] by its keychain account name.
+pub fn lookup_by_account(account: &str) -> Option<&'static SecretSpec> {
+    REGISTRY.iter().find(|s| s.keychain_account == account)
+}
+
+/// Return the shared keychain service name.
+pub fn keychain_service() -> &'static str {
+    KEYCHAIN_SERVICE
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn is_present(spec: &SecretSpec, secrets: &SecretStore) -> bool {
+    // env var
+    if let Ok(val) = std::env::var(spec.env_var) {
+        if !val.trim().is_empty() {
+            return true;
+        }
+    }
+    // keychain
+    if keychain::keychain_available() {
+        if let Ok(Some(_)) = keychain::get_credential(KEYCHAIN_SERVICE, spec.keychain_account) {
+            return true;
+        }
+    }
+    // store
+    secrets.get(spec.store_name).is_ok()
+}

--- a/scripts/setup-secrets.sh
+++ b/scripts/setup-secrets.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------
+# setup-secrets.sh — Store required RustyKrab secrets in the OS credential
+# store so the application can find them at startup.
+#
+# This script uses `rustykrab-cli keychain set` under the hood, which
+# persists each value in both the OS credential store (macOS Keychain /
+# Linux Secret Service) and the encrypted local SQLite store.
+#
+# Usage:
+#   ./scripts/setup-secrets.sh                  # interactive prompts
+#   ./scripts/setup-secrets.sh --env            # read from env vars
+#
+# The canonical credential names come from the central registry in
+# crates/rustykrab-store/src/registry.rs. If you add secrets there,
+# add the corresponding prompt here.
+# -----------------------------------------------------------------------
+
+set -euo pipefail
+
+# Detect the CLI binary.
+CLI="${RUSTYKRAB_CLI:-rustykrab-cli}"
+if ! command -v "$CLI" &>/dev/null; then
+    # Try the workspace debug build.
+    WORKSPACE_BIN="$(dirname "$0")/../target/debug/rustykrab-cli"
+    if [[ -x "$WORKSPACE_BIN" ]]; then
+        CLI="$WORKSPACE_BIN"
+    else
+        echo "ERROR: rustykrab-cli not found."
+        echo "  Build it first:  cargo build -p rustykrab-cli"
+        echo "  Or set RUSTYKRAB_CLI=/path/to/rustykrab-cli"
+        exit 1
+    fi
+fi
+
+echo "RustyKrab Secret Setup"
+echo "======================"
+echo
+echo "This will store your credentials in the OS credential store"
+echo "(macOS Keychain / Linux Secret Service) and the encrypted local store."
+echo
+
+# -----------------------------------------------------------------------
+# Registry of secrets to prompt for.
+#
+# Format: keychain_account | env_var | description | required (yes/no)
+#
+# Keep this in sync with REGISTRY in crates/rustykrab-store/src/registry.rs.
+# -----------------------------------------------------------------------
+SECRETS=(
+    "notion-api-token|NOTION_API_TOKEN|Notion integration API token (ntn_...)|yes"
+    "obsidian-api-key|OBSIDIAN_API_KEY|Obsidian Local REST API key|yes"
+    "anthropic-api-key|ANTHROPIC_API_KEY|Anthropic Claude API key|no"
+    "auth-token|RUSTYKRAB_AUTH_TOKEN|Gateway bearer auth token (auto-generated if empty)|no"
+)
+
+ENV_MODE=false
+if [[ "${1:-}" == "--env" ]]; then
+    ENV_MODE=true
+    echo "Reading values from environment variables."
+    echo
+fi
+
+stored=0
+skipped=0
+
+for entry in "${SECRETS[@]}"; do
+    IFS='|' read -r account env_var description required <<< "$entry"
+
+    value=""
+
+    if $ENV_MODE; then
+        value="${!env_var:-}"
+    else
+        req_label=""
+        if [[ "$required" == "yes" ]]; then
+            req_label=" [REQUIRED]"
+        fi
+
+        # Show current status.
+        if "$CLI" keychain status 2>/dev/null | grep -q "$account.*present"; then
+            echo "  $description: already set (skip with Enter)"
+        fi
+
+        read -rsp "$description${req_label}: " value
+        echo
+    fi
+
+    # Skip empty values.
+    if [[ -z "$value" ]]; then
+        if [[ "$required" == "yes" ]] && ! $ENV_MODE; then
+            # Check if it's already stored — allow skipping.
+            if "$CLI" keychain status 2>/dev/null | grep -q "$account.*present"; then
+                ((skipped++))
+                continue
+            fi
+            echo "  WARNING: $description is required but was left empty."
+        fi
+        ((skipped++))
+        continue
+    fi
+
+    "$CLI" keychain set "$account" "$value"
+    ((stored++))
+done
+
+echo
+echo "Done. $stored credential(s) stored, $skipped skipped."
+echo
+echo "Verify with:  $CLI keychain status"


### PR DESCRIPTION
Introduces a single source of truth for all application secrets
(registry.rs) with startup validation that fails hard when required
credentials (Notion token, Obsidian API key) are missing.

- Add `keyring` crate for Linux Secret Service / kernel keyutils
  support (macOS continues using security-framework unchanged)
- Replace ad-hoc credential resolution with registry::resolve()
- Keychain subcommands (status/set/migrate) now driven by registry
- Add scripts/setup-secrets.sh for interactive token provisioning

https://claude.ai/code/session_01Tb1L5VYwHubEWHzKNj4FFD