### PR TITLE
fix(store): make non-macOS credential path safe for headless Linux/Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,17 +1949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "linux-keyutils",
- "log",
- "zeroize",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,16 +2040,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
 ]
 
 [[package]]
@@ -3272,7 +3251,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "axum",
  "chrono",
@@ -3373,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3434,7 +3413,6 @@ dependencies = [
  "croner",
  "hex",
  "hmac",
- "keyring",
  "rand",
  "rusqlite",
  "rustykrab-core",
@@ -3450,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ argon2 = "0.5"
 security-framework = { version = "3", features = ["OSX_10_15"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 secrecy = "0.10"
-keyring = { version = "3", default-features = false, features = ["linux-native"] }
 
 # Browser automation (Chrome DevTools Protocol)
 chromiumoxide = "0.9"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,46 @@ export RUSTYKRAB_AUTH_TOKEN=$(openssl rand -hex 32)
 
 Add these to your shell profile or a secrets manager. The master key encrypts all secrets stored in the database — if you lose it, stored secrets become unreadable.
 
+### Linux / Docker setup
+
+On macOS the master key is stored in the Data Protection Keychain. On Linux and Docker there is no comparable session-persistent backend that's safe to rely on, so **`RUSTYKRAB_MASTER_KEY` is required** — the daemon refuses to start without it. (This is intentional: an auto-generated ephemeral key would render previously-encrypted secrets in `store.db` permanently unreadable on the next restart.)
+
+```bash
+# One-time: generate and persist the key somewhere durable.
+export RUSTYKRAB_MASTER_KEY=$(openssl rand -hex 32)
+```
+
+**systemd unit:** keep the key out of the unit file by sourcing it from a 0600-perm env file:
+
+```ini
+# /etc/systemd/system/rustykrab.service
+[Service]
+EnvironmentFile=/etc/rustykrab/env
+ExecStart=/usr/local/bin/rustykrab-cli
+Restart=on-failure
+```
+
+```bash
+# /etc/rustykrab/env  (chmod 0600, owned by the service user)
+RUSTYKRAB_MASTER_KEY=<hex>
+RUSTYKRAB_AUTH_TOKEN=<hex>
+ANTHROPIC_API_KEY=<sk-ant-...>
+```
+
+**Docker:** pass the key via `--env-file` or a Docker/Compose secret mounted as a file and exported in the entrypoint:
+
+```bash
+docker run --rm \
+  --env-file /path/to/rustykrab.env \
+  -v rustykrab-data:/var/lib/rustykrab \
+  -e RUSTYKRAB_DATA_DIR=/var/lib/rustykrab \
+  rustykrab:latest
+```
+
+Per-credential values (Anthropic, Notion, Telegram, etc.) come from their `RUSTYKRAB_*`/service-specific env vars — see the table above and the registry at `crates/rustykrab-store/src/registry.rs`. Anything resolved from an env var is also persisted into the encrypted SQLite store on first run, so subsequent restarts only need `RUSTYKRAB_MASTER_KEY` plus whatever you want to rotate.
+
+The `rustykrab-cli keychain` subcommand is macOS-only; on Linux/Docker use env vars or the gateway's secrets API.
+
 ## Usage
 
 The gateway listens on `127.0.0.1:3000` (loopback only, by design).

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -185,10 +185,21 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(profile = %profile.name, "harness profile loaded");
 
     // --- Master key for credential encryption ---
-    // On macOS: stored in the system Keychain (Secure Enclave / Touch ID protected).
-    // On Linux: falls back to RUSTYKRAB_MASTER_KEY env var or ephemeral key.
-    let master_key = rustykrab_store::keychain::resolve_master_key()
-        .expect("failed to resolve master encryption key");
+    // On macOS: stored in the Data Protection Keychain (loaded after first
+    // unlock, no password prompt).
+    // On Linux/Docker: must be supplied via RUSTYKRAB_MASTER_KEY — see the
+    // "Linux / Docker setup" section of the README. The daemon refuses to
+    // start without it rather than risk an ephemeral key that would leave
+    // previously-stored secrets unrecoverable.
+    let master_key = match rustykrab_store::keychain::resolve_master_key() {
+        Ok(key) => key,
+        Err(e) => {
+            eprintln!();
+            eprintln!("ERROR: {e}");
+            eprintln!();
+            std::process::exit(1);
+        }
+    };
 
     let store = rustykrab_store::Store::open(data_dir.join("db"), master_key)?;
 
@@ -208,10 +219,12 @@ async fn main() -> anyhow::Result<()> {
                 eprintln!("  {} ({})", m.spec.description, m.spec.store_name);
                 eprintln!("    Set via one of:");
                 eprintln!("      env var:    export {}=<value>", m.spec.env_var);
-                eprintln!(
-                    "      keychain:   rustykrab-cli keychain set {} <value>",
-                    m.spec.keychain_account
-                );
+                if cfg!(target_os = "macos") {
+                    eprintln!(
+                        "      keychain:   rustykrab-cli keychain set {} <value>",
+                        m.spec.keychain_account
+                    );
+                }
                 eprintln!(
                     "      store:      credential_write(action='set', name='{}', value='...')",
                     m.spec.store_name
@@ -1233,11 +1246,18 @@ fn resolve_api_key(store: &rustykrab_store::Store) -> String {
         return key;
     }
 
-    tracing::error!(
-        "ANTHROPIC_API_KEY not set. Set the env var, store it via the secrets API, \
-         or add it to the OS credential store (rustykrab-cli keychain set {}).",
-        spec.keychain_account,
-    );
+    if cfg!(target_os = "macos") {
+        tracing::error!(
+            "ANTHROPIC_API_KEY not set. Set the env var, store it via the secrets API, \
+             or add it to the OS credential store (rustykrab-cli keychain set {}).",
+            spec.keychain_account,
+        );
+    } else {
+        tracing::error!(
+            "ANTHROPIC_API_KEY not set. Set the env var or store it via the \
+             gateway secrets API."
+        );
+    }
     String::new()
 }
 
@@ -1254,20 +1274,18 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
             println!(
                 "OS credential store: {}",
                 if available {
-                    if cfg!(target_os = "macos") {
-                        "available (macOS Data Protection Keychain)"
-                    } else {
-                        "available (Secret Service)"
-                    }
+                    "available (macOS Data Protection Keychain)"
                 } else {
-                    "not available"
+                    "not supported on this platform"
                 }
             );
 
             if !available {
                 println!(
-                    "\nNo OS credential store detected. Use environment variables \
-                     or the encrypted store instead."
+                    "\nThe `keychain` subcommand is macOS-only. On Linux/Docker, \
+                     set RUSTYKRAB_MASTER_KEY and the per-credential RUSTYKRAB_* \
+                     env vars (or write secrets to the encrypted store via the \
+                     gateway secrets API). See the README for details."
                 );
                 return Ok(());
             }
@@ -1329,7 +1347,11 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
             })?;
 
             if !rustykrab_store::keychain::keychain_available() {
-                anyhow::bail!("OS credential store is not available on this platform");
+                anyhow::bail!(
+                    "the `keychain` subcommand is macOS-only. On Linux/Docker, \
+                     set the credential's RUSTYKRAB_* env var or write to the \
+                     encrypted store via the gateway secrets API."
+                );
             }
 
             let svc = rustykrab_store::registry::keychain_service();
@@ -1368,7 +1390,11 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
 
         "migrate" => {
             if !rustykrab_store::keychain::keychain_available() {
-                anyhow::bail!("OS credential store is not available on this platform");
+                anyhow::bail!(
+                    "the `keychain migrate` subcommand is macOS-only. On \
+                     Linux/Docker, credentials live in env vars or the \
+                     encrypted store — there is no OS keychain to migrate to."
+                );
             }
 
             println!("Migrating credentials to OS credential store...\n");

--- a/crates/rustykrab-store/Cargo.toml
+++ b/crates/rustykrab-store/Cargo.toml
@@ -25,6 +25,3 @@ zeroize.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework.workspace = true
-
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-keyring.workspace = true

--- a/crates/rustykrab-store/src/keychain.rs
+++ b/crates/rustykrab-store/src/keychain.rs
@@ -16,7 +16,9 @@
 
 use rustykrab_core::Error;
 
+#[cfg(target_os = "macos")]
 const SERVICE_NAME: &str = "com.rustykrab.master-key";
+#[cfg(target_os = "macos")]
 const ACCOUNT_NAME: &str = "rustykrab-encryption-key";
 
 // ---------------------------------------------------------------------------
@@ -225,85 +227,57 @@ pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     Ok(key.to_vec())
 }
 
-/// Non-macOS: use env var, then OS credential store (Secret Service on Linux),
-/// then generate an ephemeral key as a last resort.
+/// Non-macOS (Linux/Docker): the master key must come from the
+/// `RUSTYKRAB_MASTER_KEY` environment variable.
+///
+/// There is no OS credential store integration on this platform — headless
+/// Linux and Docker containers don't have a session-persistent secret backend
+/// that's safe to rely on. If the env var is unset, the daemon refuses to
+/// start rather than silently using an ephemeral key (which would render
+/// every encrypted secret in `store.db` unrecoverable on the next boot).
 #[cfg(not(target_os = "macos"))]
 pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
-    // Priority 1: environment variable (for CI, Docker, explicit override).
     if let Ok(env_key) = std::env::var("RUSTYKRAB_MASTER_KEY") {
-        tracing::info!("using master key from RUSTYKRAB_MASTER_KEY env var");
-        return hex::decode(env_key.trim()).map_err(|e| {
-            Error::Storage(format!(
-                "RUSTYKRAB_MASTER_KEY must be a hex-encoded string: {e}"
-            ))
-        });
-    }
-
-    // Priority 2: OS credential store (Secret Service on Linux).
-    if keychain_available() {
-        if let Some(key) = get_master_key()? {
-            tracing::info!("master key loaded from OS credential store");
-            return Ok(key);
+        let trimmed = env_key.trim();
+        if !trimmed.is_empty() {
+            tracing::info!("using master key from RUSTYKRAB_MASTER_KEY env var");
+            return hex::decode(trimmed).map_err(|e| {
+                Error::Storage(format!(
+                    "RUSTYKRAB_MASTER_KEY must be a hex-encoded string: {e}"
+                ))
+            });
         }
-
-        // Generate a new key and persist it in the credential store.
-        tracing::info!("no master key found — generating and storing in OS credential store");
-        let mut key = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut rand::rng(), &mut key);
-        set_master_key(&key)?;
-        tracing::info!("master key stored in OS credential store");
-        return Ok(key.to_vec());
     }
 
-    // Priority 3: ephemeral key (no credential store available).
-    tracing::warn!(
-        "RUSTYKRAB_MASTER_KEY not set and OS credential store not available — \
-         generating ephemeral key. Secrets will not survive restart."
-    );
-    let mut key = [0u8; 32];
-    rand::RngCore::fill_bytes(&mut rand::rng(), &mut key);
-    Ok(key.to_vec())
+    Err(Error::Storage(
+        "RUSTYKRAB_MASTER_KEY is not set. On Linux/Docker the master key must \
+         be provided via the RUSTYKRAB_MASTER_KEY environment variable \
+         (generate one with `openssl rand -hex 32`). See the README section \
+         \"Linux / Docker setup\" for systemd and Docker examples."
+            .to_string(),
+    ))
 }
 
-/// Retrieve the master key from the OS credential store.
+/// No OS credential store on this platform.
 #[cfg(not(target_os = "macos"))]
 pub fn get_master_key() -> Result<Option<Vec<u8>>, Error> {
-    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    match entry.get_password() {
-        Ok(hex_str) => {
-            let key = hex::decode(hex_str.trim())
-                .map_err(|e| Error::Storage(format!("keyring: invalid hex: {e}")))?;
-            Ok(Some(key))
-        }
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => {
-            tracing::debug!("keyring read failed (Secret Service may not be available): {e}");
-            Ok(None)
-        }
-    }
+    Ok(None)
 }
 
-/// Store the master key in the OS credential store (as hex).
+/// No OS credential store on this platform.
 #[cfg(not(target_os = "macos"))]
-pub fn set_master_key(key: &[u8]) -> Result<(), Error> {
-    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    entry
-        .set_password(&hex::encode(key))
-        .map_err(|e| Error::Storage(format!("keyring write failed: {e}")))
+pub fn set_master_key(_key: &[u8]) -> Result<(), Error> {
+    Err(Error::Storage(
+        "OS credential store is not supported on this platform — set \
+         RUSTYKRAB_MASTER_KEY in the environment instead"
+            .to_string(),
+    ))
 }
 
-/// Delete the master key from the OS credential store.
+/// No OS credential store on this platform.
 #[cfg(not(target_os = "macos"))]
 pub fn delete_master_key() -> Result<(), Error> {
-    let entry = keyring::Entry::new(SERVICE_NAME, ACCOUNT_NAME)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    match entry.delete_credential() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(Error::Storage(format!("keyring delete failed: {e}"))),
-    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -320,25 +294,21 @@ pub struct KeychainCredential {
     pub value: String,
 }
 
-/// Returns `true` when the current platform has a working OS credential
-/// store (macOS Keychain, Linux Secret Service, etc.).
+/// Returns `true` on macOS (Data Protection Keychain), `false` elsewhere.
 #[cfg(target_os = "macos")]
 pub fn keychain_available() -> bool {
     true
 }
 
-/// Probe the OS credential store (kernel keyutils on Linux).
+/// No OS credential store on this platform.
 ///
-/// Returns `true` if the backend responds, `false` otherwise.
+/// rustykrab targets headless Linux and Docker, where there is no
+/// session-persistent secret backend that's safe to rely on. Credentials
+/// must come from `RUSTYKRAB_MASTER_KEY` + the encrypted SQLite store
+/// (or per-credential `RUSTYKRAB_*` env vars).
 #[cfg(not(target_os = "macos"))]
 pub fn keychain_available() -> bool {
-    keyring::Entry::new("com.rustykrab.probe", "availability-check")
-        .and_then(|entry| match entry.get_password() {
-            Ok(_) => Ok(()),
-            Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(e),
-        })
-        .is_ok()
+    false
 }
 
 /// Retrieve a credential from the macOS Keychain by service and account.
@@ -366,20 +336,8 @@ pub fn get_credential(service: &str, account: &str) -> Result<Option<KeychainCre
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn get_credential(service: &str, account: &str) -> Result<Option<KeychainCredential>, Error> {
-    let entry = keyring::Entry::new(service, account)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    match entry.get_password() {
-        Ok(value) => Ok(Some(KeychainCredential {
-            service: service.to_string(),
-            account: account.to_string(),
-            value,
-        })),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(Error::Storage(format!(
-            "keyring read failed for {service}/{account}: {e}"
-        ))),
-    }
+pub fn get_credential(_service: &str, _account: &str) -> Result<Option<KeychainCredential>, Error> {
+    Ok(None)
 }
 
 /// Store a credential in the macOS Keychain under the given service/account.
@@ -393,12 +351,12 @@ pub fn set_credential(service: &str, account: &str, value: &str) -> Result<(), E
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn set_credential(service: &str, account: &str, value: &str) -> Result<(), Error> {
-    let entry = keyring::Entry::new(service, account)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    entry
-        .set_password(value)
-        .map_err(|e| Error::Storage(format!("keyring write failed for {service}/{account}: {e}")))
+pub fn set_credential(_service: &str, _account: &str, _value: &str) -> Result<(), Error> {
+    Err(Error::Storage(
+        "OS credential store is not supported on this platform — use \
+         RUSTYKRAB_* environment variables or the encrypted secrets store"
+            .to_string(),
+    ))
 }
 
 /// Delete a credential from the macOS Keychain.
@@ -408,14 +366,78 @@ pub fn delete_credential(service: &str, account: &str) -> Result<(), Error> {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn delete_credential(service: &str, account: &str) -> Result<(), Error> {
-    let entry = keyring::Entry::new(service, account)
-        .map_err(|e| Error::Storage(format!("keyring init failed: {e}")))?;
-    match entry.delete_credential() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(Error::Storage(format!(
-            "keyring delete failed for {service}/{account}: {e}"
-        ))),
+pub fn delete_credential(_service: &str, _account: &str) -> Result<(), Error> {
+    Ok(())
+}
+
+#[cfg(all(test, not(target_os = "macos")))]
+mod non_mac_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Tests in this module mutate `RUSTYKRAB_MASTER_KEY`. Run them serially
+    // so they don't race each other when cargo test parallelises.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn keychain_available_is_false() {
+        assert!(!keychain_available());
+    }
+
+    #[test]
+    fn get_credential_returns_none() {
+        assert!(get_credential("anything", "anything").unwrap().is_none());
+        assert!(get_master_key().unwrap().is_none());
+    }
+
+    #[test]
+    fn set_credential_returns_error() {
+        assert!(set_credential("svc", "acct", "value").is_err());
+        assert!(set_master_key(&[0u8; 32]).is_err());
+    }
+
+    #[test]
+    fn delete_is_noop() {
+        assert!(delete_credential("svc", "acct").is_ok());
+        assert!(delete_master_key().is_ok());
+    }
+
+    #[test]
+    fn resolve_master_key_uses_env_var() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let hex = "0".repeat(64);
+        std::env::set_var("RUSTYKRAB_MASTER_KEY", &hex);
+        let key = resolve_master_key().expect("env-var path should succeed");
+        std::env::remove_var("RUSTYKRAB_MASTER_KEY");
+        assert_eq!(key, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn resolve_master_key_errors_when_unset() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("RUSTYKRAB_MASTER_KEY");
+        let err = resolve_master_key().expect_err("unset env var must error");
+        assert!(
+            err.to_string().contains("RUSTYKRAB_MASTER_KEY"),
+            "error message should name the env var: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_master_key_errors_when_empty() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("RUSTYKRAB_MASTER_KEY", "   ");
+        let err = resolve_master_key().expect_err("blank env var must error");
+        std::env::remove_var("RUSTYKRAB_MASTER_KEY");
+        assert!(err.to_string().contains("RUSTYKRAB_MASTER_KEY"));
+    }
+
+    #[test]
+    fn resolve_master_key_rejects_invalid_hex() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("RUSTYKRAB_MASTER_KEY", "not-hex");
+        let err = resolve_master_key().expect_err("non-hex env var must error");
+        std::env::remove_var("RUSTYKRAB_MASTER_KEY");
+        assert!(err.to_string().contains("hex"));
     }
 }


### PR DESCRIPTION
The non-macOS keychain path was unsound: the `keyring` crate was wired up
with the `linux-native` feature (kernel keyutils — session-bound and lost
on logout/reboot), and on probe failure `resolve_master_key` silently
generated an ephemeral key. That left every encrypted secret in `store.db`
permanently unrecoverable on the next restart.

On non-macOS targets, drop the `keyring` dep entirely, hard-fail when
`RUSTYKRAB_MASTER_KEY` is unset, and stub the OS-credential helpers as
not-supported. Per-credential resolution still works via env var or the
encrypted SQLite store. Adds a "Linux / Docker setup" section to the
README and unit tests covering the new non-macOS behavior.

https://claude.ai/code/session_01FUue8xSREphQLRzdSyXg9N