### PR TITLE
feat: add network device discovery mechanisms (Part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/net_discovery.rs
+++ b/crates/rustykrab-tools/src/net_discovery.rs
@@ -493,18 +493,78 @@ async fn interfaces(timeout_ms: u64) -> Value {
 // Active ARP scan
 // ---------------------------------------------------------------------------
 
+/// Detect the default network interface by parsing `ip route show default`.
+///
+/// Returns the device name from the first default route (e.g. "enp0s3",
+/// "wlan0", "eth0").  Returns `None` if no default route exists or the
+/// `ip` command is unavailable.
+async fn detect_default_interface() -> Option<String> {
+    let path = system_path();
+    let output = tokio::process::Command::new("ip")
+        .args(["route", "show", "default"])
+        .env("PATH", &path)
+        .output()
+        .await
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Typical line: "default via 192.168.1.1 dev enp0s3 proto dhcp metric 100"
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let Some(idx) = parts.iter().position(|&p| p == "dev") {
+            if let Some(iface) = parts.get(idx + 1) {
+                return Some((*iface).to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Validate that an interface name is safe to pass as a CLI argument.
+///
+/// Only allows alphanumeric characters, hyphens, underscores, and dots —
+/// typical Linux interface naming (e.g. "eth0", "enp0s3", "wlan0", "br-lan").
+fn validate_interface_name(name: &str) -> std::result::Result<(), ToolError> {
+    if name.is_empty() {
+        return Err(ToolError::invalid_input("interface name must not be empty"));
+    }
+    if name.starts_with('-') {
+        return Err(ToolError::invalid_input(
+            "interface name must not start with '-'",
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        return Err(ToolError::invalid_input(
+            "interface name contains disallowed characters",
+        ));
+    }
+    Ok(())
+}
+
 /// Actively scan a subnet for all devices using ARP requests.
 ///
-/// Tries `arp-scan` first (most reliable, returns vendor info).  Falls back to
-/// `nmap -sn` (ping scan + ARP on local segment).
-async fn arp_scan(subnet: &str, timeout_ms: u64) -> Value {
+/// When `interface` is `None`, auto-detects the default interface via
+/// `ip route`.  Tries `arp-scan` first (most reliable, returns vendor
+/// info).  Falls back to `nmap -sn` (ping scan + ARP on local segment).
+async fn arp_scan(subnet: &str, interface: Option<&str>, timeout_ms: u64) -> Value {
     let path = system_path();
 
-    // Try arp-scan first: `arp-scan --localnet` or `arp-scan <cidr>`
+    // Resolve the interface to use.
+    let iface = match interface {
+        Some(i) => i.to_string(),
+        None => detect_default_interface()
+            .await
+            .unwrap_or_else(|| "eth0".to_string()),
+    };
+    let iface_arg = format!("--interface={iface}");
+
+    // Try arp-scan first.
     let arp_scan_result = timeout(
         Duration::from_millis(timeout_ms),
         tokio::process::Command::new("arp-scan")
-            .args(["--interface=eth0", "--retry=1", "--timeout=500", subnet])
+            .args([&iface_arg, "--retry=1", "--timeout=500", subnet])
             .env("PATH", &path)
             .output(),
     )
@@ -534,6 +594,7 @@ async fn arp_scan(subnet: &str, timeout_ms: u64) -> Value {
             return json!({
                 "success": true,
                 "subnet": subnet,
+                "interface": iface,
                 "source": "arp-scan",
                 "entries": entries,
                 "count": entries.len(),
@@ -541,11 +602,11 @@ async fn arp_scan(subnet: &str, timeout_ms: u64) -> Value {
         }
     }
 
-    // Fallback: nmap -sn (ping/ARP scan)
+    // Fallback: nmap -sn (ping/ARP scan), with -e <interface>.
     let nmap_result = timeout(
         Duration::from_millis(timeout_ms),
         tokio::process::Command::new("nmap")
-            .args(["-sn", "-n", subnet])
+            .args(["-sn", "-n", "-e", &iface, subnet])
             .env("PATH", &path)
             .output(),
     )
@@ -602,6 +663,7 @@ async fn arp_scan(subnet: &str, timeout_ms: u64) -> Value {
             json!({
                 "success": true,
                 "subnet": subnet,
+                "interface": iface,
                 "source": "nmap",
                 "entries": entries,
                 "count": entries.len(),
@@ -1253,6 +1315,10 @@ impl Tool for NetDiscoveryTool {
                         "type": "string",
                         "description": "CIDR subnet for arp_scan (e.g. '192.168.1.0/24')"
                     },
+                    "interface": {
+                        "type": "string",
+                        "description": "Network interface for arp_scan (e.g. 'eth0', 'enp0s3', 'wlan0'). Auto-detected from the default route if omitted."
+                    },
                     "mac": {
                         "type": "string",
                         "description": "MAC address for oui_lookup (e.g. 'AA:BB:CC:DD:EE:FF')"
@@ -1364,7 +1430,12 @@ impl Tool for NetDiscoveryTool {
                 // Full CIDR validation: well-formed, local network, sane prefix.
                 validate_scan_cidr(subnet).map_err(rustykrab_core::Error::ToolExecution)?;
 
-                let result = arp_scan(subnet, timeout_ms).await;
+                let interface = args["interface"].as_str();
+                if let Some(iface) = interface {
+                    validate_interface_name(iface).map_err(rustykrab_core::Error::ToolExecution)?;
+                }
+
+                let result = arp_scan(subnet, interface, timeout_ms).await;
                 Ok(json!({
                     "action": "arp_scan",
                     "result": result,

--- a/crates/rustykrab-tools/src/net_discovery.rs
+++ b/crates/rustykrab-tools/src/net_discovery.rs
@@ -3,7 +3,8 @@ use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Result, SandboxRequirements, Tool, ToolError};
 use serde_json::{json, Value};
 use std::net::IpAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
 use tokio::time::timeout;
 
 /// Network discovery tool for identifying hosts, services, and topology on the
@@ -16,17 +17,27 @@ use tokio::time::timeout;
 ///   types (A, AAAA, MX, TXT, SRV, NS, CNAME, PTR).
 /// - **mdns_discover**: Zero-configuration service discovery via mDNS/DNS-SD.
 ///   Finds printers, IoT devices, media servers, and other services that
-///   advertise themselves on the local network segment.
+///   advertise themselves on the local network segment.  Supports IoT service
+///   type presets for common smart-home protocols.
 /// - **arp_table**: Reads the system ARP cache to list MAC/IP mappings of
 ///   recently-seen devices — fast, passive, and doesn't generate traffic.
+/// - **arp_scan**: Actively scans a subnet to discover all IP-connected devices
+///   (including those with static IPs) via ARP requests.
+/// - **dhcp_leases**: Queries a router's DHCP lease table over SSH to discover
+///   all DHCP-assigned devices with hostnames, IPs, and MAC addresses.
+/// - **ssdp_discover**: Discovers UPnP devices on the local network via SSDP
+///   M-SEARCH multicast (Hue bridges, smart TVs, NAS, media servers).
+/// - **oui_lookup**: Looks up the manufacturer/vendor for a MAC address using
+///   the IEEE OUI database.
 /// - **traceroute**: Maps the network path (hops) to a target host.  Restricted
 ///   to private/link-local targets.
 /// - **interfaces**: Lists the host's own network interfaces with IP addresses,
 ///   subnet masks, MAC addresses, and link state.
 ///
-/// All probing actions that reach out to a target (traceroute) are restricted to
-/// RFC-1918 / link-local addresses.  Passive reads (arp_table, interfaces) and
-/// DNS lookups (which query name servers, not targets) have no such restriction.
+/// All probing actions that reach out to a target (traceroute, arp_scan) are
+/// restricted to RFC-1918 / link-local addresses.  Passive reads (arp_table,
+/// interfaces) and DNS lookups (which query name servers, not targets) have no
+/// such restriction.
 pub struct NetDiscoveryTool;
 
 impl NetDiscoveryTool {
@@ -133,6 +144,35 @@ async fn dns_lookup(name: &str, record_type: &str, timeout_ms: u64) -> Value {
             "success": false,
             "error": "DNS lookup timed out",
         }),
+    }
+}
+
+/// Resolve an mDNS preset name to a list of well-known service types.
+fn mdns_preset_service_types(preset: &str) -> std::result::Result<Vec<&'static str>, String> {
+    match preset {
+        "homekit" => Ok(vec!["_hap._tcp"]),
+        "chromecast" => Ok(vec!["_googlecast._tcp"]),
+        "sonos" => Ok(vec!["_sonos._tcp"]),
+        "airplay" => Ok(vec!["_airplay._tcp", "_raop._tcp"]),
+        "printers" => Ok(vec!["_ipp._tcp", "_printer._tcp", "_pdl-datastream._tcp"]),
+        "iot" => Ok(vec![
+            "_hap._tcp",          // HomeKit
+            "_googlecast._tcp",   // Chromecast / Google Home / Nest Hub
+            "_sonos._tcp",        // Sonos
+            "_airplay._tcp",      // AirPlay 2
+            "_raop._tcp",         // AirPlay (Remote Audio Output)
+            "_http._tcp",         // Generic HTTP (many IoT web UIs)
+            "_mqtt._tcp",         // MQTT brokers
+            "_esphomelib._tcp",   // ESPHome devices
+            "_miio._udp",         // Xiaomi IoT
+            "_printer._tcp",      // Network printers
+            "_ipp._tcp",          // IPP printers
+            "_smb._tcp",          // SMB file shares
+            "_ssh._tcp",          // SSH servers
+        ]),
+        other => Err(format!(
+            "unknown mDNS preset '{other}'. Available: homekit, chromecast, sonos, airplay, printers, iot"
+        )),
     }
 }
 
@@ -450,6 +490,591 @@ async fn interfaces(timeout_ms: u64) -> Value {
 }
 
 // ---------------------------------------------------------------------------
+// Active ARP scan
+// ---------------------------------------------------------------------------
+
+/// Actively scan a subnet for all devices using ARP requests.
+///
+/// Tries `arp-scan` first (most reliable, returns vendor info).  Falls back to
+/// `nmap -sn` (ping scan + ARP on local segment).
+async fn arp_scan(subnet: &str, timeout_ms: u64) -> Value {
+    let path = system_path();
+
+    // Try arp-scan first: `arp-scan --localnet` or `arp-scan <cidr>`
+    let arp_scan_result = timeout(
+        Duration::from_millis(timeout_ms),
+        tokio::process::Command::new("arp-scan")
+            .args(["--interface=eth0", "--retry=1", "--timeout=500", subnet])
+            .env("PATH", &path)
+            .output(),
+    )
+    .await;
+
+    if let Ok(Ok(output)) = arp_scan_result {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let mut entries = Vec::new();
+
+            for line in stdout.lines() {
+                let parts: Vec<&str> = line.split('\t').collect();
+                if parts.len() >= 3 {
+                    // arp-scan output: IP\tMAC\tVendor
+                    let ip_str = parts[0].trim();
+                    // Only include lines that start with a valid IP.
+                    if ip_str.parse::<IpAddr>().is_ok() {
+                        entries.push(json!({
+                            "ip": ip_str,
+                            "mac": parts[1].trim(),
+                            "vendor": parts[2].trim(),
+                        }));
+                    }
+                }
+            }
+
+            return json!({
+                "success": true,
+                "subnet": subnet,
+                "source": "arp-scan",
+                "entries": entries,
+                "count": entries.len(),
+            });
+        }
+    }
+
+    // Fallback: nmap -sn (ping/ARP scan)
+    let nmap_result = timeout(
+        Duration::from_millis(timeout_ms),
+        tokio::process::Command::new("nmap")
+            .args(["-sn", "-n", subnet])
+            .env("PATH", &path)
+            .output(),
+    )
+    .await;
+
+    match nmap_result {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let mut entries = Vec::new();
+            let mut current_ip = String::new();
+            let mut current_mac = String::new();
+            let mut current_vendor = String::new();
+
+            // nmap output blocks look like:
+            //   Nmap scan report for 192.168.1.1
+            //   Host is up (0.0012s latency).
+            //   MAC Address: AA:BB:CC:DD:EE:FF (Vendor Name)
+            for line in stdout.lines() {
+                let line = line.trim();
+                if line.starts_with("Nmap scan report for ") {
+                    // Flush previous entry.
+                    if !current_ip.is_empty() {
+                        entries.push(json!({
+                            "ip": current_ip,
+                            "mac": current_mac,
+                            "vendor": current_vendor,
+                        }));
+                    }
+                    current_ip = line.trim_start_matches("Nmap scan report for ").to_string();
+                    current_mac = String::new();
+                    current_vendor = String::new();
+                } else if line.starts_with("MAC Address: ") {
+                    let rest = line.trim_start_matches("MAC Address: ");
+                    if let Some((mac, vendor)) = rest.split_once(' ') {
+                        current_mac = mac.to_string();
+                        current_vendor = vendor
+                            .trim_start_matches('(')
+                            .trim_end_matches(')')
+                            .to_string();
+                    } else {
+                        current_mac = rest.to_string();
+                    }
+                }
+            }
+            // Flush last entry.
+            if !current_ip.is_empty() {
+                entries.push(json!({
+                    "ip": current_ip,
+                    "mac": current_mac,
+                    "vendor": current_vendor,
+                }));
+            }
+
+            json!({
+                "success": true,
+                "subnet": subnet,
+                "source": "nmap",
+                "entries": entries,
+                "count": entries.len(),
+            })
+        }
+        Ok(Err(e)) => json!({
+            "success": false,
+            "error": format!(
+                "Neither arp-scan nor nmap available: {e}. \
+                 Install arp-scan or nmap for active ARP scanning."
+            ),
+        }),
+        Err(_) => json!({
+            "success": false,
+            "error": "ARP scan timed out",
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OUI vendor lookup
+// ---------------------------------------------------------------------------
+
+/// Normalize a MAC address to an uppercase OUI prefix (first 3 octets).
+///
+/// Accepts "AA:BB:CC:DD:EE:FF", "AA-BB-CC-DD-EE-FF", or "AABBCCDDEEFF".
+fn normalize_oui_prefix(mac: &str) -> Option<String> {
+    let cleaned: String = mac
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .collect::<String>()
+        .to_uppercase();
+    if cleaned.len() < 6 {
+        return None;
+    }
+    // Return "AA:BB:CC" format.
+    Some(format!(
+        "{}:{}:{}",
+        &cleaned[0..2],
+        &cleaned[2..4],
+        &cleaned[4..6]
+    ))
+}
+
+/// Built-in lookup table for common IoT / smart-home OUI prefixes.
+///
+/// This covers the most frequently seen vendors in home-network device
+/// discovery.  For comprehensive lookups the tool also checks system-installed
+/// IEEE databases.
+fn builtin_oui_lookup(prefix: &str) -> Option<&'static str> {
+    // prefix is "AA:BB:CC" uppercase
+    match prefix {
+        // Amazon
+        "F0:F0:A4" | "A4:08:EA" | "74:C2:46" | "FC:65:DE" | "4C:EF:C0" | "0C:47:C9" => {
+            Some("Amazon Technologies (Echo, Ring, Fire TV)")
+        }
+        // Google / Nest
+        "F4:F5:D8" | "54:60:09" | "A4:77:33" | "30:FD:38" | "48:D6:D5" | "6C:AD:F8" => {
+            Some("Google LLC (Nest, Chromecast, Google Home)")
+        }
+        // Apple
+        "3C:22:FB" | "A8:5C:2C" | "F0:B3:EC" | "AC:BC:32" | "D0:03:4B" | "70:56:81" => {
+            Some("Apple Inc. (HomePod, Apple TV, HomeKit)")
+        }
+        // Philips Hue / Signify
+        "00:17:88" | "EC:B5:FA" => Some("Signify / Philips Lighting (Hue bridge, bulbs)"),
+        // Espressif (ESP32/ESP8266)
+        "24:0A:C4" | "30:AE:A4" | "A4:CF:12" | "AC:67:B2" | "CC:50:E3" | "24:6F:28"
+        | "84:CC:A8" | "3C:61:05" | "EC:FA:BC" | "10:52:1C" => {
+            Some("Espressif Systems (ESP32/ESP8266 — Tasmota, ESPHome, DIY IoT)")
+        }
+        // TP-Link / Kasa
+        "50:C7:BF" | "60:A4:B7" | "1C:61:B4" | "98:DA:C4" | "B0:95:75" | "E8:48:B8" => {
+            Some("TP-Link Technologies (Kasa smart plugs, routers)")
+        }
+        // Belkin / WeMo
+        "94:10:3E" | "C4:41:1E" | "EC:1A:59" | "08:86:3B" => {
+            Some("Belkin International (WeMo smart plugs)")
+        }
+        // Sonos
+        "00:0E:58" | "34:7E:5C" | "48:A6:B8" | "5C:AA:FD" | "78:28:CA" | "B8:E9:37" => {
+            Some("Sonos Inc. (speakers, amps)")
+        }
+        // Samsung / SmartThings
+        "8C:79:F5" | "D0:66:7B" | "FC:A6:67" | "C4:73:1E" => {
+            Some("Samsung Electronics (SmartThings, TVs)")
+        }
+        // Tuya
+        "D8:1F:12" | "10:D5:61" | "A0:92:08" => Some("Tuya Smart (generic smart-home devices)"),
+        // Shelly (Allterco Robotics)
+        "E8:DB:84" | "EC:62:60" | "30:C6:F7" | "C8:F0:9E" => {
+            Some("Allterco Robotics (Shelly relays, plugs)")
+        }
+        // IKEA
+        "00:0B:57" | "D0:73:D5" | "CC:86:EC" | "94:3A:F0" => {
+            Some("IKEA (TRADFRI / Dirigera smart home)")
+        }
+        // Roku
+        "D8:31:34" | "C8:3A:6B" | "B0:A7:37" | "AC:3A:7A" => {
+            Some("Roku Inc. (streaming players, TVs)")
+        }
+        // Raspberry Pi
+        "B8:27:EB" | "DC:A6:32" | "E4:5F:01" | "D8:3A:DD" | "28:CD:C1" => {
+            Some("Raspberry Pi Foundation")
+        }
+        // Synology
+        "00:11:32" => Some("Synology Inc. (NAS)"),
+        // QNAP
+        "00:08:9B" | "24:5E:BE" => Some("QNAP Systems (NAS)"),
+        // Ring (Amazon)
+        "B0:09:DA" | "18:B4:30" => Some("Ring LLC (doorbells, cameras)"),
+        // Wyze
+        "2C:AA:8E" => Some("Wyze Labs (cameras, sensors)"),
+        // Ecobee
+        "44:61:32" => Some("ecobee Inc. (thermostats)"),
+        _ => None,
+    }
+}
+
+/// Look up the vendor/manufacturer for a MAC address.
+///
+/// Checks system-installed IEEE OUI databases at standard paths, then falls
+/// back to a built-in table of common IoT/smart-home vendors.
+async fn oui_lookup(mac: &str) -> Value {
+    let prefix = match normalize_oui_prefix(mac) {
+        Some(p) => p,
+        None => {
+            return json!({
+                "success": false,
+                "error": "invalid MAC address — expected at least 6 hex digits (e.g. 'AA:BB:CC:DD:EE:FF')",
+            });
+        }
+    };
+
+    // Prefix without colons for matching some file formats.
+    let prefix_nocolon = prefix.replace(':', "");
+
+    // Try system OUI databases.
+    let oui_paths = [
+        "/usr/share/ieee-data/oui.csv",
+        "/usr/share/misc/oui.txt",
+        "/usr/share/nmap/nmap-mac-prefixes",
+        "/var/lib/ieee-data/oui.csv",
+    ];
+
+    for path in &oui_paths {
+        if let Ok(contents) = tokio::fs::read_to_string(path).await {
+            // Search for the OUI prefix in the file.
+            for line in contents.lines() {
+                let upper = line.to_uppercase();
+                if upper.contains(&prefix) || upper.contains(&prefix_nocolon) {
+                    // Extract vendor name — varies by format.
+                    let vendor = if path.ends_with(".csv") {
+                        // CSV format: MA-L,AABBCC,Vendor Name,...
+                        line.split(',')
+                            .nth(2)
+                            .unwrap_or("")
+                            .trim()
+                            .trim_matches('"')
+                    } else if path.ends_with("nmap-mac-prefixes") {
+                        // nmap format: AABBCC Vendor Name
+                        line.split_once(' ')
+                            .or_else(|| line.split_once('\t'))
+                            .map(|(_, v)| v.trim())
+                            .unwrap_or("")
+                    } else {
+                        // oui.txt format: AA-BB-CC (hex)\tVendor Name
+                        line.split_once('\t')
+                            .or_else(|| line.split_once("  "))
+                            .map(|(_, v)| v.trim())
+                            .unwrap_or("")
+                    };
+
+                    if !vendor.is_empty() {
+                        return json!({
+                            "success": true,
+                            "mac": mac,
+                            "oui_prefix": prefix,
+                            "vendor": vendor,
+                            "source": path,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall back to built-in table.
+    if let Some(vendor) = builtin_oui_lookup(&prefix) {
+        return json!({
+            "success": true,
+            "mac": mac,
+            "oui_prefix": prefix,
+            "vendor": vendor,
+            "source": "builtin",
+        });
+    }
+
+    json!({
+        "success": false,
+        "mac": mac,
+        "oui_prefix": prefix,
+        "error": "OUI prefix not found in available databases",
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SSDP / UPnP discovery
+// ---------------------------------------------------------------------------
+
+const SSDP_MULTICAST_ADDR: &str = "239.255.255.250:1900";
+const SSDP_M_SEARCH: &str = "M-SEARCH * HTTP/1.1\r\n\
+                               HOST: 239.255.255.250:1900\r\n\
+                               MAN: \"ssdp:discover\"\r\n\
+                               MX: 3\r\n\
+                               ST: ssdp:all\r\n\r\n";
+
+/// Parse an SSDP response into key-value headers.
+fn parse_ssdp_headers(response: &str) -> Value {
+    let mut headers = serde_json::Map::new();
+    for line in response.lines() {
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_uppercase();
+            let value = value.trim().to_string();
+            if !key.is_empty() && !value.is_empty() {
+                headers.insert(key, Value::String(value));
+            }
+        }
+    }
+    Value::Object(headers)
+}
+
+/// Extract a friendly name from UPnP device description XML.
+fn extract_xml_field(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    if let Some(start) = xml.find(&open) {
+        let start = start + open.len();
+        if let Some(end) = xml[start..].find(&close) {
+            let value = xml[start..start + end].trim().to_string();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+/// Discover UPnP devices on the local network via SSDP M-SEARCH.
+///
+/// Sends a multicast M-SEARCH request and collects responses.  When
+/// `fetch_descriptions` is true, fetches the device description XML from each
+/// device's LOCATION URL to extract friendly names, device types, and
+/// manufacturer info.
+async fn ssdp_discover(timeout_ms: u64, fetch_descriptions: bool) -> Value {
+    let sock = match UdpSocket::bind("0.0.0.0:0").await {
+        Ok(s) => s,
+        Err(e) => {
+            return json!({
+                "success": false,
+                "error": format!("failed to bind UDP socket: {e}"),
+            });
+        }
+    };
+
+    // Enable broadcast / multicast.
+    if let Err(e) = sock.set_broadcast(true) {
+        return json!({
+            "success": false,
+            "error": format!("failed to set broadcast: {e}"),
+        });
+    }
+
+    // Send M-SEARCH.
+    let dest: std::net::SocketAddr = match SSDP_MULTICAST_ADDR.parse() {
+        Ok(a) => a,
+        Err(e) => {
+            return json!({
+                "success": false,
+                "error": format!("invalid multicast address: {e}"),
+            });
+        }
+    };
+
+    if let Err(e) = sock.send_to(SSDP_M_SEARCH.as_bytes(), dest).await {
+        return json!({
+            "success": false,
+            "error": format!("failed to send M-SEARCH: {e}"),
+        });
+    }
+
+    // Collect responses until timeout.
+    let mut devices = Vec::new();
+    let mut seen_usns = std::collections::HashSet::new();
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms.min(15_000));
+    let mut buf = [0u8; 4096];
+
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        match timeout(remaining, sock.recv_from(&mut buf)).await {
+            Ok(Ok((n, addr))) => {
+                let resp = String::from_utf8_lossy(&buf[..n]).to_string();
+                let headers = parse_ssdp_headers(&resp);
+
+                // De-duplicate by USN (Unique Service Name).
+                let usn = headers["USN"].as_str().unwrap_or("").to_string();
+                if !usn.is_empty() && !seen_usns.insert(usn.clone()) {
+                    continue;
+                }
+
+                let location = headers["LOCATION"].as_str().unwrap_or("").to_string();
+                let st = headers["ST"].as_str().unwrap_or("").to_string();
+                let server = headers["SERVER"].as_str().unwrap_or("").to_string();
+
+                devices.push(json!({
+                    "ip": addr.ip().to_string(),
+                    "port": addr.port(),
+                    "usn": usn,
+                    "st": st,
+                    "location_url": location,
+                    "server": server,
+                }));
+            }
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+
+    // Optionally fetch device description XML from LOCATION URLs.
+    if fetch_descriptions {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        for device in &mut devices {
+            let location = device["location_url"].as_str().unwrap_or("").to_string();
+            if location.is_empty() || !location.starts_with("http") {
+                continue;
+            }
+            if let Ok(resp) = client.get(&location).send().await {
+                if let Ok(body) = resp.text().await {
+                    // Extract key fields from XML.
+                    let friendly_name = extract_xml_field(&body, "friendlyName");
+                    let device_type = extract_xml_field(&body, "deviceType");
+                    let manufacturer = extract_xml_field(&body, "manufacturer");
+                    let model_name = extract_xml_field(&body, "modelName");
+                    let model_number = extract_xml_field(&body, "modelNumber");
+
+                    if let Some(obj) = device.as_object_mut() {
+                        if let Some(v) = friendly_name {
+                            obj.insert("friendly_name".to_string(), Value::String(v));
+                        }
+                        if let Some(v) = device_type {
+                            obj.insert("device_type".to_string(), Value::String(v));
+                        }
+                        if let Some(v) = manufacturer {
+                            obj.insert("manufacturer".to_string(), Value::String(v));
+                        }
+                        if let Some(v) = model_name {
+                            obj.insert("model_name".to_string(), Value::String(v));
+                        }
+                        if let Some(v) = model_number {
+                            obj.insert("model_number".to_string(), Value::String(v));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    json!({
+        "success": true,
+        "devices": devices,
+        "count": devices.len(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// DHCP lease table
+// ---------------------------------------------------------------------------
+
+/// Query a router's DHCP lease table over SSH.
+///
+/// Connects to the router at `host` as `user` (default "root") and reads the
+/// dnsmasq lease file.  The standard location is `/tmp/dnsmasq.leases` on
+/// OpenWrt/DD-WRT routers, but `lease_file` can be overridden.
+///
+/// Lease line format: `epoch mac ip hostname client-id`
+async fn dhcp_leases(host: &str, user: &str, lease_file: &str, timeout_ms: u64) -> Value {
+    let path = system_path();
+
+    let remote_cmd = format!("cat {lease_file}");
+    let result = timeout(
+        Duration::from_millis(timeout_ms),
+        tokio::process::Command::new("ssh")
+            .args([
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=5",
+                "-l",
+                user,
+                host,
+                &remote_cmd,
+            ])
+            .env("PATH", &path)
+            .output(),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+            if !output.status.success() {
+                return json!({
+                    "success": false,
+                    "error": if stderr.is_empty() {
+                        format!("SSH command failed with exit code {}", output.status.code().unwrap_or(-1))
+                    } else {
+                        stderr
+                    },
+                });
+            }
+
+            let mut leases = Vec::new();
+            for line in stdout.lines() {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() < 4 {
+                    continue;
+                }
+                // dnsmasq format: epoch mac ip hostname [client-id]
+                let expires = parts[0].parse::<u64>().unwrap_or(0);
+                let mac = parts[1];
+                let ip = parts[2];
+                let hostname = parts[3];
+                let client_id = parts.get(4).copied().unwrap_or("");
+
+                leases.push(json!({
+                    "ip": ip,
+                    "mac": mac,
+                    "hostname": if hostname == "*" { "" } else { hostname },
+                    "lease_expires": expires,
+                    "client_id": client_id,
+                }));
+            }
+
+            json!({
+                "success": true,
+                "router": host,
+                "leases": leases,
+                "count": leases.len(),
+            })
+        }
+        Ok(Err(e)) => json!({
+            "success": false,
+            "error": format!("SSH not available: {e}"),
+        }),
+        Err(_) => json!({
+            "success": false,
+            "error": "DHCP lease query timed out",
+        }),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tool trait implementation
 // ---------------------------------------------------------------------------
 
@@ -461,12 +1086,14 @@ impl Tool for NetDiscoveryTool {
 
     fn description(&self) -> &str {
         "Discover hosts, services, and network topology. DNS lookups, mDNS/DNS-SD service \
-         discovery, ARP table, traceroute, and interface listing."
+         discovery, DHCP lease table, active ARP scan, SSDP/UPnP, OUI vendor lookup, \
+         ARP cache, traceroute, and interface listing."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
         SandboxRequirements {
             needs_fs_read: true,
+            needs_net: true,
             needs_spawn: true,
             ..SandboxRequirements::default()
         }
@@ -481,8 +1108,12 @@ impl Tool for NetDiscoveryTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["dns_lookup", "mdns_discover", "arp_table", "traceroute", "interfaces"],
-                        "description": "dns_lookup: forward/reverse DNS resolution. mdns_discover: find services via mDNS/DNS-SD. arp_table: read cached MAC/IP mappings. traceroute: map network hops to a local target. interfaces: list local network interfaces."
+                        "enum": [
+                            "dns_lookup", "mdns_discover", "arp_table", "arp_scan",
+                            "dhcp_leases", "ssdp_discover", "oui_lookup",
+                            "traceroute", "interfaces"
+                        ],
+                        "description": "dns_lookup: forward/reverse DNS resolution. mdns_discover: find services via mDNS/DNS-SD (supports IoT presets). arp_table: read cached MAC/IP mappings. arp_scan: actively scan a subnet for all devices via ARP. dhcp_leases: query router DHCP lease table over SSH. ssdp_discover: find UPnP devices via SSDP multicast. oui_lookup: look up MAC address vendor/manufacturer. traceroute: map network hops to a local target. interfaces: list local network interfaces."
                     },
                     "name": {
                         "type": "string",
@@ -495,11 +1126,36 @@ impl Tool for NetDiscoveryTool {
                     },
                     "service_type": {
                         "type": "string",
-                        "description": "mDNS service type for mdns_discover (e.g. '_http._tcp', '_ssh._tcp', '_ipp._tcp', '_smb._tcp'). Default: '_services._dns-sd._udp' to list all."
+                        "description": "mDNS service type for mdns_discover (e.g. '_http._tcp', '_ssh._tcp', '_hap._tcp'). Default: '_services._dns-sd._udp' to list all."
+                    },
+                    "preset": {
+                        "type": "string",
+                        "enum": ["homekit", "chromecast", "sonos", "airplay", "iot", "printers"],
+                        "description": "mDNS preset for mdns_discover — browses well-known IoT service types. 'iot' scans all smart-home types. Overrides service_type."
                     },
                     "host": {
                         "type": "string",
-                        "description": "Target IP address for traceroute (must be private/link-local)"
+                        "description": "Target IP for traceroute (must be private/link-local). Router IP for dhcp_leases."
+                    },
+                    "user": {
+                        "type": "string",
+                        "description": "SSH user for dhcp_leases (default: 'root')"
+                    },
+                    "lease_file": {
+                        "type": "string",
+                        "description": "Path to lease file on router for dhcp_leases (default: '/tmp/dnsmasq.leases')"
+                    },
+                    "subnet": {
+                        "type": "string",
+                        "description": "CIDR subnet for arp_scan (e.g. '192.168.1.0/24')"
+                    },
+                    "mac": {
+                        "type": "string",
+                        "description": "MAC address for oui_lookup (e.g. 'AA:BB:CC:DD:EE:FF')"
+                    },
+                    "fetch_descriptions": {
+                        "type": "boolean",
+                        "description": "For ssdp_discover: fetch UPnP device description XML from LOCATION URLs (default: false, adds latency)"
                     },
                     "timeout_ms": {
                         "type": "integer",
@@ -547,6 +1203,34 @@ impl Tool for NetDiscoveryTool {
             }
 
             "mdns_discover" => {
+                // If a preset is given, browse multiple service types at once.
+                if let Some(preset) = args["preset"].as_str() {
+                    let types = mdns_preset_service_types(preset).map_err(|e| {
+                        rustykrab_core::Error::ToolExecution(ToolError::invalid_input(e))
+                    })?;
+
+                    let mut all_services = Vec::new();
+                    // Split timeout evenly across types, minimum 3s each.
+                    let per_type_ms = (timeout_ms / types.len() as u64).max(3_000);
+                    for svc_type in &types {
+                        let result = mdns_discover(svc_type, per_type_ms).await;
+                        if let Some(services) = result["services"].as_array() {
+                            all_services.extend(services.clone());
+                        }
+                    }
+
+                    return Ok(json!({
+                        "action": "mdns_discover",
+                        "preset": preset,
+                        "service_types_queried": types,
+                        "result": {
+                            "success": true,
+                            "services": all_services,
+                            "count": all_services.len(),
+                        },
+                    }));
+                }
+
                 let service_type = args["service_type"]
                     .as_str()
                     .unwrap_or("_services._dns-sd._udp");
@@ -566,6 +1250,55 @@ impl Tool for NetDiscoveryTool {
                 }))
             }
 
+            "arp_scan" => {
+                let subnet = args["subnet"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "subnet (CIDR) is required for arp_scan, e.g. '192.168.1.0/24'",
+                    ))
+                })?;
+
+                // Validate the base IP is in a local range.
+                let base_ip_str = subnet.split('/').next().unwrap_or("");
+                if let Ok(ip) = base_ip_str.parse::<IpAddr>() {
+                    if !is_local_network(&ip) {
+                        return Err(rustykrab_core::Error::ToolExecution(
+                            ToolError::invalid_input(format!(
+                                "{ip} is not in a private/local range — only local-network scanning is allowed"
+                            )),
+                        ));
+                    }
+                }
+
+                let result = arp_scan(subnet, timeout_ms).await;
+                Ok(json!({
+                    "action": "arp_scan",
+                    "result": result,
+                }))
+            }
+
+            "oui_lookup" => {
+                let mac_str = args["mac"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "mac is required for oui_lookup (e.g. 'AA:BB:CC:DD:EE:FF')",
+                    ))
+                })?;
+
+                let result = oui_lookup(mac_str).await;
+                Ok(json!({
+                    "action": "oui_lookup",
+                    "result": result,
+                }))
+            }
+
+            "ssdp_discover" => {
+                let fetch_desc = args["fetch_descriptions"].as_bool().unwrap_or(false);
+                let result = ssdp_discover(timeout_ms, fetch_desc).await;
+                Ok(json!({
+                    "action": "ssdp_discover",
+                    "result": result,
+                }))
+            }
+
             "traceroute" => {
                 let host_str = args["host"].as_str().ok_or_else(|| {
                     rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
@@ -578,6 +1311,25 @@ impl Tool for NetDiscoveryTool {
                 let result = traceroute(ip, timeout_ms).await;
                 Ok(json!({
                     "action": "traceroute",
+                    "result": result,
+                }))
+            }
+
+            "dhcp_leases" => {
+                let host_str = args["host"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "host (router IP) is required for dhcp_leases",
+                    ))
+                })?;
+                // Validate router IP is on local network.
+                require_local(host_str).map_err(rustykrab_core::Error::ToolExecution)?;
+
+                let user = args["user"].as_str().unwrap_or("root");
+                let lease_file = args["lease_file"].as_str().unwrap_or("/tmp/dnsmasq.leases");
+
+                let result = dhcp_leases(host_str, user, lease_file, timeout_ms).await;
+                Ok(json!({
+                    "action": "dhcp_leases",
                     "result": result,
                 }))
             }

--- a/crates/rustykrab-tools/src/net_discovery.rs
+++ b/crates/rustykrab-tools/src/net_discovery.rs
@@ -987,6 +987,105 @@ async fn ssdp_discover(timeout_ms: u64, fetch_descriptions: bool) -> Value {
 // DHCP lease table
 // ---------------------------------------------------------------------------
 
+/// Validate that an SSH username is safe.
+///
+/// Rejects values that start with `-` (which could be interpreted as SSH
+/// options, enabling option injection) and values containing shell
+/// metacharacters.  Only allows alphanumeric characters, hyphens (not as
+/// the first character), underscores, and dots.
+fn validate_ssh_user(user: &str) -> std::result::Result<(), ToolError> {
+    if user.is_empty() {
+        return Err(ToolError::invalid_input("SSH user must not be empty"));
+    }
+    if user.starts_with('-') {
+        return Err(ToolError::invalid_input(
+            "SSH user must not start with '-' (option injection)",
+        ));
+    }
+    if !user
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        return Err(ToolError::invalid_input(
+            "SSH user contains disallowed characters — \
+             only alphanumeric, '-', '_', '.' are permitted",
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a CIDR subnet string for use with scanning tools.
+///
+/// Ensures the string is well-formed (`<ipv4>/<prefix>`), the base IP is
+/// in a local network range, and the prefix length is between 20 and 32
+/// to prevent accidental DoS via overly broad scans.
+fn validate_scan_cidr(cidr: &str) -> std::result::Result<(), ToolError> {
+    let parts: Vec<&str> = cidr.split('/').collect();
+    if parts.len() != 2 {
+        return Err(ToolError::invalid_input(
+            "expected CIDR notation, e.g. '192.168.1.0/24'",
+        ));
+    }
+
+    let ip: IpAddr = parts[0]
+        .parse()
+        .map_err(|e| ToolError::invalid_input(format!("invalid IP in CIDR: {e}")))?;
+
+    if !is_local_network(&ip) {
+        return Err(ToolError::invalid_input(format!(
+            "{ip} is not in a private/local range — only local-network scanning is allowed"
+        )));
+    }
+
+    let prefix_len: u32 = parts[1]
+        .parse()
+        .map_err(|e| ToolError::invalid_input(format!("invalid prefix length: {e}")))?;
+
+    if prefix_len > 32 {
+        return Err(ToolError::invalid_input("prefix length must be <= 32"));
+    }
+    if prefix_len < 20 {
+        return Err(ToolError::invalid_input(
+            "prefix length must be >= 20 (max 4094 hosts) to prevent accidental DoS",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate that a lease file path is safe to pass to a remote shell.
+///
+/// Rejects paths containing shell metacharacters, backticks, command
+/// substitution, pipes, redirects, semicolons, etc.  Only allows
+/// absolute paths with alphanumeric segments, hyphens, underscores,
+/// dots, and forward slashes.
+fn validate_lease_path(path: &str) -> std::result::Result<(), ToolError> {
+    if path.is_empty() {
+        return Err(ToolError::invalid_input("lease_file must not be empty"));
+    }
+    if !path.starts_with('/') {
+        return Err(ToolError::invalid_input(
+            "lease_file must be an absolute path (start with '/')",
+        ));
+    }
+    if path.contains("..") {
+        return Err(ToolError::invalid_input(
+            "lease_file must not contain '..' path traversal",
+        ));
+    }
+    // Allow only safe characters: alphanumeric, '/', '-', '_', '.'
+    if !path
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '-' | '_' | '.'))
+    {
+        return Err(ToolError::invalid_input(
+            "lease_file contains disallowed characters — \
+             only alphanumeric, '/', '-', '_', '.' are permitted",
+        ));
+    }
+    Ok(())
+}
+
 /// Query a router's DHCP lease table over SSH.
 ///
 /// Connects to the router at `host` as `user` (default "root") and reads the
@@ -997,7 +1096,10 @@ async fn ssdp_discover(timeout_ms: u64, fetch_descriptions: bool) -> Value {
 async fn dhcp_leases(host: &str, user: &str, lease_file: &str, timeout_ms: u64) -> Value {
     let path = system_path();
 
-    let remote_cmd = format!("cat {lease_file}");
+    // Pass the file path as a separate argument to `cat` instead of
+    // interpolating it into a shell string, preventing command injection.
+    // SSH with "--" separates ssh options from the remote command; each
+    // subsequent argument becomes a separate word in the remote argv.
     let result = timeout(
         Duration::from_millis(timeout_ms),
         tokio::process::Command::new("ssh")
@@ -1011,7 +1113,9 @@ async fn dhcp_leases(host: &str, user: &str, lease_file: &str, timeout_ms: u64) 
                 "-l",
                 user,
                 host,
-                &remote_cmd,
+                "--",
+                "cat",
+                lease_file,
             ])
             .env("PATH", &path)
             .output(),
@@ -1257,17 +1361,8 @@ impl Tool for NetDiscoveryTool {
                     ))
                 })?;
 
-                // Validate the base IP is in a local range.
-                let base_ip_str = subnet.split('/').next().unwrap_or("");
-                if let Ok(ip) = base_ip_str.parse::<IpAddr>() {
-                    if !is_local_network(&ip) {
-                        return Err(rustykrab_core::Error::ToolExecution(
-                            ToolError::invalid_input(format!(
-                                "{ip} is not in a private/local range — only local-network scanning is allowed"
-                            )),
-                        ));
-                    }
-                }
+                // Full CIDR validation: well-formed, local network, sane prefix.
+                validate_scan_cidr(subnet).map_err(rustykrab_core::Error::ToolExecution)?;
 
                 let result = arp_scan(subnet, timeout_ms).await;
                 Ok(json!({
@@ -1325,7 +1420,10 @@ impl Tool for NetDiscoveryTool {
                 require_local(host_str).map_err(rustykrab_core::Error::ToolExecution)?;
 
                 let user = args["user"].as_str().unwrap_or("root");
+                validate_ssh_user(user).map_err(rustykrab_core::Error::ToolExecution)?;
+
                 let lease_file = args["lease_file"].as_str().unwrap_or("/tmp/dnsmasq.leases");
+                validate_lease_path(lease_file).map_err(rustykrab_core::Error::ToolExecution)?;
 
                 let result = dhcp_leases(host_str, user, lease_file, timeout_ms).await;
                 Ok(json!({

--- a/crates/rustykrab-tools/src/net_scan.rs
+++ b/crates/rustykrab-tools/src/net_scan.rs
@@ -13,6 +13,8 @@ const DEFAULT_PORTS: &[u16] = &[
     21, 23, 25, 53, 110, 143, 993, 995, // FTP, Telnet, SMTP, DNS, POP3, IMAP
     3306, 5432, 6379, 27017, // MySQL, PostgreSQL, Redis, MongoDB
     1883, 8883, 5353, 9100, // MQTT, mDNS, printers
+    8123, 5683, 9123, 55443, 4455,
+    8000, // Home Assistant, CoAP, Govee, Kasa, Lutron, IoT HTTP
 ];
 
 /// Human-readable labels for common services.
@@ -33,25 +35,33 @@ fn service_label(port: u16) -> &'static str {
         1883 => "mqtt",
         3306 => "mysql",
         3389 => "rdp",
+        4455 => "lutron-caseta",
         5353 => "mdns",
         5432 => "postgresql",
+        5683 => "coap",
         5900 => "vnc",
         6379 => "redis",
+        8000 => "http-alt",
         8080 => "http-alt",
+        8123 => "home-assistant",
         8443 => "https-alt",
         8883 => "mqtt-tls",
         9100 => "printer",
+        9123 => "govee",
         27017 => "mongodb",
+        55443 => "kasa",
         _ => "unknown",
     }
 }
 
 /// Network discovery and port-scanning tool.
 ///
-/// Provides three actions:
+/// Provides four actions:
 /// - **ping_sweep**: Probes a subnet to find live hosts (TCP connect on port 80/443).
 /// - **port_scan**: Scans a list of ports on a single host.
 /// - **scan_subnet**: Combines sweep + port scan for every live host found.
+/// - **fingerprint_http**: Connects to an HTTP port and analyzes the response
+///   to identify device type, manufacturer, model, and firmware.
 ///
 /// All operations are restricted to RFC-1918 / link-local addresses so the
 /// tool cannot be used for external reconnaissance.
@@ -196,6 +206,230 @@ async fn port_scan(ip: IpAddr, ports: &[u16], timeout_ms: u64) -> Vec<Value> {
     open
 }
 
+// ---------------------------------------------------------------------------
+// HTTP fingerprinting
+// ---------------------------------------------------------------------------
+
+/// Known device signature patterns matched against HTTP response body.
+struct DeviceSignature {
+    pattern: &'static str,
+    device_type: &'static str,
+    manufacturer: &'static str,
+}
+
+const DEVICE_SIGNATURES: &[DeviceSignature] = &[
+    DeviceSignature {
+        pattern: "Shelly",
+        device_type: "smart_relay",
+        manufacturer: "Allterco Robotics (Shelly)",
+    },
+    DeviceSignature {
+        pattern: "ESPHome",
+        device_type: "esp_device",
+        manufacturer: "ESPHome",
+    },
+    DeviceSignature {
+        pattern: "Tasmota",
+        device_type: "smart_switch",
+        manufacturer: "Tasmota",
+    },
+    DeviceSignature {
+        pattern: "Home Assistant",
+        device_type: "home_automation_hub",
+        manufacturer: "Home Assistant",
+    },
+    DeviceSignature {
+        pattern: "hue personal wireless",
+        device_type: "smart_lighting_bridge",
+        manufacturer: "Signify (Philips Hue)",
+    },
+    DeviceSignature {
+        pattern: "UniFi",
+        device_type: "network_equipment",
+        manufacturer: "Ubiquiti",
+    },
+    DeviceSignature {
+        pattern: "Synology",
+        device_type: "nas",
+        manufacturer: "Synology",
+    },
+    DeviceSignature {
+        pattern: "QNAP",
+        device_type: "nas",
+        manufacturer: "QNAP",
+    },
+    DeviceSignature {
+        pattern: "Pi-hole",
+        device_type: "dns_filter",
+        manufacturer: "Pi-hole",
+    },
+    DeviceSignature {
+        pattern: "OctoPrint",
+        device_type: "3d_printer_controller",
+        manufacturer: "OctoPrint",
+    },
+    DeviceSignature {
+        pattern: "Sonos",
+        device_type: "smart_speaker",
+        manufacturer: "Sonos",
+    },
+];
+
+/// Extract the content of an HTML `<title>` tag.
+fn extract_html_title(body: &str) -> Option<String> {
+    let lower = body.to_lowercase();
+    let start = lower.find("<title>")?;
+    let after = start + "<title>".len();
+    let end = lower[after..].find("</title>")?;
+    let title = body[after..after + end].trim().to_string();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title)
+    }
+}
+
+/// Extract a simple XML field value (same as in net_discovery).
+fn extract_xml_field(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    if let Some(start) = xml.find(&open) {
+        let start = start + open.len();
+        if let Some(end) = xml[start..].find(&close) {
+            let value = xml[start..start + end].trim().to_string();
+            if !value.is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+/// Fingerprint a device by connecting to its HTTP port and analyzing the
+/// response headers and body.
+///
+/// Checks:
+/// - **Server header** — often reveals firmware name and version.
+/// - **Response body patterns** — known strings for common IoT devices.
+/// - **HTML title** — many devices include the model name.
+/// - **/description.xml** — UPnP device description with rich metadata.
+async fn fingerprint_http(ip: IpAddr, port: u16, timeout_ms: u64) -> Value {
+    let scheme = if port == 443 || port == 8443 {
+        "https"
+    } else {
+        "http"
+    };
+    let base_url = format!("{scheme}://{ip}:{port}");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .danger_accept_invalid_certs(true)
+        .redirect(reqwest::redirect::Policy::limited(3))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    // Fetch the root page.
+    let root_resp = client.get(&base_url).send().await;
+
+    let mut server_header = String::new();
+    let mut title = None;
+    let mut detected_device = None;
+    let mut detected_manufacturer = None;
+    let mut body_snippet = String::new();
+    let mut status_code = 0u16;
+
+    if let Ok(resp) = root_resp {
+        status_code = resp.status().as_u16();
+
+        // Extract Server header.
+        if let Some(srv) = resp.headers().get("server") {
+            server_header = srv.to_str().unwrap_or("").to_string();
+        }
+
+        // Read body (capped at 64KB to avoid memory issues on constrained hosts).
+        if let Ok(body) = resp.text().await {
+            let body = if body.len() > 65_536 {
+                body[..65_536].to_string()
+            } else {
+                body
+            };
+
+            title = extract_html_title(&body);
+
+            // Check body against known device signatures.
+            for sig in DEVICE_SIGNATURES {
+                if body.contains(sig.pattern)
+                    || server_header.contains(sig.pattern)
+                    || title.as_deref().is_some_and(|t| t.contains(sig.pattern))
+                {
+                    detected_device = Some(sig.device_type);
+                    detected_manufacturer = Some(sig.manufacturer);
+                    break;
+                }
+            }
+
+            // Keep a small snippet for context.
+            body_snippet = body.chars().take(200).collect();
+        }
+    }
+
+    // Try /description.xml (UPnP device description).
+    let mut upnp_info = json!(null);
+    let desc_url = format!("{base_url}/description.xml");
+    if let Ok(resp) = client.get(&desc_url).send().await {
+        if resp.status().is_success() {
+            if let Ok(body) = resp.text().await {
+                let friendly_name = extract_xml_field(&body, "friendlyName");
+                let device_type = extract_xml_field(&body, "deviceType");
+                let manufacturer = extract_xml_field(&body, "manufacturer");
+                let model_name = extract_xml_field(&body, "modelName");
+                let model_number = extract_xml_field(&body, "modelNumber");
+                let serial = extract_xml_field(&body, "serialNumber");
+                let firmware = extract_xml_field(&body, "firmwareVersion")
+                    .or_else(|| extract_xml_field(&body, "softwareVersion"));
+
+                if friendly_name.is_some() || manufacturer.is_some() {
+                    upnp_info = json!({
+                        "friendly_name": friendly_name,
+                        "device_type": device_type,
+                        "manufacturer": manufacturer,
+                        "model_name": model_name,
+                        "model_number": model_number,
+                        "serial_number": serial,
+                        "firmware_version": firmware,
+                    });
+
+                    // Use UPnP info as primary identification if available.
+                    if detected_manufacturer.is_none() {
+                        if let Some(ref mfg) = manufacturer {
+                            detected_manufacturer =
+                                // Leak into 'static isn't ideal, but we'd need
+                                // owned strings to avoid it.  Instead just leave
+                                // it in the JSON output — the caller reads the
+                                // upnp_description object.
+                                None;
+                            let _ = mfg; // suppress unused warning
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    json!({
+        "success": status_code > 0,
+        "ip": ip.to_string(),
+        "port": port,
+        "status_code": status_code,
+        "server_header": server_header,
+        "title": title,
+        "detected_device_type": detected_device,
+        "detected_manufacturer": detected_manufacturer,
+        "upnp_description": upnp_info,
+        "body_snippet": body_snippet,
+    })
+}
+
 #[async_trait]
 impl Tool for NetScanTool {
     fn name(&self) -> &str {
@@ -203,7 +437,8 @@ impl Tool for NetScanTool {
     }
 
     fn description(&self) -> &str {
-        "Discover devices and open ports on the local network. Restricted to private/link-local IP ranges."
+        "Discover devices and open ports on the local network. Port scanning, HTTP fingerprinting \
+         for device identification. Restricted to private/link-local IP ranges."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
@@ -222,8 +457,8 @@ impl Tool for NetScanTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["ping_sweep", "port_scan", "scan_subnet"],
-                        "description": "ping_sweep: find live hosts in a subnet. port_scan: scan ports on a single host. scan_subnet: sweep + port scan all live hosts."
+                        "enum": ["ping_sweep", "port_scan", "scan_subnet", "fingerprint_http"],
+                        "description": "ping_sweep: find live hosts in a subnet. port_scan: scan ports on a single host. scan_subnet: sweep + port scan all live hosts. fingerprint_http: identify a device by its HTTP response (Server header, body patterns, UPnP description.xml)."
                     },
                     "subnet": {
                         "type": "string",
@@ -231,12 +466,16 @@ impl Tool for NetScanTool {
                     },
                     "host": {
                         "type": "string",
-                        "description": "IP address to scan (required for port_scan)"
+                        "description": "IP address to scan (required for port_scan and fingerprint_http)"
+                    },
+                    "port": {
+                        "type": "integer",
+                        "description": "HTTP port for fingerprint_http (default: 80)"
                     },
                     "ports": {
                         "type": "array",
                         "items": { "type": "integer" },
-                        "description": "List of ports to scan (default: common well-known ports)"
+                        "description": "List of ports to scan (default: common well-known ports including IoT)"
                     },
                     "timeout_ms": {
                         "type": "integer",
@@ -340,6 +579,35 @@ impl Tool for NetScanTool {
                     "live_count": live.len(),
                 }))
             }
+            "fingerprint_http" => {
+                let host_str = args["host"].as_str().ok_or_else(|| {
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(
+                        "host is required for fingerprint_http",
+                    ))
+                })?;
+                let ip: IpAddr = host_str.parse().map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(ToolError::invalid_input(format!(
+                        "invalid IP address: {e}"
+                    )))
+                })?;
+                if !is_local_network(&ip) {
+                    return Err(rustykrab_core::Error::ToolExecution(
+                        ToolError::invalid_input(format!(
+                            "{ip} is not in a private/local range — only local-network scanning is allowed"
+                        )),
+                    ));
+                }
+
+                let port = args["port"].as_u64().unwrap_or(80) as u16;
+                let fp_timeout = timeout_ms.max(3_000); // fingerprinting needs a bit more time
+                let result = fingerprint_http(ip, port, fp_timeout).await;
+
+                Ok(json!({
+                    "action": "fingerprint_http",
+                    "result": result,
+                }))
+            }
+
             _ => Err(rustykrab_core::Error::ToolExecution(
                 ToolError::invalid_input(format!("unknown net_scan action: {action}")),
             )),

--- a/scripts/install-discovery-deps.sh
+++ b/scripts/install-discovery-deps.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------
+# install-discovery-deps.sh — Install system dependencies for the
+# network device discovery tools (net_discovery + net_scan).
+#
+# The discovery actions in rustykrab-tools rely on several system
+# binaries for network scanning, mDNS browsing, and SSH access.
+# This script detects the package manager and installs them.
+#
+# Usage:
+#   sudo ./scripts/install-discovery-deps.sh          # install all
+#   sudo ./scripts/install-discovery-deps.sh --check   # dry-run check only
+#
+# Dependencies installed:
+#   Required:
+#     nmap           — active ARP scan fallback, subnet scanning
+#     avahi-utils    — mDNS/DNS-SD service discovery (avahi-browse)
+#     openssh-client — SSH for DHCP lease queries and net_admin
+#     dnsutils       — DNS lookups (dig)
+#     traceroute     — network path tracing
+#     iproute2       — interface listing, ARP cache (ip command)
+#
+#   Recommended:
+#     arp-scan       — fast, reliable ARP scanning with OUI vendor data
+#     ieee-data      — IEEE OUI database for MAC vendor lookups
+#     openssl        — TLS/SSL certificate checking (net_audit)
+# -----------------------------------------------------------------------
+
+set -euo pipefail
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+    CHECK_ONLY=true
+fi
+
+# ANSI colors (disabled if not a terminal).
+if [[ -t 1 ]]; then
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    RED='\033[0;31m'
+    NC='\033[0m'
+else
+    GREEN='' YELLOW='' RED='' NC=''
+fi
+
+ok()   { echo -e "  ${GREEN}[ok]${NC}   $1"; }
+miss() { echo -e "  ${RED}[miss]${NC} $1"; }
+skip() { echo -e "  ${YELLOW}[skip]${NC} $1"; }
+
+# -----------------------------------------------------------------------
+# Detect package manager
+# -----------------------------------------------------------------------
+detect_pkg_manager() {
+    if command -v apt-get &>/dev/null; then
+        echo "apt"
+    elif command -v dnf &>/dev/null; then
+        echo "dnf"
+    elif command -v yum &>/dev/null; then
+        echo "yum"
+    elif command -v pacman &>/dev/null; then
+        echo "pacman"
+    elif command -v apk &>/dev/null; then
+        echo "apk"
+    elif command -v brew &>/dev/null; then
+        echo "brew"
+    else
+        echo "unknown"
+    fi
+}
+
+PKG_MGR=$(detect_pkg_manager)
+
+# -----------------------------------------------------------------------
+# Package name mapping per distro
+# -----------------------------------------------------------------------
+# Each entry: binary_name -> package_name for the detected package manager.
+
+declare -A APT_PKGS=(
+    [nmap]="nmap"
+    [avahi-browse]="avahi-utils"
+    [ssh]="openssh-client"
+    [dig]="dnsutils"
+    [traceroute]="traceroute"
+    [ip]="iproute2"
+    [arp-scan]="arp-scan"
+    [openssl]="openssl"
+)
+
+declare -A DNF_PKGS=(
+    [nmap]="nmap"
+    [avahi-browse]="avahi-tools"
+    [ssh]="openssh-clients"
+    [dig]="bind-utils"
+    [traceroute]="traceroute"
+    [ip]="iproute"
+    [arp-scan]="arp-scan"
+    [openssl]="openssl"
+)
+
+declare -A PACMAN_PKGS=(
+    [nmap]="nmap"
+    [avahi-browse]="avahi"
+    [ssh]="openssh"
+    [dig]="bind"
+    [traceroute]="traceroute"
+    [ip]="iproute2"
+    [arp-scan]="arp-scan"
+    [openssl]="openssl"
+)
+
+declare -A APK_PKGS=(
+    [nmap]="nmap"
+    [avahi-browse]="avahi-tools"
+    [ssh]="openssh-client"
+    [dig]="bind-tools"
+    [traceroute]="traceroute"
+    [ip]="iproute2"
+    [arp-scan]="arp-scan"
+    [openssl]="openssl"
+)
+
+declare -A BREW_PKGS=(
+    [nmap]="nmap"
+    [avahi-browse]=""
+    [ssh]=""
+    [dig]=""
+    [traceroute]=""
+    [ip]="iproute2mac"
+    [arp-scan]="arp-scan"
+    [openssl]="openssl"
+)
+
+# IEEE data package (for OUI lookups) — only available on some distros.
+IEEE_DATA_PKG=""
+case "$PKG_MGR" in
+    apt)  IEEE_DATA_PKG="ieee-data" ;;
+    dnf|yum) IEEE_DATA_PKG="hwdata" ;;
+    pacman) IEEE_DATA_PKG="" ;;
+    apk) IEEE_DATA_PKG="" ;;
+    brew) IEEE_DATA_PKG="" ;;
+esac
+
+get_pkg_name() {
+    local binary="$1"
+    case "$PKG_MGR" in
+        apt)    echo "${APT_PKGS[$binary]:-}" ;;
+        dnf|yum) echo "${DNF_PKGS[$binary]:-}" ;;
+        pacman) echo "${PACMAN_PKGS[$binary]:-}" ;;
+        apk)    echo "${APK_PKGS[$binary]:-}" ;;
+        brew)   echo "${BREW_PKGS[$binary]:-}" ;;
+        *)      echo "" ;;
+    esac
+}
+
+# -----------------------------------------------------------------------
+# Check which binaries are present
+# -----------------------------------------------------------------------
+
+REQUIRED_BINS=(nmap avahi-browse ssh dig traceroute ip)
+RECOMMENDED_BINS=(arp-scan openssl)
+
+MISSING_REQUIRED=()
+MISSING_RECOMMENDED=()
+
+echo ""
+echo "Checking network discovery dependencies..."
+echo ""
+echo "Required:"
+for bin in "${REQUIRED_BINS[@]}"; do
+    if command -v "$bin" &>/dev/null; then
+        ok "$bin ($(command -v "$bin"))"
+    else
+        miss "$bin"
+        MISSING_REQUIRED+=("$bin")
+    fi
+done
+
+echo ""
+echo "Recommended:"
+for bin in "${RECOMMENDED_BINS[@]}"; do
+    if command -v "$bin" &>/dev/null; then
+        ok "$bin ($(command -v "$bin"))"
+    else
+        miss "$bin"
+        MISSING_RECOMMENDED+=("$bin")
+    fi
+done
+
+# Check IEEE data.
+echo ""
+echo "Data files:"
+OUI_FOUND=false
+for path in /usr/share/ieee-data/oui.csv /usr/share/misc/oui.txt /usr/share/nmap/nmap-mac-prefixes /var/lib/ieee-data/oui.csv; do
+    if [[ -f "$path" ]]; then
+        ok "OUI database ($path)"
+        OUI_FOUND=true
+        break
+    fi
+done
+if ! $OUI_FOUND; then
+    miss "OUI database (IEEE MAC vendor data) — oui_lookup will use built-in table only"
+fi
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+echo ""
+
+if [[ ${#MISSING_REQUIRED[@]} -eq 0 && ${#MISSING_RECOMMENDED[@]} -eq 0 ]]; then
+    echo -e "${GREEN}All dependencies are installed.${NC}"
+    exit 0
+fi
+
+if $CHECK_ONLY; then
+    echo "Run without --check to install missing packages."
+    exit 1
+fi
+
+if [[ "$PKG_MGR" == "unknown" ]]; then
+    echo -e "${RED}Could not detect package manager.${NC}"
+    echo "Please install manually: ${MISSING_REQUIRED[*]} ${MISSING_RECOMMENDED[*]}"
+    exit 1
+fi
+
+# -----------------------------------------------------------------------
+# Install missing packages
+# -----------------------------------------------------------------------
+
+PKGS_TO_INSTALL=()
+for bin in "${MISSING_REQUIRED[@]}" "${MISSING_RECOMMENDED[@]}"; do
+    pkg=$(get_pkg_name "$bin")
+    if [[ -n "$pkg" ]]; then
+        PKGS_TO_INSTALL+=("$pkg")
+    else
+        skip "$bin — no package available for $PKG_MGR"
+    fi
+done
+
+# Add IEEE data if not present.
+if ! $OUI_FOUND && [[ -n "$IEEE_DATA_PKG" ]]; then
+    PKGS_TO_INSTALL+=("$IEEE_DATA_PKG")
+fi
+
+# De-duplicate.
+PKGS_TO_INSTALL=($(printf '%s\n' "${PKGS_TO_INSTALL[@]}" | sort -u))
+
+if [[ ${#PKGS_TO_INSTALL[@]} -eq 0 ]]; then
+    echo "No packages to install."
+    exit 0
+fi
+
+echo "Installing: ${PKGS_TO_INSTALL[*]}"
+echo ""
+
+case "$PKG_MGR" in
+    apt)
+        apt-get update -qq
+        apt-get install -y --no-install-recommends "${PKGS_TO_INSTALL[@]}"
+        ;;
+    dnf)
+        dnf install -y "${PKGS_TO_INSTALL[@]}"
+        ;;
+    yum)
+        yum install -y "${PKGS_TO_INSTALL[@]}"
+        ;;
+    pacman)
+        pacman -Sy --noconfirm "${PKGS_TO_INSTALL[@]}"
+        ;;
+    apk)
+        apk add --no-cache "${PKGS_TO_INSTALL[@]}"
+        ;;
+    brew)
+        brew install "${PKGS_TO_INSTALL[@]}"
+        ;;
+esac
+
+echo ""
+echo -e "${GREEN}Done.${NC} Re-run with --check to verify."


### PR DESCRIPTION
Extend net_discovery and net_scan tools with IP-based device discovery:

net_discovery gains 4 new actions:
- dhcp_leases: query router DHCP lease table over SSH (dnsmasq format)
- arp_scan: active subnet scanning via arp-scan/nmap fallback
- oui_lookup: MAC address vendor identification (system IEEE DB + built-in
  table covering 50+ common IoT/smart-home OUI prefixes)
- ssdp_discover: UPnP device discovery via SSDP M-SEARCH multicast with
  optional device description XML fetching

mdns_discover enhanced with IoT preset parameter supporting homekit,
chromecast, sonos, airplay, printers, and full iot scan across 13
service types.

net_scan gains:
- fingerprint_http: HTTP-based device identification via Server header,
  body pattern matching (11 known device signatures), HTML title, and
  UPnP description.xml parsing
- IoT port coverage: Home Assistant (8123), CoAP (5683), Govee (9123),
  Kasa (55443), Lutron (4455)

All new actions restricted to RFC-1918/link-local addresses.

https://claude.ai/code/session_01RR4m3byrmm3JPU3TxBmVd7