### PR TITLE
fix: install rustls ring crypto provider at startup (#347)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,13 +3308,14 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "chrono",
  "dirs",
+ "rustls",
  "rustykrab-agent",
  "rustykrab-channels",
  "rustykrab-core",
@@ -3336,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ regex = "1"
 libc = "0.2"
 
 # TLS (unified on rustls — no OpenSSL dependency)
-rustls = "0.23"
+rustls = { version = "0.23", features = ["ring"] }
 rustls-native-certs = "0.8"
 
 # Internal crates

--- a/crates/rustykrab-cli/Cargo.toml
+++ b/crates/rustykrab-cli/Cargo.toml
@@ -26,5 +26,6 @@ tracing-appender.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+rustls.workspace = true
 dirs = "6"
 toml.workspace = true

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -99,6 +99,11 @@ impl CronBackend for CronAdapter {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // --- TLS crypto provider (must be set before any rustls usage) ---
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     // --- Data directory ---
     let data_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))


### PR DESCRIPTION
The Gmail tool crashes with a panic because rustls has no crypto provider
configured. Enable the `ring` feature on the workspace rustls dependency
and call `CryptoProvider::install_default()` at the top of main() before
any TLS connections can be initiated.

Closes #347

https://claude.ai/code/session_01FJxehEqhfSd9tGDzzPrkr4