### PR TITLE
debug: dump raw LLM response when message text is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -308,6 +308,21 @@ impl AgentRunner {
 
             // Explicit end-of-turn — done.
             if stop_reason == StopReason::EndTurn {
+                // Debug: warn when the model ends its turn with empty text.
+                // This helps diagnose cases where completion_tokens > 0 but no
+                // usable text was extracted (e.g. unhandled content block types).
+                if !message.content.has_tool_calls() {
+                    let text = message.content.as_text().unwrap_or("");
+                    if text.is_empty() {
+                        tracing::warn!(
+                            iteration,
+                            completion_tokens = usage.completion_tokens,
+                            content_variant = ?std::mem::discriminant(&message.content),
+                            "EndTurn with empty assistant text — \
+                             response may contain unhandled content blocks"
+                        );
+                    }
+                }
                 return Ok(());
             }
 
@@ -537,6 +552,18 @@ impl AgentRunner {
 
             // Explicit end-of-turn — done.
             if stop_reason == StopReason::EndTurn {
+                if !message.content.has_tool_calls() {
+                    let text = message.content.as_text().unwrap_or("");
+                    if text.is_empty() {
+                        tracing::warn!(
+                            iteration,
+                            completion_tokens = usage.completion_tokens,
+                            content_variant = ?std::mem::discriminant(&message.content),
+                            "EndTurn with empty assistant text — \
+                             response may contain unhandled content blocks"
+                        );
+                    }
+                }
                 on_event(AgentEvent::Done);
                 return Ok(());
             }

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -150,7 +150,7 @@ impl AnthropicProvider {
     /// Parse the API response into our internal types.
     /// Supports multiple tool calls in a single response (parallel tool use).
     /// Fix #190: preserves text content alongside tool calls.
-    fn parse_response(resp: ApiResponse) -> Result<ModelResponse> {
+    fn parse_response(resp: &ApiResponse) -> Result<ModelResponse> {
         let usage = Usage {
             prompt_tokens: resp.usage.input_tokens,
             completion_tokens: resp.usage.output_tokens,
@@ -298,11 +298,38 @@ impl ModelProvider for AnthropicProvider {
 
             let status = resp.status();
             if status.is_success() {
-                let api_resp: ApiResponse = resp
-                    .json()
-                    .await
+                let raw_body = resp.text().await.map_err(|e| {
+                    Error::ModelProvider(format!("failed to read response body: {e}"))
+                })?;
+                let api_resp: ApiResponse = serde_json::from_str(&raw_body)
                     .map_err(|e| Error::ModelProvider(format!("failed to parse response: {e}")))?;
-                return Self::parse_response(api_resp);
+                let response = Self::parse_response(&api_resp)?;
+
+                // Debug: dump raw response when message text is empty
+                // despite having completion tokens (likely unknown content block types).
+                if response.usage.completion_tokens > 0
+                    && !response.message.content.has_tool_calls()
+                    && response
+                        .message
+                        .content
+                        .as_text()
+                        .is_none_or(|t| t.is_empty())
+                {
+                    tracing::warn!(
+                        completion_tokens = response.usage.completion_tokens,
+                        ?response.stop_reason,
+                        content_blocks = api_resp.content.len(),
+                        block_types = ?api_resp.content.iter().map(|b| match b {
+                            ResponseBlock::Text { .. } => "text",
+                            ResponseBlock::ToolUse { .. } => "tool_use",
+                            ResponseBlock::Unknown => "unknown",
+                        }).collect::<Vec<_>>(),
+                        "empty message text with completion tokens — dumping raw response"
+                    );
+                    tracing::warn!(raw_body = %raw_body, "raw Anthropic API response");
+                }
+
+                return Ok(response);
             }
 
             let error_body = resp.text().await.unwrap_or_default();
@@ -411,9 +438,19 @@ impl ModelProvider for AnthropicProvider {
                         }
                         "content_block_start" => {
                             if let Ok(evt) = serde_json::from_str::<SseContentBlockStart>(data) {
-                                if let SseContentBlock::ToolUse { id, name } = evt.content_block {
-                                    tool_meta.insert(evt.index, (id, name));
-                                    tool_input_bufs.insert(evt.index, String::new());
+                                match evt.content_block {
+                                    SseContentBlock::ToolUse { id, name } => {
+                                        tool_meta.insert(evt.index, (id, name));
+                                        tool_input_bufs.insert(evt.index, String::new());
+                                    }
+                                    SseContentBlock::Text { .. } => {}
+                                    SseContentBlock::Unknown => {
+                                        tracing::warn!(
+                                            index = evt.index,
+                                            raw_data = %data,
+                                            "streaming: unhandled content block type"
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -429,7 +466,13 @@ impl ModelProvider for AnthropicProvider {
                                             buf.push_str(&partial_json);
                                         }
                                     }
-                                    SseDelta::Unknown => {}
+                                    SseDelta::Unknown => {
+                                        tracing::debug!(
+                                            index = evt.index,
+                                            raw_data = %data,
+                                            "streaming: unhandled delta type"
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -505,6 +548,24 @@ impl ModelProvider for AnthropicProvider {
             text: text_field,
         };
 
+        // Debug: dump response info when message text is empty
+        // despite having completion tokens (likely unknown content block types).
+        if response.usage.completion_tokens > 0
+            && !response.message.content.has_tool_calls()
+            && response
+                .message
+                .content
+                .as_text()
+                .is_none_or(|t| t.is_empty())
+        {
+            tracing::warn!(
+                completion_tokens = response.usage.completion_tokens,
+                ?response.stop_reason,
+                "streaming: empty message text with completion tokens — \
+                 response may contain unhandled content block types"
+            );
+        }
+
         on_event(StreamEvent::Done(response.clone()));
         Ok(response)
     }
@@ -565,7 +626,7 @@ struct ApiResponse {
 }
 
 /// Fix #206: added Unknown catch-all so new block types don't crash deserialization.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 enum ResponseBlock {
     #[serde(rename = "text")]

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -107,6 +107,30 @@ impl OllamaProvider {
         &self.model
     }
 
+    /// Strip `<think>…</think>` blocks from assistant content so that
+    /// model thinking is not re-submitted in conversation history.
+    /// Gemma 4 and other thinking models embed reasoning inside these tags;
+    /// re-sending them degrades output quality (see model card best practices).
+    fn strip_thinking(text: &str) -> String {
+        let mut result = String::with_capacity(text.len());
+        let mut rest = text;
+        while let Some(start) = rest.find("<think>") {
+            result.push_str(&rest[..start]);
+            match rest[start..].find("</think>") {
+                Some(end) => {
+                    rest = &rest[start + end + "</think>".len()..];
+                }
+                None => {
+                    // Unclosed <think> tag — drop everything from here.
+                    rest = "";
+                    break;
+                }
+            }
+        }
+        result.push_str(rest);
+        result
+    }
+
     /// Fix #195: returns Result to propagate serialization errors.
     fn build_messages(messages: &[Message]) -> Result<Vec<OllamaMessage>> {
         messages
@@ -120,11 +144,26 @@ impl OllamaProvider {
                 };
 
                 Ok(match &msg.content {
-                    MessageContent::Text(text) => OllamaMessage {
-                        role: role.to_string(),
-                        content: Some(text.clone()),
-                        tool_calls: None,
-                    },
+                    MessageContent::Text(text) => {
+                        // Strip <think> blocks from assistant messages so
+                        // model thinking is not re-submitted in history.
+                        let content = if msg.role == Role::Assistant && text.contains("<think>") {
+                            let stripped = Self::strip_thinking(text);
+                            tracing::debug!(
+                                original_len = text.len(),
+                                stripped_len = stripped.len(),
+                                "stripped thinking blocks from assistant message"
+                            );
+                            stripped
+                        } else {
+                            text.clone()
+                        };
+                        OllamaMessage {
+                            role: role.to_string(),
+                            content: Some(content),
+                            tool_calls: None,
+                        }
+                    }
                     MessageContent::ToolCall(call) => OllamaMessage {
                         role: role.to_string(),
                         content: None,
@@ -328,10 +367,33 @@ impl ModelProvider for OllamaProvider {
 
             let status = resp.status();
             if status.is_success() {
-                let ollama_resp: OllamaResponse = resp.json().await.map_err(|e| {
+                let raw_body = resp.text().await.map_err(|e| {
+                    Error::ModelProvider(format!("failed to read Ollama response body: {e}"))
+                })?;
+                let ollama_resp: OllamaResponse = serde_json::from_str(&raw_body).map_err(|e| {
                     Error::ModelProvider(format!("failed to parse Ollama response: {e}"))
                 })?;
-                return Self::parse_response(ollama_resp);
+                let response = Self::parse_response(ollama_resp)?;
+
+                // Debug: dump raw response when message text is empty
+                // despite having completion tokens.
+                if response.usage.completion_tokens > 0
+                    && !response.message.content.has_tool_calls()
+                    && response
+                        .message
+                        .content
+                        .as_text()
+                        .is_none_or(|t| t.is_empty())
+                {
+                    tracing::warn!(
+                        completion_tokens = response.usage.completion_tokens,
+                        ?response.stop_reason,
+                        "empty message text with completion tokens — dumping raw response"
+                    );
+                    tracing::warn!(raw_body = %raw_body, "raw Ollama API response");
+                }
+
+                return Ok(response);
             }
 
             let error_body = resp.text().await.unwrap_or_default();
@@ -491,6 +553,23 @@ impl ModelProvider for OllamaProvider {
             stop_reason,
             text: None,
         };
+
+        // Debug: dump response info when message text is empty
+        // despite having completion tokens.
+        if response.usage.completion_tokens > 0
+            && !response.message.content.has_tool_calls()
+            && response
+                .message
+                .content
+                .as_text()
+                .is_none_or(|t| t.is_empty())
+        {
+            tracing::warn!(
+                completion_tokens = response.usage.completion_tokens,
+                ?response.stop_reason,
+                "streaming: empty message text with completion tokens"
+            );
+        }
 
         on_event(StreamEvent::Done(response.clone()));
         Ok(response)


### PR DESCRIPTION
When the model returns completion tokens but the extracted text is empty
(likely due to unhandled content block types like thinking blocks), log
the raw API response body at WARN level so we can diagnose the issue.

Changes:
- Anthropic provider: capture raw response body and dump it when text is
  empty; log unhandled content block types in both streaming and
  non-streaming paths; add Debug derive to ResponseBlock
- Ollama provider: same raw body dump on empty text; strip <think> blocks
  from assistant messages before re-submitting to avoid degraded output
  (per Gemma 4 model card best practices)
- Agent runner: warn at EndTurn when assistant text is empty despite
  having completion tokens (both streaming and non-streaming paths)

https://claude.ai/code/session_01GuM7Jowe1AQcttVJPZFXmD