### PR TITLE
feat: increase Telegram heartbeat timeout from 5 to 30 minutes

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -302,9 +302,10 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// How long the agent can go without emitting any event (text delta,
-/// tool start/end, etc.) before we consider it stalled.
-const HEARTBEAT_TIMEOUT_SECS: u64 = 300; // 5 minutes
+/// How long the Telegram agent can go without emitting any event (text delta,
+/// tool start/end, etc.) before we consider it stalled. Longer than the web
+/// frontend since Telegram execution is fully async.
+const HEARTBEAT_TIMEOUT_SECS: u64 = 1800; // 30 minutes
 
 /// How often to resend the "typing" indicator while the agent is working.
 /// Telegram's typing indicator expires after ~5 seconds.


### PR DESCRIPTION
Telegram execution is fully async so the agent can run much longer
without stalling the user experience. Increase the inactivity timeout
to 30 minutes while leaving the web frontend SSE timeout at 5 minutes.

https://claude.ai/code/session_01HaFpy6qygNye3KVjs377uN