### PR TITLE
fix: Data Protection Keychain via provisioning profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,86 @@ jobs:
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p rustykrab-cli
 
+      - name: Import signing certificate
+        if: runner.os == 'macOS'
+        env:
+          P12_BASE64: ${{ secrets.DEVELOPER_ID_P12 }}
+          P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          KEYCHAIN=build.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 900 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$P12_BASE64" | base64 --decode > /tmp/cert.p12
+          security import /tmp/cert.p12 -k "$KEYCHAIN" -P "$P12_PASSWORD" -T /usr/bin/codesign
+          rm /tmp/cert.p12
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+
+      - name: Codesign and bundle
+        if: runner.os == 'macOS'
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE }}
+        run: |
+          BINARY=target/${{ matrix.target }}/release/${{ matrix.artifact }}
+          VERSION=${{ needs.bump.outputs.version }}
+          APP=target/${{ matrix.target }}/release/RustyKrab.app
+
+          # Detect signing identity
+          IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          TEAM_ID=$(echo "$IDENTITY" | sed -n 's/.*(\([A-Z0-9]*\)).*/\1/p')
+
+          # Create .app bundle with embedded provisioning profile
+          mkdir -p "$APP/Contents/MacOS"
+          cp "$BINARY" "$APP/Contents/MacOS/${{ matrix.artifact }}"
+
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$APP/Contents/embedded.provisionprofile"
+
+          cat > "$APP/Contents/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleIdentifier</key>
+              <string>com.gcbh.rustykrab</string>
+              <key>CFBundleExecutable</key>
+              <string>${{ matrix.artifact }}</string>
+              <key>CFBundleName</key>
+              <string>RustyKrab</string>
+              <key>CFBundleVersion</key>
+              <string>${VERSION}</string>
+              <key>LSMinimumSystemVersion</key>
+              <string>10.15</string>
+          </dict>
+          </plist>
+          PLIST
+
+          # Sign the bundle
+          codesign \
+              --sign "$IDENTITY" \
+              --options runtime \
+              --team-id "$TEAM_ID" \
+              --identifier "com.gcbh.rustykrab" \
+              --entitlements entitlements.plist \
+              -r="designated => anchor apple generic and certificate leaf[subject.OU] = \"${TEAM_ID}\"" \
+              --force \
+              "$APP"
+
+          codesign -vvv "$APP"
+
       - name: Package artifact
         run: |
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/
-          cd dist
-          tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+          if [ -d "target/${{ matrix.target }}/release/RustyKrab.app" ]; then
+            cp -R target/${{ matrix.target }}/release/RustyKrab.app dist/
+            cd dist
+            tar czf rustykrab-${{ matrix.target }}.tar.gz RustyKrab.app
+          else
+            cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/
+            cd dist
+            tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/crates/rustykrab-store/src/keychain.rs
+++ b/crates/rustykrab-store/src/keychain.rs
@@ -56,7 +56,21 @@ fn dp_get(service: &str, account: &str) -> Result<Option<Vec<u8>>, Error> {
 
     // Legacy keychain fallback.
     match get_generic_password(service, account) {
-        Ok(bytes) => Ok(Some(bytes)),
+        Ok(bytes) => {
+            // Auto-migrate: write to Data Protection Keychain so future reads
+            // skip the legacy keychain (and its per-app ACL prompts).
+            if let Err(e) = dp_set(service, account, &bytes) {
+                tracing::debug!(
+                    "auto-migrate to Data Protection Keychain failed for \
+                     {service}/{account}: {e}"
+                );
+            } else {
+                tracing::info!(
+                    "migrated {service}/{account} from legacy to Data Protection Keychain"
+                );
+            }
+            Ok(Some(bytes))
+        }
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("could not be found") || msg.contains("errSecItemNotFound") {

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>com.apple.application-identifier</key>
+    <string>3RRX845C4X.com.gcbh.rustykrab</string>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>3RRX845C4X.*</string>
+    </array>
+    <key>com.apple.developer.team-identifier</key>
+    <string>3RRX845C4X</string>
+</dict>
 </plist>

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Codesign rustykrab-cli with keychain entitlements.
+# Codesign rustykrab-cli for macOS.
 #
 # Uses the Developer ID certificate if available, otherwise falls
-# back to ad-hoc signing. The Data Protection Keychain requires a
-# real signing identity with the keychain-access-groups entitlement.
+# back to ad-hoc signing. For Developer ID, enables hardened runtime
+# and sets the team identifier (required for notarization).
 #
 # Usage:
 #   ./scripts/codesign.sh                  # sign debug build
@@ -56,13 +56,30 @@ fi
 
 echo "Signing: $BINARY"
 echo "Identity: $IDENTITY"
+
+# Build codesign flags. For Developer ID, enable hardened runtime and set
+# the team ID with an explicit designated requirement (codesign generates a
+# broken one for bare Mach-O files).
+EXTRA_FLAGS=()
+if [ "$IDENTITY" != "-" ]; then
+    EXTRA_FLAGS+=(--options runtime)
+    TEAM_ID=$(echo "$IDENTITY" | sed -n 's/.*(\([A-Z0-9]*\)).*/\1/p')
+    if [ -n "$TEAM_ID" ]; then
+        EXTRA_FLAGS+=(--team-id "$TEAM_ID")
+        EXTRA_FLAGS+=(-r="designated => anchor apple generic and certificate leaf[subject.OU] = \"${TEAM_ID}\"")
+        echo "Team ID: $TEAM_ID"
+    fi
+fi
+
 echo "Entitlements: $ENTITLEMENTS"
 
 codesign \
     --sign "$IDENTITY" \
     --entitlements "$ENTITLEMENTS" \
     --force \
+    "${EXTRA_FLAGS[@]}" \
     "$BINARY"
 
 echo "Done. Verifying..."
+codesign -vvv "$BINARY" 2>&1
 codesign --display --entitlements - "$BINARY" 2>&1 | head -20


### PR DESCRIPTION
## Summary

- **codesign.sh**: Fix broken designated requirement for bare Mach-O files by setting explicit DR with `anchor apple generic` + team ID leaf check. Add `--options runtime` and `--team-id` flags for Developer ID signing.
- **entitlements.plist**: Add `keychain-access-groups`, `com.apple.application-identifier`, and `com.apple.developer.team-identifier` entitlements (requires provisioning profile + .app bundle wrapper).
- **keychain.rs**: Auto-migrate credentials from legacy keychain to Data Protection Keychain on first read. When `dp_get` finds a key via the legacy fallback, it writes it to Data Protection so subsequent reads skip legacy entirely — eliminating per-app ACL prompts after code signature changes.

## Context

The Data Protection Keychain has no per-app ACLs, so credentials survive binary rebuilds without password prompts. Previously this path was dead code — `keychain-access-groups` is a restricted entitlement that requires a provisioning profile, and bare Mach-O files can't embed one. macOS was SIGKILL'ing the binary on launch.

The fix: wrap the binary in a minimal `.app` bundle with `embedded.provisionprofile`. `codesign.sh` needs to be updated to produce this bundle (not yet in this PR — currently done manually in the build step).

## Test plan

- [x] `codesign.sh` signs debug binary, `codesign -vvv` passes
- [x] `--version` runs without SIGKILL
- [x] `keychain status` reads all credentials from Data Protection Keychain
- [x] Full daemon runs 5s with no keychain prompts
- [x] Tested on v2.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)