### PR TITLE
fix: enforce account and service as required params for keychain source in credential_read schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -67,18 +67,25 @@ impl Tool for CredentialReadTool {
                         "type": "string",
                         "enum": ["store", "keychain"],
                         "default": "store",
-                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
+                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain). When set to 'keychain', the 'service' and 'account' parameters MUST be provided."
                     },
                     "service": {
                         "type": "string",
-                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). Required when source is 'keychain'."
+                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). REQUIRED when source is 'keychain'."
                     },
                     "account": {
                         "type": "string",
-                        "description": "macOS Keychain account name. Required when source is 'keychain'."
+                        "description": "macOS Keychain account name. REQUIRED when source is 'keychain'."
                     }
                 },
-                "required": ["action"]
+                "required": ["action"],
+                "if": {
+                    "properties": { "source": { "const": "keychain" } },
+                    "required": ["source"]
+                },
+                "then": {
+                    "required": ["action", "account", "service"]
+                }
             }),
         }
     }


### PR DESCRIPTION
The JSON schema only marked "action" as required, so models would call
credential_read with source="keychain" but omit the account (and service)
parameters. Add an if/then conditional requirement so that when source is
"keychain", both account and service become required at the schema level.
Also uppercased "REQUIRED" in the parameter descriptions for emphasis.

https://claude.ai/code/session_01FNcrxKuHYjiZN7kpYzPzai