### PR TITLE
Fix net_scan timeout: skip non-retryable errors and add deadline awareness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -6,16 +6,33 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use chrono::Utc;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::{OrchestrationConfig, SubTask, SubTaskResult};
 use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema};
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Error, Result, Tool, ToolErrorKind};
 use tokio::sync::Semaphore;
 use uuid::Uuid;
 
 use crate::sandbox::{Sandbox, SandboxPolicy};
+
+/// Check whether an error is worth retrying.
+///
+/// Validation errors (`InvalidInput`), missing resources (`NotFound`), and
+/// permission failures (`PermissionDenied`) will never succeed on retry, so
+/// we fail fast instead of burning the pipeline time budget.
+fn is_retryable(err: &Error) -> bool {
+    match err {
+        Error::ToolExecution(te) => !matches!(
+            te.kind,
+            ToolErrorKind::InvalidInput | ToolErrorKind::NotFound | ToolErrorKind::PermissionDenied
+        ),
+        Error::ModelRateLimit(_) | Error::ModelOverloaded(_) => true,
+        _ => false,
+    }
+}
 
 /// Executes sub-tasks in parallel, respecting dependency ordering.
 pub struct ParallelExecutor {
@@ -24,6 +41,9 @@ pub struct ParallelExecutor {
     sandbox: Arc<dyn Sandbox>,
     policy: SandboxPolicy,
     config: OrchestrationConfig,
+    /// Pipeline deadline — retries and model calls check this to avoid
+    /// wasting time when the pipeline is about to time out.
+    deadline: Option<Instant>,
 }
 
 impl ParallelExecutor {
@@ -40,7 +60,15 @@ impl ParallelExecutor {
             sandbox,
             policy,
             config,
+            deadline: None,
         }
+    }
+
+    /// Set the pipeline deadline so retries can bail out early when time is
+    /// nearly up rather than burning the remaining budget on doomed attempts.
+    pub fn with_deadline(mut self, deadline: Instant) -> Self {
+        self.deadline = Some(deadline);
+        self
     }
 
     /// Execute all sub-tasks, respecting dependencies.
@@ -103,6 +131,7 @@ impl ParallelExecutor {
                 let policy = self.policy.clone();
                 let sys_ctx = system_context.map(|s| s.to_string());
                 let sem = semaphore.clone();
+                let deadline = self.deadline;
 
                 handles.push((
                     task_id,
@@ -117,6 +146,7 @@ impl ParallelExecutor {
                             &sandbox,
                             &policy,
                             &config,
+                            deadline,
                         )
                         .await
                     }),
@@ -184,6 +214,7 @@ async fn execute_sub_task(
     sandbox: &Arc<dyn Sandbox>,
     policy: &SandboxPolicy,
     config: &OrchestrationConfig,
+    deadline: Option<Instant>,
 ) -> SubTaskResult {
     // Build focused context for this sub-task.
     let mut messages = Vec::new();
@@ -275,9 +306,15 @@ async fn execute_sub_task(
 
             let calls = response.message.content.tool_calls();
             for call in calls {
-                let result =
-                    execute_tool_for_subtask(call, tools, sandbox, policy, config.max_tool_retries)
-                        .await;
+                let result = execute_tool_for_subtask(
+                    call,
+                    tools,
+                    sandbox,
+                    policy,
+                    config.max_tool_retries,
+                    deadline,
+                )
+                .await;
                 messages.push(Message {
                     id: Uuid::new_v4(),
                     role: Role::Tool,
@@ -316,13 +353,19 @@ async fn execute_sub_task(
     }
 }
 
-/// Execute a tool call within a sub-task, retrying transient failures.
+/// Execute a tool call within a sub-task, retrying only transient failures.
+///
+/// Non-retryable errors (invalid input, not-found, permission denied) fail
+/// immediately — retrying them just wastes the pipeline time budget.  The
+/// optional `deadline` prevents retries when the pipeline is about to time
+/// out, leaving remaining time for useful work instead of doomed attempts.
 async fn execute_tool_for_subtask(
     call: &ToolCall,
     tools: &[Arc<dyn Tool>],
     sandbox: &Arc<dyn Sandbox>,
     policy: &SandboxPolicy,
     max_retries: u32,
+    deadline: Option<Instant>,
 ) -> ToolResult {
     let tool = match tools.iter().find(|t| t.name() == call.name) {
         Some(t) => t,
@@ -359,16 +402,41 @@ async fn execute_tool_for_subtask(
                 };
             }
             Err(e) => {
+                let retryable = is_retryable(&e);
                 tracing::warn!(
                     tool = call.name,
                     attempt = attempt + 1,
                     max_retries,
+                    retryable,
                     error = %e,
-                    "sub-task tool call failed, retrying"
+                    "sub-task tool call failed",
                 );
                 last_err = Some(e);
+
+                // Non-retryable errors (validation, not-found, permission) will
+                // never succeed — bail out immediately.
+                if !retryable {
+                    break;
+                }
+
                 if attempt < max_retries {
                     let delay = std::time::Duration::from_millis(500 * 2u64.pow(attempt));
+
+                    // If the pipeline deadline would expire before the backoff
+                    // completes, skip the retry to preserve time for other work.
+                    if let Some(dl) = deadline {
+                        let remaining = dl.saturating_duration_since(Instant::now());
+                        if remaining < delay {
+                            tracing::warn!(
+                                tool = call.name,
+                                ?remaining,
+                                ?delay,
+                                "skipping retry — insufficient time before pipeline deadline",
+                            );
+                            break;
+                        }
+                    }
+
                     tokio::time::sleep(delay).await;
                 }
             }

--- a/crates/rustykrab-agent/src/orchestrator/pipeline.rs
+++ b/crates/rustykrab-agent/src/orchestrator/pipeline.rs
@@ -5,6 +5,7 @@
 //! entirely; complex tasks get the full treatment.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::{
@@ -75,6 +76,8 @@ impl OrchestrationPipeline {
     /// Run the pipeline for a given request at the specified complexity level.
     ///
     /// The entire pipeline is wrapped in a timeout to prevent unbounded execution.
+    /// A deadline is computed and threaded through to the executor so that tool
+    /// retries can bail out early when the pipeline is about to time out.
     pub async fn run(
         &self,
         request: &str,
@@ -84,9 +87,10 @@ impl OrchestrationPipeline {
         tracing::info!(?complexity, "running orchestration pipeline");
 
         let timeout_secs = self.config.pipeline_timeout_secs;
+        let deadline = Instant::now() + std::time::Duration::from_secs(timeout_secs);
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
-            self.run_inner(request, complexity, context),
+            self.run_inner(request, complexity, context, deadline),
         )
         .await;
 
@@ -106,14 +110,15 @@ impl OrchestrationPipeline {
         request: &str,
         complexity: TaskComplexity,
         context: Option<&str>,
+        deadline: Instant,
     ) -> Result<PipelineResult> {
         match complexity {
             TaskComplexity::Trivial | TaskComplexity::Simple => {
                 self.run_direct(request, context).await
             }
-            TaskComplexity::Moderate => self.run_moderate(request, context).await,
-            TaskComplexity::Complex => self.run_complex(request, context).await,
-            TaskComplexity::Critical => self.run_critical(request, context).await,
+            TaskComplexity::Moderate => self.run_moderate(request, context, deadline).await,
+            TaskComplexity::Complex => self.run_complex(request, context, deadline).await,
+            TaskComplexity::Critical => self.run_critical(request, context, deadline).await,
         }
     }
 
@@ -171,7 +176,12 @@ impl OrchestrationPipeline {
     /// Moderate pipeline: decompose + parallel execute + synthesize,
     /// with a continuation loop that re-decomposes remaining work
     /// until the task is complete or max_recursion_depth is reached.
-    async fn run_moderate(&self, request: &str, context: Option<&str>) -> Result<PipelineResult> {
+    async fn run_moderate(
+        &self,
+        request: &str,
+        context: Option<&str>,
+        deadline: Instant,
+    ) -> Result<PipelineResult> {
         let decomposer = Decomposer::new(self.provider.clone(), self.config.clone());
         let executor = ParallelExecutor::new(
             self.provider.clone(),
@@ -179,7 +189,8 @@ impl OrchestrationPipeline {
             self.sandbox.clone(),
             self.policy.clone(),
             self.config.clone(),
-        );
+        )
+        .with_deadline(deadline);
         let synthesizer = Synthesizer::new(self.provider.clone());
         let tool_names: Vec<&str> = self.tools.iter().map(|t| t.name()).collect();
 
@@ -328,9 +339,14 @@ impl OrchestrationPipeline {
     }
 
     /// Complex pipeline: decompose + execute + synthesize + refine.
-    async fn run_complex(&self, request: &str, context: Option<&str>) -> Result<PipelineResult> {
+    async fn run_complex(
+        &self,
+        request: &str,
+        context: Option<&str>,
+        deadline: Instant,
+    ) -> Result<PipelineResult> {
         // Run moderate pipeline first.
-        let mut result = self.run_moderate(request, context).await?;
+        let mut result = self.run_moderate(request, context, deadline).await?;
 
         // Self-refinement (with system context so the critic knows the agent has tool access).
         let refiner = RefinementLoop::new(self.provider.clone(), self.config.clone());
@@ -344,7 +360,12 @@ impl OrchestrationPipeline {
     }
 
     /// Critical pipeline: decompose + execute + synthesize + vote + refine.
-    async fn run_critical(&self, request: &str, context: Option<&str>) -> Result<PipelineResult> {
+    async fn run_critical(
+        &self,
+        request: &str,
+        context: Option<&str>,
+        deadline: Instant,
+    ) -> Result<PipelineResult> {
         // Self-consistency voting first.
         let voter = ConsistencyVoter::new(
             self.provider.clone(),
@@ -368,7 +389,7 @@ impl OrchestrationPipeline {
         }
 
         // Low confidence — fall back to full decomposition pipeline.
-        let mut result = self.run_complex(request, context).await?;
+        let mut result = self.run_complex(request, context, deadline).await?;
         result.vote = Some(vote);
         result.stages_executed.insert(0, PipelineStage::Verify);
 

--- a/crates/rustykrab-agent/src/sandbox.rs
+++ b/crates/rustykrab-agent/src/sandbox.rs
@@ -85,6 +85,9 @@ fn validate_tool_policy(tool_name: &str, policy: &SandboxPolicy) -> Result<()> {
             | "gmail"
             | "image_generate"
             | "tts"
+            | "net_scan"
+            | "net_admin"
+            | "net_audit"
     );
 
     if needs_fs_read && !policy.allow_fs_read {

--- a/crates/rustykrab-tools/src/net_scan.rs
+++ b/crates/rustykrab-tools/src/net_scan.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, Tool, ToolError};
 use serde_json::{json, Value};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
@@ -91,23 +91,27 @@ async fn tcp_probe(addr: SocketAddr, timeout_ms: u64) -> bool {
 
 /// Expand a CIDR-style subnet (e.g. `192.168.1.0/24`) into individual IPv4
 /// host addresses, excluding the network and broadcast addresses.
-fn expand_subnet(cidr: &str) -> std::result::Result<Vec<Ipv4Addr>, String> {
+fn expand_subnet(cidr: &str) -> std::result::Result<Vec<Ipv4Addr>, ToolError> {
     let parts: Vec<&str> = cidr.split('/').collect();
     if parts.len() != 2 {
-        return Err("expected CIDR notation, e.g. 192.168.1.0/24".into());
+        return Err(ToolError::invalid_input(
+            "expected CIDR notation, e.g. 192.168.1.0/24",
+        ));
     }
-    let base: Ipv4Addr = parts[0].parse().map_err(|e| format!("invalid IP: {e}"))?;
+    let base: Ipv4Addr = parts[0]
+        .parse()
+        .map_err(|e| ToolError::invalid_input(format!("invalid IP: {e}")))?;
     let prefix_len: u32 = parts[1]
         .parse()
-        .map_err(|e| format!("invalid prefix length: {e}"))?;
+        .map_err(|e| ToolError::invalid_input(format!("invalid prefix length: {e}")))?;
     if prefix_len > 32 {
-        return Err("prefix length must be <= 32".into());
+        return Err(ToolError::invalid_input("prefix length must be <= 32"));
     }
     // Limit to /20 (4094 hosts) to avoid accidental DoS.
     if prefix_len < 20 {
-        return Err(
-            "prefix length must be >= 20 (max 4094 hosts) to prevent accidental DoS".into(),
-        );
+        return Err(ToolError::invalid_input(
+            "prefix length must be >= 20 (max 4094 hosts) to prevent accidental DoS",
+        ));
     }
 
     let base_u32 = u32::from(base);
@@ -128,16 +132,16 @@ fn expand_subnet(cidr: &str) -> std::result::Result<Vec<Ipv4Addr>, String> {
 }
 
 /// Perform a ping sweep by attempting a TCP connect on probe ports.
-async fn ping_sweep(cidr: &str, timeout_ms: u64) -> std::result::Result<Vec<Value>, String> {
+async fn ping_sweep(cidr: &str, timeout_ms: u64) -> std::result::Result<Vec<Value>, ToolError> {
     let hosts = expand_subnet(cidr)?;
     let probe_ports: &[u16] = &[80, 443, 22, 445];
 
     // Verify all hosts are in local network ranges.
     for h in &hosts {
         if !is_local_network(&IpAddr::V4(*h)) {
-            return Err(format!(
+            return Err(ToolError::invalid_input(format!(
                 "host {h} is not in a private/local range — only local-network scanning is allowed"
-            ));
+            )));
         }
     }
 
@@ -256,12 +260,14 @@ impl Tool for NetScanTool {
         match action {
             "ping_sweep" => {
                 let subnet = args["subnet"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("subnet is required for ping_sweep".into())
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "subnet is required for ping_sweep",
+                    ))
                 })?;
 
                 let live = ping_sweep(subnet, timeout_ms)
                     .await
-                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+                    .map_err(rustykrab_core::Error::ToolExecution)?;
 
                 Ok(json!({
                     "action": "ping_sweep",
@@ -272,14 +278,20 @@ impl Tool for NetScanTool {
             }
             "port_scan" => {
                 let host_str = args["host"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("host is required for port_scan".into())
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "host is required for port_scan",
+                    ))
                 })?;
                 let ip: IpAddr = host_str.parse().map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(format!("invalid IP address: {e}").into())
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(format!(
+                        "invalid IP address: {e}"
+                    )))
                 })?;
                 if !is_local_network(&ip) {
                     return Err(rustykrab_core::Error::ToolExecution(
-                        format!("{ip} is not in a private/local range — only local-network scanning is allowed").into(),
+                        ToolError::invalid_input(format!(
+                            "{ip} is not in a private/local range — only local-network scanning is allowed"
+                        )),
                     ));
                 }
 
@@ -293,14 +305,14 @@ impl Tool for NetScanTool {
             }
             "scan_subnet" => {
                 let subnet = args["subnet"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution(
-                        "subnet is required for scan_subnet".into(),
-                    )
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "subnet is required for scan_subnet",
+                    ))
                 })?;
 
                 let live = ping_sweep(subnet, timeout_ms)
                     .await
-                    .map_err(|e| rustykrab_core::Error::ToolExecution(e.into()))?;
+                    .map_err(rustykrab_core::Error::ToolExecution)?;
 
                 let mut results = Vec::new();
                 for host_val in &live {
@@ -322,7 +334,7 @@ impl Tool for NetScanTool {
                 }))
             }
             _ => Err(rustykrab_core::Error::ToolExecution(
-                format!("unknown net_scan action: {action}").into(),
+                ToolError::invalid_input(format!("unknown net_scan action: {action}")),
             )),
         }
     }


### PR DESCRIPTION
The pipeline was timing out (300s) because net_scan CIDR validation
failures were retried 3 times despite being deterministic errors that
could never succeed. Combined with slow LLM calls (35-49s each), this
exhausted the pipeline budget and returned HTTP 500.

Three fixes:

1. net_scan now returns ToolError::InvalidInput for all validation
   errors (CIDR prefix, IP format, non-local ranges) instead of the
   catch-all Internal kind.

2. The retry loop in execute_tool_for_subtask now checks error kind
   before retrying — InvalidInput, NotFound, and PermissionDenied
   errors fail immediately instead of burning time on doomed retries.

3. The pipeline deadline is threaded through to the executor so retries
   bail out when remaining time is less than the backoff delay.

Also adds net_scan, net_admin, net_audit to the sandbox needs_net
policy check — they were missing, which is a defense-in-depth gap.

https://claude.ai/code/session_01VkGziQLaf4eaYFhjjHTmjR