### PR TITLE
fix: add missing sandbox requirements for net_discovery and nodes tools

### DIFF
--- a/crates/rustykrab-tools/src/net_discovery.rs
+++ b/crates/rustykrab-tools/src/net_discovery.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool, ToolError};
+use rustykrab_core::{Result, SandboxRequirements, Tool, ToolError};
 use serde_json::{json, Value};
 use std::net::IpAddr;
 use std::time::Duration;
@@ -462,6 +462,14 @@ impl Tool for NetDiscoveryTool {
     fn description(&self) -> &str {
         "Discover hosts, services, and network topology. DNS lookups, mDNS/DNS-SD service \
          discovery, ARP table, traceroute, and interface listing."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_fs_read: true,
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
 
 /// A built-in tool that discovers and interacts with paired RustyKrab nodes.
@@ -33,6 +33,13 @@ impl Tool for NodesTool {
 
     fn description(&self) -> &str {
         "Discover and interact with paired RustyKrab nodes on the network."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
     }
 
     fn schema(&self) -> ToolSchema {


### PR DESCRIPTION
The v2.1.0 fix replaced the hardcoded sandbox tool allowlist with
Tool::sandbox_requirements(), but net_discovery (added in v2.2.0) and
nodes never declared their actual requirements. This meant both tools
bypassed sandbox policy enforcement — net_discovery could spawn
processes and read /proc without needing ShellExec/FileRead capabilities,
and nodes could make HTTP requests without HttpRequest capability.

https://claude.ai/code/session_01XhA3pHu5inBPCsmxkCPMkj