### PR TITLE
Drop Intel macOS build, fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,6 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
             artifact: rustykrab-cli
-          - target: x86_64-apple-darwin
-            os: macos-13
-            artifact: rustykrab-cli
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- **Pin macOS runners to correct architectures** — use `macos-14` (ARM) for `aarch64-apple-darwin` instead of `macos-latest` which could drift
- **Drop `x86_64-apple-darwin` target** — `ort-sys` (ONNX Runtime, used by `fastembed`) does not provide prebuilt binaries for Intel macOS, causing build failures. Apple stopped shipping Intel Macs in 2020; Intel users can build from source.
- **Add `workflow_dispatch` trigger** — allows manually triggering a release from the Actions UI without merging a PR
- **Sync `Cargo.lock`** — crate versions were stale at 1.2.0, updated to match workspace version 1.3.1

## Test plan
- [ ] Merge and trigger release workflow via Actions → Release → Run workflow
- [ ] Verify `aarch64-apple-darwin` and `x86_64-unknown-linux-gnu` builds succeed
- [ ] Verify GitHub Release is created with `.tar.gz` artifacts attached
- [ ] Download macOS artifact, extract, and confirm binary runs

https://claude.ai/code/session_014LDNyH3tBL6cuFqx3sqUs4