### PR TITLE
feat(agent): configurable max_context_tokens for local inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "axum",
  "chrono",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ All configuration is via environment variables. No plaintext config files.
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use |
 | `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
+| `RUSTYKRAB_MAX_CONTEXT_TOKENS` | `128000` (cloud) / `32000` (ollama) | Context budget used to compute the compaction threshold. Default is provider-aware: 128k for cloud providers (Anthropic) and 32k for local Ollama, where prompt evaluation on consumer GPUs times out long before a 128k window fills. Set to override the default for either provider |
 | `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` | `65536` | Hard upper bound on the context window used to compute the compaction threshold. Keeps compaction firing at a sane size even when the backing model advertises a much larger window |
-| `RUSTYKRAB_COMPACTION_SUMMARY_MAX_TOKENS` | `8192` | Hard upper bound on the final compaction summary. If the summarizer returns a summary larger than this, it is re-summarized (up to 3 passes) and eventually truncated. Prevents oversized summaries from refilling the context window |
+| `RUSTYKRAB_COMPACTION_SUMMARY_MAX_TOKENS` | `8192` | Env-configurable upper bound on the final compaction summary. The effective cap is further bounded by `RUSTYKRAB_MAX_CONTEXT_TOKENS / 4`, so on a 32k local-Ollama deployment the summary stays under 8k regardless of this value. If the summarizer returns a summary larger than the effective cap, it is re-summarized (up to 3 passes) and eventually truncated |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
-| `OLLAMA_NUM_CTX` | — | Explicit client-side `num_ctx` override. Omitted by default so the server's own `OLLAMA_CONTEXT_LENGTH` (or per-model default) wins |
+| `RUSTYKRAB_NUM_CTX` | — | Explicit client-side `num_ctx` override for local providers. Takes precedence over `OLLAMA_NUM_CTX`. Omitted by default so the server's own `OLLAMA_CONTEXT_LENGTH` (or per-model default) wins |
+| `OLLAMA_NUM_CTX` | — | Legacy alias for `RUSTYKRAB_NUM_CTX`. Used only when `RUSTYKRAB_NUM_CTX` is unset |
 | `OLLAMA_TIMEOUT_SECS` | `900` | HTTP request timeout for Ollama in seconds |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -133,8 +133,12 @@ fn truncate_summary_to_tokens(s: &str, max_tokens: usize) -> String {
     out
 }
 
-/// Read the compaction summary cap once. Treats non-positive values as
-/// unset and falls back to the default.
+/// Read the env-configurable compaction summary cap once. Treats
+/// non-positive values as unset and falls back to the default. This is
+/// the *upper* bound from configuration; the effective cap used at
+/// runtime is further bounded by `max_context_tokens / 4` via
+/// [`AgentRunner::effective_compaction_summary_cap`] so summaries on
+/// small-context (local) deployments can't eclipse the context window.
 fn compaction_summary_max_tokens() -> usize {
     static CAP: OnceLock<usize> = OnceLock::new();
     *CAP.get_or_init(|| {
@@ -1226,6 +1230,18 @@ impl AgentRunner {
             .min(compaction_context_ceiling())
     }
 
+    /// Effective cap on the compacted-history summary in tokens. Combines
+    /// the env-configurable upper bound (default 8k) with a hard ceiling
+    /// of `max_context_tokens / 4` so a summary can never consume more
+    /// than a quarter of the usable context window. On a 32k local-Ollama
+    /// deployment this keeps the summary under 8k; on a 128k cloud model
+    /// the env cap is the binding constraint.
+    fn effective_compaction_summary_cap(&self) -> usize {
+        let env_cap = compaction_summary_max_tokens();
+        let quarter_cap = (self.config.max_context_tokens / 4).max(1);
+        env_cap.min(quarter_cap)
+    }
+
     /// Truncate a previously-stored compaction summary that exceeds the
     /// current cap. Handles conversations compacted by older code that
     /// didn't bound the summary size — without this, loading such a
@@ -1240,7 +1256,7 @@ impl AgentRunner {
         let Some(stored) = conv.summary.clone() else {
             return;
         };
-        let cap_tokens = compaction_summary_max_tokens();
+        let cap_tokens = self.effective_compaction_summary_cap();
         let stored_tokens = Self::estimate_text_tokens(&stored);
         if stored_tokens <= cap_tokens {
             return;
@@ -1509,7 +1525,7 @@ impl AgentRunner {
         mut summary: String,
         input_budget: usize,
     ) -> Result<String> {
-        let cap_tokens = compaction_summary_max_tokens();
+        let cap_tokens = self.effective_compaction_summary_cap();
 
         for attempt in 0..MAX_SUMMARY_CAP_RESUMMARIZE_ATTEMPTS {
             let tokens = Self::estimate_text_tokens(&summary);
@@ -1580,7 +1596,7 @@ impl AgentRunner {
         let ratio = compaction_input_budget_ratio();
         let input_budget =
             ((ceiling as f64 * ratio) as usize).saturating_sub(SUMMARIZER_RESPONSE_RESERVE_TOKENS);
-        let summary_cap_tokens = compaction_summary_max_tokens();
+        let summary_cap_tokens = self.effective_compaction_summary_cap();
         tracing::debug!(
             ceiling,
             ratio,
@@ -2300,7 +2316,7 @@ mod compaction_tests {
             .expect("cap enforcement should succeed");
 
         let tokens = AgentRunner::estimate_text_tokens(&out);
-        let cap = compaction_summary_max_tokens();
+        let cap = runner.effective_compaction_summary_cap();
         // Truncation appends a marker that nudges the final length slightly
         // past the raw cap in token terms; allow the marker's overhead.
         assert!(
@@ -2345,7 +2361,7 @@ mod compaction_tests {
         let provider = Arc::new(CountingProvider::new(None));
         let runner = build_runner(Arc::clone(&provider));
 
-        let cap = compaction_summary_max_tokens();
+        let cap = runner.effective_compaction_summary_cap();
         // 10x the cap in chars/tokens to guarantee it exceeds the cap.
         let bloated = "x".repeat(cap * 10 * 4);
         let bloated_tokens = AgentRunner::estimate_text_tokens(&bloated);

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -181,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
 
     // --- Harness profile ---
     // Load from file or use a preset. Supported: default, coding, research, creative
-    let profile = load_harness_profile(&data_dir)?;
+    let mut profile = load_harness_profile(&data_dir)?;
     tracing::info!(profile = %profile.name, "harness profile loaded");
 
     // --- Master key for credential encryption ---
@@ -277,6 +277,19 @@ async fn main() -> anyhow::Result<()> {
             Arc::new(p)
         }
     };
+
+    // Override the harness profile's context budget with a
+    // provider-aware default, or the RUSTYKRAB_MAX_CONTEXT_TOKENS env
+    // var if set. Cloud models ship with large windows (Claude at 200k);
+    // local Ollama deployments on consumer hardware can't chew through
+    // anywhere near that before the HTTP timeout fires, so default to
+    // 32k for Ollama and keep the 128k default for everything else.
+    profile.max_context_tokens = resolve_max_context_tokens(&provider_name);
+    tracing::info!(
+        max_context_tokens = profile.max_context_tokens,
+        provider = %provider_name,
+        "compaction context budget configured"
+    );
 
     // --- Skills directory (needed by skill tools and skill loader) ---
     let skills_dir = data_dir.join("skills");
@@ -1056,6 +1069,26 @@ fn load_orchestration_config(data_dir: &std::path::Path) -> anyhow::Result<Orche
     }
 
     Ok(config)
+}
+
+/// Resolve the effective `max_context_tokens` value.
+///
+/// Priority:
+/// 1. `RUSTYKRAB_MAX_CONTEXT_TOKENS` env var when set to a positive integer
+/// 2. Provider-aware default: 32k for Ollama (local inference with
+///    limited GPU memory), 128k for everything else (cloud models)
+fn resolve_max_context_tokens(provider_name: &str) -> usize {
+    if let Some(v) = std::env::var("RUSTYKRAB_MAX_CONTEXT_TOKENS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v > 0)
+    {
+        return v;
+    }
+    match provider_name {
+        "ollama" => 32_000,
+        _ => 128_000,
+    }
 }
 
 /// Load harness profile from file or env var preset.

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -36,13 +36,21 @@ pub struct OllamaConfig {
     pub think: bool,
 }
 
-/// Read `num_ctx` from the `OLLAMA_NUM_CTX` env var.  Returns `None` when
-/// the var is unset or unparseable so the request omits `num_ctx` and the
-/// Ollama server's own configuration (e.g. `OLLAMA_CONTEXT_LENGTH`) wins.
+/// Read `num_ctx` from the environment. Checks `RUSTYKRAB_NUM_CTX` first
+/// (the canonical RustyKrab-namespaced name), then falls back to
+/// `OLLAMA_NUM_CTX` for backward compatibility. Returns `None` when
+/// neither var is set or parseable, so the request omits `num_ctx` and
+/// the Ollama server's own configuration (e.g. `OLLAMA_CONTEXT_LENGTH`)
+/// wins.
 fn num_ctx_from_env() -> Option<u32> {
-    std::env::var("OLLAMA_NUM_CTX")
+    std::env::var("RUSTYKRAB_NUM_CTX")
         .ok()
         .and_then(|v| v.parse::<u32>().ok())
+        .or_else(|| {
+            std::env::var("OLLAMA_NUM_CTX")
+                .ok()
+                .and_then(|v| v.parse::<u32>().ok())
+        })
 }
 
 /// Rough characters-per-token ratio used for client-side context budgeting.
@@ -1152,25 +1160,32 @@ mod tests {
 
     #[test]
     fn default_config_omits_num_ctx_when_env_unset() {
-        // Guard: when OLLAMA_NUM_CTX is not set, constructors leave num_ctx
-        // as None so the server's own OLLAMA_CONTEXT_LENGTH wins.
+        // Guard: when neither RUSTYKRAB_NUM_CTX nor OLLAMA_NUM_CTX is set,
+        // constructors leave num_ctx as None so the server's own
+        // OLLAMA_CONTEXT_LENGTH wins.
         //
         // std::env is process-global; restore it after the test so we don't
         // contaminate sibling tests that may set it themselves.
-        let saved = std::env::var("OLLAMA_NUM_CTX").ok();
+        let saved_ollama = std::env::var("OLLAMA_NUM_CTX").ok();
+        let saved_rk = std::env::var("RUSTYKRAB_NUM_CTX").ok();
         // SAFETY: single-threaded section of this test. `cargo test` runs
         // tests on separate threads by default but we're only reading/writing
         // our own var and restoring it.
         unsafe {
             std::env::remove_var("OLLAMA_NUM_CTX");
+            std::env::remove_var("RUSTYKRAB_NUM_CTX");
         }
         assert_eq!(OllamaConfig::default().num_ctx, None);
         assert_eq!(OllamaConfig::tool_calling().num_ctx, None);
         assert_eq!(OllamaConfig::creative().num_ctx, None);
         unsafe {
-            match saved {
+            match saved_ollama {
                 Some(v) => std::env::set_var("OLLAMA_NUM_CTX", v),
                 None => std::env::remove_var("OLLAMA_NUM_CTX"),
+            }
+            match saved_rk {
+                Some(v) => std::env::set_var("RUSTYKRAB_NUM_CTX", v),
+                None => std::env::remove_var("RUSTYKRAB_NUM_CTX"),
             }
         }
     }


### PR DESCRIPTION
Compaction was hardcoded to fire at 85% of a 128k window, which is
far too high for Ollama on consumer GPUs — prompt evaluation times
out before compaction can run. Make the context budget runtime-
configurable with a provider-aware default.

- Add RUSTYKRAB_MAX_CONTEXT_TOKENS env var; default 128k for cloud
  providers, 32k for Ollama
- Add RUSTYKRAB_NUM_CTX env var as the canonical name for the Ollama
  client-side num_ctx override; falls back to OLLAMA_NUM_CTX
- Bound the compaction summary cap at max_context_tokens/4 so a
  summary can never consume more than a quarter of the context on a
  small-window deployment

Fixes the 80k-token blow-up on conv_id=a8ff8b3f that has been
failing across v2.6.5-v2.6.10. Related: #262, #263.

https://claude.ai/code/session_01Q2aYqGAXkotrRdWU9jheAL