### PR TITLE
fix: replace hardcoded sandbox allowlist with Tool::sandbox_requirements()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -8,7 +8,7 @@ use rustykrab_core::session::Session;
 use rustykrab_core::types::{
     Conversation, Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema,
 };
-use rustykrab_core::{Error, Result, Tool, ToolErrorKind};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool, ToolErrorKind};
 use uuid::Uuid;
 
 use crate::sandbox::{Sandbox, SandboxPolicy};
@@ -814,16 +814,18 @@ async fn execute_single_tool(
 
     tracing::info!(tool = call.name, session = %session_id, "executing tool in sandbox");
 
-    let allow_net = capabilities.has(&Capability::HttpRequest);
+    // Ask the tool what sandbox capabilities it needs.
+    let requirements = tool.sandbox_requirements();
+
     let policy = SandboxPolicy {
-        allow_net,
         allow_fs_read: capabilities.has(&Capability::FileRead),
         allow_fs_write: capabilities.has(&Capability::FileWrite),
+        allow_net: capabilities.has(&Capability::HttpRequest),
         allow_spawn: capabilities.has(&Capability::ShellExec),
         // Network tools (net_scan, net_admin, net_audit) can take several
-        // minutes to sweep a subnet. Use a 5-minute timeout when network
-        // access is enabled; keep the default 30s for everything else.
-        timeout_secs: if allow_net {
+        // minutes to sweep a subnet. Use a 5-minute timeout when the tool
+        // actually needs network access; keep the default 30s for everything else.
+        timeout_secs: if requirements.needs_net {
             300
         } else {
             SandboxPolicy::default().timeout_secs
@@ -832,12 +834,12 @@ async fn execute_single_tool(
     };
 
     // Enforce sandbox policy BEFORE tool execution.
-    // Check that the tool's required capabilities match the policy.
-    enforce_sandbox_policy(&call.name, &policy)?;
+    // Check that the tool's declared requirements are permitted by the policy.
+    enforce_sandbox_policy(&call.name, &requirements, &policy)?;
 
     // Run sandbox enforcement check (validates the sandbox layer agrees)
     sandbox
-        .execute(&call.name, call.arguments.clone(), &policy)
+        .execute(&call.name, call.arguments.clone(), &requirements, &policy)
         .await
         .map_err(|e| Error::Auth(format!("sandbox denied tool '{}': {e}", call.name)))?;
 
@@ -875,80 +877,30 @@ async fn execute_single_tool(
 
 /// Enforce sandbox policy constraints before tool execution.
 ///
-/// Maps tool names to required capabilities and rejects calls
-/// that violate the policy. Each tool is checked against ALL
-/// capabilities it requires, not just the first match.
-fn enforce_sandbox_policy(tool_name: &str, policy: &SandboxPolicy) -> Result<()> {
-    let needs_fs_read = matches!(tool_name, "read" | "pdf" | "image");
-    let needs_fs_write = matches!(
-        tool_name,
-        "write" | "edit" | "apply_patch" | "tts" | "image_generate" | "skill_create" | "canvas"
-    );
-    let needs_spawn = matches!(tool_name, "exec" | "process" | "code_execution");
-    let needs_net = matches!(
-        tool_name,
-        "http_request"
-            | "http_session"
-            | "web_fetch"
-            | "web_search"
-            | "x_search"
-            | "browser"
-            | "gmail"
-            | "image_generate"
-            | "tts"
-            | "net_scan"
-            | "net_admin"
-            | "net_audit"
-    );
-    let is_known = needs_fs_read
-        || needs_fs_write
-        || needs_spawn
-        || needs_net
-        || matches!(
-            tool_name,
-            "memory_save"
-                | "memory_search"
-                | "memory_get"
-                | "memory_delete"
-                | "credential_read"
-                | "credential_write"
-                | "message"
-                | "gateway"
-                | "nodes"
-                | "cron"
-                | "subagents"
-                | "sessions_spawn"
-                | "sessions_send"
-                | "sessions_list"
-                | "sessions_yield"
-                | "sessions_history"
-                | "session_status"
-                | "session_manager"
-                | "agents_list"
-        );
-
-    if !is_known {
-        tracing::warn!(tool = tool_name, "unknown tool denied by sandbox policy");
-        return Err(Error::Auth(format!(
-            "tool '{tool_name}' is not recognized by sandbox policy and was denied"
-        )));
-    }
-    if needs_fs_read && !policy.allow_fs_read {
+/// Checks each tool's self-declared [`SandboxRequirements`] against the
+/// session's [`SandboxPolicy`]. No hardcoded tool-name allowlist — tools
+/// declare their own needs via [`Tool::sandbox_requirements`].
+fn enforce_sandbox_policy(
+    tool_name: &str,
+    requirements: &SandboxRequirements,
+    policy: &SandboxPolicy,
+) -> Result<()> {
+    if requirements.needs_fs_read && !policy.allow_fs_read {
         return Err(Error::Auth(format!(
             "tool '{tool_name}' requires filesystem read access, which is denied by policy"
         )));
     }
-    if needs_fs_write && !policy.allow_fs_write {
+    if requirements.needs_fs_write && !policy.allow_fs_write {
         return Err(Error::Auth(format!(
             "tool '{tool_name}' requires filesystem write access, which is denied by policy"
         )));
     }
-    if needs_spawn && !policy.allow_spawn {
+    if requirements.needs_spawn && !policy.allow_spawn {
         return Err(Error::Auth(format!(
             "tool '{tool_name}' requires process spawning, which is denied by policy"
         )));
     }
-    if needs_net && !policy.allow_net {
+    if requirements.needs_net && !policy.allow_net {
         return Err(Error::Auth(format!(
             "tool '{tool_name}' requires network access, which is denied by policy"
         )));

--- a/crates/rustykrab-agent/src/sandbox.rs
+++ b/crates/rustykrab-agent/src/sandbox.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use rustykrab_core::{Error, Result};
+use rustykrab_core::{Error, Result, SandboxRequirements};
 use serde_json::Value;
 
 /// Policy that controls what a sandboxed tool execution can do.
@@ -57,55 +57,44 @@ impl SandboxPolicy {
 pub trait Sandbox: Send + Sync {
     /// Execute a tool call within the sandbox.
     ///
-    /// The sandbox receives the tool name, arguments, and a policy
-    /// controlling what the sandboxed code can do.
-    async fn execute(&self, tool_name: &str, args: Value, policy: &SandboxPolicy) -> Result<Value>;
+    /// The sandbox receives the tool name, arguments, the tool's declared
+    /// requirements, and a policy controlling what the sandboxed code can do.
+    async fn execute(
+        &self,
+        tool_name: &str,
+        args: Value,
+        requirements: &SandboxRequirements,
+        policy: &SandboxPolicy,
+    ) -> Result<Value>;
 }
 
 /// Validate that a tool's required capabilities are permitted by the policy.
 ///
 /// This is a defense-in-depth check that mirrors the runner's
 /// `enforce_sandbox_policy()`. Even if the runner check is bypassed,
-/// the sandbox itself rejects disallowed operations.
-fn validate_tool_policy(tool_name: &str, policy: &SandboxPolicy) -> Result<()> {
-    let needs_fs_read = matches!(tool_name, "read" | "pdf" | "image");
-    let needs_fs_write = matches!(
-        tool_name,
-        "write" | "edit" | "apply_patch" | "tts" | "image_generate" | "skill_create" | "canvas"
-    );
-    let needs_spawn = matches!(tool_name, "exec" | "process" | "code_execution");
-    let needs_net = matches!(
-        tool_name,
-        "http_request"
-            | "http_session"
-            | "web_fetch"
-            | "web_search"
-            | "x_search"
-            | "browser"
-            | "gmail"
-            | "image_generate"
-            | "tts"
-            | "net_scan"
-            | "net_admin"
-            | "net_audit"
-    );
-
-    if needs_fs_read && !policy.allow_fs_read {
+/// the sandbox itself rejects disallowed operations. Requirements come
+/// from [`Tool::sandbox_requirements`] — no hardcoded tool-name lists.
+fn validate_tool_policy(
+    tool_name: &str,
+    requirements: &SandboxRequirements,
+    policy: &SandboxPolicy,
+) -> Result<()> {
+    if requirements.needs_fs_read && !policy.allow_fs_read {
         return Err(Error::Auth(format!(
             "sandbox denied tool '{tool_name}': filesystem read access not permitted"
         )));
     }
-    if needs_fs_write && !policy.allow_fs_write {
+    if requirements.needs_fs_write && !policy.allow_fs_write {
         return Err(Error::Auth(format!(
             "sandbox denied tool '{tool_name}': filesystem write access not permitted"
         )));
     }
-    if needs_spawn && !policy.allow_spawn {
+    if requirements.needs_spawn && !policy.allow_spawn {
         return Err(Error::Auth(format!(
             "sandbox denied tool '{tool_name}': process spawning not permitted"
         )));
     }
-    if needs_net && !policy.allow_net {
+    if requirements.needs_net && !policy.allow_net {
         return Err(Error::Auth(format!(
             "sandbox denied tool '{tool_name}': network access not permitted"
         )));
@@ -138,12 +127,18 @@ impl Default for ProcessSandbox {
 
 #[async_trait]
 impl Sandbox for ProcessSandbox {
-    async fn execute(&self, tool_name: &str, args: Value, policy: &SandboxPolicy) -> Result<Value> {
+    async fn execute(
+        &self,
+        tool_name: &str,
+        args: Value,
+        requirements: &SandboxRequirements,
+        policy: &SandboxPolicy,
+    ) -> Result<Value> {
         use tokio::time::{timeout, Duration};
 
         // Enforce policy constraints: reject tool calls that require
         // capabilities not granted by the policy.
-        validate_tool_policy(tool_name, policy)?;
+        validate_tool_policy(tool_name, requirements, policy)?;
 
         let timeout_duration = Duration::from_secs(policy.timeout_secs);
         let tool = tool_name.to_string();
@@ -176,6 +171,7 @@ impl Sandbox for NoSandbox {
         &self,
         _tool_name: &str,
         args: Value,
+        _requirements: &SandboxRequirements,
         _policy: &SandboxPolicy,
     ) -> Result<Value> {
         Ok(args)
@@ -187,6 +183,34 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn req_spawn() -> SandboxRequirements {
+        SandboxRequirements {
+            needs_spawn: true,
+            ..Default::default()
+        }
+    }
+    fn req_fs_read() -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_read: true,
+            ..Default::default()
+        }
+    }
+    fn req_fs_write() -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..Default::default()
+        }
+    }
+    fn req_net() -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..Default::default()
+        }
+    }
+    fn req_none() -> SandboxRequirements {
+        SandboxRequirements::default()
+    }
+
     #[tokio::test]
     async fn sandbox_denies_code_execution_without_spawn() {
         let sandbox = ProcessSandbox::new();
@@ -195,7 +219,12 @@ mod tests {
             ..SandboxPolicy::default()
         };
         let result = sandbox
-            .execute("code_execution", json!({"code": "print(1)"}), &policy)
+            .execute(
+                "code_execution",
+                json!({"code": "print(1)"}),
+                &req_spawn(),
+                &policy,
+            )
             .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -211,7 +240,7 @@ mod tests {
         };
         let args = json!({"code": "print(1)"});
         let result = sandbox
-            .execute("code_execution", args.clone(), &policy)
+            .execute("code_execution", args.clone(), &req_spawn(), &policy)
             .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), args);
@@ -222,7 +251,12 @@ mod tests {
         let sandbox = ProcessSandbox::new();
         let policy = SandboxPolicy::default(); // all denied
         let result = sandbox
-            .execute("read", json!({"path": "/etc/passwd"}), &policy)
+            .execute(
+                "read",
+                json!({"path": "/etc/passwd"}),
+                &req_fs_read(),
+                &policy,
+            )
             .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -240,7 +274,12 @@ mod tests {
             ..SandboxPolicy::default()
         };
         let result = sandbox
-            .execute("write", json!({"path": "/tmp/x", "content": "y"}), &policy)
+            .execute(
+                "write",
+                json!({"path": "/tmp/x", "content": "y"}),
+                &req_fs_write(),
+                &policy,
+            )
             .await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -258,6 +297,7 @@ mod tests {
             .execute(
                 "http_request",
                 json!({"url": "http://example.com"}),
+                &req_net(),
                 &policy,
             )
             .await;
@@ -272,7 +312,7 @@ mod tests {
         let policy = SandboxPolicy::default();
         // Memory tools don't require fs/net/spawn
         let result = sandbox
-            .execute("memory_save", json!({"fact": "test"}), &policy)
+            .execute("memory_save", json!({"fact": "test"}), &req_none(), &policy)
             .await;
         assert!(result.is_ok());
     }
@@ -287,7 +327,12 @@ mod tests {
         };
         // The async block should be interrupted by the zero timeout
         let result = sandbox
-            .execute("code_execution", json!({"code": "x"}), &policy)
+            .execute(
+                "code_execution",
+                json!({"code": "x"}),
+                &req_spawn(),
+                &policy,
+            )
             .await;
         // With timeout_secs=0, this may or may not timeout depending on
         // scheduling, so we just verify it doesn't panic. A real timeout
@@ -300,13 +345,53 @@ mod tests {
         let sandbox = ProcessSandbox::new();
         let policy = SandboxPolicy::trusted();
         // Trusted allows fs_read, fs_write, net but NOT spawn
-        assert!(sandbox.execute("read", json!({}), &policy).await.is_ok());
-        assert!(sandbox.execute("write", json!({}), &policy).await.is_ok());
         assert!(sandbox
-            .execute("http_request", json!({}), &policy)
+            .execute("read", json!({}), &req_fs_read(), &policy)
+            .await
+            .is_ok());
+        assert!(sandbox
+            .execute("write", json!({}), &req_fs_write(), &policy)
+            .await
+            .is_ok());
+        assert!(sandbox
+            .execute("http_request", json!({}), &req_net(), &policy)
             .await
             .is_ok());
         // Spawn is still denied in trusted policy
-        assert!(sandbox.execute("exec", json!({}), &policy).await.is_err());
+        assert!(sandbox
+            .execute("exec", json!({}), &req_spawn(), &policy)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn sandbox_allows_new_net_tools_with_net_policy() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_net: true,
+            ..SandboxPolicy::default()
+        };
+        // Tools like obsidian/notion that declare needs_net work without
+        // being in any hardcoded allowlist.
+        assert!(sandbox
+            .execute("obsidian", json!({}), &req_net(), &policy)
+            .await
+            .is_ok());
+        assert!(sandbox
+            .execute("notion", json!({}), &req_net(), &policy)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sandbox_denies_new_net_tools_without_net_policy() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy::default(); // all denied
+        let result = sandbox
+            .execute("obsidian", json!({}), &req_net(), &policy)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("network access not permitted"), "got: {err}");
     }
 }

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -12,4 +12,4 @@ pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;
 pub use orchestration::{OrchestrationConfig, RecursiveCall, TaskComplexity, VoteResult};
 pub use session::Session;
-pub use tool::Tool;
+pub use tool::{SandboxRequirements, Tool};

--- a/crates/rustykrab-core/src/tool.rs
+++ b/crates/rustykrab-core/src/tool.rs
@@ -4,6 +4,23 @@ use serde_json::Value;
 use crate::error::Result;
 use crate::types::ToolSchema;
 
+/// Declares what sandbox capabilities a tool requires at runtime.
+///
+/// Each tool overrides [`Tool::sandbox_requirements`] to declare its needs.
+/// The sandbox enforces these requirements against the session's policy —
+/// no hardcoded tool-name allowlists required.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SandboxRequirements {
+    /// Tool reads from the filesystem.
+    pub needs_fs_read: bool,
+    /// Tool writes to the filesystem.
+    pub needs_fs_write: bool,
+    /// Tool makes network requests.
+    pub needs_net: bool,
+    /// Tool spawns child processes.
+    pub needs_spawn: bool,
+}
+
 /// Trait implemented by every tool available to the agent.
 #[async_trait]
 pub trait Tool: Send + Sync {
@@ -25,6 +42,16 @@ pub trait Tool: Send + Sync {
     /// tool that will fail due to missing configuration.
     fn available(&self) -> bool {
         true
+    }
+
+    /// Declare the sandbox capabilities this tool requires.
+    ///
+    /// The runner checks these requirements against the session's
+    /// [`SandboxPolicy`] before execution. Tools that need no special
+    /// capabilities (e.g. in-memory operations) can use the default,
+    /// which requires nothing.
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements::default()
     }
 
     /// Execute the tool with the given arguments, returning a JSON result.

--- a/crates/rustykrab-tools/src/apply_patch.rs
+++ b/crates/rustykrab-tools/src/apply_patch.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -211,6 +211,13 @@ impl Tool for ApplyPatchTool {
 
     fn description(&self) -> &str {
         "Apply a unified diff patch to one or more files."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -19,7 +19,7 @@ use base64::Engine;
 use chromiumoxide::cdp::browser_protocol::network::Cookie;
 use chromiumoxide::page::ScreenshotParams;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -127,6 +127,13 @@ impl Tool for BrowserTool {
          cookies — list cookies; \
          pdf — export page as PDF. \
          Cookies persist across calls. Use snapshot + act for reliable element interaction."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/canvas.rs
+++ b/crates/rustykrab-tools/src/canvas.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A built-in tool that creates and manipulates visual canvas content.
@@ -33,6 +33,13 @@ impl Tool for CanvasTool {
 
     fn description(&self) -> &str {
         "Create and manipulate visual canvas content: present HTML/SVG, evaluate scripts, and take snapshots."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/code_execution.rs
+++ b/crates/rustykrab-tools/src/code_execution.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::timeout;
@@ -62,6 +62,13 @@ impl Tool for CodeExecutionTool {
          sandbox with no network access and restricted filesystem writes. \
          Use this for data processing, file format conversion, calculations, \
          and any task that benefits from Python libraries."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/edit.rs
+++ b/crates/rustykrab-tools/src/edit.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -31,6 +31,13 @@ impl Tool for EditTool {
 
     fn description(&self) -> &str {
         "Replace an exact string match in a file with new content."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/exec.rs
+++ b/crates/rustykrab-tools/src/exec.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::timeout;
@@ -207,6 +207,13 @@ impl Tool for ExecTool {
 
     fn description(&self) -> &str {
         "Execute a shell command and return its output. Commands are validated against an allowlist."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_store::SecretStore;
 use serde_json::{json, Value};
 
@@ -903,6 +903,13 @@ impl Tool for GmailTool {
         "Interact with Gmail via IMAP/SMTP using an app password. Supports searching, \
          reading, sending, listing labels, moving messages, marking read/unread, and trashing. \
          Requires gmail_email and gmail_app_password credentials to be stored first."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/http_request.rs
+++ b/crates/rustykrab-tools/src/http_request.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -39,6 +39,13 @@ impl Tool for HttpRequestTool {
 
     fn description(&self) -> &str {
         "Make an HTTP request to a URL and return the response body."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/http_session.rs
+++ b/crates/rustykrab-tools/src/http_session.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
@@ -65,6 +65,13 @@ impl Tool for HttpSessionTool {
          this tool maintains cookies across requests within a named session, enabling \
          login flows and authenticated web interactions. Use different session names \
          for different services."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/image.rs
+++ b/crates/rustykrab-tools/src/image.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// Maximum image download size (50 MB).
@@ -36,6 +36,13 @@ impl Tool for ImageTool {
 
     fn description(&self) -> &str {
         "Analyze an image from a URL or file path and describe its contents."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_read: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/image_generate.rs
+++ b/crates/rustykrab-tools/src/image_generate.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A built-in tool that generates images from text prompts using a configured API.
@@ -30,6 +30,14 @@ impl Tool for ImageGenerateTool {
 
     fn description(&self) -> &str {
         "Generate an image from a text prompt using a configured image generation API."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn available(&self) -> bool {

--- a/crates/rustykrab-tools/src/net_admin.rs
+++ b/crates/rustykrab-tools/src/net_admin.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
@@ -129,6 +129,13 @@ impl Tool for NetAdminTool {
 
     fn description(&self) -> &str {
         "Remote administration for machines you own on the local network. Supports SSH command execution and Wake-on-LAN."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/net_audit.rs
+++ b/crates/rustykrab-tools/src/net_audit.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
@@ -235,6 +235,13 @@ impl Tool for NetAuditTool {
 
     fn description(&self) -> &str {
         "Security auditing for local network services. Grab banners, check TLS/SSL, and probe SSH configurations."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/net_scan.rs
+++ b/crates/rustykrab-tools/src/net_scan.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool, ToolError};
+use rustykrab_core::{Result, SandboxRequirements, Tool, ToolError};
 use serde_json::{json, Value};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
@@ -204,6 +204,13 @@ impl Tool for NetScanTool {
 
     fn description(&self) -> &str {
         "Discover devices and open ports on the local network. Restricted to private/link-local IP ranges."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/notion.rs
+++ b/crates/rustykrab-tools/src/notion.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_store::SecretStore;
 use serde_json::{json, Value};
 
@@ -653,6 +653,13 @@ impl Tool for NotionTool {
          Supports rich content: headings, callouts, toggles, tables, checklists, \
          bookmarks, quotes, dividers, images, and more. \
          Perfect for trip plans, project docs, reports, and knowledge bases."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/obsidian.rs
+++ b/crates/rustykrab-tools/src/obsidian.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_store::SecretStore;
 use serde_json::{json, Value};
 
@@ -395,6 +395,13 @@ impl Tool for ObsidianTool {
          Supports creating, reading, updating, searching, and deleting markdown notes. \
          Documents synced from Notion are automatically stored in the configured sync folder. \
          Requires the Obsidian Local REST API community plugin."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/pdf.rs
+++ b/crates/rustykrab-tools/src/pdf.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -51,6 +51,13 @@ impl Tool for PdfTool {
         "Extract text content from a PDF file. Supports locked/encrypted PDFs \
          with a password parameter. If pymupdf is not installed, it will fall \
          back to pdftotext or PyPDF2."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_read: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/process.rs
+++ b/crates/rustykrab-tools/src/process.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
@@ -99,6 +99,13 @@ impl Tool for ProcessTool {
 
     fn description(&self) -> &str {
         "Manage background processes: start, stop, or list. Only allowlisted commands can be started."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/read.rs
+++ b/crates/rustykrab-tools/src/read.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rustykrab_core::error::ToolError;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -35,6 +35,13 @@ impl Tool for ReadTool {
 
     fn description(&self) -> &str {
         "Read the contents of a file at a given path."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_read: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/skill_create.rs
+++ b/crates/rustykrab-tools/src/skill_create.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A tool that creates new SKILL.md skills on disk.
@@ -39,6 +39,13 @@ impl Tool for SkillCreateTool {
         "Create a new SKILL.md skill on disk. The skill becomes available on next restart. \
          Provide a name (lowercase a-z, 0-9, hyphens, underscores), a short description, \
          and the markdown instructions body."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/tts.rs
+++ b/crates/rustykrab-tools/src/tts.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// Maximum TTS response size (100 MB).
@@ -36,6 +36,14 @@ impl Tool for TtsTool {
 
     fn description(&self) -> &str {
         "Convert text to speech audio using a configured TTS API."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn available(&self) -> bool {

--- a/crates/rustykrab-tools/src/video.rs
+++ b/crates/rustykrab-tools/src/video.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use rustykrab_channels::video::{CompositionElement, VideoChannel, VideoProject};
@@ -238,6 +238,14 @@ impl Tool for VideoTool {
          explanations, greetings, or any visual content. Requires Node.js >= 22 \
          and FFmpeg. Templates: blank, warm-grain, play-mode, swiss-grid, \
          vignelli, decision-tree, kinetic-type, product-promo, nyt-graph."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/web_fetch.rs
+++ b/crates/rustykrab-tools/src/web_fetch.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -44,6 +44,13 @@ impl Tool for WebFetchTool {
     fn description(&self) -> &str {
         "Fetch a web page and return its content as clean, readable text with HTML stripped. \
          Use this to read articles, documentation, or any web page."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/web_search.rs
+++ b/crates/rustykrab-tools/src/web_search.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A tool that searches the web using DuckDuckGo and returns results.
@@ -38,6 +38,13 @@ impl Tool for WebSearchTool {
     fn description(&self) -> &str {
         "Search the web using DuckDuckGo and return a list of results with titles, \
          URLs, and snippets. Use this to find information, discover URLs, or research topics."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/write.rs
+++ b/crates/rustykrab-tools/src/write.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -31,6 +31,13 @@ impl Tool for WriteTool {
 
     fn description(&self) -> &str {
         "Write content to a file at a given path, creating directories as needed."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_write: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/x_search.rs
+++ b/crates/rustykrab-tools/src/x_search.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A built-in tool that searches X (Twitter) posts and returns matching results.
@@ -30,6 +30,13 @@ impl Tool for XSearchTool {
 
     fn description(&self) -> &str {
         "Search X (Twitter) posts and return matching results."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {


### PR DESCRIPTION
The sandbox policy used a hardcoded tool-name allowlist that rejected any
tool not explicitly listed (obsidian, notion, video were missing). Every
new tool required manual updates to two separate match blocks in runner.rs
and sandbox.rs.

Now each tool declares its own sandbox requirements via a new
`sandbox_requirements()` method on the Tool trait. The runner and sandbox
query the tool directly — no hardcoded lists, no "unrecognized tool"
errors when adding new tools.

https://claude.ai/code/session_017Yr6uehmP8np7EfUp79i4S