### PR TITLE
feat(cron): persistent conversations across scheduled runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -94,7 +94,35 @@ impl CronBackend for CronAdapter {
     }
 
     async fn delete_job(&self, job_id: &str) -> rustykrab_core::Result<serde_json::Value> {
+        // Grab the conversation id (if any) before the row goes away so we
+        // can reap the associated persistent conversation below. Missing
+        // jobs are fine; delete_job returns `false` without error.
+        let conversation_id = match self.store.jobs().get_job(job_id) {
+            Ok(job) => job.conversation_id,
+            Err(rustykrab_core::Error::NotFound(_)) => None,
+            Err(e) => return Err(e),
+        };
+
         let deleted = self.store.jobs().delete_job(job_id)?;
+
+        if deleted {
+            if let Some(cid) = conversation_id {
+                if let Ok(uuid) = uuid::Uuid::parse_str(&cid) {
+                    // NotFound is fine — the conversation may already be gone.
+                    match self.store.conversations().delete(uuid) {
+                        Ok(()) | Err(rustykrab_core::Error::NotFound(_)) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                job_id = %job_id,
+                                conv_id = %cid,
+                                "failed to reap conversation for deleted job: {e}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(serde_json::json!({ "deleted": deleted, "job_id": job_id }))
     }
 

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -5,8 +5,9 @@ use tokio::sync::{mpsc, Mutex, Semaphore};
 
 use chrono::Utc;
 use rustykrab_agent::AgentEvent;
-use rustykrab_core::types::MessageContent;
+use rustykrab_core::types::{Conversation, MessageContent};
 use rustykrab_gateway::AppState;
+use uuid::Uuid;
 
 /// Where a task originated and how to deliver results.
 #[derive(Debug, Clone)]
@@ -146,16 +147,17 @@ async fn execute_cron_task(
     let started_at = Utc::now();
     tracing::info!(job_id = %job_id, task = %task_prompt, "executing scheduled job");
 
-    // Create a fresh conversation for this job execution.
-    let mut conv = match state.store.conversations().create() {
-        Ok(c) => c,
+    // Load the job so we can resume its persistent conversation and use
+    // last_run_at in the prompt.
+    let job = match store.jobs().get_job(job_id) {
+        Ok(j) => j,
         Err(e) => {
-            tracing::error!(job_id = %job_id, "failed to create conversation for scheduled job: {e}");
+            tracing::error!(job_id = %job_id, "failed to load scheduled job: {e}");
             let finished_at = Utc::now();
             let _ = store.jobs().record_run(
                 job_id,
                 "error",
-                Some(&format!("failed to create conversation: {e}")),
+                Some(&format!("failed to load job: {e}")),
                 started_at,
                 finished_at,
             );
@@ -163,11 +165,23 @@ async fn execute_cron_task(
         }
     };
 
-    // Prefix the task so the agent knows this is a scheduled execution.
-    let prompt = format!(
-        "[Scheduled task] The following task was scheduled by the user and is now due. \
-         Execute it and provide the result concisely.\n\nTask: {task_prompt}"
-    );
+    let mut conv = match resume_or_create_conversation(&job, state, store) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(job_id = %job_id, "failed to resume conversation for scheduled job: {e}");
+            let finished_at = Utc::now();
+            let _ = store.jobs().record_run(
+                job_id,
+                "error",
+                Some(&format!("failed to resume conversation: {e}")),
+                started_at,
+                finished_at,
+            );
+            return;
+        }
+    };
+
+    let prompt = build_scheduled_prompt(task_prompt, job.last_run_at);
 
     // Run the agent.
     let no_op_event = |_event: AgentEvent| {};
@@ -237,8 +251,67 @@ async fn execute_cron_task(
         tracing::error!(job_id = %job_id, "failed to mark scheduled job as executed: {e}");
     }
 
-    // Clean up the ephemeral conversation.
-    if let Err(e) = state.store.conversations().delete(conv.id) {
-        tracing::warn!(job_id = %job_id, "failed to clean up job conversation: {e}");
+    // Conversation is intentionally NOT deleted: the next run of this job
+    // resumes it so the agent sees prior context. Deletion happens when
+    // the job itself is deleted (see CronAdapter::delete_job).
+}
+
+/// Resume this job's persistent conversation, or create one on the first
+/// run. If the stored id points at a conversation that has been deleted
+/// out from under us, silently create a fresh one and re-link.
+fn resume_or_create_conversation(
+    job: &rustykrab_store::ScheduledJob,
+    state: &AppState,
+    store: &rustykrab_store::Store,
+) -> Result<Conversation, rustykrab_core::Error> {
+    if let Some(cid) = &job.conversation_id {
+        if let Ok(uuid) = Uuid::parse_str(cid) {
+            match state.store.conversations().get(uuid) {
+                Ok(c) => return Ok(c),
+                Err(rustykrab_core::Error::NotFound(_)) => {
+                    tracing::warn!(
+                        job_id = %job.id,
+                        stale_conv_id = %cid,
+                        "stored conversation missing; creating replacement"
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+        } else {
+            tracing::warn!(
+                job_id = %job.id,
+                bad_conv_id = %cid,
+                "stored conversation id is malformed; creating replacement"
+            );
+        }
+    }
+
+    let conv = state.store.conversations().create()?;
+    store
+        .jobs()
+        .set_conversation_id(&job.id, &conv.id.to_string())?;
+    Ok(conv)
+}
+
+/// Build the user message prepended to the agent's turn. On the first run
+/// there's no prior context, so we say so; on subsequent runs the prompt
+/// points the agent at the conversation history it already has.
+fn build_scheduled_prompt(
+    task_prompt: &str,
+    last_run_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> String {
+    match last_run_at {
+        Some(last) => format!(
+            "[Scheduled task] Your scheduled task is due again. Earlier runs are in \
+             this conversation — refer to them for any state, filenames, or \
+             decisions you made previously. Last run was at {last}.\n\n\
+             Task: {task_prompt}"
+        ),
+        None => format!(
+            "[Scheduled task] Your scheduled task is due for the first time. This \
+             conversation will persist across runs, so any state you want to reuse \
+             (filenames, conventions, summaries) can simply be written down here.\n\n\
+             Task: {task_prompt}"
+        ),
     }
 }

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -22,6 +22,10 @@ pub struct ScheduledJob {
     pub next_run_at: DateTime<Utc>,
     pub last_run_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+    /// The conversation this job resumes on each run. `None` until the first
+    /// run creates and persists one; subsequent runs append to the same
+    /// conversation so the agent sees prior context.
+    pub conversation_id: Option<String>,
 }
 
 /// A recorded execution of a scheduled job.
@@ -75,12 +79,13 @@ impl JobStore {
             next_run_at,
             last_run_at: None,
             created_at: now,
+            conversation_id: None,
         };
 
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, one_shot, enabled, next_run_at, last_run_at, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, one_shot, enabled, next_run_at, last_run_at, created_at, conversation_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 job.id,
                 job.schedule,
@@ -92,6 +97,7 @@ impl JobStore {
                 job.next_run_at.to_rfc3339(),
                 job.last_run_at.map(|t| t.to_rfc3339()),
                 job.created_at.to_rfc3339(),
+                job.conversation_id,
             ],
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -103,32 +109,32 @@ impl JobStore {
     pub fn list_jobs(&self) -> Result<Vec<ScheduledJob>, Error> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
-            .prepare(
-                "SELECT id, schedule, task, channel, chat_id, one_shot, enabled, next_run_at, last_run_at, created_at
-                 FROM scheduled_jobs ORDER BY next_run_at",
-            )
+            .prepare(&format!(
+                "SELECT {JOB_COLUMNS} FROM scheduled_jobs ORDER BY next_run_at",
+            ))
             .map_err(|e| Error::Storage(e.to_string()))?;
 
         let jobs = stmt
-            .query_map([], |row| {
-                Ok(ScheduledJob {
-                    id: row.get(0)?,
-                    schedule: row.get(1)?,
-                    task: row.get(2)?,
-                    channel: row.get(3)?,
-                    chat_id: row.get(4)?,
-                    one_shot: row.get::<_, i32>(5)? != 0,
-                    enabled: row.get::<_, i32>(6)? != 0,
-                    next_run_at: parse_stored_timestamp(row.get::<_, String>(7)?),
-                    last_run_at: row.get::<_, Option<String>>(8)?.map(parse_stored_timestamp),
-                    created_at: parse_stored_timestamp(row.get::<_, String>(9)?),
-                })
-            })
+            .query_map([], row_to_job)
             .map_err(|e| Error::Storage(e.to_string()))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Error::Storage(e.to_string()))?;
 
         Ok(jobs)
+    }
+
+    /// Fetch a single scheduled job by ID. Returns `NotFound` if absent.
+    pub fn get_job(&self, job_id: &str) -> Result<ScheduledJob, Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            &format!("SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE id = ?1"),
+            params![job_id],
+            row_to_job,
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => Error::NotFound(format!("job {job_id}")),
+            other => Error::Storage(other.to_string()),
+        })
     }
 
     /// Delete a scheduled job by ID.
@@ -140,32 +146,29 @@ impl JobStore {
         Ok(rows > 0)
     }
 
+    /// Attach a conversation id to a job. Called on the first run once the
+    /// executor has created (or resumed) the conversation the agent uses.
+    pub fn set_conversation_id(&self, job_id: &str, conversation_id: &str) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE scheduled_jobs SET conversation_id = ?1 WHERE id = ?2",
+            params![conversation_id, job_id],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
     /// Return all enabled jobs whose `next_run_at` is at or before `now`.
     pub fn get_due_jobs(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledJob>, Error> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
-            .prepare(
-                "SELECT id, schedule, task, channel, chat_id, one_shot, enabled, next_run_at, last_run_at, created_at
-                 FROM scheduled_jobs
-                 WHERE enabled = 1 AND next_run_at <= ?1",
-            )
+            .prepare(&format!(
+                "SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE enabled = 1 AND next_run_at <= ?1",
+            ))
             .map_err(|e| Error::Storage(e.to_string()))?;
 
         let jobs = stmt
-            .query_map(params![now.to_rfc3339()], |row| {
-                Ok(ScheduledJob {
-                    id: row.get(0)?,
-                    schedule: row.get(1)?,
-                    task: row.get(2)?,
-                    channel: row.get(3)?,
-                    chat_id: row.get(4)?,
-                    one_shot: row.get::<_, i32>(5)? != 0,
-                    enabled: row.get::<_, i32>(6)? != 0,
-                    next_run_at: parse_stored_timestamp(row.get::<_, String>(7)?),
-                    last_run_at: row.get::<_, Option<String>>(8)?.map(parse_stored_timestamp),
-                    created_at: parse_stored_timestamp(row.get::<_, String>(9)?),
-                })
-            })
+            .query_map(params![now.to_rfc3339()], row_to_job)
             .map_err(|e| Error::Storage(e.to_string()))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -275,6 +278,28 @@ impl JobStore {
 
         Ok(runs)
     }
+}
+
+/// Column list for `SELECT`s against `scheduled_jobs`. Kept in sync with
+/// [`row_to_job`].
+const JOB_COLUMNS: &str = "id, schedule, task, channel, chat_id, one_shot, enabled, \
+     next_run_at, last_run_at, created_at, conversation_id";
+
+/// Decode a row produced by a `SELECT {JOB_COLUMNS}` into a [`ScheduledJob`].
+fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduledJob> {
+    Ok(ScheduledJob {
+        id: row.get(0)?,
+        schedule: row.get(1)?,
+        task: row.get(2)?,
+        channel: row.get(3)?,
+        chat_id: row.get(4)?,
+        one_shot: row.get::<_, i32>(5)? != 0,
+        enabled: row.get::<_, i32>(6)? != 0,
+        next_run_at: parse_stored_timestamp(row.get::<_, String>(7)?),
+        last_run_at: row.get::<_, Option<String>>(8)?.map(parse_stored_timestamp),
+        created_at: parse_stored_timestamp(row.get::<_, String>(9)?),
+        conversation_id: row.get::<_, Option<String>>(10)?,
+    })
 }
 
 /// Parse a schedule string, returning `(is_one_shot, next_run_at)`.
@@ -431,5 +456,64 @@ mod tests {
         let (one_shot, next_run) = parse_schedule("0 9 * * *", now).unwrap();
         assert!(!one_shot);
         assert!(next_run > now);
+    }
+
+    /// Build a [`JobStore`] backed by an in-memory SQLite connection with
+    /// just the schema the tests need. Avoids pulling in a tempdir crate.
+    fn in_memory_jobs() -> JobStore {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE scheduled_jobs (
+                id              TEXT PRIMARY KEY,
+                schedule        TEXT NOT NULL,
+                task            TEXT NOT NULL,
+                channel         TEXT,
+                chat_id         TEXT,
+                one_shot        INTEGER NOT NULL DEFAULT 0,
+                enabled         INTEGER NOT NULL DEFAULT 1,
+                next_run_at     TEXT NOT NULL,
+                last_run_at     TEXT,
+                created_at      TEXT NOT NULL,
+                conversation_id TEXT
+            );
+            CREATE TABLE job_runs (
+                id          TEXT PRIMARY KEY,
+                job_id      TEXT NOT NULL,
+                status      TEXT NOT NULL,
+                output      TEXT,
+                started_at  TEXT NOT NULL,
+                finished_at TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        JobStore::new(Arc::new(Mutex::new(conn)))
+    }
+
+    #[test]
+    fn conversation_id_round_trip() {
+        let jobs = in_memory_jobs();
+        let job = jobs.create_job("*/5 * * * *", "ping", None, None).unwrap();
+        assert!(
+            job.conversation_id.is_none(),
+            "newly created jobs have no conversation yet"
+        );
+
+        jobs.set_conversation_id(&job.id, "conv-123").unwrap();
+        let reloaded = jobs.get_job(&job.id).unwrap();
+        assert_eq!(reloaded.conversation_id.as_deref(), Some("conv-123"));
+
+        // list_jobs and get_due_jobs also propagate the column.
+        let listed = jobs.list_jobs().unwrap();
+        assert_eq!(listed[0].conversation_id.as_deref(), Some("conv-123"));
+    }
+
+    #[test]
+    fn get_job_missing_returns_not_found() {
+        let jobs = in_memory_jobs();
+        let err = jobs.get_job("nope").unwrap_err();
+        assert!(
+            matches!(err, Error::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
     }
 }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -68,16 +68,17 @@ impl Store {
             );
 
             CREATE TABLE IF NOT EXISTS scheduled_jobs (
-                id          TEXT PRIMARY KEY,
-                schedule    TEXT NOT NULL,
-                task        TEXT NOT NULL,
-                channel     TEXT,
-                chat_id     TEXT,
-                one_shot    INTEGER NOT NULL DEFAULT 0,
-                enabled     INTEGER NOT NULL DEFAULT 1,
-                next_run_at TEXT NOT NULL,
-                last_run_at TEXT,
-                created_at  TEXT NOT NULL
+                id              TEXT PRIMARY KEY,
+                schedule        TEXT NOT NULL,
+                task            TEXT NOT NULL,
+                channel         TEXT,
+                chat_id         TEXT,
+                one_shot        INTEGER NOT NULL DEFAULT 0,
+                enabled         INTEGER NOT NULL DEFAULT 1,
+                next_run_at     TEXT NOT NULL,
+                last_run_at     TEXT,
+                created_at      TEXT NOT NULL,
+                conversation_id TEXT
             );
 
             CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_due
@@ -106,6 +107,26 @@ impl Store {
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
+
+        // Additive migration for pre-existing databases. PRAGMA table_info
+        // lists current columns; only ALTER if conversation_id is missing.
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(scheduled_jobs)")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let existing: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        drop(stmt);
+        if !existing.iter().any(|c| c == "conversation_id") {
+            conn.execute(
+                "ALTER TABLE scheduled_jobs ADD COLUMN conversation_id TEXT",
+                [],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Each scheduled job now resumes the same conversation on every fire
instead of getting a fresh, empty one created-then-deleted around the
agent call. This gives the agent continuity for multi-run tasks
(filename conventions, "since last check" windows, prior summaries)
without pushing state into memory search.

Changes:
- scheduled_jobs gets a nullable conversation_id column (additive
  migration via PRAGMA table_info + ADD COLUMN for existing DBs).
- JobStore gains get_job and set_conversation_id; row decoding is
  centralised in row_to_job so the three select sites can't drift.
- execute_cron_task loads the job, resumes its conversation (or
  creates + persists one on first run, and re-links on stale id),
  and no longer deletes the conversation afterward.
- CronAdapter::delete_job fetches the job first so it can reap the
  associated conversation when the job row is removed.
- Prompt wrapper distinguishes first run from subsequent runs and
  surfaces last_run_at so the agent knows the window it's covering.

Inspired by OpenClaw's cron-owned session keyed on job id.

Note: pre-commit clippy/test run was partial — rustykrab-store and
rustykrab-tools passed, but rustykrab-cli could not build in this
sandbox because ort-sys (pulled in transitively via fastembed) tries
to download prebuilt ONNX binaries from a CDN that returns HTTP 403.
This is unrelated to the changes; CI will run the full workspace check.