### PR TITLE
fix(providers): raise Ollama HTTP timeout to 15 min and skip retry on timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/trace.rs
+++ b/crates/rustykrab-agent/src/trace.rs
@@ -149,7 +149,7 @@ impl ExecutionTracer {
             .iter()
             .map(|(n, s)| (n.clone(), s.clone()))
             .collect();
-        sorted.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
         sorted.truncate(limit);
         sorted
     }
@@ -167,7 +167,7 @@ impl ExecutionTracer {
 
         // Sort by call count descending.
         let mut sorted: Vec<_> = inner.stats.iter().collect();
-        sorted.sort_by(|a, b| b.1.calls.cmp(&a.1.calls));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.calls));
 
         for (name, stats) in &sorted {
             let rate = (stats.success_rate() * 100.0) as u32;

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -94,8 +94,16 @@ pub struct OllamaProvider {
 
 impl OllamaProvider {
     pub fn new(model: impl Into<String>) -> Self {
+        // Large prompts (near the 100K `num_ctx`) can easily take more than
+        // five minutes for prompt evaluation on a local GPU, so allow up to
+        // 15 minutes per request before we give up.  Can be overridden via
+        // `OLLAMA_TIMEOUT_SECS`.
+        let timeout_secs = std::env::var("OLLAMA_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(900);
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(300))
+            .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(10))
             .build()
             .expect("failed to build HTTP client");
@@ -384,6 +392,22 @@ impl ModelProvider for OllamaProvider {
             let resp = match self.client.post(&url).json(&body).send().await {
                 Ok(r) => r,
                 Err(e) => {
+                    // Don't retry timeouts: retrying the same 99K-token prompt
+                    // would just burn another 15-minute budget for the same
+                    // failure.  The caller (agent loop) needs to reduce context
+                    // or abort before re-trying.
+                    if e.is_timeout() {
+                        tracing::warn!(
+                            model = %self.model,
+                            num_messages = ollama_messages.len(),
+                            num_ctx = self.config.num_ctx,
+                            "Ollama request timed out — not retrying (reduce context or raise OLLAMA_TIMEOUT_SECS)"
+                        );
+                        return Err(Error::ModelProvider(format!(
+                            "Ollama request timed out after the configured HTTP timeout. \
+                             Reduce prompt size or raise OLLAMA_TIMEOUT_SECS: {e}"
+                        )));
+                    }
                     last_err = Some(Error::ModelProvider(format!(
                         "failed to connect to Ollama at {}: {e}. Is Ollama running?",
                         self.base_url
@@ -500,6 +524,19 @@ impl ModelProvider for OllamaProvider {
             let r = match self.client.post(&url).json(&body).send().await {
                 Ok(r) => r,
                 Err(e) => {
+                    // Don't retry timeouts — see `chat` for rationale.
+                    if e.is_timeout() {
+                        tracing::warn!(
+                            model = %self.model,
+                            num_messages = ollama_messages.len(),
+                            num_ctx = self.config.num_ctx,
+                            "Ollama streaming request timed out — not retrying"
+                        );
+                        return Err(Error::ModelProvider(format!(
+                            "Ollama streaming request timed out after the configured HTTP timeout. \
+                             Reduce prompt size or raise OLLAMA_TIMEOUT_SECS: {e}"
+                        )));
+                    }
                     last_err = Some(Error::ModelProvider(format!(
                         "failed to connect to Ollama at {}: {e}. Is Ollama running?",
                         self.base_url

--- a/crates/rustykrab-tools/src/sanitize.rs
+++ b/crates/rustykrab-tools/src/sanitize.rs
@@ -61,71 +61,59 @@ pub fn html_to_text(html: &str, include_links: bool) -> String {
                             in_script_or_style = true;
                         }
                     }
-                    "br" | "hr" => {
-                        if !in_script_or_style {
-                            if in_anchor {
-                                anchor_text.push('\n');
-                            } else {
-                                result.push('\n');
-                            }
+                    "br" | "hr" if !in_script_or_style => {
+                        if in_anchor {
+                            anchor_text.push('\n');
+                        } else {
+                            result.push('\n');
                         }
                     }
                     "p" | "div" | "section" | "article" | "main" | "header" | "footer" | "nav"
-                    | "aside" | "blockquote" | "tr" | "table" => {
-                        if !in_script_or_style {
-                            if is_closing {
-                                if in_anchor {
-                                    anchor_text.push_str("\n\n");
-                                } else {
-                                    result.push_str("\n\n");
-                                }
+                    | "aside" | "blockquote" | "tr" | "table"
+                        if !in_script_or_style =>
+                    {
+                        if is_closing {
+                            if in_anchor {
+                                anchor_text.push_str("\n\n");
                             } else {
-                                if in_anchor {
-                                    anchor_text.push('\n');
-                                } else {
-                                    result.push('\n');
-                                }
+                                result.push_str("\n\n");
                             }
+                        } else if in_anchor {
+                            anchor_text.push('\n');
+                        } else {
+                            result.push('\n');
                         }
                     }
-                    "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
-                        if !in_script_or_style {
-                            result.push_str("\n\n");
-                        }
+                    "h1" | "h2" | "h3" | "h4" | "h5" | "h6" if !in_script_or_style => {
+                        result.push_str("\n\n");
                     }
-                    "li" => {
-                        if !in_script_or_style && !is_closing {
-                            result.push_str("\n- ");
-                        }
+                    "li" if !in_script_or_style && !is_closing => {
+                        result.push_str("\n- ");
                     }
-                    "a" => {
-                        if !in_script_or_style && include_links {
-                            if is_closing {
-                                // End of anchor — emit markdown link
-                                if !current_href.is_empty() && !anchor_text.trim().is_empty() {
-                                    result.push('[');
-                                    result.push_str(anchor_text.trim());
-                                    result.push_str("](");
-                                    result.push_str(&current_href);
-                                    result.push(')');
-                                } else {
-                                    result.push_str(anchor_text.trim());
-                                }
-                                in_anchor = false;
-                                anchor_text.clear();
-                                current_href.clear();
+                    "a" if !in_script_or_style && include_links => {
+                        if is_closing {
+                            // End of anchor — emit markdown link
+                            if !current_href.is_empty() && !anchor_text.trim().is_empty() {
+                                result.push('[');
+                                result.push_str(anchor_text.trim());
+                                result.push_str("](");
+                                result.push_str(&current_href);
+                                result.push(')');
                             } else {
-                                // Extract href from tag attributes
-                                current_href = extract_href(&tag_name);
-                                in_anchor = true;
-                                anchor_text.clear();
+                                result.push_str(anchor_text.trim());
                             }
+                            in_anchor = false;
+                            anchor_text.clear();
+                            current_href.clear();
+                        } else {
+                            // Extract href from tag attributes
+                            current_href = extract_href(&tag_name);
+                            in_anchor = true;
+                            anchor_text.clear();
                         }
                     }
-                    "td" | "th" => {
-                        if !in_script_or_style && is_closing {
-                            result.push('\t');
-                        }
+                    "td" | "th" if !in_script_or_style && is_closing => {
+                        result.push('\t');
                     }
                     _ => {}
                 }


### PR DESCRIPTION
The Ollama provider's 5-minute HTTP timeout was too short for large prompts
near the 100K num_ctx, where prompt evaluation alone can exceed 5 minutes
on a local GPU. Bump the default to 900 s (15 min) and make it configurable
via OLLAMA_TIMEOUT_SECS.

Also fix the retry loop: previously a timeout would fall through to the
connection-error branch and be retried up to MAX_RETRIES times with the
same 99K-token body, burning another 15-minute window per attempt for the
same failure. On timeout we now bail out immediately with a clear error
message so the caller can reduce context or raise the limit.

Applies to both the non-streaming `chat` path and the streaming `chat_stream`
initial request.