### PR TITLE
refactor: replace RLM text markers with REPL-style tool-based context exploration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,10 +3252,11 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
+ "regex",
  "rustykrab-core",
  "serde",
  "serde_json",
@@ -3266,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3285,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3325,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "axum",
  "chrono",
@@ -3348,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3369,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3385,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3401,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3424,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,6 +3256,7 @@ version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures",
  "regex",
  "rustykrab-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ imap = "2"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls", "rustls-native-certs", "aws-lc-rs", "builder"] }
 mail-parser = "0.9"
 
+# Futures combinators
+futures = "0.3"
+
 # Regular expressions
 regex = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ imap = "2"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls", "rustls-native-certs", "aws-lc-rs", "builder"] }
 mail-parser = "0.9"
 
+# Regular expressions
+regex = "1"
+
 # System-level interfaces (resource limits, process isolation)
 libc = "0.2"
 

--- a/crates/rustykrab-agent/Cargo.toml
+++ b/crates/rustykrab-agent/Cargo.toml
@@ -14,3 +14,4 @@ tracing.workspace = true
 serde.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+regex.workspace = true

--- a/crates/rustykrab-agent/Cargo.toml
+++ b/crates/rustykrab-agent/Cargo.toml
@@ -14,4 +14,5 @@ tracing.workspace = true
 serde.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+futures.workspace = true
 regex.workspace = true

--- a/crates/rustykrab-agent/src/lib.rs
+++ b/crates/rustykrab-agent/src/lib.rs
@@ -11,7 +11,7 @@ pub use orchestrator::{
     ConsistencyVoter, Decomposer, OrchestrationPipeline, ParallelExecutor, PipelineResult,
     RefinementLoop, Synthesizer,
 };
-pub use rlm::{ContextManager, RecursiveExecutor};
+pub use rlm::RecursiveExecutor;
 pub use router::HarnessRouter;
 pub use runner::{AgentConfig, AgentEvent, AgentRunner};
 pub use sandbox::{NoSandbox, ProcessSandbox, Sandbox, SandboxPolicy};

--- a/crates/rustykrab-agent/src/rlm/context_manager.rs
+++ b/crates/rustykrab-agent/src/rlm/context_manager.rs
@@ -1,72 +1,8 @@
-//! Context budgeting for recursive calls.
-//!
-//! Ensures no single model call exceeds its context budget by
-//! tracking token usage and splitting work across sub-calls.
+//! Token estimation utility for recursive calls.
 
-use rustykrab_core::orchestration::OrchestrationConfig;
-
-/// Manages context budgets across the recursive call tree.
-pub struct ContextManager {
-    config: OrchestrationConfig,
-}
-
-impl ContextManager {
-    pub fn new(config: OrchestrationConfig) -> Self {
-        Self { config }
-    }
-
-    /// Calculate the context budget for a child call at a given depth.
-    ///
-    /// Budget decreases at deeper levels to prevent runaway resource usage.
-    /// Each level gets ~75% of the parent's budget.
-    pub fn child_budget(&self, parent_budget: usize, depth: usize) -> usize {
-        let max_depth = self.config.max_recursion_depth;
-        if depth >= max_depth {
-            return 0;
-        }
-
-        // Each level gets 75% of the parent's budget.
-        let factor = 0.75_f64.powi(depth as i32);
-        let budget = (parent_budget as f64 * factor) as usize;
-
-        // Floor at 2K tokens — below that, model output quality degrades.
-        budget.max(2048).min(parent_budget)
-    }
-
-    /// Estimate token count for a string (conservative: ~3.5 chars/token).
-    pub fn estimate_tokens(text: &str) -> usize {
-        (text.len() as f64 / 3.5).ceil() as usize
-    }
-
-    /// Check if adding text would exceed the budget.
-    pub fn would_exceed(&self, current_tokens: usize, text: &str, budget: usize) -> bool {
-        current_tokens + Self::estimate_tokens(text) > budget
-    }
-
-    /// Truncate text to fit within a token budget.
-    pub fn truncate_to_budget(text: &str, max_tokens: usize) -> String {
-        let max_chars = (max_tokens as f64 * 3.5) as usize;
-        if text.len() <= max_chars {
-            return text.to_string();
-        }
-
-        // Find a clean char boundary.
-        let truncate_at = text
-            .char_indices()
-            .take_while(|(i, _)| *i < max_chars)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(max_chars.min(text.len()));
-
-        let mut result = text[..truncate_at].to_string();
-        result.push_str("… [truncated]");
-        result
-    }
-
-    /// Maximum recursion depth allowed.
-    pub fn max_depth(&self) -> usize {
-        self.config.max_recursion_depth
-    }
+/// Estimate token count for a string (conservative: ~3.5 chars/token).
+pub fn estimate_tokens(text: &str) -> usize {
+    (text.len() as f64 / 3.5).ceil() as usize
 }
 
 #[cfg(test)]
@@ -74,44 +10,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_child_budget_decreases() {
-        let config = OrchestrationConfig::default();
-        let parent_budget = config.sub_task_context_budget;
-        let cm = ContextManager::new(config);
-
-        let b0 = cm.child_budget(parent_budget, 0);
-        let b1 = cm.child_budget(parent_budget, 1);
-        let b2 = cm.child_budget(parent_budget, 2);
-
-        assert!(b0 > b1, "depth 0 budget should be > depth 1");
-        assert!(b1 > b2, "depth 1 budget should be > depth 2");
+    fn test_estimate_tokens() {
+        // 35 bytes / 3.5 = 10 tokens
+        assert_eq!(estimate_tokens(&"a".repeat(35)), 10);
     }
 
     #[test]
-    fn test_child_budget_at_max_depth() {
-        let config = OrchestrationConfig {
-            max_recursion_depth: 3,
-            ..Default::default()
-        };
-        let parent_budget = config.sub_task_context_budget;
-        let cm = ContextManager::new(config);
-
-        assert_eq!(cm.child_budget(parent_budget, 3), 0);
-        assert_eq!(cm.child_budget(parent_budget, 10), 0);
-    }
-
-    #[test]
-    fn test_truncate_to_budget() {
-        let text = "a".repeat(10000);
-        let truncated = ContextManager::truncate_to_budget(&text, 100);
-        assert!(truncated.len() < 500); // 100 tokens * 3.5 + some overhead
-        assert!(truncated.ends_with("… [truncated]"));
-    }
-
-    #[test]
-    fn test_truncate_short_text() {
-        let text = "hello world";
-        let result = ContextManager::truncate_to_budget(text, 100);
-        assert_eq!(result, "hello world");
+    fn test_estimate_tokens_empty() {
+        assert_eq!(estimate_tokens(""), 0);
     }
 }

--- a/crates/rustykrab-agent/src/rlm/mod.rs
+++ b/crates/rustykrab-agent/src/rlm/mod.rs
@@ -12,5 +12,5 @@ pub mod context_manager;
 pub mod recursive_call;
 pub mod repl_tools;
 
-pub use context_manager::ContextManager;
+pub use context_manager::estimate_tokens;
 pub use recursive_call::RecursiveExecutor;

--- a/crates/rustykrab-agent/src/rlm/mod.rs
+++ b/crates/rustykrab-agent/src/rlm/mod.rs
@@ -1,14 +1,16 @@
 //! Recursive Language Model (RLM) pattern.
 //!
-//! Implements the RLM scaffold from Prime Intellect's research:
-//! - The user's request is treated as a variable processed programmatically
-//! - The model can request sub-LLM calls (recursive delegation)
-//! - Each sub-call gets its own focused context window
-//! - Results are collected and fed back to the parent call
-//! - No single call handles the full context — the Rust layer manages the tree
+//! Implements the REPL-style RLM scaffold from the foundational paper
+//! (Zhang, Kraska, Khattab — arXiv 2512.24601):
+//!
+//! - Context is stored as an external variable, NOT in the prompt
+//! - The model explores context via tools: peek, search, sub_query
+//! - Sub-queries recurse on model-selected context slices
+//! - No single call handles the full context — the tool layer manages it
 
 pub mod context_manager;
 pub mod recursive_call;
+pub mod repl_tools;
 
 pub use context_manager::ContextManager;
 pub use recursive_call::RecursiveExecutor;

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -127,7 +127,7 @@ async fn execute_repl_call_impl(
         provider.clone(),
         config.clone(),
         depth,
-        semaphore,
+        semaphore.clone(),
     );
     let schemas: Vec<_> = tools.iter().map(|t| t.schema()).collect();
 
@@ -175,22 +175,28 @@ async fn execute_repl_call_impl(
     let timeout_secs = config.model_call_timeout_secs;
 
     for round in 0..max_rounds {
-        let response = match tokio::time::timeout(
-            std::time::Duration::from_secs(timeout_secs),
-            provider.chat(&messages, &schemas),
-        )
-        .await
-        {
-            Ok(Ok(r)) => r,
-            Ok(Err(e)) => {
-                tracing::error!(depth, round, error = %e, "RLM REPL: model call failed");
-                return Err(e);
-            }
-            Err(_) => {
-                tracing::error!(depth, round, "RLM REPL: model call timed out");
-                return Err(Error::Internal(format!(
-                    "RLM model call timed out after {timeout_secs}s"
-                )));
+        // Acquire a semaphore permit for the LLM call only — released
+        // before tool execution so recursive sub_query calls can
+        // acquire their own permits without deadlocking.
+        let response = {
+            let _permit = semaphore.acquire().await.expect("semaphore closed");
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(timeout_secs),
+                provider.chat(&messages, &schemas),
+            )
+            .await
+            {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => {
+                    tracing::error!(depth, round, error = %e, "RLM REPL: model call failed");
+                    return Err(e);
+                }
+                Err(_) => {
+                    tracing::error!(depth, round, "RLM REPL: model call timed out");
+                    return Err(Error::Internal(format!(
+                        "RLM model call timed out after {timeout_secs}s"
+                    )));
+                }
             }
         };
 

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -1,273 +1,285 @@
-//! Recursive call tree execution.
+//! REPL-style recursive call execution.
 //!
-//! The model can request sub-LLM calls by emitting a special format
-//! in its response. Each sub-call gets its own focused context window.
-//! Results are summarized before injection back into the parent context.
+//! Following the foundational RLM paper (Zhang, Kraska, Khattab —
+//! arXiv 2512.24601), the context is stored **outside** the prompt as
+//! an external variable.  The model explores it via tools:
+//!
+//! - `context_info`  — get metadata (length, tokens, preview)
+//! - `context_peek`  — view a slice by character position
+//! - `context_search` — regex search for patterns
+//! - `sub_query`     — launch a recursive sub-call on a context slice
+//!
+//! This replaces the previous approach where context was truncated into
+//! the prompt and the model emitted `[SUB_CALL: ...]` text markers.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::Utc;
 use rustykrab_core::model::ModelProvider;
-use rustykrab_core::orchestration::{OrchestrationConfig, RecursiveCall};
-use rustykrab_core::types::{Message, MessageContent, Role};
+use rustykrab_core::orchestration::OrchestrationConfig;
+use rustykrab_core::tool::Tool;
+use rustykrab_core::types::{Message, MessageContent, Role, ToolResult};
 use rustykrab_core::{Error, Result};
 use tokio::sync::Semaphore;
 use uuid::Uuid;
 
 use super::context_manager::ContextManager;
+use super::repl_tools;
 
-/// Executes recursive call trees where the model can delegate sub-queries.
+/// Executes recursive queries where the model explores context via tools.
 pub struct RecursiveExecutor {
     provider: Arc<dyn ModelProvider>,
     config: OrchestrationConfig,
 }
-
-/// Marker format the model uses to request a sub-call.
-/// The model emits: [SUB_CALL: <question>]
-const SUB_CALL_PREFIX: &str = "[SUB_CALL:";
-const SUB_CALL_SUFFIX: &str = "]";
 
 impl RecursiveExecutor {
     pub fn new(provider: Arc<dyn ModelProvider>, config: OrchestrationConfig) -> Self {
         Self { provider, config }
     }
 
-    /// Execute a recursive query, allowing the model to delegate sub-queries.
+    /// Execute a recursive query, allowing the model to explore context
+    /// via REPL tools and delegate sub-queries on specific slices.
     pub async fn execute(&self, prompt: &str, context: Option<&str>) -> Result<String> {
         tracing::info!(
-            budget = self.config.sub_task_context_budget,
             max_depth = self.config.max_recursion_depth,
+            max_tool_rounds = self.config.max_tool_rounds,
             prompt_len = prompt.len(),
-            "RLM: starting recursive execution"
+            context_len = context.map(|c| c.len()).unwrap_or(0),
+            "RLM REPL: starting recursive execution"
         );
+
         let start = std::time::Instant::now();
-        let root = RecursiveCall::root(prompt, self.config.sub_task_context_budget);
-        let result = execute_call(
+        let context_arc = Arc::new(context.unwrap_or_default().to_string());
+        let semaphore = Arc::new(Semaphore::new(self.config.max_concurrent_tasks));
+
+        let result = execute_repl_call(
             self.provider.clone(),
             self.config.clone(),
-            root,
-            context.map(|s| s.to_string()),
+            prompt.to_string(),
+            context_arc,
+            0,
+            semaphore,
         )
         .await;
+
         let elapsed = start.elapsed();
         match &result {
             Ok(text) => tracing::info!(
                 duration_ms = elapsed.as_millis() as u64,
                 response_len = text.len(),
-                "RLM: recursive execution completed"
+                "RLM REPL: recursive execution completed"
             ),
             Err(e) => tracing::error!(
                 duration_ms = elapsed.as_millis() as u64,
                 error = %e,
-                "RLM: recursive execution failed"
+                "RLM REPL: recursive execution failed"
             ),
         }
         result
     }
 }
 
-/// Execute a single call in the recursive tree.
+/// Execute a single REPL call at the given depth.
 ///
-/// This is a free function (not a method) so it can be spawned into
-/// tokio tasks without lifetime issues. Returns a boxed future to
-/// enable recursive async calls with `Send` bound.
-fn execute_call(
+/// Public within the crate so that [`repl_tools::SubQueryTool`] can
+/// call it recursively.
+pub(crate) fn execute_repl_call(
     provider: Arc<dyn ModelProvider>,
     config: OrchestrationConfig,
-    call: RecursiveCall,
-    context: Option<String>,
+    prompt: String,
+    context: Arc<String>,
+    depth: usize,
+    semaphore: Arc<Semaphore>,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send>> {
-    Box::pin(execute_call_impl(provider, config, call, context))
+    Box::pin(execute_repl_call_impl(
+        provider, config, prompt, context, depth, semaphore,
+    ))
 }
 
-async fn execute_call_impl(
+async fn execute_repl_call_impl(
     provider: Arc<dyn ModelProvider>,
     config: OrchestrationConfig,
-    call: RecursiveCall,
-    context: Option<String>,
+    prompt: String,
+    context: Arc<String>,
+    depth: usize,
+    semaphore: Arc<Semaphore>,
 ) -> Result<String> {
-    let context_mgr = ContextManager::new(config.clone());
-
     tracing::info!(
-        depth = call.depth,
-        budget = call.context_budget,
-        prompt_preview = &call.prompt[..call.prompt.len().min(100)],
-        "RLM: executing call"
+        depth,
+        context_chars = context.len(),
+        prompt_preview = &prompt[..prompt.len().min(100)],
+        "RLM REPL: executing call"
     );
 
-    if call.depth >= context_mgr.max_depth() {
+    // At max depth, answer directly with the context in the prompt.
+    // The context at this level is a small, model-selected slice.
+    if depth >= config.max_recursion_depth {
         tracing::warn!(
-            depth = call.depth,
-            "RLM: max recursion depth reached, answering directly"
+            depth,
+            "RLM REPL: max recursion depth reached, answering directly"
         );
-        return direct_call(&provider, &call.prompt, context.as_deref()).await;
+        return direct_call(&provider, &prompt, &context).await;
     }
 
-    let budget = context_mgr.child_budget(call.context_budget, call.depth);
-    if budget == 0 {
-        tracing::warn!(
-            depth = call.depth,
-            "RLM: budget exhausted, answering directly"
-        );
-        return direct_call(&provider, &call.prompt, context.as_deref()).await;
-    }
+    // Build REPL tools for this depth level.
+    let tools = repl_tools::repl_tools(
+        context.clone(),
+        provider.clone(),
+        config.clone(),
+        depth,
+        semaphore,
+    );
+    let schemas: Vec<_> = tools.iter().map(|t| t.schema()).collect();
 
-    // Build the prompt instructing the model it can delegate.
+    // System prompt — tells the model about the context variable and
+    // available tools. Context text is NOT in the prompt.
+    let estimated_tokens = ContextManager::estimate_tokens(&context);
     let system = format!(
-        "You are a reasoning engine. Answer the question below.\n\
-         If you need to break a sub-question out for separate analysis, \
-         wrap it in [SUB_CALL: your sub-question here].\n\
-         Sub-calls will be resolved and their results substituted back.\n\
-         You can use up to 3 sub-calls per response.\n\
-         Current depth: {}/{}\n\
-         Context budget: {} tokens",
-        call.depth,
-        context_mgr.max_depth(),
-        budget,
+        "You are a reasoning engine. Answer the question below.\n\n\
+         You have access to a context variable ({} chars, ~{} tokens, {} lines).\n\
+         Use the provided tools to examine, search, and query the context.\n\
+         Do NOT try to answer from memory — always consult the context.\n\n\
+         Strategy:\n\
+         1. Start with context_info to understand the context structure.\n\
+         2. Use context_search to find relevant sections.\n\
+         3. Use context_peek to read specific sections in detail.\n\
+         4. Use sub_query to delegate focused questions on specific \
+            sections if the context is too large to process at once.\n\n\
+         Be efficient with tool calls. Batch information into larger \
+         peeks rather than many small ones.\n\
+         Current depth: {}/{}",
+        context.len(),
+        estimated_tokens,
+        context.lines().count(),
+        depth,
+        config.max_recursion_depth,
     );
 
-    let mut messages = vec![Message {
-        id: Uuid::new_v4(),
-        role: Role::System,
-        content: MessageContent::Text(system),
-        created_at: Utc::now(),
-    }];
-
-    if let Some(ref ctx) = context {
-        let ctx = ContextManager::truncate_to_budget(ctx, budget / 3);
-        messages.push(Message {
+    let mut messages = vec![
+        Message {
             id: Uuid::new_v4(),
             role: Role::System,
-            content: MessageContent::Text(format!("Context:\n{ctx}")),
+            content: MessageContent::Text(system),
             created_at: Utc::now(),
-        });
-    }
+        },
+        Message {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content: MessageContent::Text(prompt),
+            created_at: Utc::now(),
+        },
+    ];
 
-    messages.push(Message {
-        id: Uuid::new_v4(),
-        role: Role::User,
-        content: MessageContent::Text(call.prompt.clone()),
-        created_at: Utc::now(),
-    });
+    // Tool-use loop — mirrors the pattern in orchestrator/executor.rs.
+    let max_rounds = config.max_tool_rounds;
+    let timeout_secs = config.model_call_timeout_secs;
 
-    let response = provider.chat(&messages, &[]).await?;
-    let text = response
-        .message
-        .content
-        .as_text()
-        .ok_or_else(|| Error::Internal("recursive call returned non-text".into()))?;
-
-    // Check for sub-call requests.
-    let sub_calls = extract_sub_calls(text);
-    if sub_calls.is_empty() {
-        tracing::debug!(depth = call.depth, "RLM: no sub-calls requested");
-        return Ok(text.to_string());
-    }
-
-    let sub_call_previews: Vec<&str> = sub_calls
-        .iter()
-        .map(|(_, p)| &p[..p.len().min(80)])
-        .collect();
-    tracing::info!(
-        depth = call.depth,
-        sub_calls = sub_calls.len(),
-        prompts = ?sub_call_previews,
-        "RLM: model requested sub-calls"
-    );
-
-    // Execute sub-calls concurrently, bounded by a semaphore to prevent
-    // pathological workloads from spawning unbounded concurrent LLM calls
-    // (fixes ASYNC-M1).
-    let semaphore = Arc::new(Semaphore::new(config.max_concurrent_tasks));
-    let mut handles = Vec::new();
-    for (_, sub_prompt) in &sub_calls {
-        let child = RecursiveCall::child(
-            call.id,
-            sub_prompt.clone(),
-            context_mgr.child_budget(budget, call.depth + 1),
-            call.depth + 1,
-        );
-        let provider = provider.clone();
-        let config = config.clone();
-        let child_context = context.clone();
-        let sem = semaphore.clone();
-
-        handles.push(tokio::spawn(async move {
-            let _permit = sem.acquire().await.expect("semaphore closed");
-            execute_call(provider, config, child, child_context).await
-        }));
-    }
-
-    // Collect results keyed by original marker text for exact substitution.
-    let mut sub_results: HashMap<String, String> = HashMap::new();
-    for (i, handle) in handles.into_iter().enumerate() {
-        let result = match handle.await {
-            Ok(Ok(text)) => {
-                tracing::info!(
-                    depth = call.depth,
-                    sub_call_index = i,
-                    result_len = text.len(),
-                    "RLM: sub-call completed"
-                );
-                text
-            }
+    for round in 0..max_rounds {
+        let response = match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            provider.chat(&messages, &schemas),
+        )
+        .await
+        {
+            Ok(Ok(r)) => r,
             Ok(Err(e)) => {
-                tracing::error!(
-                    depth = call.depth,
-                    sub_call_index = i,
-                    error = %e,
-                    "RLM: sub-call failed"
-                );
-                format!("[Error resolving sub-call: {e}]")
+                tracing::error!(depth, round, error = %e, "RLM REPL: model call failed");
+                return Err(e);
             }
-            Err(e) => {
-                tracing::error!(
-                    depth = call.depth,
-                    sub_call_index = i,
-                    error = %e,
-                    "RLM: sub-call panicked"
-                );
-                format!("[Sub-call panicked: {e}]")
+            Err(_) => {
+                tracing::error!(depth, round, "RLM REPL: model call timed out");
+                return Err(Error::Internal(format!(
+                    "RLM model call timed out after {timeout_secs}s"
+                )));
             }
         };
-        sub_results.insert(sub_calls[i].0.clone(), result);
+
+        // If the model wants to use tools, execute them and continue.
+        if response.message.content.has_tool_calls() {
+            messages.push(response.message.clone());
+
+            let calls = response.message.content.tool_calls();
+            tracing::debug!(
+                depth,
+                round,
+                tool_calls = calls.len(),
+                tools = ?calls.iter().map(|c| &c.name).collect::<Vec<_>>(),
+                "RLM REPL: executing tool calls"
+            );
+
+            for call in calls {
+                let result = execute_repl_tool(call, &tools).await;
+                messages.push(Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Tool,
+                    content: MessageContent::ToolResult(result),
+                    created_at: Utc::now(),
+                });
+            }
+            continue;
+        }
+
+        // Text response — call is complete.
+        let answer = response.message.content.as_text().unwrap_or("").to_string();
+        tracing::info!(
+            depth,
+            rounds_used = round + 1,
+            answer_len = answer.len(),
+            "RLM REPL: call completed"
+        );
+        return Ok(answer);
     }
 
-    tracing::info!(
-        depth = call.depth,
-        resolved_count = sub_results.len(),
-        "RLM: all sub-calls resolved, substituting results"
-    );
-
-    // Substitute results back using the original marker text to avoid
-    // mismatches from whitespace trimming.
-    let mut resolved = text.to_string();
-    for (marker, result) in &sub_results {
-        let summary = ContextManager::truncate_to_budget(result, budget / 4);
-        resolved = resolved.replace(marker, &summary);
-    }
-
-    // Clean up any remaining unresolved markers.
-    if resolved.contains(SUB_CALL_PREFIX) {
-        resolved = remove_unresolved_markers(&resolved);
-    }
-
-    Ok(resolved)
+    tracing::error!(depth, max_rounds, "RLM REPL: exceeded max tool rounds");
+    Err(Error::Internal("RLM exceeded max tool-call rounds".into()))
 }
 
-/// Direct model call without sub-call support.
+/// Execute a single REPL tool call by name.
+async fn execute_repl_tool(
+    call: &rustykrab_core::types::ToolCall,
+    tools: &[Arc<dyn Tool>],
+) -> ToolResult {
+    let tool = match tools.iter().find(|t| t.name() == call.name) {
+        Some(t) => t,
+        None => {
+            return ToolResult {
+                call_id: call.id.clone(),
+                output: serde_json::json!({
+                    "error": format!("unknown tool: {}", call.name)
+                }),
+                is_error: true,
+            };
+        }
+    };
+
+    match tool.execute(call.arguments.clone()).await {
+        Ok(output) => ToolResult {
+            call_id: call.id.clone(),
+            output,
+            is_error: false,
+        },
+        Err(e) => ToolResult {
+            call_id: call.id.clone(),
+            output: serde_json::json!({ "error": e.to_string() }),
+            is_error: true,
+        },
+    }
+}
+
+/// Direct model call at max depth — context goes into the prompt since
+/// the model has no tools to explore it. At this level the context is a
+/// small, model-selected slice (not the original full blob).
 async fn direct_call(
     provider: &Arc<dyn ModelProvider>,
     prompt: &str,
-    context: Option<&str>,
+    context: &str,
 ) -> Result<String> {
     let mut messages = Vec::new();
-    if let Some(ctx) = context {
+    if !context.is_empty() {
         messages.push(Message {
             id: Uuid::new_v4(),
             role: Role::System,
-            content: MessageContent::Text(ctx.to_string()),
+            content: MessageContent::Text(format!("Context:\n{context}")),
             created_at: Utc::now(),
         });
     }
@@ -282,99 +294,164 @@ async fn direct_call(
     Ok(response.message.content.as_text().unwrap_or("").to_string())
 }
 
-/// Extract sub-call prompts from model output.
-///
-/// Returns `(original_marker, trimmed_prompt)` pairs so that the caller
-/// can substitute results using the exact original marker text, avoiding
-/// mismatches caused by whitespace trimming.
-fn extract_sub_calls(text: &str) -> Vec<(String, String)> {
-    let mut calls = Vec::new();
-    let mut remaining = text;
-
-    while let Some(start) = remaining.find(SUB_CALL_PREFIX) {
-        let after_prefix = &remaining[start + SUB_CALL_PREFIX.len()..];
-        if let Some(end) = after_prefix.find(SUB_CALL_SUFFIX) {
-            let prompt = after_prefix[..end].trim().to_string();
-            if !prompt.is_empty() {
-                let marker_len = SUB_CALL_PREFIX.len() + end + SUB_CALL_SUFFIX.len();
-                let original_marker = remaining[start..start + marker_len].to_string();
-                calls.push((original_marker, prompt));
-            }
-            remaining = &after_prefix[end + SUB_CALL_SUFFIX.len()..];
-        } else {
-            break;
-        }
-    }
-
-    // Limit to 3 sub-calls per response.
-    calls.truncate(3);
-    calls
-}
-
-/// Remove unresolved [SUB_CALL: ...] markers from text.
-fn remove_unresolved_markers(text: &str) -> String {
-    let mut result = String::with_capacity(text.len());
-    let mut remaining = text;
-
-    while let Some(start) = remaining.find(SUB_CALL_PREFIX) {
-        result.push_str(&remaining[..start]);
-        let after_prefix = &remaining[start + SUB_CALL_PREFIX.len()..];
-        if let Some(end) = after_prefix.find(SUB_CALL_SUFFIX) {
-            remaining = &after_prefix[end + SUB_CALL_SUFFIX.len()..];
-        } else {
-            remaining = after_prefix;
-        }
-    }
-    result.push_str(remaining);
-    result
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_extract_sub_calls() {
-        let text = "I need to check two things: \
-                    [SUB_CALL: What is the weather in Tokyo?] \
-                    and also [SUB_CALL: What time is it in London?]";
-        let calls = extract_sub_calls(text);
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].1, "What is the weather in Tokyo?");
-        assert_eq!(calls[1].1, "What time is it in London?");
-        // Verify original markers are captured for exact replacement
-        assert_eq!(calls[0].0, "[SUB_CALL: What is the weather in Tokyo?]");
-        assert_eq!(calls[1].0, "[SUB_CALL: What time is it in London?]");
+    use async_trait::async_trait;
+    use rustykrab_core::model::{ModelResponse, StopReason, StreamEvent, Usage};
+    use rustykrab_core::types::ToolSchema;
+    use serde_json::Value;
+    use std::sync::Mutex;
+
+    /// A mock provider that returns canned responses.
+    struct MockProvider {
+        responses: Mutex<Vec<ModelResponse>>,
     }
 
-    #[test]
-    fn test_extract_sub_calls_preserves_original_marker() {
-        // Extra whitespace in the original should be preserved in the marker
-        let text = "[SUB_CALL:  extra spaces here  ]";
-        let calls = extract_sub_calls(text);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "[SUB_CALL:  extra spaces here  ]");
-        assert_eq!(calls[0].1, "extra spaces here");
+    impl MockProvider {
+        fn new(responses: Vec<ModelResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+            }
+        }
+
+        fn text_response(text: &str) -> ModelResponse {
+            ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content: MessageContent::Text(text.to_string()),
+                    created_at: Utc::now(),
+                },
+                usage: Usage {
+                    prompt_tokens: 10,
+                    completion_tokens: 10,
+                    ..Default::default()
+                },
+                stop_reason: StopReason::EndTurn,
+                text: Some(text.to_string()),
+            }
+        }
+
+        fn tool_call_response(tool_name: &str, args: Value) -> ModelResponse {
+            use rustykrab_core::types::ToolCall;
+            ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content: MessageContent::ToolCall(ToolCall {
+                        id: "call_1".to_string(),
+                        name: tool_name.to_string(),
+                        arguments: args,
+                    }),
+                    created_at: Utc::now(),
+                },
+                usage: Usage {
+                    prompt_tokens: 10,
+                    completion_tokens: 10,
+                    ..Default::default()
+                },
+                stop_reason: StopReason::ToolUse,
+                text: None,
+            }
+        }
     }
 
-    #[test]
-    fn test_extract_sub_calls_empty() {
-        let text = "No sub-calls here, just a regular response.";
-        let calls = extract_sub_calls(text);
-        assert!(calls.is_empty());
+    #[async_trait]
+    impl ModelProvider for MockProvider {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> Result<ModelResponse> {
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                Ok(Self::text_response("(no more responses)"))
+            } else {
+                Ok(responses.remove(0))
+            }
+        }
+
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+            _on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+        ) -> Result<ModelResponse> {
+            self.chat(messages, tools).await
+        }
     }
 
-    #[test]
-    fn test_extract_sub_calls_max_three() {
-        let text = "[SUB_CALL: a] [SUB_CALL: b] [SUB_CALL: c] [SUB_CALL: d]";
-        let calls = extract_sub_calls(text);
-        assert_eq!(calls.len(), 3);
+    #[tokio::test]
+    async fn test_direct_answer_no_tools() {
+        // Model immediately returns a text answer.
+        let provider = Arc::new(MockProvider::new(vec![MockProvider::text_response(
+            "The answer is 42",
+        )]));
+        let config = OrchestrationConfig::default();
+        let executor = RecursiveExecutor::new(provider, config);
+
+        let result = executor
+            .execute("What is the answer?", Some("some context"))
+            .await
+            .unwrap();
+        assert_eq!(result, "The answer is 42");
     }
 
-    #[test]
-    fn test_remove_unresolved_markers() {
-        let text = "Here [SUB_CALL: something] and there";
-        let cleaned = remove_unresolved_markers(text);
-        assert_eq!(cleaned, "Here  and there");
+    #[tokio::test]
+    async fn test_tool_use_then_answer() {
+        // Model first calls context_info, then answers.
+        let provider = Arc::new(MockProvider::new(vec![
+            MockProvider::tool_call_response("context_info", serde_json::json!({})),
+            MockProvider::text_response("The context has 11 characters"),
+        ]));
+        let config = OrchestrationConfig::default();
+        let executor = RecursiveExecutor::new(provider, config);
+
+        let result = executor
+            .execute("How long is the context?", Some("hello world"))
+            .await
+            .unwrap();
+        assert_eq!(result, "The context has 11 characters");
+    }
+
+    #[tokio::test]
+    async fn test_peek_then_answer() {
+        let provider = Arc::new(MockProvider::new(vec![
+            MockProvider::tool_call_response(
+                "context_peek",
+                serde_json::json!({"start": 0, "end": 5}),
+            ),
+            MockProvider::text_response("The first word is Hello"),
+        ]));
+        let config = OrchestrationConfig::default();
+        let executor = RecursiveExecutor::new(provider, config);
+
+        let result = executor
+            .execute("What is the first word?", Some("Hello, world!"))
+            .await
+            .unwrap();
+        assert_eq!(result, "The first word is Hello");
+    }
+
+    #[tokio::test]
+    async fn test_max_depth_direct_call() {
+        // At max depth, context goes directly into the prompt.
+        let provider = Arc::new(MockProvider::new(vec![MockProvider::text_response(
+            "Direct answer",
+        )]));
+        let config = OrchestrationConfig {
+            max_recursion_depth: 0,
+            ..Default::default()
+        };
+        let executor = RecursiveExecutor::new(provider, config);
+
+        let result = executor.execute("question", Some("ctx")).await.unwrap();
+        assert_eq!(result, "Direct answer");
     }
 }

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -23,7 +23,7 @@ use rustykrab_core::{Error, Result};
 use tokio::sync::Semaphore;
 use uuid::Uuid;
 
-use super::context_manager::ContextManager;
+use super::context_manager::estimate_tokens;
 use super::repl_tools;
 
 /// Executes recursive queries where the model explores context via tools.
@@ -39,10 +39,15 @@ impl RecursiveExecutor {
 
     /// Execute a recursive query, allowing the model to explore context
     /// via REPL tools and delegate sub-queries on specific slices.
+    ///
+    /// The entire execution tree is bounded by `pipeline_timeout_secs`
+    /// to prevent runaway recursion from consuming unbounded wall time.
     pub async fn execute(&self, prompt: &str, context: Option<&str>) -> Result<String> {
+        let pipeline_timeout = self.config.pipeline_timeout_secs;
         tracing::info!(
             max_depth = self.config.max_recursion_depth,
             max_tool_rounds = self.config.max_tool_rounds,
+            pipeline_timeout_secs = pipeline_timeout,
             prompt_len = prompt.len(),
             context_len = context.map(|c| c.len()).unwrap_or(0),
             "RLM REPL: starting recursive execution"
@@ -52,30 +57,44 @@ impl RecursiveExecutor {
         let context_arc = Arc::new(context.unwrap_or_default().to_string());
         let semaphore = Arc::new(Semaphore::new(self.config.max_concurrent_tasks));
 
-        let result = execute_repl_call(
-            self.provider.clone(),
-            self.config.clone(),
-            prompt.to_string(),
-            context_arc,
-            0,
-            semaphore,
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(pipeline_timeout),
+            execute_repl_call(
+                self.provider.clone(),
+                self.config.clone(),
+                prompt.to_string(),
+                context_arc,
+                0,
+                semaphore,
+            ),
         )
         .await;
 
         let elapsed = start.elapsed();
-        match &result {
-            Ok(text) => tracing::info!(
+        match result {
+            Ok(Ok(ref text)) => tracing::info!(
                 duration_ms = elapsed.as_millis() as u64,
                 response_len = text.len(),
                 "RLM REPL: recursive execution completed"
             ),
-            Err(e) => tracing::error!(
+            Ok(Err(ref e)) => tracing::error!(
                 duration_ms = elapsed.as_millis() as u64,
                 error = %e,
                 "RLM REPL: recursive execution failed"
             ),
+            Err(_) => tracing::error!(
+                duration_ms = elapsed.as_millis() as u64,
+                pipeline_timeout_secs = pipeline_timeout,
+                "RLM REPL: pipeline timeout exceeded"
+            ),
         }
-        result
+
+        match result {
+            Ok(inner) => inner,
+            Err(_) => Err(Error::Internal(format!(
+                "RLM pipeline timed out after {pipeline_timeout}s"
+            ))),
+        }
     }
 }
 
@@ -133,10 +152,11 @@ async fn execute_repl_call_impl(
 
     // System prompt — tells the model about the context variable and
     // available tools. Context text is NOT in the prompt.
-    let estimated_tokens = ContextManager::estimate_tokens(&context);
+    let estimated_tokens = estimate_tokens(&context);
     let system = format!(
         "You are a reasoning engine. Answer the question below.\n\n\
-         You have access to a context variable ({} chars, ~{} tokens, {} lines).\n\
+         You have access to a context variable ({} bytes, ~{} tokens, {} lines).\n\
+         All positions in tools use byte offsets (snapped to UTF-8 boundaries).\n\
          Use the provided tools to examine, search, and query the context.\n\
          Do NOT try to answer from memory — always consult the context.\n\n\
          Strategy:\n\
@@ -179,7 +199,10 @@ async fn execute_repl_call_impl(
         // before tool execution so recursive sub_query calls can
         // acquire their own permits without deadlocking.
         let response = {
-            let _permit = semaphore.acquire().await.expect("semaphore closed");
+            let _permit = semaphore
+                .acquire()
+                .await
+                .map_err(|_| Error::Internal("RLM semaphore closed".into()))?;
             match tokio::time::timeout(
                 std::time::Duration::from_secs(timeout_secs),
                 provider.chat(&messages, &schemas),
@@ -213,8 +236,18 @@ async fn execute_repl_call_impl(
                 "RLM REPL: executing tool calls"
             );
 
-            for call in calls {
-                let result = execute_repl_tool(call, &tools).await;
+            // Execute tool calls concurrently within a round so
+            // parallel sub_queries don't block each other.
+            let futs: Vec<_> = calls
+                .into_iter()
+                .map(|call| {
+                    let call = call.clone();
+                    let tools = tools.clone();
+                    async move { execute_repl_tool(&call, &tools).await }
+                })
+                .collect();
+            let results = futures::future::join_all(futs).await;
+            for result in results {
                 messages.push(Message {
                     id: Uuid::new_v4(),
                     role: Role::Tool,
@@ -245,7 +278,7 @@ async fn execute_repl_tool(
     call: &rustykrab_core::types::ToolCall,
     tools: &[Arc<dyn Tool>],
 ) -> ToolResult {
-    let tool = match tools.iter().find(|t| t.name() == call.name) {
+    let tool = match tools.iter().find(|t| t.name() == call.name.as_str()) {
         Some(t) => t,
         None => {
             return ToolResult {

--- a/crates/rustykrab-agent/src/rlm/repl_tools.rs
+++ b/crates/rustykrab-agent/src/rlm/repl_tools.rs
@@ -1,0 +1,439 @@
+//! REPL-style tools for recursive context exploration.
+//!
+//! Instead of dumping the full context into the prompt, we store it
+//! externally and give the model tools to peek, search, and delegate
+//! sub-queries — mirroring the foundational RLM paper's Python REPL
+//! approach (Zhang, Kraska, Khattab — arXiv 2512.24601).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use regex::Regex;
+use rustykrab_core::model::ModelProvider;
+use rustykrab_core::orchestration::OrchestrationConfig;
+use rustykrab_core::tool::Tool;
+use rustykrab_core::types::ToolSchema;
+use serde_json::{json, Value};
+use tokio::sync::Semaphore;
+
+use super::context_manager::ContextManager;
+
+/// Maximum characters returned by a single `context_peek` call.
+const MAX_PEEK_CHARS: usize = 50_000;
+
+/// Build the set of REPL tools for a given recursion level.
+///
+/// At `depth >= max_recursion_depth - 1` the `sub_query` tool is
+/// omitted so the model must answer directly from peek/search results.
+pub fn repl_tools(
+    context: Arc<String>,
+    provider: Arc<dyn ModelProvider>,
+    config: OrchestrationConfig,
+    depth: usize,
+    semaphore: Arc<Semaphore>,
+) -> Vec<Arc<dyn Tool>> {
+    let mut tools: Vec<Arc<dyn Tool>> = vec![
+        Arc::new(ContextInfoTool {
+            context: context.clone(),
+        }),
+        Arc::new(ContextPeekTool {
+            context: context.clone(),
+        }),
+        Arc::new(ContextSearchTool {
+            context: context.clone(),
+        }),
+    ];
+
+    if depth < config.max_recursion_depth.saturating_sub(1) {
+        tools.push(Arc::new(SubQueryTool {
+            context,
+            provider,
+            config,
+            depth,
+            semaphore,
+        }));
+    }
+
+    tools
+}
+
+// ── context_info ────────────────────────────────────────────────────
+
+struct ContextInfoTool {
+    context: Arc<String>,
+}
+
+#[async_trait]
+impl Tool for ContextInfoTool {
+    fn name(&self) -> &str {
+        "context_info"
+    }
+
+    fn description(&self) -> &str {
+        "Get metadata about the context variable: character count, \
+         estimated token count, line count, and a short preview of the \
+         first 500 characters."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, _args: Value) -> rustykrab_core::Result<Value> {
+        let length_chars = self.context.len();
+        let estimated_tokens = ContextManager::estimate_tokens(&self.context);
+        let line_count = self.context.lines().count();
+        let preview_end = self
+            .context
+            .char_indices()
+            .take_while(|(i, _)| *i < 500)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(length_chars.min(500));
+        let preview = &self.context[..preview_end];
+
+        Ok(json!({
+            "length_chars": length_chars,
+            "estimated_tokens": estimated_tokens,
+            "line_count": line_count,
+            "preview": preview
+        }))
+    }
+}
+
+// ── context_peek ────────────────────────────────────────────────────
+
+struct ContextPeekTool {
+    context: Arc<String>,
+}
+
+#[async_trait]
+impl Tool for ContextPeekTool {
+    fn name(&self) -> &str {
+        "context_peek"
+    }
+
+    fn description(&self) -> &str {
+        "View a slice of the context by character position. Returns \
+         context[start..end]. Clamped to context bounds and a safety \
+         limit of 50 000 characters per call."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "integer",
+                        "description": "Start character position (0-indexed, inclusive)"
+                    },
+                    "end": {
+                        "type": "integer",
+                        "description": "End character position (exclusive)"
+                    }
+                },
+                "required": ["start", "end"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let start = args["start"].as_u64().unwrap_or(0) as usize;
+        let end = args["end"].as_u64().unwrap_or(0) as usize;
+
+        let ctx_len = self.context.len();
+        let start = start.min(ctx_len);
+        let end = end.min(ctx_len).max(start);
+
+        // Snap to char boundaries.
+        let start = snap_to_char_boundary(&self.context, start);
+        let end = snap_to_char_boundary(&self.context, end);
+
+        // Enforce safety limit.
+        let effective_end = end.min(start + MAX_PEEK_CHARS);
+        let effective_end = snap_to_char_boundary(&self.context, effective_end);
+
+        let slice = &self.context[start..effective_end];
+        let truncated = effective_end < end;
+
+        Ok(json!({
+            "text": slice,
+            "start": start,
+            "end": effective_end,
+            "truncated": truncated
+        }))
+    }
+}
+
+// ── context_search ──────────────────────────────────────────────────
+
+struct ContextSearchTool {
+    context: Arc<String>,
+}
+
+#[async_trait]
+impl Tool for ContextSearchTool {
+    fn name(&self) -> &str {
+        "context_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the context using a regex pattern. Returns matching \
+         lines with their line numbers and character offsets. Use this \
+         to locate relevant sections before peeking at them."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regex pattern to search for (case-insensitive)"
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of matches to return (default 20)"
+                    }
+                },
+                "required": ["pattern"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let pattern = args["pattern"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing pattern".into()))?;
+        let max_results = args["max_results"].as_u64().unwrap_or(20) as usize;
+
+        let re = Regex::new(&format!("(?i){pattern}")).map_err(|e| {
+            rustykrab_core::Error::ToolExecution(format!("invalid regex: {e}").into())
+        })?;
+
+        let mut matches = Vec::new();
+        let mut char_offset = 0usize;
+
+        for (line_num, line) in self.context.lines().enumerate() {
+            if re.is_match(line) {
+                matches.push(json!({
+                    "line_number": line_num + 1,
+                    "char_offset": char_offset,
+                    "text": if line.len() > 200 {
+                        format!("{}...", &line[..line.floor_char_boundary(200)])
+                    } else {
+                        line.to_string()
+                    }
+                }));
+                if matches.len() >= max_results {
+                    break;
+                }
+            }
+            // +1 for the newline character.
+            char_offset += line.len() + 1;
+        }
+
+        Ok(json!({
+            "total_matches": matches.len(),
+            "matches": matches
+        }))
+    }
+}
+
+// ── sub_query ───────────────────────────────────────────────────────
+
+struct SubQueryTool {
+    context: Arc<String>,
+    provider: Arc<dyn ModelProvider>,
+    config: OrchestrationConfig,
+    depth: usize,
+    semaphore: Arc<Semaphore>,
+}
+
+#[async_trait]
+impl Tool for SubQueryTool {
+    fn name(&self) -> &str {
+        "sub_query"
+    }
+
+    fn description(&self) -> &str {
+        "Launch a focused sub-LLM call on a specific slice of the \
+         context. The sub-call gets its own tool set to explore the \
+         slice. Use this to delegate analysis of a section you have \
+         identified via context_peek or context_search. Be thoughtful \
+         about batching — aim for larger slices rather than many tiny \
+         calls."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The question for the sub-call to answer"
+                    },
+                    "start": {
+                        "type": "integer",
+                        "description": "Start character position of the context slice (inclusive)"
+                    },
+                    "end": {
+                        "type": "integer",
+                        "description": "End character position of the context slice (exclusive)"
+                    }
+                },
+                "required": ["question", "start", "end"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let question = args["question"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing question".into()))?;
+        let start = args["start"].as_u64().unwrap_or(0) as usize;
+        let end = args["end"].as_u64().unwrap_or(0) as usize;
+
+        let ctx_len = self.context.len();
+        let start = snap_to_char_boundary(&self.context, start.min(ctx_len));
+        let end = snap_to_char_boundary(&self.context, end.min(ctx_len).max(start));
+
+        let child_context = Arc::new(self.context[start..end].to_string());
+
+        tracing::info!(
+            depth = self.depth + 1,
+            context_slice = format!("[{}..{}]", start, end),
+            question_preview = &question[..question.len().min(80)],
+            "RLM REPL: launching sub_query"
+        );
+
+        // Acquire semaphore permit to bound concurrent LLM calls.
+        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
+
+        let answer = super::recursive_call::execute_repl_call(
+            self.provider.clone(),
+            self.config.clone(),
+            question.to_string(),
+            child_context,
+            self.depth + 1,
+            self.semaphore.clone(),
+        )
+        .await?;
+
+        Ok(json!({ "answer": answer }))
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/// Snap a byte offset forward to the nearest UTF-8 character boundary.
+fn snap_to_char_boundary(s: &str, offset: usize) -> usize {
+    let mut pos = offset.min(s.len());
+    while pos < s.len() && !s.is_char_boundary(pos) {
+        pos += 1;
+    }
+    pos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_snap_to_char_boundary() {
+        let s = "hello 世界";
+        // "hello " is 6 bytes, "世" is 3 bytes, "界" is 3 bytes = 12 total
+        assert_eq!(snap_to_char_boundary(s, 0), 0);
+        assert_eq!(snap_to_char_boundary(s, 6), 6);
+        // Middle of "世" (bytes 6,7,8) should snap to 9
+        assert_eq!(snap_to_char_boundary(s, 7), 9);
+        assert_eq!(snap_to_char_boundary(s, 8), 9);
+        // Past end should clamp
+        assert_eq!(snap_to_char_boundary(s, 100), 12);
+    }
+
+    #[tokio::test]
+    async fn test_context_info() {
+        let ctx = Arc::new("Line one\nLine two\nLine three".to_string());
+        let tool = ContextInfoTool { context: ctx };
+        let result = tool.execute(json!({})).await.unwrap();
+        assert_eq!(result["line_count"], 3);
+        assert_eq!(result["length_chars"], 28);
+        assert!(result["estimated_tokens"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_context_peek_basic() {
+        let ctx = Arc::new("Hello, world! This is a test.".to_string());
+        let tool = ContextPeekTool { context: ctx };
+        let result = tool.execute(json!({"start": 0, "end": 13})).await.unwrap();
+        assert_eq!(result["text"], "Hello, world!");
+        assert_eq!(result["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn test_context_peek_clamps_bounds() {
+        let ctx = Arc::new("short".to_string());
+        let tool = ContextPeekTool { context: ctx };
+        let result = tool
+            .execute(json!({"start": 0, "end": 99999}))
+            .await
+            .unwrap();
+        assert_eq!(result["text"], "short");
+    }
+
+    #[tokio::test]
+    async fn test_context_search_finds_matches() {
+        let ctx = Arc::new(
+            "The temperature in Tokyo is 25C.\n\
+             Rain expected in London.\n\
+             Tokyo will be sunny tomorrow."
+                .to_string(),
+        );
+        let tool = ContextSearchTool { context: ctx };
+        let result = tool
+            .execute(json!({"pattern": "tokyo", "max_results": 10}))
+            .await
+            .unwrap();
+        assert_eq!(result["total_matches"], 2);
+        let matches = result["matches"].as_array().unwrap();
+        assert_eq!(matches[0]["line_number"], 1);
+        assert_eq!(matches[1]["line_number"], 3);
+    }
+
+    #[tokio::test]
+    async fn test_context_search_invalid_regex() {
+        let ctx = Arc::new("test".to_string());
+        let tool = ContextSearchTool { context: ctx };
+        let result = tool.execute(json!({"pattern": "[invalid"})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_context_search_respects_max_results() {
+        let ctx = Arc::new("match\nmatch\nmatch\nmatch\nmatch".to_string());
+        let tool = ContextSearchTool { context: ctx };
+        let result = tool
+            .execute(json!({"pattern": "match", "max_results": 2}))
+            .await
+            .unwrap();
+        assert_eq!(result["total_matches"], 2);
+    }
+}

--- a/crates/rustykrab-agent/src/rlm/repl_tools.rs
+++ b/crates/rustykrab-agent/src/rlm/repl_tools.rs
@@ -324,9 +324,11 @@ impl Tool for SubQueryTool {
             "RLM REPL: launching sub_query"
         );
 
-        // Acquire semaphore permit to bound concurrent LLM calls.
-        let _permit = self.semaphore.acquire().await.expect("semaphore closed");
-
+        // NOTE: We do NOT acquire the semaphore here. The semaphore
+        // gates individual provider.chat() calls inside
+        // execute_repl_call's tool-use loop. Holding a permit across
+        // the entire recursive subtree would deadlock at
+        // depth >= permit count.
         let answer = super::recursive_call::execute_repl_call(
             self.provider.clone(),
             self.config.clone(),

--- a/crates/rustykrab-agent/src/rlm/repl_tools.rs
+++ b/crates/rustykrab-agent/src/rlm/repl_tools.rs
@@ -229,11 +229,14 @@ impl Tool for ContextSearchTool {
         })?;
 
         let mut matches = Vec::new();
-        let mut byte_offset = 0usize;
         let mut total_count = 0usize;
+        // Track byte offset by pointer arithmetic against the original
+        // string so we handle both \n and \r\n correctly.
+        let ctx_start = self.context.as_ptr() as usize;
 
         for (line_num, line) in self.context.lines().enumerate() {
             if re.is_match(line) {
+                let byte_offset = line.as_ptr() as usize - ctx_start;
                 total_count += 1;
                 if matches.len() < max_results {
                     matches.push(json!({
@@ -247,8 +250,6 @@ impl Tool for ContextSearchTool {
                     }));
                 }
             }
-            // +1 for the newline character.
-            byte_offset += line.len() + 1;
         }
 
         Ok(json!({
@@ -451,5 +452,17 @@ mod tests {
         assert_eq!(result["returned_matches"], 2);
         assert_eq!(result["truncated"], true);
         assert_eq!(result["matches"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_context_search_crlf_offsets() {
+        // \r\n line endings — byte offsets must account for 2-byte separators
+        let ctx = Arc::new("first\r\nsecond\r\nthird".to_string());
+        let tool = ContextSearchTool { context: ctx };
+        let result = tool.execute(json!({"pattern": "third"})).await.unwrap();
+        let matches = result["matches"].as_array().unwrap();
+        assert_eq!(matches.len(), 1);
+        // "first\r\n" = 7 bytes, "second\r\n" = 8 bytes → "third" starts at byte 15
+        assert_eq!(matches[0]["byte_offset"], 15);
     }
 }

--- a/crates/rustykrab-agent/src/rlm/repl_tools.rs
+++ b/crates/rustykrab-agent/src/rlm/repl_tools.rs
@@ -16,7 +16,7 @@ use rustykrab_core::types::ToolSchema;
 use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 
-use super::context_manager::ContextManager;
+use super::context_manager::estimate_tokens;
 
 /// Maximum characters returned by a single `context_peek` call.
 const MAX_PEEK_CHARS: usize = 50_000;
@@ -70,9 +70,9 @@ impl Tool for ContextInfoTool {
     }
 
     fn description(&self) -> &str {
-        "Get metadata about the context variable: character count, \
-         estimated token count, line count, and a short preview of the \
-         first 500 characters."
+        "Get metadata about the context variable: byte length, \
+         character count, estimated token count, line count, and a \
+         short preview of the first 500 characters."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -88,8 +88,9 @@ impl Tool for ContextInfoTool {
     }
 
     async fn execute(&self, _args: Value) -> rustykrab_core::Result<Value> {
-        let length_chars = self.context.len();
-        let estimated_tokens = ContextManager::estimate_tokens(&self.context);
+        let length_bytes = self.context.len();
+        let length_chars = self.context.chars().count();
+        let estimated_tokens = estimate_tokens(&self.context);
         let line_count = self.context.lines().count();
         let preview_end = self
             .context
@@ -97,10 +98,11 @@ impl Tool for ContextInfoTool {
             .take_while(|(i, _)| *i < 500)
             .last()
             .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(length_chars.min(500));
+            .unwrap_or(length_bytes.min(500));
         let preview = &self.context[..preview_end];
 
         Ok(json!({
+            "length_bytes": length_bytes,
             "length_chars": length_chars,
             "estimated_tokens": estimated_tokens,
             "line_count": line_count,
@@ -122,9 +124,10 @@ impl Tool for ContextPeekTool {
     }
 
     fn description(&self) -> &str {
-        "View a slice of the context by character position. Returns \
-         context[start..end]. Clamped to context bounds and a safety \
-         limit of 50 000 characters per call."
+        "View a slice of the context by byte offset. Returns \
+         context[start..end]. Offsets are snapped to valid UTF-8 \
+         boundaries. Clamped to context bounds and a safety limit \
+         of 50 000 bytes per call."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -136,11 +139,11 @@ impl Tool for ContextPeekTool {
                 "properties": {
                     "start": {
                         "type": "integer",
-                        "description": "Start character position (0-indexed, inclusive)"
+                        "description": "Start byte offset (0-indexed, inclusive). Snapped to nearest UTF-8 boundary."
                     },
                     "end": {
                         "type": "integer",
-                        "description": "End character position (exclusive)"
+                        "description": "End byte offset (exclusive). Snapped to nearest UTF-8 boundary."
                     }
                 },
                 "required": ["start", "end"]
@@ -190,8 +193,8 @@ impl Tool for ContextSearchTool {
 
     fn description(&self) -> &str {
         "Search the context using a regex pattern. Returns matching \
-         lines with their line numbers and character offsets. Use this \
-         to locate relevant sections before peeking at them."
+         lines with their line numbers and byte offsets. Use the \
+         byte_offset values with context_peek or sub_query."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -226,29 +229,32 @@ impl Tool for ContextSearchTool {
         })?;
 
         let mut matches = Vec::new();
-        let mut char_offset = 0usize;
+        let mut byte_offset = 0usize;
+        let mut total_count = 0usize;
 
         for (line_num, line) in self.context.lines().enumerate() {
             if re.is_match(line) {
-                matches.push(json!({
-                    "line_number": line_num + 1,
-                    "char_offset": char_offset,
-                    "text": if line.len() > 200 {
-                        format!("{}...", &line[..line.floor_char_boundary(200)])
-                    } else {
-                        line.to_string()
-                    }
-                }));
-                if matches.len() >= max_results {
-                    break;
+                total_count += 1;
+                if matches.len() < max_results {
+                    matches.push(json!({
+                        "line_number": line_num + 1,
+                        "byte_offset": byte_offset,
+                        "text": if line.len() > 200 {
+                            format!("{}...", &line[..line.floor_char_boundary(200)])
+                        } else {
+                            line.to_string()
+                        }
+                    }));
                 }
             }
             // +1 for the newline character.
-            char_offset += line.len() + 1;
+            byte_offset += line.len() + 1;
         }
 
         Ok(json!({
-            "total_matches": matches.len(),
+            "total_matches": total_count,
+            "returned_matches": matches.len(),
+            "truncated": total_count > matches.len(),
             "matches": matches
         }))
     }
@@ -292,11 +298,11 @@ impl Tool for SubQueryTool {
                     },
                     "start": {
                         "type": "integer",
-                        "description": "Start character position of the context slice (inclusive)"
+                        "description": "Start byte offset of the context slice (inclusive). Snapped to nearest UTF-8 boundary."
                     },
                     "end": {
                         "type": "integer",
-                        "description": "End character position of the context slice (exclusive)"
+                        "description": "End byte offset of the context slice (exclusive). Snapped to nearest UTF-8 boundary."
                     }
                 },
                 "required": ["question", "start", "end"]
@@ -377,7 +383,8 @@ mod tests {
         let tool = ContextInfoTool { context: ctx };
         let result = tool.execute(json!({})).await.unwrap();
         assert_eq!(result["line_count"], 3);
-        assert_eq!(result["length_chars"], 28);
+        assert_eq!(result["length_bytes"], 28);
+        assert_eq!(result["length_chars"], 28); // ASCII: bytes == chars
         assert!(result["estimated_tokens"].as_u64().unwrap() > 0);
     }
 
@@ -415,8 +422,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result["total_matches"], 2);
+        assert_eq!(result["returned_matches"], 2);
+        assert_eq!(result["truncated"], false);
         let matches = result["matches"].as_array().unwrap();
         assert_eq!(matches[0]["line_number"], 1);
+        assert!(matches[0].get("byte_offset").is_some());
         assert_eq!(matches[1]["line_number"], 3);
     }
 
@@ -436,6 +446,10 @@ mod tests {
             .execute(json!({"pattern": "match", "max_results": 2}))
             .await
             .unwrap();
-        assert_eq!(result["total_matches"], 2);
+        // total_matches reports the true count, not the capped count
+        assert_eq!(result["total_matches"], 5);
+        assert_eq!(result["returned_matches"], 2);
+        assert_eq!(result["truncated"], true);
+        assert_eq!(result["matches"].as_array().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
Following the foundational RLM paper (Zhang, Kraska, Khattab — arXiv
2512.24601), context is now stored externally instead of being truncated
into the prompt. The model explores it via four REPL tools:

- context_info: metadata (length, tokens, lines, preview)
- context_peek: view a slice by character position
- context_search: regex search returning line numbers and offsets
- sub_query: recursive sub-call on a model-selected context slice

This replaces the previous approach where context was positionally
truncated (budget/3) into the prompt and the model emitted [SUB_CALL:]
text markers. The model now controls what it reads, mirroring the
paper's "context as a programmable variable" design.

Key changes:
- New repl_tools.rs with Tool trait implementations
- Rewritten recursive_call.rs with tool-use loop
- At max depth, sub_query is withheld so model answers directly
- Semaphore-bounded concurrency and timeouts preserved

https://claude.ai/code/session_01QzLbWWqi2un7J31eyn1Zc7