### PR TITLE
fix: upgrade croner v2→v3 and improve cron tool error messages (#262)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,11 +691,13 @@ dependencies = [
 
 [[package]]
 name = "croner"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
 dependencies = [
  "chrono",
+ "derive_builder",
+ "strum",
 ]
 
 [[package]]
@@ -3250,7 +3252,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3264,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3283,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3311,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3323,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3346,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3367,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3383,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3399,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3422,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3745,6 +3747,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
-croner = "2"
+croner = "3"
 
 # Cryptography
 ed25519-dalek = { version = "2", features = ["rand_core", "serde"] }

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -243,29 +243,28 @@ fn try_parse_datetime(s: &str) -> Option<DateTime<Utc>> {
 
 /// Compute the next occurrence of a cron expression after `after`.
 ///
-/// Handles both standard 5-field cron (`minute hour dom month dow`) and
-/// 6-field cron with seconds (`second minute hour dom month dow`).
+/// Accepts standard 5-field cron (`minute hour dom month dow`), 6-field
+/// with seconds, or 7-field with seconds and year.
 fn compute_next_cron_run(expression: &str, after: DateTime<Utc>) -> Result<DateTime<Utc>, Error> {
-    let normalized = normalize_cron_expression(expression);
-    let cron: Cron = normalized
+    let cron: Cron = expression
         .parse()
-        .map_err(|e| Error::Config(format!("invalid cron expression '{expression}': {e}")))?;
+        .map_err(|e| {
+            Error::Config(format!(
+                "invalid cron expression '{expression}': {e}. \
+                 Use standard 5-field format: minute(0-59) hour(0-23) day(1-31) month(1-12) weekday(0-6, 0=Sun). \
+                 Example: '0 9 * * *' for daily at 9 AM"
+            ))
+        })?;
 
     cron.find_next_occurrence(&after, false)
-        .map_err(|e| Error::Config(format!("could not compute next cron occurrence: {e}")))
-}
-
-/// Normalize a cron expression for `croner` which requires 6 fields
-/// (seconds minutes hours day-of-month month day-of-week).
-///
-/// If the input has 5 fields (standard cron), prepend `0` for seconds.
-fn normalize_cron_expression(expr: &str) -> String {
-    let fields: Vec<&str> = expr.split_whitespace().collect();
-    if fields.len() == 5 {
-        format!("0 {expr}")
-    } else {
-        expr.to_string()
-    }
+        .map_err(|_| {
+            Error::Config(format!(
+                "cron expression '{expression}' cannot produce a future occurrence. \
+                 The expression may be too restrictive or invalid. \
+                 Use standard 5-field format: minute(0-59) hour(0-23) day(1-31) month(1-12) weekday(0-6, 0=Sun). \
+                 Example: '0 9 * * 1-5' for weekdays at 9 AM"
+            ))
+        })
 }
 
 /// Parse an RFC 3339 timestamp stored in SQLite.
@@ -273,4 +272,84 @@ fn parse_stored_timestamp(s: String) -> DateTime<Utc> {
     DateTime::parse_from_rfc3339(&s)
         .map(|dt| dt.with_timezone(&Utc))
         .unwrap_or_else(|_| Utc::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_next_cron_5_field_expression() {
+        let now = Utc::now();
+        let result = compute_next_cron_run("*/5 * * * *", now);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert!(result.unwrap() > now);
+    }
+
+    #[test]
+    fn compute_next_cron_6_field_expression() {
+        let now = Utc::now();
+        let result = compute_next_cron_run("0 */5 * * * *", now);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert!(result.unwrap() > now);
+    }
+
+    #[test]
+    fn compute_next_cron_too_few_fields_gives_actionable_error() {
+        let now = Utc::now();
+        let err = compute_next_cron_run("* *", now).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid cron expression"), "got: {msg}");
+        assert!(msg.contains("Example:"), "got: {msg}");
+    }
+
+    #[test]
+    fn compute_next_cron_garbage_gives_actionable_error() {
+        let now = Utc::now();
+        let err = compute_next_cron_run("not a cron", now).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid cron expression"), "got: {msg}");
+        assert!(msg.contains("Example:"), "got: {msg}");
+    }
+
+    #[test]
+    fn compute_next_cron_unreachable_gives_actionable_error() {
+        let now = Utc::now();
+        // February 31st never exists
+        let err = compute_next_cron_run("0 0 31 2 *", now).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot produce a future occurrence"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("Example:"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_schedule_one_shot_in_past_fails() {
+        let now = Utc::now();
+        let err = parse_schedule("2020-01-01T00:00:00Z", now).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("one-shot schedule must be in the future"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_one_shot_in_future_succeeds() {
+        let now = Utc::now();
+        let future = (now + chrono::Duration::hours(1)).to_rfc3339();
+        let (one_shot, next_run) = parse_schedule(&future, now).unwrap();
+        assert!(one_shot);
+        assert!(next_run > now);
+    }
+
+    #[test]
+    fn parse_schedule_valid_cron() {
+        let now = Utc::now();
+        let (one_shot, next_run) = parse_schedule("0 9 * * *", now).unwrap();
+        assert!(!one_shot);
+        assert!(next_run > now);
+    }
 }

--- a/crates/rustykrab-tools/src/cron.rs
+++ b/crates/rustykrab-tools/src/cron.rs
@@ -41,7 +41,25 @@ impl Tool for CronTool {
                     },
                     "schedule": {
                         "type": "string",
-                        "description": "Cron expression for recurring schedules (e.g. '0 9 * * *' for daily at 9am, '*/30 * * * *' for every 30 minutes) or an ISO 8601 timestamp for one-shot tasks (e.g. '2025-04-12T14:30:00Z'). Required for create."
+                        "description": concat!(
+                            "Required for create. Must be ONE of:\n",
+                            "\n",
+                            "1) Standard 5-field cron expression: minute hour day-of-month month day-of-week\n",
+                            "   Fields: minute(0-59) hour(0-23) day(1-31) month(1-12) weekday(0-6, 0=Sun)\n",
+                            "   Allowed operators: * (any), */N (every N), N-M (range), N,M (list)\n",
+                            "   Examples:\n",
+                            "   - '0 9 * * *'     → daily at 9:00 AM\n",
+                            "   - '*/30 * * * *'  → every 30 minutes\n",
+                            "   - '0 9 * * 1-5'   → weekdays at 9:00 AM\n",
+                            "   - '0 0 1 * *'     → first day of every month at midnight\n",
+                            "   - '0 8,12,18 * * *' → daily at 8 AM, noon, and 6 PM\n",
+                            "\n",
+                            "2) ISO 8601 timestamp for one-shot tasks (must be in the future):\n",
+                            "   - '2025-04-12T14:30:00Z'\n",
+                            "\n",
+                            "IMPORTANT: Use only the standard 5-field format. Do NOT use non-standard extensions, ",
+                            "named months/days (like 'MON'), or 6-field expressions.",
+                        )
                     },
                     "task": {
                         "type": "string",


### PR DESCRIPTION
The croner v2.2.0 library is incompatible with chrono 0.4.44, causing
`find_next_occurrence` to fail with "CronScheduler time search limit
exceeded" for ALL expressions — not just invalid ones. This was the root
cause of the 300s pipeline timeouts reported in #262.

Changes:
- Upgrade croner dependency from v2 to v3 (fixes chrono compatibility)
- Enrich the cron tool schema description with explicit 5-field format
  guidance, field ranges, allowed operators, and common examples so LLMs
  generate valid expressions
- Replace cryptic croner errors with actionable messages that include the
  offending expression, the expected format, and a concrete example
- Remove normalize_cron_expression (croner v3 handles 5-7 fields natively)
- Add 8 unit tests covering valid expressions, field-count validation,
  garbage input, unreachable schedules, and one-shot timestamp handling

Closes #262

https://claude.ai/code/session_01Y9zP2mrTrtcfzCPRES5TGT