### PR TITLE
fix: make account/service required in credential tool schemas (#263)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -41,10 +41,13 @@ impl Tool for CredentialReadTool {
         "Read a stored credential/secret by name, or list all stored credential names. \
          Use this to retrieve API keys, passwords, or tokens needed to authenticate \
          with external services. Credentials are stored encrypted at rest.\n\n\
-         Set source to 'keychain' to read credentials directly from the macOS Keychain \
-         (requires service and account parameters). This is useful during remote \
-         deployment to pull SSH keys, deploy tokens, or API keys stored in the \
-         system Keychain."
+         Set source to 'keychain' to read credentials directly from the macOS Keychain. \
+         When using keychain source, you MUST provide both 'service' and 'account' \
+         parameters.\n\n\
+         Examples:\n\
+         - List secrets from local store: {\"action\": \"list\", \"source\": \"store\"}\n\
+         - Read from local store: {\"action\": \"get\", \"source\": \"store\", \"name\": \"my_api_key\"}\n\
+         - Read from keychain: {\"action\": \"get\", \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
     }
 
     fn schema(&self) -> ToolSchema {
@@ -67,25 +70,18 @@ impl Tool for CredentialReadTool {
                         "type": "string",
                         "enum": ["store", "keychain"],
                         "default": "store",
-                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain). When set to 'keychain', the 'service' and 'account' parameters MUST be provided."
+                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
                     },
                     "service": {
                         "type": "string",
-                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). REQUIRED when source is 'keychain'."
+                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). REQUIRED — provide the service name associated with the keychain entry."
                     },
                     "account": {
                         "type": "string",
-                        "description": "macOS Keychain account name. REQUIRED when source is 'keychain'."
+                        "description": "macOS Keychain account name. REQUIRED — provide the account name associated with the keychain entry (e.g. 'deploy_token', 'api_key', 'rustykrab')."
                     }
                 },
-                "required": ["action"],
-                "if": {
-                    "properties": { "source": { "const": "keychain" } },
-                    "required": ["source"]
-                },
-                "then": {
-                    "required": ["action", "account", "service"]
-                }
+                "required": ["action", "source", "service", "account"]
             }),
         }
     }
@@ -159,12 +155,20 @@ impl CredentialReadTool {
             "get" | "read" => {
                 let service = args["service"].as_str().ok_or_else(|| {
                     Error::ToolExecution(
-                        "missing 'service' parameter (required when source is 'keychain')".into(),
+                        "missing 'service' parameter. Provide the macOS Keychain service \
+                         name (the 'Where' field in Keychain Access). Example: \
+                         {\"action\": \"get\", \"source\": \"keychain\", \"service\": \"myapp\", \
+                         \"account\": \"deploy_token\"}"
+                            .into(),
                     )
                 })?;
                 let account = args["account"].as_str().ok_or_else(|| {
                     Error::ToolExecution(
-                        "missing 'account' parameter (required when source is 'keychain')".into(),
+                        "missing 'account' parameter. Provide the macOS Keychain account \
+                         name associated with the entry (e.g. 'deploy_token', 'api_key'). \
+                         Example: {\"action\": \"get\", \"source\": \"keychain\", \
+                         \"service\": \"myapp\", \"account\": \"deploy_token\"}"
+                            .into(),
                     )
                 })?;
 

--- a/crates/rustykrab-tools/src/credential_write.rs
+++ b/crates/rustykrab-tools/src/credential_write.rs
@@ -30,11 +30,16 @@ impl Tool for CredentialWriteTool {
         "Store, update, or delete a credential/secret. Use this to save API keys, \
          passwords, or tokens so they can be retrieved later with credential_read. \
          All credentials are encrypted at rest.\n\n\
-         Set source to 'keychain' to write to the macOS Keychain instead of the \
-         local store (requires service and account parameters).\n\n\
-         Use the 'import_from_keychain' action to copy a credential from the macOS \
-         Keychain into the encrypted local store — useful for preparing deployment \
-         bundles that work on non-macOS targets."
+         Set source to 'keychain' to write to the macOS Keychain. When using keychain \
+         source, you MUST provide both 'service' and 'account' parameters. The \
+         'import_from_keychain' action also requires 'service' and 'account'.\n\n\
+         Examples:\n\
+         - Store in local store: {\"action\": \"set\", \"name\": \"my_api_key\", \"value\": \"sk-123\", \
+         \"source\": \"store\", \"service\": \"\", \"account\": \"\"}\n\
+         - Store in keychain: {\"action\": \"set\", \"name\": \"deploy_key\", \"value\": \"sk-123\", \
+         \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}\n\
+         - Import from keychain: {\"action\": \"import_from_keychain\", \"name\": \"local_copy\", \
+         \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
     }
 
     fn schema(&self) -> ToolSchema {
@@ -65,14 +70,14 @@ impl Tool for CredentialWriteTool {
                     },
                     "service": {
                         "type": "string",
-                        "description": "macOS Keychain service name. Required when source is 'keychain' or action is 'import_from_keychain'."
+                        "description": "macOS Keychain service name. REQUIRED — provide the service name for the keychain entry."
                     },
                     "account": {
                         "type": "string",
-                        "description": "macOS Keychain account name. Required when source is 'keychain' or action is 'import_from_keychain'."
+                        "description": "macOS Keychain account name. REQUIRED — provide the account name for the keychain entry (e.g. 'deploy_token', 'api_key')."
                     }
                 },
-                "required": ["action", "name"]
+                "required": ["action", "name", "source", "service", "account"]
             }),
         }
     }
@@ -148,12 +153,19 @@ impl CredentialWriteTool {
 
         let service = args["service"].as_str().ok_or_else(|| {
             Error::ToolExecution(
-                "missing 'service' parameter (required when source is 'keychain')".into(),
+                "missing 'service' parameter. Provide the macOS Keychain service \
+                 name. Example: {\"action\": \"set\", \"name\": \"key\", \"value\": \"val\", \
+                 \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
+                    .into(),
             )
         })?;
         let account = args["account"].as_str().ok_or_else(|| {
             Error::ToolExecution(
-                "missing 'account' parameter (required when source is 'keychain')".into(),
+                "missing 'account' parameter. Provide the macOS Keychain account \
+                 name (e.g. 'deploy_token', 'api_key'). Example: {\"action\": \"set\", \
+                 \"name\": \"key\", \"value\": \"val\", \"source\": \"keychain\", \
+                 \"service\": \"myapp\", \"account\": \"deploy_token\"}"
+                    .into(),
             )
         })?;
 
@@ -212,10 +224,22 @@ impl CredentialWriteTool {
         }
 
         let service = args["service"].as_str().ok_or_else(|| {
-            Error::ToolExecution("missing 'service' parameter for import_from_keychain".into())
+            Error::ToolExecution(
+                "missing 'service' parameter. Provide the macOS Keychain service name \
+                 to import from. Example: {\"action\": \"import_from_keychain\", \
+                 \"name\": \"local_copy\", \"source\": \"keychain\", \"service\": \"myapp\", \
+                 \"account\": \"deploy_token\"}"
+                    .into(),
+            )
         })?;
         let account = args["account"].as_str().ok_or_else(|| {
-            Error::ToolExecution("missing 'account' parameter for import_from_keychain".into())
+            Error::ToolExecution(
+                "missing 'account' parameter. Provide the macOS Keychain account name \
+                 to import from (e.g. 'deploy_token', 'api_key'). Example: \
+                 {\"action\": \"import_from_keychain\", \"name\": \"local_copy\", \
+                 \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
+                    .into(),
+            )
         })?;
 
         // Read from Keychain.


### PR DESCRIPTION
LLMs ignore JSON Schema if/then conditionals, causing them to omit the
required account and service parameters when calling credential_read with
source "keychain". This leads to repeated tool failures and pipeline
timeouts as retries exhaust without self-correction.

Changes:
- Remove if/then conditional from credential_read schema; add account,
  service, and source to the top-level required array instead
- Add account, service, and source to credential_write required array
- Add usage examples to both tool descriptions so models see the
  expected parameter shape
- Improve error messages with concrete examples to enable model
  self-correction on retry

Closes #263

https://claude.ai/code/session_01ShXH4gEKhuFdH1AfV79PhC