### PR TITLE
Fix orchestration pipeline timeout by adding deadline awareness and missing timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "axum",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/orchestrator/executor.rs
+++ b/crates/rustykrab-agent/src/orchestrator/executor.rs
@@ -330,7 +330,9 @@ async fn execute_sub_task(
 
         // Summarize if output is too long.
         let output = if config.summarize_sub_results && output.len() > 2000 {
-            summarize_output(provider, &output).await.unwrap_or(output)
+            summarize_output(provider, &output, config.model_call_timeout_secs)
+                .await
+                .unwrap_or(output)
         } else {
             output
         };
@@ -451,7 +453,11 @@ async fn execute_tool_for_subtask(
 }
 
 /// Summarize a long output to stay within context budgets.
-async fn summarize_output(provider: &Arc<dyn ModelProvider>, output: &str) -> Result<String> {
+async fn summarize_output(
+    provider: &Arc<dyn ModelProvider>,
+    output: &str,
+    timeout_secs: u64,
+) -> Result<String> {
     let messages = vec![Message {
         id: Uuid::new_v4(),
         role: Role::User,
@@ -461,7 +467,16 @@ async fn summarize_output(provider: &Arc<dyn ModelProvider>, output: &str) -> Re
         created_at: Utc::now(),
     }];
 
-    let response = provider.chat(&messages, &[]).await?;
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(timeout_secs),
+        provider.chat(&messages, &[]),
+    )
+    .await
+    .map_err(|_| {
+        Error::Internal(format!(
+            "summarize model call timed out after {timeout_secs}s"
+        ))
+    })??;
     Ok(response
         .message
         .content

--- a/crates/rustykrab-agent/src/orchestrator/pipeline.rs
+++ b/crates/rustykrab-agent/src/orchestrator/pipeline.rs
@@ -78,15 +78,28 @@ impl OrchestrationPipeline {
     /// The entire pipeline is wrapped in a timeout to prevent unbounded execution.
     /// A deadline is computed and threaded through to the executor so that tool
     /// retries can bail out early when the pipeline is about to time out.
+    ///
+    /// The configured `pipeline_timeout_secs` is treated as the base budget and
+    /// scaled by complexity: trivial/simple get 1×, moderate gets 2×, complex
+    /// gets 3×, and critical gets 4×.  This prevents complex tasks (which make
+    /// many sequential model calls) from being killed by a budget sized for
+    /// simple tasks.
     pub async fn run(
         &self,
         request: &str,
         complexity: TaskComplexity,
         context: Option<&str>,
     ) -> Result<PipelineResult> {
-        tracing::info!(?complexity, "running orchestration pipeline");
+        let multiplier = match complexity {
+            TaskComplexity::Trivial | TaskComplexity::Simple => 1,
+            TaskComplexity::Moderate => 2,
+            TaskComplexity::Complex => 3,
+            TaskComplexity::Critical => 4,
+        };
+        let timeout_secs = self.config.pipeline_timeout_secs * multiplier;
 
-        let timeout_secs = self.config.pipeline_timeout_secs;
+        tracing::info!(?complexity, timeout_secs, "running orchestration pipeline");
+
         let deadline = Instant::now() + std::time::Duration::from_secs(timeout_secs);
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),

--- a/crates/rustykrab-agent/src/orchestrator/pipeline.rs
+++ b/crates/rustykrab-agent/src/orchestrator/pipeline.rs
@@ -191,7 +191,7 @@ impl OrchestrationPipeline {
             self.config.clone(),
         )
         .with_deadline(deadline);
-        let synthesizer = Synthesizer::new(self.provider.clone());
+        let synthesizer = Synthesizer::new(self.provider.clone(), self.config.clone());
         let tool_names: Vec<&str> = self.tools.iter().map(|t| t.name()).collect();
 
         let max_cycles = self.config.max_recursion_depth.max(1);
@@ -199,7 +199,24 @@ impl OrchestrationPipeline {
         let mut accumulated_results = Vec::new();
         let mut stages = Vec::new();
 
+        // Reserve a minimum time buffer for the final synthesis pass so
+        // the pipeline doesn't time out between the last execute and
+        // synthesize steps.  This also prevents starting new cycles that
+        // have no chance of completing.
+        let min_remaining_secs = self.config.model_call_timeout_secs + 10;
+
         for cycle in 0..max_cycles {
+            // Check whether enough time remains to start another cycle.
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.as_secs() < min_remaining_secs {
+                tracing::warn!(
+                    cycle,
+                    remaining_secs = remaining.as_secs(),
+                    "skipping cycle — insufficient time before pipeline deadline",
+                );
+                break;
+            }
+
             // Build the decomposition request: on the first cycle, use the
             // original request. On subsequent cycles, ask the decomposer to
             // plan the remaining work given what has been completed so far.

--- a/crates/rustykrab-agent/src/orchestrator/synthesizer.rs
+++ b/crates/rustykrab-agent/src/orchestrator/synthesizer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use rustykrab_core::model::ModelProvider;
-use rustykrab_core::orchestration::SubTaskResult;
+use rustykrab_core::orchestration::{OrchestrationConfig, SubTaskResult};
 use rustykrab_core::types::{Message, MessageContent, Role};
 use rustykrab_core::Result;
 use uuid::Uuid;
@@ -16,6 +16,7 @@ use uuid::Uuid;
 /// Synthesizes sub-task results into a final coherent response.
 pub struct Synthesizer {
     provider: Arc<dyn ModelProvider>,
+    config: OrchestrationConfig,
 }
 
 const SYNTHESIZE_PROMPT: &str = r#"You are synthesizing results from multiple sub-tasks into a single coherent response for the user.
@@ -33,8 +34,8 @@ Instructions:
 - Be concise and direct"#;
 
 impl Synthesizer {
-    pub fn new(provider: Arc<dyn ModelProvider>) -> Self {
-        Self { provider }
+    pub fn new(provider: Arc<dyn ModelProvider>, config: OrchestrationConfig) -> Self {
+        Self { provider, config }
     }
 
     /// Synthesize sub-task results into a final response.
@@ -99,13 +100,16 @@ impl Synthesizer {
             created_at: Utc::now(),
         });
 
+        let timeout_secs = self.config.model_call_timeout_secs;
         let response = tokio::time::timeout(
-            std::time::Duration::from_secs(120),
+            std::time::Duration::from_secs(timeout_secs),
             self.provider.chat(&messages, &[]),
         )
         .await
         .map_err(|_| {
-            rustykrab_core::Error::Internal("synthesis model call timed out after 120s".into())
+            rustykrab_core::Error::Internal(format!(
+                "synthesis model call timed out after {timeout_secs}s"
+            ))
         })??;
         Ok(response.message.content.as_text().unwrap_or("").to_string())
     }

--- a/crates/rustykrab-agent/src/orchestrator/verifier.rs
+++ b/crates/rustykrab-agent/src/orchestrator/verifier.rs
@@ -70,6 +70,7 @@ impl ConsistencyVoter {
             let context = context.map(|s| s.to_string());
             let sem = semaphore.clone();
 
+            let model_timeout = self.config.model_call_timeout_secs;
             handles.push(tokio::spawn(async move {
                 let _permit = sem.acquire().await.expect("semaphore closed");
                 let mut messages = Vec::new();
@@ -88,16 +89,15 @@ impl ConsistencyVoter {
                     created_at: Utc::now(),
                 });
 
-                let timeout_secs = 120u64;
                 let result = match tokio::time::timeout(
-                    std::time::Duration::from_secs(timeout_secs),
+                    std::time::Duration::from_secs(model_timeout),
                     provider.chat(&messages, &[]),
                 )
                 .await
                 {
                     Ok(inner) => inner,
                     Err(_) => Err(rustykrab_core::Error::Internal(format!(
-                        "voting sample timed out after {timeout_secs}s"
+                        "voting sample timed out after {model_timeout}s"
                     ))),
                 };
                 tracing::debug!(sample = i, "consistency sample completed");
@@ -180,7 +180,7 @@ impl ConsistencyVoter {
             created_at: Utc::now(),
         }];
 
-        let timeout_secs = 120u64;
+        let timeout_secs = self.config.model_call_timeout_secs;
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             self.provider.chat(&messages, &[]),

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1017,6 +1017,16 @@ fn load_orchestration_config(data_dir: &std::path::Path) -> anyhow::Result<Orche
     if let Ok(model) = std::env::var("ORCHESTRATION_PRIMARY_MODEL") {
         config.primary_model = Some(model);
     }
+    if let Ok(val) = std::env::var("ORCHESTRATION_PIPELINE_TIMEOUT_SECS") {
+        if let Ok(secs) = val.parse() {
+            config.pipeline_timeout_secs = secs;
+        }
+    }
+    if let Ok(val) = std::env::var("ORCHESTRATION_MODEL_CALL_TIMEOUT_SECS") {
+        if let Ok(secs) = val.parse() {
+            config.model_call_timeout_secs = secs;
+        }
+    }
 
     Ok(config)
 }


### PR DESCRIPTION
- Add timeout to summarize_output() which could hang indefinitely
- Use config model_call_timeout_secs in Synthesizer/ConsistencyVoter instead of hardcoded 120s
- Add deadline check at start of each moderate pipeline cycle to skip cycles that can't finish
- Add ORCHESTRATION_PIPELINE_TIMEOUT_SECS and ORCHESTRATION_MODEL_CALL_TIMEOUT_SECS env var overrides

https://claude.ai/code/session_01RwVoE2wjnJnCXTQAyjiWxB