### PR TITLE
Fix Telegram chat ID visibility and bare @mention handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.1"
+version = "2.2.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -288,7 +288,24 @@ impl TelegramChannel {
                 continue;
             }
 
-            let body: GetUpdatesResponse = match resp.json().await {
+            let raw_text = match resp.text().await {
+                Ok(t) => t,
+                Err(e) => {
+                    consecutive_errors += 1;
+                    let delay = backoff_delay(consecutive_errors);
+                    tracing::error!(
+                        consecutive_errors,
+                        delay_secs = delay.as_secs(),
+                        "failed to read Telegram response body: {e}"
+                    );
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+            };
+
+            tracing::debug!(raw_json = %raw_text, "raw getUpdates response");
+
+            let body: GetUpdatesResponse = match serde_json::from_str(&raw_text) {
                 Ok(b) => b,
                 Err(e) => {
                     consecutive_errors += 1;
@@ -336,6 +353,11 @@ impl TelegramChannel {
         if !constant_time_eq(header, secret) {
             return Err(Error::Auth("invalid Telegram webhook secret".into()));
         }
+
+        tracing::debug!(
+            raw_json = %String::from_utf8_lossy(payload),
+            "raw Telegram webhook payload"
+        );
 
         let update: Update = serde_json::from_slice(payload)?;
         self.handle_update(update).await
@@ -387,6 +409,16 @@ impl TelegramChannel {
 
         let chat_id = msg.chat.id;
         let thread_id = msg.message_thread_id.unwrap_or(0);
+
+        tracing::debug!(
+            update_id = update.update_id,
+            chat_id,
+            chat_type = %msg.chat.chat_type,
+            chat_title = ?msg.chat.title,
+            thread_id,
+            user_id = msg.from.as_ref().map(|u| u.id),
+            "parsed Telegram update IDs"
+        );
 
         // Chat allowlist check.
         if !self.allowed_chats.is_empty() && !self.allowed_chats.contains(&chat_id) {

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -433,9 +433,42 @@ impl TelegramChannel {
             return Ok(());
         }
 
-        let text = match msg.text {
+        // Extract text from the message. Telegram sends bare @mentions with
+        // text: null and the mention in the entities array. Fall back to
+        // caption for media messages.
+        let has_mention = msg
+            .entities
+            .iter()
+            .any(|e| e.entity_type == "mention" || e.entity_type == "text_mention");
+        let text = match msg.text.or(msg.caption) {
             Some(t) => t,
-            None => return Ok(()), // Ignore non-text messages for now.
+            None if has_mention => {
+                // Bare @mention with no other text — acknowledge and return.
+                tracing::info!(
+                    chat_id,
+                    thread_id,
+                    entities_count = msg.entities.len(),
+                    "received bare @mention with no text body"
+                );
+                let _ = self
+                    .send_text(
+                        chat_id,
+                        "Hi! You mentioned me — send a message and I'll help.",
+                        thread_id,
+                    )
+                    .await;
+                return Ok(());
+            }
+            None => {
+                tracing::debug!(
+                    chat_id,
+                    thread_id,
+                    entities_count = msg.entities.len(),
+                    caption_entities_count = msg.caption_entities.len(),
+                    "ignoring non-text message (no text or caption)"
+                );
+                return Ok(());
+            }
         };
 
         // Handle bot commands before forwarding to the agent.
@@ -627,6 +660,15 @@ pub struct TelegramMessage {
     pub chat: Chat,
     pub from: Option<User>,
     pub text: Option<String>,
+    /// Caption for media messages (photos, documents, etc.).
+    #[serde(default)]
+    pub caption: Option<String>,
+    /// Entities in the text (mentions, commands, URLs, etc.).
+    #[serde(default)]
+    pub entities: Vec<MessageEntity>,
+    /// Entities in the caption.
+    #[serde(default)]
+    pub caption_entities: Vec<MessageEntity>,
     pub date: i64,
     /// Forum topic thread ID. Present when the message belongs to a forum topic.
     #[serde(default)]
@@ -634,6 +676,14 @@ pub struct TelegramMessage {
     /// Whether this message was sent inside a forum topic.
     #[serde(default)]
     pub is_topic_message: Option<bool>,
+}
+
+#[derive(Deserialize)]
+pub struct MessageEntity {
+    #[serde(rename = "type")]
+    pub entity_type: String,
+    pub offset: i64,
+    pub length: i64,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

- **Agent can now see Telegram chat IDs**: `Conversation.channel_source` and `channel_id` fields existed but were never populated. Now when the Telegram loop creates a new conversation it sets `channel_source="telegram"` and `channel_id=<chat_id>`. The orchestrator appends this as a "Channel context" section in the system prompt so the agent knows which chat it's operating in.
- **Raw JSON logging**: Added `debug!`-level logging of the raw Telegram JSON in both the polling and webhook paths, plus parsed IDs after deserialization. Lets us compare what Telegram actually sends vs what we parse to diagnose ID format issues (e.g. `-5106186076` vs `-1005106186076`).
- **Bare @mention fix**: Telegram delivers a bare `@BotName` mention with `text: null` and the mention in an `entities` array. Previously this silently returned with no log and no response. Now we detect bare mentions, reply with an acknowledgement, and log ignored non-text messages at debug level.
- **Caption fallback**: Messages with no `text` but a `caption` (e.g. photo with caption) now use the caption as the message body instead of being silently dropped.

## Test plan

- [x] `cargo check -p rustykrab-channels -p rustykrab-gateway` compiles clean
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p rustykrab-channels -p rustykrab-gateway` — all tests pass
- [ ] Deploy and set `RUST_LOG=rustykrab_channels=debug` to verify raw JSON appears in logs
- [ ] Send a message from the problematic group and compare raw `chat.id` in JSON vs parsed value
- [ ] Send a bare `@RustyCraBot` mention and verify the bot responds
- [ ] Verify new conversations show "Channel context" in the system prompt with correct chat ID
- [ ] Reset a conversation and confirm the new one also gets channel metadata stamped

https://claude.ai/code/session_01AjAzZrFVQu2q5Lo5WPrWsJ