### PR TITLE
feat(agent): enable subagent delegation via agents_list/subagents tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,13 +3272,14 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "regex",
  "rustykrab-core",
+ "rustykrab-tools",
  "serde",
  "serde_json",
  "tokio",
@@ -3288,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "axum",
  "chrono",
@@ -3373,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3450,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/Cargo.toml
+++ b/crates/rustykrab-agent/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 rustykrab-core.workspace = true
+rustykrab-tools.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 serde_json.workspace = true

--- a/crates/rustykrab-agent/src/lib.rs
+++ b/crates/rustykrab-agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod rlm;
 pub mod router;
 mod runner;
 pub mod sandbox;
+pub mod subagent;
 pub mod trace;
 pub mod voting;
 
@@ -11,5 +12,6 @@ pub use rlm::RecursiveExecutor;
 pub use router::HarnessRouter;
 pub use runner::{AgentConfig, AgentEvent, AgentRunner, OnMessageCallback};
 pub use sandbox::{NoSandbox, ProcessSandbox, Sandbox, SandboxPolicy};
+pub use subagent::SubagentRunner;
 pub use trace::{ExecutionTracer, ToolStats, ToolTrace};
 pub use voting::ConsistencyVoter;

--- a/crates/rustykrab-agent/src/subagent.rs
+++ b/crates/rustykrab-agent/src/subagent.rs
@@ -1,0 +1,364 @@
+//! Sub-agent delegation runtime.
+//!
+//! [`SubagentRunner`] implements [`rustykrab_tools::SessionManager`] and
+//! is wired up via `rustykrab_tools::session_tools(...)`. The model calls
+//! the `agents_list` and `subagents` tools; this struct turns those calls
+//! into a fresh nested [`AgentRunner`] invocation against a
+//! [`AgentDefinition`] from the registry.
+//!
+//! The full multi-session API (`sessions_spawn` / `sessions_send` /
+//! `sessions_yield` / etc.) is intentionally stubbed — those tools are
+//! a separate feature and will be wired up in a follow-up.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustykrab_core::active_tools::SESSION_TOOL_CONTEXT;
+use rustykrab_core::model::ModelProvider;
+use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
+use rustykrab_core::{AgentRegistry, CapabilitySet, Error, Result, Session, Tool};
+use rustykrab_tools::SessionManager;
+use serde_json::{json, Value};
+use tokio::sync::Semaphore;
+use uuid::Uuid;
+
+use crate::harness::HarnessProfile;
+use crate::runner::AgentRunner;
+use crate::sandbox::Sandbox;
+
+/// Runs sub-agents against an [`AgentRegistry`] using a fresh
+/// [`AgentRunner`] per call.
+///
+/// A semaphore serialises concurrent calls so that a model emitting
+/// parallel `subagents` tool calls in one turn does not stack multiple
+/// nested loops on top of a local Ollama provider. The default permit
+/// count is taken from `OrchestrationConfig::max_concurrent_tasks`.
+pub struct SubagentRunner {
+    provider: Arc<dyn ModelProvider>,
+    tools: Vec<Arc<dyn Tool>>,
+    sandbox: Arc<dyn Sandbox>,
+    registry: Arc<AgentRegistry>,
+    concurrency: Arc<Semaphore>,
+}
+
+impl SubagentRunner {
+    pub fn new(
+        provider: Arc<dyn ModelProvider>,
+        tools: Vec<Arc<dyn Tool>>,
+        sandbox: Arc<dyn Sandbox>,
+        registry: Arc<AgentRegistry>,
+        concurrency: usize,
+    ) -> Self {
+        let permits = concurrency.max(1);
+        Self {
+            provider,
+            tools,
+            sandbox,
+            registry,
+            concurrency: Arc::new(Semaphore::new(permits)),
+        }
+    }
+
+    /// Build a session whose capabilities are the intersection of the
+    /// parent session's capabilities and the agent definition's
+    /// `allowed_tools` list. If `allowed_tools` is `None`, the parent's
+    /// capabilities pass through unchanged.
+    fn derive_capabilities(&self, allowed_tools: Option<&[String]>) -> CapabilitySet {
+        let parent = SESSION_TOOL_CONTEXT
+            .try_with(|ctx| (*ctx.capabilities).clone())
+            .ok();
+
+        match (parent, allowed_tools) {
+            (Some(parent_caps), Some(allowed)) => {
+                let names: Vec<&str> = allowed
+                    .iter()
+                    .filter(|name| parent_caps.can_use_tool(name))
+                    .map(|s| s.as_str())
+                    .collect();
+                CapabilitySet::for_tools(&names)
+            }
+            (Some(parent_caps), None) => parent_caps,
+            (None, Some(allowed)) => {
+                let names: Vec<&str> = allowed.iter().map(|s| s.as_str()).collect();
+                CapabilitySet::for_tools(&names)
+            }
+            (None, None) => CapabilitySet::default_safe(),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionManager for SubagentRunner {
+    async fn list_sessions(&self) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_list is not implemented yet".into(),
+        ))
+    }
+
+    async fn get_session_history(&self, _session_id: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_history is not implemented yet".into(),
+        ))
+    }
+
+    async fn send_to_session(&self, _session_id: &str, _message: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_send is not implemented yet".into(),
+        ))
+    }
+
+    async fn spawn_session(
+        &self,
+        _system_prompt: Option<&str>,
+        _capabilities: Option<Vec<String>>,
+    ) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_spawn is not implemented yet".into(),
+        ))
+    }
+
+    async fn yield_session(&self, _result: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_yield is not implemented yet".into(),
+        ))
+    }
+
+    async fn get_session_status(&self, _session_id: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "session_status is not implemented yet".into(),
+        ))
+    }
+
+    async fn list_agents(&self) -> Result<Value> {
+        let defs = self.registry.list();
+        let agents: Vec<Value> = defs
+            .iter()
+            .map(|d| {
+                json!({
+                    "id": d.id,
+                    "description": d.description,
+                    "profile": d.profile,
+                    "allowed_tools": d.allowed_tools,
+                })
+            })
+            .collect();
+        Ok(json!({ "agents": agents }))
+    }
+
+    async fn run_subagent(&self, agent_id: &str, task: &str) -> Result<Value> {
+        let def = self
+            .registry
+            .get(agent_id)
+            .ok_or_else(|| Error::ToolExecution(format!("unknown agent_id: {agent_id}").into()))?;
+
+        // Serialise nested runs so a parallel-tool-call burst from the
+        // model doesn't fan out into multiple concurrent local-model
+        // loops.
+        let _permit = self
+            .concurrency
+            .acquire()
+            .await
+            .map_err(|_| Error::Internal("subagent semaphore closed".into()))?;
+
+        let profile = match def.profile.as_str() {
+            "coding" => HarnessProfile::coding(),
+            "research" => HarnessProfile::research(),
+            "creative" => HarnessProfile::creative(),
+            _ => HarnessProfile::default(),
+        };
+
+        let caps = self.derive_capabilities(def.allowed_tools.as_deref());
+        let conv_id = Uuid::new_v4();
+        let session = Session::with_capabilities(conv_id, caps);
+
+        let now = Utc::now();
+        let mut conv = Conversation {
+            id: conv_id,
+            messages: vec![
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::System,
+                    content: MessageContent::Text(def.system_prompt.clone()),
+                    created_at: now,
+                },
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::User,
+                    content: MessageContent::Text(task.to_string()),
+                    created_at: now,
+                },
+            ],
+            created_at: now,
+            updated_at: now,
+            summary: None,
+            detected_profile: Some(def.profile.clone()),
+            channel_source: Some("subagent".into()),
+            channel_id: Some(def.id.clone()),
+            channel_thread_id: None,
+        };
+
+        let runner = AgentRunner::new(
+            self.provider.clone(),
+            self.tools.clone(),
+            self.sandbox.clone(),
+        )
+        .with_config(profile.to_agent_config());
+
+        runner.run(&mut conv, &session).await.map_err(|e| {
+            Error::ToolExecution(format!("subagent '{}' failed: {e}", def.id).into())
+        })?;
+
+        let answer = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+            .and_then(|m| m.content.as_text())
+            .unwrap_or("")
+            .to_string();
+
+        let iterations = conv
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Assistant)
+            .count();
+
+        Ok(json!({
+            "agent_id": def.id,
+            "result": answer,
+            "iterations": iterations,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use rustykrab_core::model::{ModelResponse, StopReason, StreamEvent, Usage};
+    use rustykrab_core::types::ToolSchema;
+    use std::sync::Mutex;
+
+    use crate::sandbox::NoSandbox;
+
+    struct ScriptedProvider {
+        responses: Mutex<Vec<ModelResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<ModelResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> Result<ModelResponse> {
+            let mut q = self.responses.lock().unwrap();
+            if q.is_empty() {
+                Ok(text_response("(no more responses)"))
+            } else {
+                Ok(q.remove(0))
+            }
+        }
+
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+            _on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+        ) -> Result<ModelResponse> {
+            self.chat(messages, tools).await
+        }
+    }
+
+    fn text_response(text: &str) -> ModelResponse {
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+                created_at: Utc::now(),
+            },
+            usage: Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                ..Default::default()
+            },
+            stop_reason: StopReason::EndTurn,
+            text: Some(text.to_string()),
+        }
+    }
+
+    fn make_runner(provider: Arc<dyn ModelProvider>) -> SubagentRunner {
+        SubagentRunner::new(
+            provider,
+            Vec::new(),
+            Arc::new(NoSandbox),
+            Arc::new(AgentRegistry::with_defaults()),
+            1,
+        )
+    }
+
+    #[tokio::test]
+    async fn list_agents_returns_registered_defs() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        let v = runner.list_agents().await.unwrap();
+        let agents = v.get("agents").and_then(|a| a.as_array()).unwrap();
+        let ids: Vec<&str> = agents
+            .iter()
+            .filter_map(|a| a.get("id").and_then(|i| i.as_str()))
+            .collect();
+        assert_eq!(ids, vec!["coder", "planner", "researcher"]);
+    }
+
+    #[tokio::test]
+    async fn run_subagent_unknown_id_errors() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        let err = runner.run_subagent("nope", "do a thing").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown agent_id"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_subagent_returns_assistant_text() {
+        let provider = Arc::new(ScriptedProvider::new(vec![text_response("done")]));
+        let runner = make_runner(provider);
+
+        let v = runner
+            .run_subagent("planner", "plan something")
+            .await
+            .unwrap();
+        assert_eq!(v.get("agent_id").and_then(|i| i.as_str()), Some("planner"));
+        assert_eq!(v.get("result").and_then(|r| r.as_str()), Some("done"));
+    }
+
+    #[tokio::test]
+    async fn sessions_apis_return_not_implemented() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        assert!(runner.list_sessions().await.is_err());
+        assert!(runner.spawn_session(None, None).await.is_err());
+        assert!(runner.yield_session("x").await.is_err());
+        assert!(runner.get_session_status("x").await.is_err());
+        assert!(runner.send_to_session("x", "y").await.is_err());
+        assert!(runner.get_session_history("x").await.is_err());
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -15,12 +15,13 @@ const BUILD_DATE: &str = env!("RUSTYKRAB_BUILD_DATE");
 fn version_string() -> String {
     format!("{VERSION} ({GIT_HASH}{GIT_DIRTY}, {BUILD_DATE})")
 }
-use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter};
+use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter, ProcessSandbox, SubagentRunner};
 use rustykrab_channels::telegram::ChannelMessage;
 use rustykrab_channels::{TelegramChannel, VideoChannel, VideoConfig};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::types::MessageContent;
+use rustykrab_core::AgentRegistry;
 use rustykrab_gateway::AppState;
 use rustykrab_memory::backend::HybridMemoryBackend;
 use rustykrab_memory::embedding::FastEmbedder;
@@ -444,15 +445,32 @@ async fn main() -> anyhow::Result<()> {
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");
 
+    // --- Orchestration config (used by RLM module and subagent throttle) ---
+    let orchestration_config = load_orchestration_config(&data_dir)?;
+
+    // --- Sub-agent tools (subagents, agents_list) ---
+    // Snapshot the tool list as it stands now so the sub-agent can call
+    // every parent tool except the session/subagent meta-tools we are
+    // about to add — that prevents a sub-agent from re-spawning itself
+    // through the same registry. The per-tool depth guard inside
+    // `SubagentsTool` is the second line of defence.
+    let agent_registry = Arc::new(AgentRegistry::with_defaults());
+    let subagent_runner: Arc<dyn rustykrab_tools::SessionManager> = Arc::new(SubagentRunner::new(
+        provider.clone(),
+        tools.clone(),
+        Arc::new(ProcessSandbox::new()),
+        agent_registry,
+        orchestration_config.max_concurrent_tasks,
+    ));
+    tools.extend(rustykrab_tools::session_tools(subagent_runner));
+    tracing::info!("subagent tools registered");
+
     // --- Harness router (auto-selects profile per message) ---
     // Reuses the main provider for classification to avoid model swapping.
     // The classification prompt is ~50 tokens — negligible overhead on any model.
     let classifier: Arc<dyn ModelProvider> = provider.clone();
 
     let router = Arc::new(HarnessRouter::new(classifier).with_base(profile));
-
-    // --- Orchestration config (used by RLM module) ---
-    let orchestration_config = load_orchestration_config(&data_dir)?;
 
     // --- Build gateway state ---
     // Clone store handle so we can flush it after the server shuts down.

--- a/crates/rustykrab-core/src/agent_def.rs
+++ b/crates/rustykrab-core/src/agent_def.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+/// A named sub-agent definition: system prompt, harness profile, and the
+/// tool subset the sub-agent is allowed to use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefinition {
+    /// Stable identifier referenced by the `subagents` tool.
+    pub id: String,
+    /// Short description shown in `agents_list`.
+    pub description: String,
+    /// System prompt prepended to the sub-agent's conversation.
+    pub system_prompt: String,
+    /// Harness profile name: `coding`, `research`, `creative`, or `default`.
+    pub profile: String,
+    /// Tools the sub-agent may call. `None` means inherit the parent's
+    /// active capability set unchanged.
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+/// Read-only catalog of [`AgentDefinition`]s.
+#[derive(Debug, Default, Clone)]
+pub struct AgentRegistry {
+    by_id: HashMap<String, Arc<AgentDefinition>>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, def: AgentDefinition) {
+        self.by_id.insert(def.id.clone(), Arc::new(def));
+    }
+
+    pub fn get(&self, id: &str) -> Option<Arc<AgentDefinition>> {
+        self.by_id.get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<Arc<AgentDefinition>> {
+        let mut defs: Vec<_> = self.by_id.values().cloned().collect();
+        defs.sort_by(|a, b| a.id.cmp(&b.id));
+        defs
+    }
+
+    /// Built-in catalog: researcher, coder, planner.
+    pub fn with_defaults() -> Self {
+        let mut reg = Self::new();
+        reg.insert(AgentDefinition {
+            id: "researcher".into(),
+            description: "Investigates a question using web/search/memory tools and returns a synthesized answer.".into(),
+            system_prompt: "You are a focused research sub-agent. Answer the user's question by gathering evidence with the available tools, then return a concise synthesis with citations or sources where applicable. Do not ask follow-up questions; produce a final answer in one turn loop.".into(),
+            profile: "research".into(),
+            allowed_tools: None,
+        });
+        reg.insert(AgentDefinition {
+            id: "coder".into(),
+            description: "Reads, edits, and runs code to implement a change or diagnose a bug.".into(),
+            system_prompt: "You are a focused coding sub-agent. Implement the requested change end-to-end: read relevant files, apply edits, and verify with tests or a build. Return a short summary of what you changed.".into(),
+            profile: "coding".into(),
+            allowed_tools: None,
+        });
+        reg.insert(AgentDefinition {
+            id: "planner".into(),
+            description: "Drafts a step-by-step implementation plan without making changes.".into(),
+            system_prompt: "You are a planning sub-agent. Read enough of the codebase to ground your reasoning, then produce a concrete, ordered plan with file paths and named functions. Do not modify any files.".into(),
+            profile: "default".into(),
+            allowed_tools: None,
+        });
+        reg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_contain_three_agents() {
+        let reg = AgentRegistry::with_defaults();
+        let ids: Vec<String> = reg.list().iter().map(|d| d.id.clone()).collect();
+        assert_eq!(ids, vec!["coder", "planner", "researcher"]);
+    }
+
+    #[test]
+    fn get_returns_definition_by_id() {
+        let reg = AgentRegistry::with_defaults();
+        let def = reg.get("coder").expect("coder agent exists");
+        assert_eq!(def.profile, "coding");
+    }
+
+    #[test]
+    fn unknown_id_returns_none() {
+        let reg = AgentRegistry::with_defaults();
+        assert!(reg.get("nonexistent").is_none());
+    }
+}

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod active_tools;
+pub mod agent_def;
 pub mod capability;
 pub mod crypto;
 pub mod error;
@@ -11,6 +12,7 @@ pub mod types;
 pub use active_tools::{
     with_session_context, ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT,
 };
+pub use agent_def::{AgentDefinition, AgentRegistry};
 pub use capability::{Capability, CapabilitySet};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;


### PR DESCRIPTION
Adds an `AgentRegistry` of named sub-agent definitions in
`rustykrab-core` and a `SubagentRunner` in `rustykrab-agent` that
implements `rustykrab_tools::SessionManager` for the `agents_list`
and `subagents` tools (the rest of the session API stays stubbed).

Each `subagents` call spins up a fresh `AgentRunner` against a chosen
`HarnessProfile`, with capabilities derived from the parent session's
capabilities intersected with the agent's `allowed_tools` list. A
semaphore sized to `OrchestrationConfig::max_concurrent_tasks`
serialises nested runs so a model emitting parallel `subagents` calls
does not stack concurrent loops on a local provider.

Ships three built-in agents: researcher, coder, planner.