### PR TITLE
fix: surface real error when Gmail credentials are inaccessible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "1.4.7"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -34,18 +34,27 @@ impl GmailTool {
 
     /// Get email and app password from the credential store.
     fn get_credentials(&self) -> Result<(String, String)> {
-        let email = self.secrets.get(KEY_EMAIL).map_err(|_| {
+        let email = self.secrets.get(KEY_EMAIL).map_err(|e| {
             Error::ToolExecution(
-                "gmail_email not found. Store it with: \
-                 credential_write(action='set', name='gmail_email', value='you@gmail.com')"
-                    .into(),
+                format!(
+                    "gmail_email not available: {e}. Store it with: \
+                     credential_write(action='set', name='gmail_email', value='you@gmail.com'). \
+                     If you already stored it, the master encryption key may have changed \
+                     (set RUSTYKRAB_MASTER_KEY for persistence across restarts)."
+                )
+                .into(),
             )
         })?;
-        let password = self.secrets.get(KEY_APP_PASSWORD).map_err(|_| {
+        let password = self.secrets.get(KEY_APP_PASSWORD).map_err(|e| {
             Error::ToolExecution(
-                "gmail_app_password not found. Store it with: \
-                 credential_write(action='set', name='gmail_app_password', value='YOUR_APP_PASSWORD')"
-                    .into(),
+                format!(
+                    "gmail_app_password not available: {e}. Store it with: \
+                     credential_write(action='set', name='gmail_app_password', \
+                     value='YOUR_APP_PASSWORD'). If you already stored it, the master \
+                     encryption key may have changed (set RUSTYKRAB_MASTER_KEY for \
+                     persistence across restarts)."
+                )
+                .into(),
             )
         })?;
         Ok((email, password))
@@ -996,12 +1005,24 @@ impl Tool for GmailTool {
 
 /// Get credentials from SecretStore (for use in spawn_blocking closures).
 fn get_creds(secrets: &SecretStore) -> Result<(String, String)> {
-    let email = secrets.get(KEY_EMAIL).map_err(|_| {
-        Error::ToolExecution("gmail_email not configured. Run gmail(action='setup') first.".into())
-    })?;
-    let password = secrets.get(KEY_APP_PASSWORD).map_err(|_| {
+    let email = secrets.get(KEY_EMAIL).map_err(|e| {
         Error::ToolExecution(
-            "gmail_app_password not configured. Run gmail(action='setup') first.".into(),
+            format!(
+                "gmail_email not available: {e}. Run gmail(action='setup') first. \
+                 If you already stored it, the master encryption key may have changed \
+                 (set RUSTYKRAB_MASTER_KEY for persistence across restarts)."
+            )
+            .into(),
+        )
+    })?;
+    let password = secrets.get(KEY_APP_PASSWORD).map_err(|e| {
+        Error::ToolExecution(
+            format!(
+                "gmail_app_password not available: {e}. Run gmail(action='setup') first. \
+                 If you already stored it, the master encryption key may have changed \
+                 (set RUSTYKRAB_MASTER_KEY for persistence across restarts)."
+            )
+            .into(),
         )
     })?;
     Ok((email, password))


### PR DESCRIPTION
The gmail tool was swallowing the underlying error from SecretStore::get()
and replacing it with a generic "not found" message. When the actual cause
is a decryption failure (e.g., ephemeral master key changed across restarts),
the user saw a misleading "gmail_email not found" instead of the real error.

Now the error message includes the underlying cause and a hint about
RUSTYKRAB_MASTER_KEY for persistence.

https://claude.ai/code/session_01QVyYhthEhLvRrMZnbTVE4F