### PR TITLE
Expose Telegram chat ID and thread ID to the agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.5"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.3"
+version = "2.2.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -697,6 +697,9 @@ async fn telegram_agent_loop(
                                 Ok(mut conv) => {
                                     conv.channel_source = Some("telegram".to_string());
                                     conv.channel_id = Some(chat_id.to_string());
+                                    if thread_id != 0 {
+                                        conv.channel_thread_id = Some(thread_id.to_string());
+                                    }
                                     if let Err(e) = state.store.conversations().save(&conv) {
                                         tracing::warn!(
                                             chat_id,
@@ -803,6 +806,19 @@ async fn process_telegram_message(
             return "Internal error — please try again.".to_string();
         }
     };
+
+    // Ensure channel metadata is present (backfills conversations created
+    // before this field was populated).
+    if conv.channel_source.is_none() {
+        conv.channel_source = Some("telegram".to_string());
+        conv.channel_id = Some(chat_id.to_string());
+        if thread_id != 0 {
+            conv.channel_thread_id = Some(thread_id.to_string());
+        }
+    }
+    if conv.channel_thread_id.is_none() && thread_id != 0 {
+        conv.channel_thread_id = Some(thread_id.to_string());
+    }
 
     // Append user message.
     conv.messages.push(message);

--- a/crates/rustykrab-core/src/types.rs
+++ b/crates/rustykrab-core/src/types.rs
@@ -162,6 +162,9 @@ pub struct Conversation {
     /// Channel-specific identifier (e.g. Telegram chat_id as string).
     #[serde(default)]
     pub channel_id: Option<String>,
+    /// Channel-specific thread/topic identifier (e.g. Telegram forum thread_id).
+    #[serde(default)]
+    pub channel_thread_id: Option<String>,
 }
 
 /// JSON-Schema-style description of a tool parameter.

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -45,6 +45,9 @@ async fn build_and_inject_system_prompt(
         if let Some(ref cid) = conv.channel_id {
             system_prompt.push_str(&format!("- Chat ID: {cid}\n"));
         }
+        if let Some(ref tid) = conv.channel_thread_id {
+            system_prompt.push_str(&format!("- Thread ID: {tid}\n"));
+        }
     }
 
     // 3. Inject system prompt as first message.

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -48,6 +48,14 @@ async fn build_and_inject_system_prompt(
         if let Some(ref tid) = conv.channel_thread_id {
             system_prompt.push_str(&format!("- Thread ID: {tid}\n"));
         }
+        tracing::debug!(
+            channel_source = source.as_str(),
+            channel_id = ?conv.channel_id,
+            channel_thread_id = ?conv.channel_thread_id,
+            "injected channel context into system prompt"
+        );
+    } else {
+        tracing::debug!("no channel_source on conversation — skipping channel context");
     }
 
     // 3. Inject system prompt as first message.

--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -29,6 +29,7 @@ impl ConversationStore {
             detected_profile: None,
             channel_source: None,
             channel_id: None,
+            channel_thread_id: None,
         };
         self.save(&conv)?;
         Ok(conv)


### PR DESCRIPTION
## Summary

- Add `channel_thread_id` field to `Conversation` for Telegram forum topic IDs
- Stamp `channel_source`, `channel_id`, and `channel_thread_id` when creating new Telegram conversations
- Backfill all three fields on every conversation load in `process_telegram_message()` so existing/pre-patch conversations also get the metadata
- Surface all channel context (source, chat ID, thread ID) in the system prompt so the agent can see it

## Test plan

- [x] `cargo check -p rustykrab-gateway -p rustykrab-channels` compiles clean
- [x] `cargo fmt --all -- --check` passes
- [ ] Send a message in an existing Telegram chat — verify the agent's system prompt now contains `## Channel context` with the correct chat ID
- [ ] Send a message in a forum topic — verify thread ID appears in channel context
- [ ] Create a new conversation (/start) — verify metadata is stamped from the start

https://claude.ai/code/session_01AjAzZrFVQu2q5Lo5WPrWsJ