### PR TITLE
fix(memory): default retain() to Working lifecycle stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-memory/src/writer.rs
+++ b/crates/rustykrab-memory/src/writer.rs
@@ -61,7 +61,7 @@ impl MemoryWriter {
         turn: ConversationTurn,
         agent_id: Uuid,
     ) -> rustykrab_core::Result<Uuid> {
-        self.retain_with_stage(turn, agent_id, LifecycleStage::Episodic)
+        self.retain_with_stage(turn, agent_id, LifecycleStage::Working)
             .await
     }
 
@@ -246,7 +246,8 @@ impl MemoryWriter {
                 ..Default::default()
             },
         };
-        self.retain(turn, agent_id).await
+        self.retain_with_stage(turn, agent_id, LifecycleStage::Episodic)
+            .await
     }
 
     /// Rebuild the FTS5 index from all retrievable memories in storage.


### PR DESCRIPTION
Honor the documented Working→Episodic lifecycle: retain() now starts
memories in Working so finalize_session can promote them. save_fact()
explicitly requests Episodic to preserve the memory_save tool semantic.

Fixes #288