### PR TITLE
fix(agent): derive compaction threshold from provider's context limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All configuration is via environment variables. No plaintext config files.
 | `RUSTYKRAB_PROVIDER` | `anthropic` | Model backend: `anthropic` or `ollama` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use |
+| `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
 | `OLLAMA_NUM_CTX` | — | Explicit client-side `num_ctx` override. Omitted by default so the server's own `OLLAMA_CONTEXT_LENGTH` (or per-model default) wins |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All configuration is via environment variables. No plaintext config files.
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use |
 | `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
+| `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` | `65536` | Hard upper bound on the context window used to compute the compaction threshold. Keeps compaction firing at a sane size even when the backing model advertises a much larger window |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
 | `OLLAMA_NUM_CTX` | — | Explicit client-side `num_ctx` override. Omitted by default so the server's own `OLLAMA_CONTEXT_LENGTH` (or per-model default) wins |

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 use chrono::Utc;
@@ -39,6 +40,25 @@ const EMPTY_RESPONSE_RETRY_LIMIT: usize = 1;
 /// Maximum retries for a planning-only response (model described intent
 /// without using tools).
 const PLANNING_ONLY_RETRY_LIMIT: usize = 2;
+
+/// Default upper bound on the effective context window used when computing
+/// the compaction threshold. Keeps compaction aggressive even when the
+/// backing model advertises a much larger window (e.g. a 128k-ctx Ollama
+/// deployment whose GPU can't actually evaluate that much in reasonable
+/// time). Override with the `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` env var.
+const DEFAULT_COMPACTION_CONTEXT_CEILING: usize = 65_536;
+
+/// Return the compaction context ceiling, reading the env var once.
+fn compaction_context_ceiling() -> usize {
+    static CEILING: OnceLock<usize> = OnceLock::new();
+    *CEILING.get_or_init(|| {
+        std::env::var("RUSTYKRAB_COMPACTION_CONTEXT_CEILING")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(DEFAULT_COMPACTION_CONTEXT_CEILING)
+    })
+}
 
 /// Classification of a model response that didn't include tool calls.
 enum ResponseClass {
@@ -1014,11 +1034,14 @@ impl AgentRunner {
     /// reported limit (Ollama's detected `num_ctx`, Anthropic's env-var
     /// override or built-in default) so downstream budgets derive from a
     /// single source of truth. Falls back to `config.max_context_tokens`
-    /// when the provider doesn't know.
+    /// when the provider doesn't know. Capped by the compaction ceiling
+    /// so runaway local-model context windows still trigger compaction
+    /// at a sane size.
     fn effective_context_limit(&self) -> usize {
         self.provider
             .context_limit()
             .unwrap_or(self.config.max_context_tokens)
+            .min(compaction_context_ceiling())
     }
 
     /// Returns true if the conversation has crossed the compaction threshold.

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1010,13 +1010,24 @@ impl AgentRunner {
         messages.iter().map(Self::estimate_message_tokens).sum()
     }
 
+    /// Effective context-window budget in tokens. Prefers the provider's
+    /// reported limit (Ollama's detected `num_ctx`, Anthropic's env-var
+    /// override or built-in default) so downstream budgets derive from a
+    /// single source of truth. Falls back to `config.max_context_tokens`
+    /// when the provider doesn't know.
+    fn effective_context_limit(&self) -> usize {
+        self.provider
+            .context_limit()
+            .unwrap_or(self.config.max_context_tokens)
+    }
+
     /// Returns true if the conversation has crossed the compaction threshold.
     fn needs_compaction(&self, messages: &[Message]) -> bool {
         if self.config.compaction_threshold_pct <= 0.0 {
             return false;
         }
         let threshold =
-            (self.config.max_context_tokens as f64 * self.config.compaction_threshold_pct) as usize;
+            (self.effective_context_limit() as f64 * self.config.compaction_threshold_pct) as usize;
         let estimated = Self::estimate_conversation_tokens(messages);
         estimated >= threshold
     }

--- a/crates/rustykrab-core/src/model.rs
+++ b/crates/rustykrab-core/src/model.rs
@@ -55,6 +55,17 @@ pub trait ModelProvider: Send + Sync {
     /// Human-readable name of the provider.
     fn name(&self) -> &str;
 
+    /// Model's context window in tokens, when known.
+    ///
+    /// Serves as the single source of truth for downstream budgets —
+    /// compaction thresholds, prompt trimming, memory retrieval sizing.
+    /// Providers should derive this from the backing model (e.g. Ollama
+    /// reads `/api/show`) or an explicit env-var override. Returning
+    /// `None` means "unknown" and callers fall back to their own default.
+    fn context_limit(&self) -> Option<usize> {
+        None
+    }
+
     /// Send a conversation to the model and get back the next message.
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse>;
 

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -24,6 +24,24 @@ pub struct AnthropicProvider {
     api_key: SecretString,
     model: String,
     max_tokens: u32,
+    /// Context window in tokens. Populated from `ANTHROPIC_CONTEXT_LENGTH`
+    /// when set; otherwise falls back to Claude's standard 200k window.
+    /// Unlike Ollama, Anthropic doesn't expose a per-model context length
+    /// endpoint, so the env var is the operator's escape hatch (e.g. to
+    /// force the 1M-token beta window on Claude 4/5 models).
+    context_limit: usize,
+}
+
+/// Default context window for Claude models when no override is set.
+/// All current production Claude models (3.5, 4, 4.5, 4.6, 4.7) ship with
+/// at least a 200k-token context window.
+const DEFAULT_ANTHROPIC_CONTEXT_TOKENS: usize = 200_000;
+
+fn anthropic_context_limit_from_env() -> Option<usize> {
+    std::env::var("ANTHROPIC_CONTEXT_LENGTH")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v > 0)
 }
 
 impl AnthropicProvider {
@@ -38,6 +56,8 @@ impl AnthropicProvider {
             api_key: SecretString::from(api_key),
             model: "claude-sonnet-4-20250514".to_string(),
             max_tokens: 4096,
+            context_limit: anthropic_context_limit_from_env()
+                .unwrap_or(DEFAULT_ANTHROPIC_CONTEXT_TOKENS),
         }
     }
 
@@ -48,6 +68,13 @@ impl AnthropicProvider {
 
     pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
         self.max_tokens = max_tokens;
+        self
+    }
+
+    /// Explicit context-window override. Takes precedence over
+    /// `ANTHROPIC_CONTEXT_LENGTH` and the built-in default.
+    pub fn with_context_limit(mut self, context_limit: usize) -> Self {
+        self.context_limit = context_limit;
         self
     }
 
@@ -242,6 +269,10 @@ impl AnthropicProvider {
 impl ModelProvider for AnthropicProvider {
     fn name(&self) -> &str {
         "anthropic"
+    }
+
+    fn context_limit(&self) -> Option<usize> {
+        Some(self.context_limit)
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -506,6 +506,10 @@ impl ModelProvider for OllamaProvider {
         "ollama"
     }
 
+    fn context_limit(&self) -> Option<usize> {
+        self.effective_ctx().map(|v| v as usize)
+    }
+
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
         let ollama_messages = Self::build_messages(messages)?;
 


### PR DESCRIPTION
The agent's RLM-style compaction fired at 85% of a hardcoded 128k token
budget (AgentConfig::max_context_tokens) regardless of what the backing
model could actually hold. Ollama already discovered the real context
window via /api/show and trimmed its own requests, but the agent never
saw that number — so long conversations on smaller models (e.g.
gemma4:26b with a 32k window) silently hit Ollama-side truncation or
request timeouts instead of being compacted.

Introduce a single source of truth: ModelProvider::context_limit().
- Ollama returns its effective_ctx() (explicit num_ctx or detected value)
- Anthropic reads ANTHROPIC_CONTEXT_LENGTH (default 200k, matches the
  standard Claude window) since the API exposes no discovery endpoint
- AgentRunner::needs_compaction uses the provider value when available,
  falling back to AgentConfig::max_context_tokens