### PR TITLE
feat(memory): auto-persist every conversation turn to working memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.2"
+version = "2.6.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,6 +3359,7 @@ dependencies = [
  "rustykrab-agent",
  "rustykrab-channels",
  "rustykrab-core",
+ "rustykrab-memory",
  "rustykrab-skills",
  "rustykrab-store",
  "serde",

--- a/crates/rustykrab-agent/src/lib.rs
+++ b/crates/rustykrab-agent/src/lib.rs
@@ -9,7 +9,7 @@ pub mod voting;
 pub use harness::HarnessProfile;
 pub use rlm::RecursiveExecutor;
 pub use router::HarnessRouter;
-pub use runner::{AgentConfig, AgentEvent, AgentRunner};
+pub use runner::{AgentConfig, AgentEvent, AgentRunner, OnMessageCallback};
 pub use sandbox::{NoSandbox, ProcessSandbox, Sandbox, SandboxPolicy};
 pub use trace::{ExecutionTracer, ToolStats, ToolTrace};
 pub use voting::ConsistencyVoter;

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -230,6 +230,20 @@ impl AgentRunner {
         &self.tracer
     }
 
+    /// Append a message to the conversation, bump `updated_at`, and fire
+    /// `on_message`. This is the single choke point every synthesized or
+    /// model-produced message flows through, so memory auto-persist sees
+    /// every turn — user prompts, assistant responses, tool results,
+    /// reflection injections, and the compaction summary — not just LLM
+    /// responses.
+    fn push_message(&self, conv: &mut Conversation, message: Message) {
+        conv.messages.push(message.clone());
+        conv.updated_at = Utc::now();
+        if let Some(ref cb) = self.on_message {
+            cb(&message);
+        }
+    }
+
     /// Run the agent loop on a conversation within a session's capability scope.
     ///
     /// Each call creates a fresh ExecutionTracer to prevent cross-session
@@ -285,15 +299,18 @@ impl AgentRunner {
                 && !soft_warning_injected
             {
                 soft_warning_injected = true;
-                conv.messages.push(Message {
-                    id: Uuid::new_v4(),
-                    role: Role::System,
-                    content: MessageContent::Text(format!(
-                        "[Warning: {iteration}/{} iterations used.]",
-                        self.config.max_iterations
-                    )),
-                    created_at: Utc::now(),
-                });
+                self.push_message(
+                    conv,
+                    Message {
+                        id: Uuid::new_v4(),
+                        role: Role::System,
+                        content: MessageContent::Text(format!(
+                            "[Warning: {iteration}/{} iterations used.]",
+                            self.config.max_iterations
+                        )),
+                        created_at: Utc::now(),
+                    },
+                );
             }
 
             let llm_start = std::time::Instant::now();
@@ -313,12 +330,7 @@ impl AgentRunner {
                 "LLM call completed"
             );
 
-            conv.messages.push(message.clone());
-            conv.updated_at = Utc::now();
-
-            if let Some(ref cb) = self.on_message {
-                cb(&message);
-            }
+            self.push_message(conv, message.clone());
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
@@ -392,9 +404,8 @@ impl AgentRunner {
                             }
                         }
                     };
-                    conv.messages.push(tool_msg);
+                    self.push_message(conv, tool_msg);
                 }
-                conv.updated_at = Utc::now();
 
                 // Reflection on repeated errors.
                 if had_errors {
@@ -417,12 +428,15 @@ impl AgentRunner {
             match stop_reason {
                 StopReason::MaxTokens => {
                     tracing::warn!("model hit max tokens, prompting to continue");
-                    conv.messages.push(Message {
-                        id: Uuid::new_v4(),
-                        role: Role::User,
-                        content: MessageContent::Text("Continue.".to_string()),
-                        created_at: Utc::now(),
-                    });
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::User,
+                            content: MessageContent::Text("Continue.".to_string()),
+                            created_at: Utc::now(),
+                        },
+                    );
                     continue;
                 }
                 StopReason::EndTurn => {
@@ -448,14 +462,17 @@ impl AgentRunner {
                                 tracing::warn!("empty response retries exhausted");
                                 return Ok(());
                             }
-                            conv.messages.push(Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(
-                                    "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
-                                ),
-                                created_at: Utc::now(),
-                            });
+                            self.push_message(
+                                conv,
+                                Message {
+                                    id: Uuid::new_v4(),
+                                    role: Role::User,
+                                    content: MessageContent::Text(
+                                        "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
+                                    ),
+                                    created_at: Utc::now(),
+                                },
+                            );
                             continue;
                         }
                         ResponseClass::PlanningOnly => {
@@ -476,14 +493,17 @@ impl AgentRunner {
                                 retries = planning_only_retries,
                                 "model produced planning-only text without action, re-prompting"
                             );
-                            conv.messages.push(Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(
-                                    "Don't just describe what you plan to do — actually do it using the tools available to you.".to_string(),
-                                ),
-                                created_at: Utc::now(),
-                            });
+                            self.push_message(
+                                conv,
+                                Message {
+                                    id: Uuid::new_v4(),
+                                    role: Role::User,
+                                    content: MessageContent::Text(
+                                        "Don't just describe what you plan to do — actually do it using the tools available to you.".to_string(),
+                                    ),
+                                    created_at: Utc::now(),
+                                },
+                            );
                             continue;
                         }
                     }
@@ -516,14 +536,17 @@ impl AgentRunner {
                         retries = empty_tool_use_retries,
                         "stop reason is ToolUse but no tool calls found in response, re-prompting"
                     );
-                    conv.messages.push(Message {
-                        id: Uuid::new_v4(),
-                        role: Role::User,
-                        content: MessageContent::Text(
-                            "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
-                        ),
-                        created_at: Utc::now(),
-                    });
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::User,
+                            content: MessageContent::Text(
+                                "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
+                            ),
+                            created_at: Utc::now(),
+                        },
+                    );
                     continue;
                 }
             }
@@ -534,19 +557,21 @@ impl AgentRunner {
             max_iterations = self.config.max_iterations,
             "iteration cap reached — escalating to user"
         );
-        conv.messages.push(Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(format!(
-                "You have reached the iteration limit ({} iterations). \
-                 Summarize what you accomplished and what remains.",
-                self.config.max_iterations
-            )),
-            created_at: Utc::now(),
-        });
+        self.push_message(
+            conv,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(format!(
+                    "You have reached the iteration limit ({} iterations). \
+                     Summarize what you accomplished and what remains.",
+                    self.config.max_iterations
+                )),
+                created_at: Utc::now(),
+            },
+        );
         let final_response = self.provider.chat(&conv.messages, &[]).await?;
-        conv.messages.push(final_response.message);
-        conv.updated_at = Utc::now();
+        self.push_message(conv, final_response.message);
         Ok(())
     }
 
@@ -606,15 +631,18 @@ impl AgentRunner {
                 && !soft_warning_injected
             {
                 soft_warning_injected = true;
-                conv.messages.push(Message {
-                    id: Uuid::new_v4(),
-                    role: Role::System,
-                    content: MessageContent::Text(format!(
-                        "[Warning: {iteration}/{} iterations used.]",
-                        self.config.max_iterations
-                    )),
-                    created_at: Utc::now(),
-                });
+                self.push_message(
+                    conv,
+                    Message {
+                        id: Uuid::new_v4(),
+                        role: Role::System,
+                        content: MessageContent::Text(format!(
+                            "[Warning: {iteration}/{} iterations used.]",
+                            self.config.max_iterations
+                        )),
+                        created_at: Utc::now(),
+                    },
+                );
             }
 
             let stream_callback = |event: StreamEvent| {
@@ -643,12 +671,7 @@ impl AgentRunner {
                 "LLM call completed"
             );
 
-            conv.messages.push(message.clone());
-            conv.updated_at = Utc::now();
-
-            if let Some(ref cb) = self.on_message {
-                cb(&message);
-            }
+            self.push_message(conv, message.clone());
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
@@ -733,9 +756,8 @@ impl AgentRunner {
                         success,
                         error_message,
                     });
-                    conv.messages.push(tool_msg);
+                    self.push_message(conv, tool_msg);
                 }
-                conv.updated_at = Utc::now();
 
                 if had_errors {
                     consecutive_errors += 1;
@@ -758,12 +780,15 @@ impl AgentRunner {
             match stop_reason {
                 StopReason::MaxTokens => {
                     tracing::warn!("model hit max tokens, prompting to continue");
-                    conv.messages.push(Message {
-                        id: Uuid::new_v4(),
-                        role: Role::User,
-                        content: MessageContent::Text("Continue.".to_string()),
-                        created_at: Utc::now(),
-                    });
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::User,
+                            content: MessageContent::Text("Continue.".to_string()),
+                            created_at: Utc::now(),
+                        },
+                    );
                     continue;
                 }
                 StopReason::EndTurn => {
@@ -794,14 +819,17 @@ impl AgentRunner {
                                 on_event(AgentEvent::Done);
                                 return Ok(());
                             }
-                            conv.messages.push(Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(
-                                    "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
-                                ),
-                                created_at: Utc::now(),
-                            });
+                            self.push_message(
+                                conv,
+                                Message {
+                                    id: Uuid::new_v4(),
+                                    role: Role::User,
+                                    content: MessageContent::Text(
+                                        "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
+                                    ),
+                                    created_at: Utc::now(),
+                                },
+                            );
                             continue;
                         }
                         ResponseClass::PlanningOnly => {
@@ -824,14 +852,17 @@ impl AgentRunner {
                                 retries = planning_only_retries,
                                 "model produced planning-only text without action, re-prompting"
                             );
-                            conv.messages.push(Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(
-                                    "Don't just describe what you plan to do — actually do it using the tools available to you.".to_string(),
-                                ),
-                                created_at: Utc::now(),
-                            });
+                            self.push_message(
+                                conv,
+                                Message {
+                                    id: Uuid::new_v4(),
+                                    role: Role::User,
+                                    content: MessageContent::Text(
+                                        "Don't just describe what you plan to do — actually do it using the tools available to you.".to_string(),
+                                    ),
+                                    created_at: Utc::now(),
+                                },
+                            );
                             continue;
                         }
                     }
@@ -862,14 +893,17 @@ impl AgentRunner {
                         retries = empty_tool_use_retries,
                         "stop reason is ToolUse but no tool calls found in response, re-prompting"
                     );
-                    conv.messages.push(Message {
-                        id: Uuid::new_v4(),
-                        role: Role::User,
-                        content: MessageContent::Text(
-                            "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
-                        ),
-                        created_at: Utc::now(),
-                    });
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::User,
+                            content: MessageContent::Text(
+                                "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
+                            ),
+                            created_at: Utc::now(),
+                        },
+                    );
                     continue;
                 }
             }
@@ -880,16 +914,19 @@ impl AgentRunner {
             max_iterations = self.config.max_iterations,
             "iteration cap reached — escalating to user"
         );
-        conv.messages.push(Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(format!(
-                "You have reached the iteration limit ({} iterations). \
-                 Summarize what you accomplished and what remains.",
-                self.config.max_iterations
-            )),
-            created_at: Utc::now(),
-        });
+        self.push_message(
+            conv,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(format!(
+                    "You have reached the iteration limit ({} iterations). \
+                     Summarize what you accomplished and what remains.",
+                    self.config.max_iterations
+                )),
+                created_at: Utc::now(),
+            },
+        );
         let stream_callback = |event: StreamEvent| {
             if let StreamEvent::TextDelta(delta) = event {
                 on_event(AgentEvent::TextDelta(delta));
@@ -899,8 +936,7 @@ impl AgentRunner {
             .provider
             .chat_stream(&conv.messages, &[], &stream_callback)
             .await?;
-        conv.messages.push(final_response.message);
-        conv.updated_at = Utc::now();
+        self.push_message(conv, final_response.message);
         on_event(AgentEvent::Done);
         Ok(())
     }
@@ -1101,6 +1137,26 @@ impl AgentRunner {
             return Ok(());
         }
 
+        // Synthesize the two new messages compaction produces. They need
+        // to flow through on_message so memory picks them up — even though
+        // they're inserted into `new_messages` directly below rather than
+        // through push_message (compaction replaces conv.messages wholesale).
+        let summary_msg = Message {
+            id: Uuid::new_v4(),
+            role: Role::Assistant,
+            content: MessageContent::Text(summary.clone()),
+            created_at: Utc::now(),
+        };
+        let continuation_msg = Message {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content: MessageContent::Text(
+                "Continue from the summary above. Do not repeat already-completed work."
+                    .to_string(),
+            ),
+            created_at: Utc::now(),
+        };
+
         // Preserve system messages (they contain the agent's identity and
         // instructions) and the first user message (the original task).
         let mut new_messages: Vec<Message> = Vec::new();
@@ -1119,28 +1175,22 @@ impl AgentRunner {
             new_messages.push(first_user.clone());
         }
 
-        // Insert the summary as an assistant message.
-        new_messages.push(Message {
-            id: Uuid::new_v4(),
-            role: Role::Assistant,
-            content: MessageContent::Text(summary.clone()),
-            created_at: Utc::now(),
-        });
-
-        // Continuation prompt so the model picks up where it left off.
-        new_messages.push(Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(
-                "Continue from the summary above. Do not repeat already-completed work."
-                    .to_string(),
-            ),
-            created_at: Utc::now(),
-        });
+        new_messages.push(summary_msg.clone());
+        new_messages.push(continuation_msg.clone());
 
         conv.messages = new_messages;
         conv.summary = Some(summary);
         conv.updated_at = Utc::now();
+
+        // Fire on_message only for the newly synthesized turns. The preserved
+        // system/first-user messages already flowed through push_message when
+        // they were first appended; the dropped history was persisted the
+        // same way, so memory still holds it even though in-context it's
+        // been replaced by the summary.
+        if let Some(ref cb) = self.on_message {
+            cb(&summary_msg);
+            cb(&continuation_msg);
+        }
 
         let after_tokens = Self::estimate_conversation_tokens(&conv.messages);
         tracing::info!(
@@ -1179,12 +1229,15 @@ impl AgentRunner {
         }
         text.push_str("Try a different approach.");
 
-        conv.messages.push(Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(text),
-            created_at: Utc::now(),
-        });
+        self.push_message(
+            conv,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(text),
+                created_at: Utc::now(),
+            },
+        );
     }
 }
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -437,7 +437,8 @@ async fn main() -> anyhow::Result<()> {
     let mut state = rustykrab_gateway::AppState::new(store, tools, provider, auth_token)
         .with_harness_router(router)
         .with_orchestration_config(orchestration_config)
-        .with_skill_registry(skill_registry);
+        .with_skill_registry(skill_registry)
+        .with_memory(Arc::clone(&memory_system), agent_id);
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-gateway/Cargo.toml
+++ b/crates/rustykrab-gateway/Cargo.toml
@@ -10,6 +10,7 @@ rustykrab-core.workspace = true
 rustykrab-store.workspace = true
 rustykrab-agent.workspace = true
 rustykrab-channels.workspace = true
+rustykrab-memory.workspace = true
 rustykrab-skills.workspace = true
 axum.workspace = true
 tokio.workspace = true

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -1,12 +1,17 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
 use axum::http::StatusCode;
 use chrono::Utc;
 use uuid::Uuid;
 
 use crate::AppState;
-use rustykrab_agent::{AgentEvent, AgentRunner};
+use rustykrab_agent::{AgentEvent, AgentRunner, OnMessageCallback};
 use rustykrab_core::capability::CapabilitySet;
 use rustykrab_core::session::Session;
 use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
+use rustykrab_memory::types::{ConversationTurn, LifecycleStage, TurnMetadata};
+use rustykrab_memory::MemorySystem;
 use rustykrab_skills::SystemPromptBuilder;
 
 /// Build the system prompt and inject it as the first message in the conversation.
@@ -79,6 +84,87 @@ async fn build_and_inject_system_prompt(
     }
 }
 
+/// Translate an agent `Message` into a memory `ConversationTurn`.
+fn message_to_turn(msg: &Message, session_id: Uuid, turn_number: u32) -> ConversationTurn {
+    let speaker = match msg.role {
+        Role::System => "system",
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    };
+    let content = match &msg.content {
+        MessageContent::Text(t) => t.clone(),
+        MessageContent::ToolCall(tc) => {
+            format!("tool_call:{}({})", tc.name, tc.arguments)
+        }
+        MessageContent::MultiToolCall(tcs) => tcs
+            .iter()
+            .map(|tc| format!("tool_call:{}({})", tc.name, tc.arguments))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        MessageContent::ToolResult(tr) => format!("tool_result:{}", tr.output),
+    };
+    let involves_tool_use = matches!(
+        msg.content,
+        MessageContent::ToolCall(_)
+            | MessageContent::MultiToolCall(_)
+            | MessageContent::ToolResult(_)
+    );
+    // Same estimator the agent runner uses for compaction budgeting.
+    let token_count = Some(((content.len() as f64 / 3.5).ceil() as u32).saturating_add(4));
+
+    ConversationTurn {
+        id: msg.id,
+        session_id,
+        turn_number,
+        speaker: speaker.to_string(),
+        content,
+        token_count,
+        metadata: TurnMetadata {
+            involves_tool_use,
+            user_flagged: false,
+            tags: Vec::new(),
+        },
+    }
+}
+
+/// Build an `on_message` callback that auto-persists every conversation
+/// turn into working memory.  Returns `None` when memory isn't wired —
+/// the runner then behaves as it did before (no persistence).
+///
+/// The callback is sync (the agent loop is sync at the hook) but memory
+/// writes are async, so each call spawns a detached task.  Failures are
+/// logged but don't block the agent loop — memory is eventual-consistency
+/// relative to the conversation. System messages are skipped; they are
+/// infrastructure (agent prompt, warnings) rather than conversation content.
+/// Duplicate content is de-duplicated on the memory side via SHA-256 hash,
+/// so re-firing the callback for an already-persisted message is safe.
+fn build_memory_callback(state: &AppState, conv: &Conversation) -> Option<OnMessageCallback> {
+    let memory: Arc<MemorySystem> = state.memory.clone()?;
+    let agent_id = state.agent_id?;
+    let session_id = conv.id;
+    // Start the turn counter from the current message count so turns
+    // are numbered consistently across a multi-request conversation.
+    let turn_counter = Arc::new(AtomicU32::new(conv.messages.len() as u32));
+
+    Some(Arc::new(move |msg: &Message| {
+        if msg.role == Role::System {
+            return;
+        }
+        let turn_number = turn_counter.fetch_add(1, Ordering::Relaxed);
+        let turn = message_to_turn(msg, session_id, turn_number);
+        let memory = Arc::clone(&memory);
+        tokio::spawn(async move {
+            if let Err(e) = memory
+                .retain_with_stage(turn, agent_id, LifecycleStage::Working)
+                .await
+            {
+                tracing::warn!(error = %e, "failed to persist turn to working memory");
+            }
+        });
+    }))
+}
+
 /// Shared setup: build system prompt, inject it, create session and runner.
 /// Returns `(AgentRunner, Session)`.
 async fn prepare_agent(
@@ -106,12 +192,25 @@ async fn prepare_agent(
     // Resolve profile again for agent config (cheap — no LLM call on cache hit).
     let profile = state.profile_for(user_content).await;
 
-    let runner = AgentRunner::new(
+    let mut runner = AgentRunner::new(
         state.provider.clone(),
         state.tools.clone(),
         state.sandbox.clone(),
     )
     .with_config(profile.to_agent_config());
+
+    if let Some(cb) = build_memory_callback(state, conv) {
+        // The inbound user message was pushed onto conv.messages by
+        // routes.rs before the runner was constructed, so it never goes
+        // through push_message. Fire the callback once so the user turn
+        // is persisted alongside everything the runner generates.
+        if let Some(last) = conv.messages.last() {
+            if last.role == Role::User {
+                cb(last);
+            }
+        }
+        runner = runner.with_on_message(cb);
+    }
 
     Ok((runner, session))
 }

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -2,9 +2,11 @@ use rustykrab_agent::{HarnessProfile, HarnessRouter, ProcessSandbox, Sandbox};
 use rustykrab_channels::{SignalChannel, TelegramChannel, VideoChannel};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
+use rustykrab_memory::MemorySystem;
 use rustykrab_skills::SkillRegistry;
 use rustykrab_store::Store;
 use std::sync::{Arc, RwLock};
+use uuid::Uuid;
 
 use crate::origin::OriginPolicy;
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
@@ -33,6 +35,12 @@ pub struct AppState {
     pub orchestration_config: OrchestrationConfig,
     /// Skill registry for SKILL.md-based skills.
     pub skill_registry: Arc<SkillRegistry>,
+    /// Hybrid memory system for auto-persisting conversation turns.
+    /// `None` when no memory backend is configured.
+    pub memory: Option<Arc<MemorySystem>>,
+    /// Persistent agent identifier, used as the owner for memory writes.
+    /// `None` when memory is not configured.
+    pub agent_id: Option<Uuid>,
 }
 
 impl AppState {
@@ -57,7 +65,18 @@ impl AppState {
             harness_router: None,
             orchestration_config: OrchestrationConfig::default(),
             skill_registry: Arc::new(SkillRegistry::new()),
+            memory: None,
+            agent_id: None,
         }
+    }
+
+    /// Attach the memory system and the agent identifier used for writes.
+    /// When set, the gateway wires an `on_message` hook into the agent
+    /// runner that persists every conversation turn into working memory.
+    pub fn with_memory(mut self, memory: Arc<MemorySystem>, agent_id: Uuid) -> Self {
+        self.memory = Some(memory);
+        self.agent_id = Some(agent_id);
+        self
     }
 
     /// Override the origin policy.


### PR DESCRIPTION
## Summary

Wires the agent runner's `on_message` hook end-to-end so the hybrid memory system (vector + BM25 + temporal + graph) is actually populated from live conversations, rather than starved of input as it is today.

Before this change, `rustykrab-memory` was architecturally complete but functionally close to empty — only explicit `memory_save` tool calls wrote anything, and compaction actively destroyed the richest source of memory content (raw conversation history) without routing it anywhere. Every time compaction fired, we lost the detailed context that should have been promoted to long-term memory.

## Changes

- **`runner.rs`** — new `push_message(&self, conv, msg)` helper is now the single choke point for every message added. All 19 prior `conv.messages.push(...)` sites route through it, so `on_message` fires for user prompts, assistant responses, tool results, reflection injections, soft warnings, iteration-cap escalations, and the compaction summary — not just LLM responses (2 of 19 before).
- **`compact_history`** — fires `on_message` for the synthesized summary + continuation prompt. Dropped pre-compaction messages were already persisted when originally pushed, so they survive in memory even after being replaced in-context by the summary.
- **`AppState`** — carries `Option<Arc<MemorySystem>>` + `Option<Uuid> agent_id`, set via a new `.with_memory(...)` builder.
- **`orchestrate.rs`** — `build_memory_callback` constructs a sync callback that translates `Message` → `ConversationTurn` and spawns `retain_with_stage(..., Working)` per message. System messages are skipped (infrastructure, not content); SHA-256 dedup on the memory side makes repeat persistence harmless on continuing conversations. Fires once explicitly for the inbound user message that `routes.rs` pushed before the runner started.
- **`cli/main.rs`** — plumbs the existing `memory_system` + `agent_id` into `AppState`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rustykrab-core -p rustykrab-agent -p rustykrab-providers -p rustykrab-memory -p rustykrab-gateway --all-targets`
- [x] `cargo test -p rustykrab-agent -p rustykrab-gateway`
- [ ] Manual: start a new conversation, verify `memory_search` returns hits from earlier turns (previously returned nothing)
- [ ] Manual: drive a conversation past the compaction threshold and confirm pre-compaction turns remain searchable in memory
- [ ] Manual: confirm Telegram / WebChat / Signal all get the same behavior (all converge on the single `orchestrate.rs` wiring point)

https://claude.ai/code/session_01T7MRwq1Z6MJkpcoTHJLyXN