### PR TITLE
fix: handle stream read errors gracefully instead of crashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.2.3"
+version = "2.2.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -378,22 +378,50 @@ impl ModelProvider for AnthropicProvider {
 
         tracing::debug!(model = %self.model, "calling Anthropic Messages API (streaming)");
 
-        let resp = self
-            .client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", self.api_key.expose_secret())
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| Error::ModelProvider(e.to_string()))?;
+        // Retry the initial connection with the same backoff as the non-streaming path.
+        let mut last_err = None;
+        let mut resp = None;
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                tracing::warn!(attempt, "retrying Anthropic streaming API after {delay:?}");
+                tokio::time::sleep(delay).await;
+            }
 
-        let status = resp.status();
-        if !status.is_success() {
-            let error_body = resp.text().await.unwrap_or_default();
-            return Err(Self::map_status_error(status, &error_body));
+            let r = match self
+                .client
+                .post("https://api.anthropic.com/v1/messages")
+                .header("x-api-key", self.api_key.expose_secret())
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(Error::ModelProvider(e.to_string()));
+                    continue;
+                }
+            };
+
+            let status = r.status();
+            if !status.is_success() {
+                let error_body = r.text().await.unwrap_or_default();
+                let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
+                last_err = Some(Self::map_status_error(status, &error_body));
+                if !is_retryable {
+                    break;
+                }
+                continue;
+            }
+
+            resp = Some(r);
+            break;
         }
+        let resp = resp.ok_or_else(|| {
+            last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into()))
+        })?;
 
         // Parse SSE events from the response body.
         let mut buffer = String::new();
@@ -412,11 +440,35 @@ impl ModelProvider for AnthropicProvider {
         let mut stop_reason = StopReason::EndTurn;
 
         let mut response = resp;
-        while let Some(chunk) = response
-            .chunk()
-            .await
-            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
-        {
+        let mut stream_interrupted = false;
+        let mut chunks_received: u64 = 0;
+        let mut bytes_received: u64 = 0;
+        let stream_start = std::time::Instant::now();
+        loop {
+            let chunk = match response.chunk().await {
+                Ok(Some(chunk)) => chunk,
+                Ok(None) => break, // stream finished normally
+                Err(e) => {
+                    let elapsed = stream_start.elapsed();
+                    tracing::warn!(
+                        error = %e,
+                        error_debug = ?e,
+                        model = %self.model,
+                        chunks_received,
+                        bytes_received,
+                        elapsed_ms = elapsed.as_millis() as u64,
+                        accumulated_text_len = full_text.len(),
+                        pending_tool_calls = tool_input_bufs.len(),
+                        last_event_type = %current_event_type,
+                        buffer_len = buffer.len(),
+                        "stream read error mid-stream, returning partial response"
+                    );
+                    stream_interrupted = true;
+                    break;
+                }
+            };
+            chunks_received += 1;
+            bytes_received += chunk.len() as u64;
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
             while let Some(newline_pos) = buffer.find('\n') {
@@ -509,6 +561,31 @@ impl ModelProvider for AnthropicProvider {
                 }
                 // Blank lines and other lines are ignored.
             }
+        }
+
+        let stream_elapsed = stream_start.elapsed();
+        if stream_interrupted {
+            tracing::info!(
+                chunks_received,
+                bytes_received,
+                elapsed_ms = stream_elapsed.as_millis() as u64,
+                completed_tool_calls = tool_calls.len(),
+                discarded_partial_tool_calls = tool_input_bufs.len(),
+                text_len = full_text.len(),
+                "stream interrupted — returning partial Anthropic response"
+            );
+            // Discard any in-progress tool calls that never received a
+            // `content_block_stop` event (their JSON is incomplete and
+            // would fail to parse downstream).
+            tool_input_bufs.clear();
+            tool_meta.clear();
+        } else {
+            tracing::debug!(
+                chunks_received,
+                bytes_received,
+                elapsed_ms = stream_elapsed.as_millis() as u64,
+                "Anthropic stream completed normally"
+            );
         }
 
         let usage = Usage {

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -446,24 +446,44 @@ impl ModelProvider for OllamaProvider {
 
         let url = format!("{}/api/chat", self.base_url);
 
-        let resp = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                Error::ModelProvider(format!(
-                    "failed to connect to Ollama at {}: {e}. Is Ollama running?",
-                    self.base_url
-                ))
-            })?;
+        // Retry the initial connection with the same backoff as the non-streaming path.
+        let mut last_err = None;
+        let mut resp = None;
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                tracing::warn!(attempt, "retrying Ollama streaming API after {delay:?}");
+                tokio::time::sleep(delay).await;
+            }
 
-        let status = resp.status();
-        if !status.is_success() {
-            let error_body = resp.text().await.unwrap_or_default();
-            return Err(Self::map_status_error(status, &error_body));
+            let r = match self.client.post(&url).json(&body).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(Error::ModelProvider(format!(
+                        "failed to connect to Ollama at {}: {e}. Is Ollama running?",
+                        self.base_url
+                    )));
+                    continue;
+                }
+            };
+
+            let status = r.status();
+            if !status.is_success() {
+                let error_body = r.text().await.unwrap_or_default();
+                let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
+                last_err = Some(Self::map_status_error(status, &error_body));
+                if !is_retryable {
+                    break;
+                }
+                continue;
+            }
+
+            resp = Some(r);
+            break;
         }
+        let resp = resp.ok_or_else(|| {
+            last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into()))
+        })?;
 
         // Parse newline-delimited JSON chunks.
         let mut buffer = String::new();
@@ -474,11 +494,32 @@ impl ModelProvider for OllamaProvider {
         let mut done_reason: Option<String> = None;
 
         let mut response = resp;
-        while let Some(chunk) = response
-            .chunk()
-            .await
-            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
-        {
+        let mut chunks_received: u64 = 0;
+        let mut bytes_received: u64 = 0;
+        let stream_start = std::time::Instant::now();
+        loop {
+            let chunk = match response.chunk().await {
+                Ok(Some(chunk)) => chunk,
+                Ok(None) => break, // stream finished normally
+                Err(e) => {
+                    let elapsed = stream_start.elapsed();
+                    tracing::warn!(
+                        error = %e,
+                        error_debug = ?e,
+                        model = %self.model,
+                        base_url = %self.base_url,
+                        chunks_received,
+                        bytes_received,
+                        elapsed_ms = elapsed.as_millis() as u64,
+                        accumulated_text_len = full_text.len(),
+                        buffer_len = buffer.len(),
+                        "stream read error mid-stream, returning partial response"
+                    );
+                    break;
+                }
+            };
+            chunks_received += 1;
+            bytes_received += chunk.len() as u64;
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
             while let Some(newline_pos) = buffer.find('\n') {
@@ -518,6 +559,15 @@ impl ModelProvider for OllamaProvider {
                 }
             }
         }
+
+        let stream_elapsed = stream_start.elapsed();
+        tracing::debug!(
+            chunks_received,
+            bytes_received,
+            elapsed_ms = stream_elapsed.as_millis() as u64,
+            text_len = full_text.len(),
+            "Ollama stream completed"
+        );
 
         let stop_reason = if !tool_calls.is_empty() {
             StopReason::ToolUse


### PR DESCRIPTION
Mid-stream errors (e.g. "error decoding response body") from
response.chunk() were propagated immediately via `?`, crashing the
entire agent loop. Additionally, chat_stream() had no retry logic for
the initial HTTP connection, unlike the non-streaming chat() path.

Changes:
- Add connection-level retry with exponential backoff to chat_stream()
  in both Anthropic and Ollama providers, matching the existing chat()
  retry behavior (up to 3 retries on 429/5xx).
- Catch mid-stream chunk errors gracefully: log a warning and break out
  of the streaming loop, returning whatever content was accumulated
  rather than propagating the error.
- Discard incomplete tool calls on stream interruption (Anthropic) to
  avoid downstream JSON parse failures from truncated input buffers.
- Add detailed diagnostic logging: chunk count, bytes received, elapsed
  time, buffer state, pending tool calls, and last SSE event type to
  aid future debugging of stream failures.

https://claude.ai/code/session_017Vb4YgN8SgPsMVsTd8KRUB