### PR TITLE
fix: harden release script against special characters in PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,12 @@ jobs:
 
       - name: Bump version
         id: bump
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '0' }}
+          BUMP_TYPE: ${{ steps.bump-type.outputs.bump }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title || 'Manual release' }}"
-          PR_NUMBER="${{ github.event.pull_request.number || '0' }}"
-          ./scripts/release.sh "${{ steps.bump-type.outputs.bump }}" \
+          ./scripts/release.sh "$BUMP_TYPE" \
             --ci \
             --pr-title "$PR_TITLE" \
             --pr-number "$PR_NUMBER"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,8 +89,20 @@ if [ "$CI_MODE" = true ] && [ -n "$PR_TITLE" ]; then
         PR_REF=" (#$PR_NUMBER)"
     fi
 
-    # Insert the new version heading after [Unreleased], and append the PR entry
-    sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE\n\n- ${PR_TITLE}${PR_REF}/" "$CHANGELOG"
+    # Insert the new version heading after [Unreleased], and append the PR entry.
+    # Use awk + ENVIRON instead of sed so special characters in PR titles
+    # (quotes, parentheses, slashes, ampersands) don't cause syntax errors.
+    export _PR_TITLE="$PR_TITLE"
+    export _PR_REF="$PR_REF"
+    awk -v ver="$NEXT" -v date="$DATE" '
+        /^## \[Unreleased\]/ {
+            print
+            print ""
+            printf "## [%s] - %s\n\n- %s%s\n", ver, date, ENVIRON["_PR_TITLE"], ENVIRON["_PR_REF"]
+            next
+        }
+        { print }
+    ' "$CHANGELOG" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "$CHANGELOG"
 else
     # Local: just promote the [Unreleased] section to the new version heading
     sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE/" "$CHANGELOG"


### PR DESCRIPTION
PR titles containing quotes, parentheses, or other shell metacharacters
broke the release workflow (e.g. `Revert "... (#255)"`). Two fixes:

1. Workflow: move ${{ }} expression interpolation from inline `run:`
   into `env:` block so the runner sets environment variables instead
   of pasting untrusted text into bash source code.

2. release.sh: replace `sed` substitution with `awk` + `ENVIRON` for
   the changelog entry so special characters (quotes, parens, slashes,
   ampersands, backslashes) pass through safely.

https://claude.ai/code/session_01QDKXF39N55Qi5cvTgLY5dQ