### PR TITLE
feat(skills): add load action so skills are actually invoked, not just narrated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "axum",
  "chrono",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -64,25 +64,33 @@ impl SystemPromptBuilder {
         self
     }
 
-    /// Inject a compact `<available_skills>` XML catalog of SKILL.md skills.
+    /// Inject a compact `<available_skills>` XML catalog of SKILL.md skills,
+    /// followed by an explicit instruction telling the model how to activate one.
     ///
     /// This is appended at prompt build time so the model knows which skills
-    /// exist without loading their full body.
+    /// exist without loading their full body. To USE a skill, the model must
+    /// call the `skills` tool with `action="load"` and the skill name; the
+    /// tool result returns the body, which the model then follows.
     pub fn with_available_skills(mut self, skills: &[&SkillMd]) -> Self {
         if skills.is_empty() {
             return self;
         }
-        let mut xml = String::from("<available_skills>\n");
+        let mut section = String::from("<available_skills>\n");
         for s in skills {
             let name = escape_xml(&s.frontmatter.name);
             let desc = escape_xml(&s.frontmatter.description);
-            let loc = escape_xml(&s.path.display().to_string());
-            xml.push_str(&format!(
-                "  <skill name=\"{name}\" description=\"{desc}\" location=\"{loc}\" />\n"
+            section.push_str(&format!(
+                "  <skill name=\"{name}\" description=\"{desc}\" />\n"
             ));
         }
-        xml.push_str("</available_skills>");
-        self.sections.push(xml);
+        section.push_str("</available_skills>\n");
+        section.push_str(
+            "To use a skill above, call the `skills` tool with \
+             action=\"load\" and the skill `name`. The tool result contains \
+             the skill body — follow those instructions for the rest of the \
+             turn. Do not claim to have a skill without loading it.",
+        );
+        self.sections.push(section);
         self
     }
 
@@ -116,4 +124,63 @@ fn escape_xml(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill_md::{RequirementValidation, SkillMdFrontmatter};
+    use std::path::PathBuf;
+
+    fn fixture(name: &str, description: &str) -> SkillMd {
+        SkillMd {
+            path: PathBuf::from(format!("/var/lib/rustykrab/skills/{name}")),
+            frontmatter: SkillMdFrontmatter {
+                name: name.to_string(),
+                description: description.to_string(),
+                version: "1.0".to_string(),
+                requires: Default::default(),
+                user_invocable: true,
+                emoji: None,
+                extra: Default::default(),
+            },
+            raw_body: String::new(),
+            validation: RequirementValidation {
+                missing_env: Vec::new(),
+                missing_bins: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn available_skills_includes_invocation_instruction() {
+        let s = fixture("flight-monitor", "Watch flight prices");
+        let prompt = SystemPromptBuilder::new()
+            .with_available_skills(&[&s])
+            .build();
+        assert!(prompt.contains("<skill name=\"flight-monitor\""));
+        assert!(prompt.contains("description=\"Watch flight prices\""));
+        assert!(prompt.contains("action=\"load\""));
+        assert!(prompt.contains("`skills` tool"));
+    }
+
+    #[test]
+    fn available_skills_does_not_leak_filesystem_paths() {
+        let s = fixture("local-skill", "Local thing");
+        let prompt = SystemPromptBuilder::new()
+            .with_available_skills(&[&s])
+            .build();
+        assert!(
+            !prompt.contains("/var/lib/rustykrab/skills/local-skill"),
+            "filesystem path leaked into prompt: {prompt}"
+        );
+    }
+
+    #[test]
+    fn available_skills_empty_omits_section() {
+        let prompt = SystemPromptBuilder::new()
+            .with_available_skills(&[])
+            .build();
+        assert!(!prompt.contains("available_skills"));
+    }
 }

--- a/crates/rustykrab-tools/src/skills.rs
+++ b/crates/rustykrab-tools/src/skills.rs
@@ -7,11 +7,15 @@ use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_skills::SkillRegistry;
 use serde_json::{json, Value};
 
-/// A tool that creates and deletes SKILL.md skills.
+/// A tool that creates, deletes, and loads SKILL.md skills.
 ///
 /// Skills are written to `$DATA_DIR/skills/<name>/SKILL.md`. When a live
 /// `SkillRegistry` handle is supplied, the change is hot-loaded — available
 /// on the next agent turn with no restart required.
+///
+/// `load` is the activation path: the model calls it with a skill name from
+/// the `<available_skills>` catalog and receives the full SKILL.md body in
+/// the tool result, which it then follows for the remainder of the turn.
 pub struct SkillsTool {
     skills_dir: PathBuf,
     registry: Option<Arc<SkillRegistry>>,
@@ -143,6 +147,46 @@ impl SkillsTool {
         }))
     }
 
+    async fn action_load(&self, args: &Value) -> Result<Value> {
+        let name = args["name"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution("missing 'name'".into()))?;
+
+        if !is_valid_name(name) {
+            return Err(Error::ToolExecution(
+                "invalid skill name: must be 1-64 chars, lowercase a-z, 0-9, hyphens, underscores only".into(),
+            ));
+        }
+
+        // Prefer the live registry — it reflects hot-loaded skills and skips
+        // a disk read. Fall back to disk so `load` works even when no registry
+        // handle was wired (e.g. tests, ad-hoc invocations).
+        if let Some(ref registry) = self.registry {
+            if let Some(skill) = registry.get_md(name) {
+                return Ok(load_response(name, &skill));
+            }
+        }
+
+        let skill_dir = self.skills_dir.join(name);
+        let skill_md_path = skill_dir.join("SKILL.md");
+        if !skill_md_path.is_file() {
+            return Err(Error::ToolExecution(
+                format!("skill '{name}' not found").into(),
+            ));
+        }
+
+        let skill_dir_owned = skill_dir.clone();
+        let skill_md_path_owned = skill_md_path.clone();
+        let loaded = tokio::task::spawn_blocking(move || {
+            rustykrab_skills::load_single_skill(&skill_dir_owned, &skill_md_path_owned)
+        })
+        .await
+        .map_err(|e| Error::ToolExecution(format!("load task join failed: {e}").into()))?
+        .map_err(|e| Error::ToolExecution(format!("failed to load skill: {e}").into()))?;
+
+        Ok(load_response(name, &loaded))
+    }
+
     async fn action_delete(&self, args: &Value) -> Result<Value> {
         let name = args["name"]
             .as_str()
@@ -187,6 +231,23 @@ impl SkillsTool {
     }
 }
 
+/// Build the JSON tool result returned by `action_load`. The body is the
+/// SKILL.md instructions the model must follow next.
+fn load_response(name: &str, skill: &rustykrab_skills::SkillMd) -> Value {
+    let satisfied = skill.validation.is_satisfied();
+    json!({
+        "action": "load",
+        "name": name,
+        "description": skill.frontmatter.description,
+        "version": skill.frontmatter.version,
+        "body": skill.raw_body,
+        "requirements_satisfied": satisfied,
+        "missing_env": skill.validation.missing_env,
+        "missing_bins": skill.validation.missing_bins,
+        "instruction": "Follow the instructions in `body` for the rest of this turn.",
+    })
+}
+
 /// Validate that a skill name contains only `[a-z0-9_-]` and is 1–64 chars.
 /// Strict allowlist blocks path traversal.
 fn is_valid_name(name: &str) -> bool {
@@ -204,9 +265,12 @@ impl Tool for SkillsTool {
     }
 
     fn description(&self) -> &str {
-        "Create or delete SKILL.md skills on disk. Skills are hot-loaded into the \
-         registry immediately (available on the next agent turn, no restart required). \
-         Actions: 'create' (name, description, instructions), 'delete' (name)."
+        "Create, delete, or load SKILL.md skills. To USE a skill listed in \
+         <available_skills>, call this tool with action='load' and the skill \
+         name — the tool result contains the skill body, which you must then \
+         follow. Other actions: 'create' (name, description, instructions), \
+         'delete' (name). Created/deleted skills are hot-loaded into the \
+         registry on the next agent turn."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
@@ -225,8 +289,8 @@ impl Tool for SkillsTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["create", "delete"],
-                        "description": "Action to perform"
+                        "enum": ["load", "create", "delete"],
+                        "description": "Action to perform. Use 'load' to activate a skill from <available_skills> and receive its body."
                     },
                     "name": {
                         "type": "string",
@@ -274,10 +338,11 @@ impl Tool for SkillsTool {
             .ok_or_else(|| Error::ToolExecution("missing 'action'".into()))?;
 
         match action {
+            "load" => self.action_load(&args).await,
             "create" => self.action_create(&args).await,
             "delete" => self.action_delete(&args).await,
             other => Err(Error::ToolExecution(
-                format!("unknown action '{other}', expected one of: create, delete").into(),
+                format!("unknown action '{other}', expected one of: load, create, delete").into(),
             )),
         }
     }
@@ -457,6 +522,86 @@ mod tests {
         assert_eq!(result["unregistered"], true);
         assert!(registry.get_md("to-remove").is_none());
         assert!(!tmp.path().join("to-remove").exists());
+    }
+
+    #[tokio::test]
+    async fn load_returns_body_from_disk() {
+        let (tool, tmp) = make_tool();
+        std::fs::create_dir_all(tmp.path().join("on-disk")).unwrap();
+        std::fs::write(
+            tmp.path().join("on-disk/SKILL.md"),
+            "---\nname = \"on-disk\"\ndescription = \"Disk skill\"\n---\nDo the disk thing.\n",
+        )
+        .unwrap();
+
+        let result = tool
+            .execute(json!({ "action": "load", "name": "on-disk" }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["action"], "load");
+        assert_eq!(result["name"], "on-disk");
+        assert_eq!(result["description"], "Disk skill");
+        assert!(result["body"]
+            .as_str()
+            .unwrap()
+            .contains("Do the disk thing."));
+        assert_eq!(result["requirements_satisfied"], true);
+    }
+
+    #[tokio::test]
+    async fn load_prefers_registry_over_disk() {
+        let tmp = TempDir::new().unwrap();
+        let registry = Arc::new(SkillRegistry::new());
+        let tool = SkillsTool::with_registry(tmp.path().to_path_buf(), registry.clone());
+
+        // Create via the tool so the registry is populated.
+        tool.execute(json!({
+            "action": "create",
+            "name": "live-load",
+            "description": "Live skill",
+            "instructions": "Live body content."
+        }))
+        .await
+        .unwrap();
+
+        // Mutate the on-disk file so we can prove the registry is what's read.
+        std::fs::write(
+            tmp.path().join("live-load/SKILL.md"),
+            "---\nname = \"live-load\"\ndescription = \"Stale\"\n---\nStale disk body.\n",
+        )
+        .unwrap();
+
+        let result = tool
+            .execute(json!({ "action": "load", "name": "live-load" }))
+            .await
+            .unwrap();
+
+        assert_eq!(result["description"], "Live skill");
+        assert!(result["body"]
+            .as_str()
+            .unwrap()
+            .contains("Live body content."));
+    }
+
+    #[tokio::test]
+    async fn load_errors_when_skill_missing() {
+        let (tool, _tmp) = make_tool();
+        let r = tool
+            .execute(json!({ "action": "load", "name": "ghost" }))
+            .await;
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn load_rejects_invalid_name() {
+        let (tool, _tmp) = make_tool();
+        let r = tool
+            .execute(json!({ "action": "load", "name": "../etc/passwd" }))
+            .await;
+        assert!(r.is_err());
+        assert!(r.unwrap_err().to_string().contains("invalid skill name"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
The system prompt advertised an `<available_skills>` catalog but offered the
model no way to activate one. With no invocation tool and no instructions on
how to use a skill, the model would respond "yes, I have a skill for that"
without ever following the SKILL.md body — pure narration.

This adds a `load` action to the `skills` tool. The model calls
`skills(action="load", name="...")` and gets the skill body back in the tool
result, which it then follows for the rest of the turn. The catalog now
includes an explicit instruction telling the model it must load before
claiming to use a skill.

The tool prefers the live registry (hot-loaded skills) and falls back to disk.
The catalog also drops the on-disk path attribute — the model uses the name
to load and never needed the path.

https://claude.ai/code/session_01WHmjFhWehCQUewPEN4Rg9Y