### PR TITLE
[fix] read tool returns NotFound for missing files

### DIFF
--- a/crates/rustykrab-tools/src/read.rs
+++ b/crates/rustykrab-tools/src/read.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rustykrab_core::error::ToolError;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Result, Tool};
 use serde_json::{json, Value};
@@ -73,7 +74,13 @@ impl Tool for ReadTool {
 
         // Check file size before reading
         let metadata = tokio::fs::metadata(&safe_path).await.map_err(|e| {
-            rustykrab_core::Error::ToolExecution(format!("failed to stat {path}: {e}").into())
+            if e.kind() == std::io::ErrorKind::NotFound {
+                rustykrab_core::Error::ToolExecution(ToolError::not_found(format!(
+                    "file not found: {path}"
+                )))
+            } else {
+                rustykrab_core::Error::ToolExecution(format!("failed to stat {path}: {e}").into())
+            }
         })?;
 
         if metadata.len() > MAX_FILE_SIZE {
@@ -88,7 +95,13 @@ impl Tool for ReadTool {
         }
 
         let content = tokio::fs::read_to_string(&safe_path).await.map_err(|e| {
-            rustykrab_core::Error::ToolExecution(format!("failed to read {path}: {e}").into())
+            if e.kind() == std::io::ErrorKind::NotFound {
+                rustykrab_core::Error::ToolExecution(ToolError::not_found(format!(
+                    "file not found: {path}"
+                )))
+            } else {
+                rustykrab_core::Error::ToolExecution(format!("failed to read {path}: {e}").into())
+            }
         })?;
 
         let lines: Vec<&str> = content.lines().collect();


### PR DESCRIPTION
## Summary
- The `read` tool was returning `ToolErrorKind::Internal` for missing files instead of `ToolErrorKind::NotFound`
- The agent runner's retry logic treats `Internal` as transient and retries with exponential backoff, so a missing file would be retried up to `max_tool_retries` (default 2) times before surfacing the error — wasting ~3.5s and contributing to pipeline timeouts
- Now checks for `std::io::ErrorKind::NotFound` from both `metadata()` and `read_to_string()` calls and returns `ToolError::not_found()`, which the retry logic correctly skips

## Context
Observed at 23:39 — the agent hallucinated a filename (`drafted_explanation.md`), the read tool retried 3 times on the deterministic not-found error, and the pipeline hit the 300s timeout.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets` passes  
- [x] `cargo test --workspace` — all 78 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)