### PR TITLE
fix: grant net_discovery capability to Telegram chat sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1244,9 +1244,17 @@ async fn execute_single_tool(
     session_id: uuid::Uuid,
 ) -> Result<ToolResult> {
     if !capabilities.can_use_tool(&call.name) {
+        let granted: Vec<String> = capabilities
+            .list()
+            .filter_map(|c| match c {
+                rustykrab_core::capability::Capability::Tool(name) => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
         tracing::warn!(
             tool = call.name,
             session = %session_id,
+            granted_tool_count = granted.len(),
             "tool call denied: insufficient capabilities"
         );
         return Err(Error::Auth(format!(
@@ -1255,9 +1263,16 @@ async fn execute_single_tool(
         )));
     }
 
+    // Look up the tool by exact name first, then by trimmed/base name so
+    // that the lookup stays consistent with can_use_tool's normalisation.
+    let call_name_trimmed = call.name.trim();
+    let call_base_name = call_name_trimmed
+        .split(':')
+        .next()
+        .unwrap_or(call_name_trimmed);
     let tool = tools
         .iter()
-        .find(|t| t.name() == call.name)
+        .find(|t| t.name() == call_name_trimmed || t.name() == call_base_name)
         .ok_or_else(|| Error::ToolExecution(format!("unknown tool: {}", call.name).into()))?;
 
     // Basic schema validation: check required parameters are present.

--- a/crates/rustykrab-core/src/capability.rs
+++ b/crates/rustykrab-core/src/capability.rs
@@ -68,9 +68,27 @@ impl CapabilitySet {
     }
 
     /// Check whether the set has permission to use a specific tool.
+    ///
+    /// Normalises the tool name before lookup: trims whitespace and, if
+    /// the name contains a colon separator (e.g. `"net_discovery:arp_scan"`
+    /// emitted by some models), checks the base name as well.
     pub fn can_use_tool(&self, tool_name: &str) -> bool {
-        self.capabilities
-            .contains(&Capability::Tool(tool_name.to_string()))
+        let trimmed = tool_name.trim();
+        if self
+            .capabilities
+            .contains(&Capability::Tool(trimmed.to_string()))
+        {
+            return true;
+        }
+        // Fall back to the base name before any colon separator.
+        if let Some(base) = trimmed.split(':').next() {
+            if base != trimmed {
+                return self
+                    .capabilities
+                    .contains(&Capability::Tool(base.to_string()));
+            }
+        }
+        false
     }
 
     /// Create a capability set that grants access to a specific set of tools
@@ -108,5 +126,54 @@ impl CapabilitySet {
     /// Return all granted capabilities.
     pub fn list(&self) -> impl Iterator<Item = &Capability> {
         self.capabilities.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_tools_permissive_includes_net_discovery() {
+        let tools = &["http_request", "read", "exec", "net_scan", "net_discovery"];
+        let caps = CapabilitySet::for_tools_permissive(tools);
+
+        assert!(caps.can_use_tool("net_discovery"));
+        assert!(caps.can_use_tool("net_scan"));
+        assert!(caps.can_use_tool("http_request"));
+        assert!(caps.has(&Capability::FileRead));
+        assert!(caps.has(&Capability::ShellExec));
+        assert!(caps.has(&Capability::HttpRequest));
+    }
+
+    #[test]
+    fn can_use_tool_trims_whitespace() {
+        let caps = CapabilitySet::for_tools(&["net_discovery"]);
+        assert!(caps.can_use_tool("net_discovery"));
+        assert!(caps.can_use_tool("net_discovery "));
+        assert!(caps.can_use_tool(" net_discovery"));
+        assert!(caps.can_use_tool(" net_discovery "));
+    }
+
+    #[test]
+    fn can_use_tool_handles_colon_separator() {
+        let caps = CapabilitySet::for_tools(&["net_discovery"]);
+        assert!(caps.can_use_tool("net_discovery:arp_scan"));
+        assert!(caps.can_use_tool("net_discovery:interfaces"));
+        assert!(caps.can_use_tool("net_discovery:dns_lookup"));
+    }
+
+    #[test]
+    fn can_use_tool_rejects_unknown() {
+        let caps = CapabilitySet::for_tools(&["net_discovery"]);
+        assert!(!caps.can_use_tool("net_scan"));
+        assert!(!caps.can_use_tool("unknown_tool"));
+    }
+
+    #[test]
+    fn default_safe_denies_tools() {
+        let caps = CapabilitySet::default_safe();
+        assert!(!caps.can_use_tool("net_discovery"));
+        assert!(caps.has(&Capability::HttpRequest));
     }
 }

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -95,6 +95,11 @@ async fn prepare_agent(
         .filter(|t| t.available())
         .map(|t| t.name())
         .collect();
+    tracing::debug!(
+        tool_count = tool_names.len(),
+        tools = ?tool_names,
+        "granting session capabilities for available tools"
+    );
     let caps = CapabilitySet::for_tools_permissive(&tool_names);
     let session = Session::with_capabilities(conv.id, caps);
 


### PR DESCRIPTION
The session capability gate was rejecting net_discovery tool calls with
"session does not have permission to use tool". Root cause: the
can_use_tool() check required an exact string match on the tool name,
but models (especially via Ollama) can return tool names with trailing
whitespace or composite "tool:action" names that don't match the
registered capability.

Changes:
- Make can_use_tool() normalise tool names: trim whitespace and fall back
  to the base name before any colon separator
- Align tool lookup in execute_single_tool() with the same normalisation
  so capability check and tool resolution stay consistent
- Add diagnostic tracing in prepare_agent() logging which tools get
  capabilities granted (visible at DEBUG level)
- Add unit tests for whitespace trimming, colon-separator handling, and
  net_discovery inclusion in for_tools_permissive()

https://claude.ai/code/session_01JPj2ni8WejqPfRAUaByhCm