### PR TITLE
debug: add raw JSON logging for Telegram updates to diagnose chat ID issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -288,7 +288,24 @@ impl TelegramChannel {
                 continue;
             }
 
-            let body: GetUpdatesResponse = match resp.json().await {
+            let raw_text = match resp.text().await {
+                Ok(t) => t,
+                Err(e) => {
+                    consecutive_errors += 1;
+                    let delay = backoff_delay(consecutive_errors);
+                    tracing::error!(
+                        consecutive_errors,
+                        delay_secs = delay.as_secs(),
+                        "failed to read Telegram response body: {e}"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+            };
+
+            tracing::debug!(raw_json = %raw_text, "raw getUpdates response");
+
+            let body: GetUpdatesResponse = match serde_json::from_str(&raw_text) {
                 Ok(b) => b,
                 Err(e) => {
                     consecutive_errors += 1;
@@ -336,6 +353,11 @@ impl TelegramChannel {
         if !constant_time_eq(header, secret) {
             return Err(Error::Auth("invalid Telegram webhook secret".into()));
         }
+
+        tracing::debug!(
+            raw_json = %String::from_utf8_lossy(payload),
+            "raw Telegram webhook payload"
+        );
 
         let update: Update = serde_json::from_slice(payload)?;
         self.handle_update(update).await
@@ -387,6 +409,16 @@ impl TelegramChannel {
 
         let chat_id = msg.chat.id;
         let thread_id = msg.message_thread_id.unwrap_or(0);
+
+        tracing::debug!(
+            update_id = update.update_id,
+            chat_id,
+            chat_type = %msg.chat.chat_type,
+            chat_title = ?msg.chat.title,
+            thread_id,
+            user_id = msg.from.as_ref().map(|u| u.id),
+            "parsed Telegram update IDs"
+        );
 
         // Chat allowlist check.
         if !self.allowed_chats.is_empty() && !self.allowed_chats.contains(&chat_id) {


### PR DESCRIPTION
Log the raw JSON from Telegram at debug level in both the polling and
webhook paths, plus the parsed chat/user IDs after deserialization.
This lets us compare what Telegram actually sends vs what we parse,
to determine if IDs like -5106186076 arrive that way or if a -100
prefix is being dropped somewhere.

https://claude.ai/code/session_01AjAzZrFVQu2q5Lo5WPrWsJ