### PR TITLE
fix: require explicit EndTurn stop reason before exiting agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.0.4"
+version = "2.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use rustykrab_core::model::ModelProvider;
+use rustykrab_core::model::{ModelProvider, StopReason};
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::tool::Tool;
 use rustykrab_core::types::{Message, MessageContent, Role, ToolResult};
@@ -258,15 +258,52 @@ async fn execute_repl_call_impl(
             continue;
         }
 
-        // Text response — call is complete.
-        let answer = response.message.content.as_text().unwrap_or("").to_string();
-        tracing::info!(
+        // Explicit end-of-turn or text response — call is complete.
+        if response.stop_reason == StopReason::EndTurn {
+            let answer = response.message.content.as_text().unwrap_or("").to_string();
+            tracing::info!(
+                depth,
+                rounds_used = round + 1,
+                answer_len = answer.len(),
+                "RLM REPL: call completed"
+            );
+            return Ok(answer);
+        }
+
+        // MaxTokens — prompt to continue.
+        if response.stop_reason == StopReason::MaxTokens {
+            tracing::warn!(
+                depth,
+                round,
+                "RLM REPL: model hit max tokens, prompting to continue"
+            );
+            messages.push(response.message);
+            messages.push(Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text("Continue.".to_string()),
+                created_at: Utc::now(),
+            });
+            continue;
+        }
+
+        // Stop reason indicates tool use but no tool calls found — re-prompt.
+        tracing::warn!(
             depth,
-            rounds_used = round + 1,
-            answer_len = answer.len(),
-            "RLM REPL: call completed"
+            round,
+            stop_reason = ?response.stop_reason,
+            "RLM REPL: stop reason indicates tool use but no tool calls found, re-prompting"
         );
-        return Ok(answer);
+        messages.push(Message {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content: MessageContent::Text(
+                "Your previous response indicated a tool call but none was found. Please retry."
+                    .to_string(),
+            ),
+            created_at: Utc::now(),
+        });
+        continue;
     }
 
     tracing::error!(depth, max_rounds, "RLM REPL: exceeded max tool rounds");

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -306,8 +306,26 @@ impl AgentRunner {
                 continue;
             }
 
-            // Text response — done.
-            return Ok(());
+            // Explicit end-of-turn — done.
+            if stop_reason == StopReason::EndTurn {
+                return Ok(());
+            }
+
+            // Stop reason indicates tool use but no tool calls found in content.
+            // Re-prompt rather than silently ending the turn.
+            tracing::warn!(
+                ?stop_reason,
+                "stop reason indicates tool use but no tool calls found in response, re-prompting"
+            );
+            conv.messages.push(Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(
+                    "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
+                ),
+                created_at: Utc::now(),
+            });
+            continue;
         }
 
         // Escalate to user instead of hard-failing.
@@ -517,8 +535,27 @@ impl AgentRunner {
                 continue;
             }
 
-            on_event(AgentEvent::Done);
-            return Ok(());
+            // Explicit end-of-turn — done.
+            if stop_reason == StopReason::EndTurn {
+                on_event(AgentEvent::Done);
+                return Ok(());
+            }
+
+            // Stop reason indicates tool use but no tool calls found in content.
+            // Re-prompt rather than silently ending the turn.
+            tracing::warn!(
+                ?stop_reason,
+                "stop reason indicates tool use but no tool calls found in response, re-prompting"
+            );
+            conv.messages.push(Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(
+                    "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
+                ),
+                created_at: Utc::now(),
+            });
+            continue;
         }
 
         // Escalate to user.


### PR DESCRIPTION
Previously the agent loop exited on any stop reason that wasn't
MaxTokens when no tool calls were found in the response content.
This caused silent turn termination when the API reported
stop_reason "tool_use" but tool call parsing failed (e.g. malformed
JSON in streaming content blocks).

Now the loop only exits on an explicit StopReason::EndTurn. If the
stop reason is ToolUse but no tool calls were extracted, the agent
re-prompts the model to retry rather than silently ending. Applied
the same fix to the RLM recursive call path, which also gains
proper MaxTokens continuation handling it was missing.

https://claude.ai/code/session_014NxYSxgzMQu5H1gnUz7D4L