### PR TITLE
Fix credential_read tool to return actual credential values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.3"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -4,15 +4,6 @@ use rustykrab_core::{Error, Result, Tool};
 use rustykrab_store::SecretStore;
 use serde_json::{json, Value};
 
-/// Mask a secret value so only the first 4 and last 4 characters are visible.
-fn mask_secret(value: &str) -> String {
-    if value.len() > 8 {
-        format!("{}...{}", &value[..4], &value[value.len() - 4..])
-    } else {
-        "*".repeat(value.len())
-    }
-}
-
 /// A tool that reads credentials from the encrypted SecretStore or from the
 /// macOS Keychain.
 ///
@@ -113,7 +104,7 @@ impl CredentialReadTool {
                     Ok(value) => Ok(json!({
                         "source": "store",
                         "name": name,
-                        "value": mask_secret(&value),
+                        "value": value,
                     })),
                     Err(rustykrab_core::Error::NotFound(_)) => Ok(json!({
                         "error": format!("no secret found with name '{name}'"),
@@ -183,7 +174,7 @@ impl CredentialReadTool {
                             "source": "keychain",
                             "service": cred.service,
                             "account": cred.account,
-                            "value": mask_secret(&cred.value),
+                            "value": cred.value,
                         }))
                     }
                     Ok(None) => Ok(json!({


### PR DESCRIPTION
The tool was always masking secret values via mask_secret(), returning
only the first 4 and last 4 characters. This made the tool unusable for
its stated purpose of retrieving API keys for programmatic use by the
agent. Remove mask_secret() and return the full credential value from
both the local SecretStore and macOS Keychain code paths.

Fixes #273

https://claude.ai/code/session_01FJKAve2vWHmSoW1KHKEaRD