### PR TITLE
Fix agent visibility of Telegram chat IDs

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -694,7 +694,15 @@ async fn telegram_agent_loop(
                                 id
                             }
                             None => match state.store.conversations().create() {
-                                Ok(conv) => {
+                                Ok(mut conv) => {
+                                    conv.channel_source = Some("telegram".to_string());
+                                    conv.channel_id = Some(chat_id.to_string());
+                                    if let Err(e) = state.store.conversations().save(&conv) {
+                                        tracing::warn!(
+                                            chat_id,
+                                            "failed to persist channel metadata: {e}"
+                                        );
+                                    }
                                     let id = conv.id;
                                     states.insert(
                                         key,

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -36,7 +36,16 @@ async fn build_and_inject_system_prompt(
         builder = builder.with_available_skills(&refs);
     }
 
-    let system_prompt = builder.build();
+    let mut system_prompt = builder.build();
+
+    // Append channel context so the agent knows where this conversation lives.
+    if let Some(ref source) = conv.channel_source {
+        system_prompt.push_str("\n\n## Channel context\n");
+        system_prompt.push_str(&format!("- Source: {source}\n"));
+        if let Some(ref cid) = conv.channel_id {
+            system_prompt.push_str(&format!("- Chat ID: {cid}\n"));
+        }
+    }
 
     // 3. Inject system prompt as first message.
     if conv


### PR DESCRIPTION
## Summary

- `Conversation.channel_source` and `channel_id` fields existed but were never populated — the agent had no way to know which Telegram chat it was operating in
- Now when the Telegram loop creates a new conversation it stamps `channel_source="telegram"` and `channel_id=<chat_id>` on the conversation
- The orchestrator appends a `## Channel context` section to the system prompt with the source and chat ID so the agent can reference it

## Test plan

- [x] `cargo check -p rustykrab-gateway` compiles clean
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo test -p rustykrab-channels -p rustykrab-gateway` — all tests pass
- [ ] Reset a Telegram conversation and verify the new one shows "Channel context" in the system prompt with the correct chat ID
- [ ] Confirm existing (pre-patch) conversations still work without channel metadata

https://claude.ai/code/session_01AjAzZrFVQu2q5Lo5WPrWsJ