### PR TITLE
[feat] register Gmail credentials in secret registry

### DIFF
--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -58,6 +58,20 @@ pub static REGISTRY: &[SecretSpec] = &[
         required: true,
     },
     SecretSpec {
+        store_name: "gmail_email",
+        env_var: "GMAIL_EMAIL",
+        keychain_account: "gmail-email",
+        description: "Gmail email address (for IMAP/SMTP)",
+        required: false,
+    },
+    SecretSpec {
+        store_name: "gmail_app_password",
+        env_var: "GMAIL_APP_PASSWORD",
+        keychain_account: "gmail-app-password",
+        description: "Gmail app password (for IMAP/SMTP)",
+        required: false,
+    },
+    SecretSpec {
         store_name: "rustykrab_auth_token",
         env_var: "RUSTYKRAB_AUTH_TOKEN",
         keychain_account: "auth-token",


### PR DESCRIPTION
## Summary
- Adds `gmail_email` and `gmail_app_password` to the central secret registry in `rustykrab-store`
- Enables setting Gmail credentials via the existing CLI: `rustykrab-cli keychain set gmail-email you@gmail.com` and `rustykrab-cli keychain set gmail-app-password xxxx-xxxx-xxxx-xxxx`
- Credentials are resolved through the standard priority chain: env var (`GMAIL_EMAIL` / `GMAIL_APP_PASSWORD`) -> OS keychain -> encrypted SQLite store

Previously, Gmail credentials could only be stored by calling the `credential_write` tool or the `gmail(action='setup')` tool action directly — there was no way to pre-seed them from the CLI or environment.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo test --workspace` — all 78 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)