### PR TITLE
feat(tools): add tools_list and tools_load meta-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,19 +3336,20 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.5"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -3,6 +3,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 use chrono::Utc;
+use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT};
 use rustykrab_core::capability::Capability;
 use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent};
 use rustykrab_core::session::Session;
@@ -11,6 +12,15 @@ use rustykrab_core::types::{
 };
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool, ToolErrorKind};
 use uuid::Uuid;
+
+/// Names of meta-tools that are always included in the schema sent to the
+/// model, regardless of the active tool set. These are how the model
+/// discovers and loads the rest of the catalog.
+const META_TOOL_NAMES: &[&str] = &["tools_list", "tools_load"];
+
+fn is_meta_tool(name: &str) -> bool {
+    META_TOOL_NAMES.contains(&name)
+}
 
 use crate::sandbox::{Sandbox, SandboxPolicy};
 use crate::trace::{ExecutionTracer, ToolTrace};
@@ -227,6 +237,7 @@ pub struct AgentRunner {
     config: AgentConfig,
     tracer: ExecutionTracer,
     on_message: Option<OnMessageCallback>,
+    active_tools: Arc<ActiveToolsRegistry>,
 }
 
 impl AgentRunner {
@@ -242,6 +253,40 @@ impl AgentRunner {
             config: AgentConfig::default(),
             tracer: ExecutionTracer::new(),
             on_message: None,
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+        }
+    }
+
+    /// Share a per-gateway active-tools registry with the runner so the
+    /// `tools_load` meta-tool can persist activations across conversations.
+    pub fn with_active_tools(mut self, registry: Arc<ActiveToolsRegistry>) -> Self {
+        self.active_tools = registry;
+        self
+    }
+
+    /// Build the set of schemas sent to the model on the next request,
+    /// honoring session capabilities and the per-conversation active set.
+    /// Meta-tools (`tools_list`, `tools_load`) are always included so the
+    /// agent can always discover and load more tools.
+    fn compute_schemas(&self, session: &Session, conv_id: Uuid) -> Vec<ToolSchema> {
+        let active = self.active_tools.active_for(conv_id);
+        self.tools
+            .iter()
+            .filter(|t| {
+                t.available()
+                    && session.capabilities.can_use_tool(t.name())
+                    && (is_meta_tool(t.name()) || active.contains(t.name()))
+            })
+            .map(|t| t.schema())
+            .collect()
+    }
+
+    fn build_session_context(&self, session: &Session) -> SessionToolContext {
+        SessionToolContext {
+            conversation_id: session.conversation_id,
+            capabilities: Arc::new(session.capabilities.clone()),
+            all_tools: Arc::new(self.tools.clone()),
+            active_tools: self.active_tools.clone(),
         }
     }
 
@@ -281,19 +326,19 @@ impl AgentRunner {
     /// Each call creates a fresh ExecutionTracer to prevent cross-session
     /// information leakage (H8).
     pub async fn run(&self, conv: &mut Conversation, session: &Session) -> Result<()> {
+        let ctx = self.build_session_context(session);
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, self.run_inner(conv, session))
+            .await
+    }
+
+    async fn run_inner(&self, conv: &mut Conversation, session: &Session) -> Result<()> {
         if session.is_expired() {
             return Err(Error::Auth("session has expired".into()));
         }
 
         // Create a per-run tracer to prevent cross-session data leaks (H8)
         let tracer = ExecutionTracer::new();
-
-        let schemas: Vec<ToolSchema> = self
-            .tools
-            .iter()
-            .filter(|t| t.available() && session.capabilities.can_use_tool(t.name()))
-            .map(|t| t.schema())
-            .collect();
 
         let mut consecutive_errors = 0;
         let mut soft_warning_injected = false;
@@ -344,6 +389,11 @@ impl AgentRunner {
                     },
                 );
             }
+
+            // Recompute the tool schemas on every iteration so that any
+            // activations performed by `tools_load` during the previous
+            // iteration are reflected in the next API call.
+            let schemas = self.compute_schemas(session, session.conversation_id);
 
             let llm_start = std::time::Instant::now();
             let ModelResponse {
@@ -622,18 +672,23 @@ impl AgentRunner {
         session: &Session,
         on_event: &(dyn Fn(AgentEvent) + Send + Sync),
     ) -> Result<()> {
+        let ctx = self.build_session_context(session);
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, self.run_streaming_inner(conv, session, on_event))
+            .await
+    }
+
+    async fn run_streaming_inner(
+        &self,
+        conv: &mut Conversation,
+        session: &Session,
+        on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    ) -> Result<()> {
         if session.is_expired() {
             return Err(Error::Auth("session has expired".into()));
         }
 
         let tracer = ExecutionTracer::new();
-
-        let schemas: Vec<ToolSchema> = self
-            .tools
-            .iter()
-            .filter(|t| t.available() && session.capabilities.can_use_tool(t.name()))
-            .map(|t| t.schema())
-            .collect();
 
         let mut consecutive_errors = 0;
         let mut soft_warning_injected = false;
@@ -682,6 +737,11 @@ impl AgentRunner {
                     on_event(AgentEvent::TextDelta(delta));
                 }
             };
+
+            // Recompute the tool schemas on every iteration so that any
+            // activations performed by `tools_load` during the previous
+            // iteration are reflected in the next API call.
+            let schemas = self.compute_schemas(session, session.conversation_id);
 
             let llm_start = std::time::Instant::now();
             let ModelResponse {

--- a/crates/rustykrab-core/Cargo.toml
+++ b/crates/rustykrab-core/Cargo.toml
@@ -11,4 +11,5 @@ chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 uuid.workspace = true

--- a/crates/rustykrab-core/src/active_tools.rs
+++ b/crates/rustykrab-core/src/active_tools.rs
@@ -1,0 +1,136 @@
+//! Per-session "active tools" registry used by the `tools_list` / `tools_load`
+//! meta-tools.
+//!
+//! The meta-tools let an agent discover the full tool catalog and then
+//! selectively load subsets of tools into its active context, keeping the
+//! per-request schema payload small. This module provides:
+//!
+//! - [`ActiveToolsRegistry`] — a thread-safe map from conversation id to the
+//!   set of tool names currently active for that conversation.
+//! - [`SESSION_TOOL_CONTEXT`] — a [`tokio::task_local`] that threads the
+//!   currently-executing session's conversation id, capability set, and tool
+//!   catalog to any tool invoked inside the agent runner's scope.
+//!
+//! The runner wraps its loop in [`SESSION_TOOL_CONTEXT::scope`]; meta-tools
+//! read the context via [`with_session_context`] to know which conversation
+//! they belong to.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+
+use uuid::Uuid;
+
+use crate::capability::CapabilitySet;
+use crate::tool::Tool;
+
+/// Tracks which tools are "active" for each conversation.
+///
+/// Conversations start with an empty active set. The meta-tool `tools_load`
+/// populates it; the runner filters the schemas sent to the model down to
+/// (meta tools) ∪ (active set).
+#[derive(Debug, Default)]
+pub struct ActiveToolsRegistry {
+    inner: RwLock<HashMap<Uuid, HashSet<String>>>,
+}
+
+impl ActiveToolsRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the given tools as active for a conversation.
+    pub fn activate<I, S>(&self, conversation_id: Uuid, names: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        let entry = guard.entry(conversation_id).or_default();
+        for name in names {
+            entry.insert(name.into());
+        }
+    }
+
+    /// Return a snapshot of the active tool names for a conversation.
+    pub fn active_for(&self, conversation_id: Uuid) -> HashSet<String> {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        guard.get(&conversation_id).cloned().unwrap_or_default()
+    }
+
+    /// Check whether a specific tool is active for a conversation.
+    pub fn is_active(&self, conversation_id: Uuid, name: &str) -> bool {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        guard
+            .get(&conversation_id)
+            .map(|set| set.contains(name))
+            .unwrap_or(false)
+    }
+
+    /// Forget the active set for a conversation (used on session teardown).
+    pub fn clear(&self, conversation_id: Uuid) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        guard.remove(&conversation_id);
+    }
+}
+
+/// Context made available to tools invoked inside the runner's scope.
+#[derive(Clone)]
+pub struct SessionToolContext {
+    pub conversation_id: Uuid,
+    pub capabilities: Arc<CapabilitySet>,
+    pub all_tools: Arc<Vec<Arc<dyn Tool>>>,
+    pub active_tools: Arc<ActiveToolsRegistry>,
+}
+
+tokio::task_local! {
+    pub static SESSION_TOOL_CONTEXT: SessionToolContext;
+}
+
+/// Run `f` with the current session's tool context, if one has been set by
+/// the enclosing runner. Returns `None` if invoked outside a runner scope.
+pub fn with_session_context<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&SessionToolContext) -> R,
+{
+    SESSION_TOOL_CONTEXT.try_with(|ctx| f(ctx)).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activate_and_query() {
+        let reg = ActiveToolsRegistry::new();
+        let conv = Uuid::new_v4();
+        assert!(reg.active_for(conv).is_empty());
+        reg.activate(conv, ["read", "write"]);
+        assert!(reg.is_active(conv, "read"));
+        assert!(reg.is_active(conv, "write"));
+        assert!(!reg.is_active(conv, "exec"));
+        let active = reg.active_for(conv);
+        assert_eq!(active.len(), 2);
+    }
+
+    #[test]
+    fn conversations_are_isolated() {
+        let reg = ActiveToolsRegistry::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        reg.activate(a, ["read"]);
+        reg.activate(b, ["write"]);
+        assert!(reg.is_active(a, "read"));
+        assert!(!reg.is_active(a, "write"));
+        assert!(reg.is_active(b, "write"));
+        assert!(!reg.is_active(b, "read"));
+    }
+
+    #[test]
+    fn clear_removes_session_entry() {
+        let reg = ActiveToolsRegistry::new();
+        let conv = Uuid::new_v4();
+        reg.activate(conv, ["read"]);
+        reg.clear(conv);
+        assert!(reg.active_for(conv).is_empty());
+    }
+}

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod active_tools;
 pub mod capability;
 pub mod crypto;
 pub mod error;
@@ -7,6 +8,9 @@ pub mod session;
 pub mod tool;
 pub mod types;
 
+pub use active_tools::{
+    with_session_context, ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT,
+};
 pub use capability::{Capability, CapabilitySet};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -197,7 +197,8 @@ async fn prepare_agent(
         state.tools.clone(),
         state.sandbox.clone(),
     )
-    .with_config(profile.to_agent_config());
+    .with_config(profile.to_agent_config())
+    .with_active_tools(state.active_tools.clone());
 
     if let Some(cb) = build_memory_callback(state, conv) {
         // The inbound user message was pushed onto conv.messages by

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -1,5 +1,6 @@
 use rustykrab_agent::{HarnessProfile, HarnessRouter, ProcessSandbox, Sandbox};
 use rustykrab_channels::{SignalChannel, TelegramChannel, VideoChannel};
+use rustykrab_core::active_tools::ActiveToolsRegistry;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_memory::MemorySystem;
@@ -41,6 +42,10 @@ pub struct AppState {
     /// Persistent agent identifier, used as the owner for memory writes.
     /// `None` when memory is not configured.
     pub agent_id: Option<Uuid>,
+    /// Shared registry backing the `tools_load` / `tools_list` meta-tools.
+    /// Tracks which tools are "active" per conversation so schemas sent to
+    /// the model stay compact until the agent explicitly loads more.
+    pub active_tools: Arc<ActiveToolsRegistry>,
 }
 
 impl AppState {
@@ -67,6 +72,7 @@ impl AppState {
             skill_registry: Arc::new(SkillRegistry::new()),
             memory: None,
             agent_id: None,
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
         }
     }
 

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -80,6 +80,10 @@ mod credential_write;
 // Skill tools
 mod skills;
 
+// Meta tools (tool discovery &amp; activation)
+mod tools_list;
+mod tools_load;
+
 // --- Public re-exports ---
 
 // Filesystem
@@ -157,6 +161,10 @@ pub use credential_write::CredentialWriteTool;
 // Skills
 pub use self::skills::SkillsTool;
 
+// Meta tools
+pub use tools_list::ToolsListTool;
+pub use tools_load::ToolsLoadTool;
+
 /// Collect all built-in tools that require no external backend into a Vec.
 ///
 /// Tools that need access to the secret store (credential_read, credential_write)
@@ -165,6 +173,9 @@ pub fn builtin_tools(
     secrets: rustykrab_store::SecretStore,
 ) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
     vec![
+        // Meta — tool discovery and lazy schema loading. Always registered.
+        std::sync::Arc::new(ToolsListTool::new()),
+        std::sync::Arc::new(ToolsLoadTool::new()),
         // HTTP
         std::sync::Arc::new(HttpRequestTool::new()),
         std::sync::Arc::new(HttpSessionTool::new()),

--- a/crates/rustykrab-tools/src/tools_list.rs
+++ b/crates/rustykrab-tools/src/tools_list.rs
@@ -1,0 +1,116 @@
+use async_trait::async_trait;
+use rustykrab_core::active_tools::with_session_context;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// Categorize a tool by its name. Keeps the Tool trait minimal while still
+/// giving agents a useful axis to filter on.
+pub(crate) fn categorize(name: &str) -> &'static str {
+    match name {
+        "tools_list" | "tools_load" => "meta",
+        "read" | "write" | "edit" | "apply_patch" => "filesystem",
+        "exec" | "process" | "code_execution" => "runtime",
+        "web_fetch" | "web_search" | "x_search" | "http_request" | "http_session" | "browser" => {
+            "web"
+        }
+        "image" | "video" | "canvas" => "media",
+        "cron" | "gateway" => "automation",
+        "gmail" | "notion" | "obsidian" => "integration",
+        "skills" => "skills",
+        "message" => "messaging",
+        "nodes" => "devices",
+        _ if name.starts_with("memory_") => "memory",
+        _ if name.starts_with("sessions_")
+            || name.starts_with("session_")
+            || name.starts_with("agents_")
+            || name == "subagents" =>
+        {
+            "session"
+        }
+        _ if name.starts_with("credential_") => "credentials",
+        _ => "general",
+    }
+}
+
+/// Meta-tool that lists every tool the current session is allowed to use,
+/// with optional filtering by category.
+pub struct ToolsListTool;
+
+impl ToolsListTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ToolsListTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ToolsListTool {
+    fn name(&self) -> &str {
+        "tools_list"
+    }
+
+    fn description(&self) -> &str {
+        "List every tool the current session is allowed to use. Returns an \
+         array of {name, description, category}. Pass `category` to filter."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "description": "Optional category to filter the listing (e.g. \"filesystem\", \"web\", \"memory\")."
+                    }
+                },
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let category_filter = args
+            .get("category")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+
+        let listing = with_session_context(|ctx| {
+            let caps = ctx.capabilities.clone();
+            ctx.all_tools
+                .iter()
+                .filter(|t| t.available() && caps.can_use_tool(t.name()))
+                .map(|t| {
+                    let name = t.name().to_string();
+                    let category = categorize(&name).to_string();
+                    json!({
+                        "name": name,
+                        "description": t.description(),
+                        "category": category,
+                    })
+                })
+                .filter(|entry| match &category_filter {
+                    Some(c) => entry
+                        .get("category")
+                        .and_then(Value::as_str)
+                        .map(|v| v == c)
+                        .unwrap_or(false),
+                    None => true,
+                })
+                .collect::<Vec<_>>()
+        })
+        .ok_or_else(|| {
+            Error::ToolExecution("tools_list invoked outside of an agent session context".into())
+        })?;
+
+        Ok(json!({ "tools": listing }))
+    }
+}

--- a/crates/rustykrab-tools/src/tools_load.rs
+++ b/crates/rustykrab-tools/src/tools_load.rs
@@ -1,0 +1,123 @@
+use async_trait::async_trait;
+use rustykrab_core::active_tools::with_session_context;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// Meta-tool that marks a set of tools as "active" on the current session.
+///
+/// Subsequent model API calls include only the schemas for the meta-tools
+/// plus the currently-active set, keeping the per-request payload small.
+pub struct ToolsLoadTool;
+
+impl ToolsLoadTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ToolsLoadTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for ToolsLoadTool {
+    fn name(&self) -> &str {
+        "tools_load"
+    }
+
+    fn description(&self) -> &str {
+        "Load a set of tools into the current session's active set so \
+         subsequent API calls include their full schemas. Accepts an array \
+         of tool names."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "names": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Tool names to activate for this session."
+                    }
+                },
+                "required": ["names"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let names: Vec<String> = args
+            .get("names")
+            .and_then(Value::as_array)
+            .ok_or_else(|| Error::ToolExecution("missing `names` array".into()))?
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect();
+
+        if names.is_empty() {
+            return Err(Error::ToolExecution(
+                "`names` must contain at least one tool name".into(),
+            ));
+        }
+
+        let result = with_session_context(|ctx| {
+            let caps = ctx.capabilities.clone();
+
+            let mut loaded = Vec::new();
+            let mut unknown = Vec::new();
+            let mut forbidden = Vec::new();
+
+            for requested in &names {
+                let matched = ctx
+                    .all_tools
+                    .iter()
+                    .find(|t| t.name() == requested.as_str() && t.available());
+
+                match matched {
+                    None => unknown.push(requested.clone()),
+                    Some(tool) => {
+                        if caps.can_use_tool(tool.name()) {
+                            loaded.push(tool.name().to_string());
+                        } else {
+                            forbidden.push(requested.clone());
+                        }
+                    }
+                }
+            }
+
+            if !loaded.is_empty() {
+                ctx.active_tools
+                    .activate(ctx.conversation_id, loaded.iter().cloned());
+            }
+
+            let active_now: Vec<String> = {
+                let mut v: Vec<String> = ctx
+                    .active_tools
+                    .active_for(ctx.conversation_id)
+                    .into_iter()
+                    .collect();
+                v.sort();
+                v
+            };
+
+            json!({
+                "loaded": loaded,
+                "unknown": unknown,
+                "forbidden": forbidden,
+                "active": active_now,
+            })
+        })
+        .ok_or_else(|| {
+            Error::ToolExecution("tools_load invoked outside of an agent session context".into())
+        })?;
+
+        Ok(result)
+    }
+}


### PR DESCRIPTION
Register two meta-tools unconditionally in `builtin_tools()`:

- `tools_list(category?)` returns `{name, description, category}` for every
  tool the session is allowed to use, with optional category filtering.
- `tools_load(names)` marks tools as "active" for the current conversation so
  subsequent API calls include their full schemas.

Under the hood:

- `rustykrab-core::active_tools` exposes an `ActiveToolsRegistry` keyed by
  conversation id and a `SESSION_TOOL_CONTEXT` tokio task-local that the
  runner scopes every agent loop in.
- `AgentRunner` now recomputes the schema set on every iteration so tools
  activated mid-loop show up in the next chat call. Meta-tools are always
  included so the catalog stays discoverable.
- `AppState` carries a shared registry so activations persist across the
  per-request `AgentRunner` instances built in `prepare_agent`.

https://claude.ai/code/session_012PoYvyJBTthzVv381ARsDR