### PR TITLE
feat(browser): pierce shadow DOM and iframes, occlusion-aware snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,7 +3251,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -240,6 +240,10 @@ impl Tool for BrowserTool {
                     "depth": {
                         "type": "integer",
                         "description": "Snapshot: max tree depth (default: 10)"
+                    },
+                    "highlight": {
+                        "type": "boolean",
+                        "description": "Snapshot: paint numbered overlay boxes on each ref so a subsequent screenshot shows the labels (default: false). Overlays auto-clear on the next snapshot."
                     }
                 },
                 "required": ["action"]
@@ -352,6 +356,7 @@ impl Tool for BrowserTool {
                     compact: args["compact"].as_bool().unwrap_or(false),
                     max_depth: args["depth"].as_u64().unwrap_or(10) as usize,
                     selector: args["selector"].as_str().map(|s| s.to_string()),
+                    highlight: args["highlight"].as_bool().unwrap_or(false),
                 };
 
                 let key = Self::store_key(&profile, target_id);

--- a/crates/rustykrab-tools/src/browser/snapshot.rs
+++ b/crates/rustykrab-tools/src/browser/snapshot.rs
@@ -1,4 +1,5 @@
-//! Accessibility-tree snapshot system modeled after OpenClaw's snapshot/ref pattern.
+//! Accessibility-tree snapshot system modeled after OpenClaw's snapshot/ref pattern,
+//! with browser-use-inspired enhancements.
 //!
 //! Takes a snapshot of the page's accessibility tree, assigns stable numeric
 //! refs to interactive elements, and returns a structured representation that
@@ -7,6 +8,14 @@
 //! Two snapshot modes:
 //! - **ai**: Compact text summary with numeric refs (default)
 //! - **aria**: Full accessibility tree with `e`-prefixed refs (e.g., e12)
+//!
+//! Enhancements over the baseline AX-tree extractor:
+//! - Pierces open shadow roots (Web Components, Angular Material, etc.).
+//! - Pierces same-origin iframes.
+//! - Filters out occluded / zero-size / fully transparent elements.
+//! - Prefers stable selectors (`data-testid`, `aria-label`, `name`) over
+//!   fragile nth-of-type chains.
+//! - Optional numbered highlight overlay for screenshots.
 
 use chromiumoxide::Page;
 use rustykrab_core::{Error, Result};
@@ -18,12 +27,19 @@ use tokio::sync::Mutex;
 /// Maximum depth for accessibility tree traversal.
 const DEFAULT_MAX_DEPTH: usize = 10;
 
+/// Marker between segments of a shadow-DOM piercing selector.
+#[allow(dead_code)]
+pub(crate) const SHADOW_SEP: &str = " >>> ";
+/// Marker between an iframe selector and the inner-document selector.
+#[allow(dead_code)]
+pub(crate) const IFRAME_SEP: &str = " ||| ";
+
 /// A single element ref from a snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElementRef {
     /// The ref identifier (numeric for ai mode, e-prefixed for aria mode).
     pub ref_id: String,
-    /// CSS selector that can locate this element.
+    /// Primary selector, possibly chained via `>>>` (shadow) or `|||` (iframe).
     pub selector: String,
     /// Element role (button, link, textbox, etc.).
     pub role: String,
@@ -93,6 +109,10 @@ pub struct SnapshotOptions {
     pub max_depth: usize,
     /// CSS selector to scope the snapshot to a subtree.
     pub selector: Option<String>,
+    /// If true, paint numbered overlay boxes on each snapshotted ref so a
+    /// subsequent screenshot shows the labels visually. Overlays auto-clear on
+    /// the next snapshot.
+    pub highlight: bool,
 }
 
 impl Default for SnapshotOptions {
@@ -103,58 +123,138 @@ impl Default for SnapshotOptions {
             compact: false,
             max_depth: DEFAULT_MAX_DEPTH,
             selector: None,
+            highlight: false,
         }
     }
 }
 
 /// JavaScript that extracts the accessibility tree from a page.
 ///
-/// Returns an array of objects with: tag, role, name, value, selector, interactive,
-/// bounds (x, y, w, h), depth, children count.
+/// Walks the document, open shadow roots, and same-origin iframes. Returns an
+/// array of objects with: tag, role, name, value, selector (possibly chained),
+/// interactive, bounds (x, y, w, h), depth.
+///
+/// Args: [maxDepth, interactiveOnly, scopeSelector, highlight]
 const SNAPSHOT_JS: &str = r#"
 (function() {
-    const INTERACTIVE_ROLES = new Set([
+    var INTERACTIVE_ROLES = new Set([
         'button', 'link', 'textbox', 'checkbox', 'radio', 'combobox',
         'listbox', 'menuitem', 'menuitemcheckbox', 'menuitemradio',
         'option', 'searchbox', 'slider', 'spinbutton', 'switch',
         'tab', 'treeitem'
     ]);
-    const INTERACTIVE_TAGS = new Set([
+    var INTERACTIVE_TAGS = new Set([
         'A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'DETAILS', 'SUMMARY'
     ]);
+    var SHADOW_SEP = ' >>> ';
+    var IFRAME_SEP = ' ||| ';
 
-    function getSelector(el) {
-        if (el.id) return '#' + CSS.escape(el.id);
-        if (el === document.body) return 'body';
-        const tag = el.tagName.toLowerCase();
-        const parent = el.parentElement;
-        if (!parent) return tag;
-        const siblings = Array.from(parent.children).filter(c => c.tagName === el.tagName);
-        if (siblings.length === 1) return getSelector(parent) + ' > ' + tag;
-        const idx = siblings.indexOf(el) + 1;
-        return getSelector(parent) + ' > ' + tag + ':nth-of-type(' + idx + ')';
+    var MAX_DEPTH = arguments[0] || 10;
+    var INTERACTIVE_ONLY = arguments[1] || false;
+    var SCOPE_SELECTOR = arguments[2] || null;
+    var HIGHLIGHT = arguments[3] || false;
+
+    // Always clear stale highlights from a previous snapshot, even if we are
+    // not painting new ones this call.
+    var STALE_HIGHLIGHT_ID = '__rustykrab_overlay__';
+    var stale = document.getElementById(STALE_HIGHLIGHT_ID);
+    if (stale) stale.remove();
+
+    function csqEscape(s) {
+        if (window.CSS && CSS.escape) return CSS.escape(s);
+        return String(s).replace(/[^a-zA-Z0-9_-]/g, function(c) { return '\\' + c; });
+    }
+
+    // Build a CSS selector for an element, scoped to its owner Document or
+    // ShadowRoot. Prefers stable attributes.
+    function localSelector(el) {
+        if (el.id && !/^[0-9]/.test(el.id)) return '#' + csqEscape(el.id);
+        var tid = el.getAttribute && el.getAttribute('data-testid');
+        if (tid) return el.tagName.toLowerCase() + '[data-testid="' + cssAttrEscape(tid) + '"]';
+        var dataQa = el.getAttribute && el.getAttribute('data-qa');
+        if (dataQa) return el.tagName.toLowerCase() + '[data-qa="' + cssAttrEscape(dataQa) + '"]';
+        var name = el.getAttribute && el.getAttribute('name');
+        if (name && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT' || el.tagName === 'BUTTON')) {
+            return el.tagName.toLowerCase() + '[name="' + cssAttrEscape(name) + '"]';
+        }
+        var aria = el.getAttribute && el.getAttribute('aria-label');
+        if (aria && aria.length < 100) {
+            return el.tagName.toLowerCase() + '[aria-label="' + cssAttrEscape(aria) + '"]';
+        }
+        // Fallback: structural path within the local root.
+        return structuralPath(el);
+    }
+
+    function cssAttrEscape(s) {
+        return String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    }
+
+    function structuralPath(el) {
+        var parts = [];
+        var node = el;
+        while (node && node.nodeType === 1) {
+            var parent = node.parentElement;
+            // Stop when we cross out of the local root (shadow/iframe boundary).
+            if (!parent) break;
+            var tag = node.tagName.toLowerCase();
+            if (node.id && !/^[0-9]/.test(node.id)) {
+                parts.unshift('#' + csqEscape(node.id));
+                break;
+            }
+            var siblings = Array.from(parent.children).filter(function(c) {
+                return c.tagName === node.tagName;
+            });
+            if (siblings.length === 1) {
+                parts.unshift(tag);
+            } else {
+                var idx = siblings.indexOf(node) + 1;
+                parts.unshift(tag + ':nth-of-type(' + idx + ')');
+            }
+            node = parent;
+        }
+        return parts.join(' > ') || el.tagName.toLowerCase();
+    }
+
+    // Compose a chained selector that pierces shadow/iframe boundaries.
+    // chain is an array like [{kind:'doc', el:host}, {kind:'shadow', host:host}, {kind:'iframe', host:iframe}]
+    // Each segment contributes a localSelector(el) plus an appropriate separator.
+    function chainedSelector(el, chain) {
+        var localPart = localSelector(el);
+        if (!chain.length) return localPart;
+        var s = '';
+        for (var i = 0; i < chain.length; i++) {
+            var seg = chain[i];
+            var hostSel = localSelector(seg.host);
+            if (i === 0) {
+                s = hostSel;
+            } else {
+                s = s + (chain[i - 1].kind === 'shadow' ? SHADOW_SEP : IFRAME_SEP) + hostSel;
+            }
+        }
+        var lastBoundary = chain[chain.length - 1].kind === 'shadow' ? SHADOW_SEP : IFRAME_SEP;
+        return s + lastBoundary + localPart;
     }
 
     function isInteractive(el) {
-        const role = (el.getAttribute('role') || '').toLowerCase();
+        var role = (el.getAttribute && (el.getAttribute('role') || '')).toLowerCase();
         if (INTERACTIVE_ROLES.has(role)) return true;
         if (INTERACTIVE_TAGS.has(el.tagName)) return true;
-        if (el.hasAttribute('onclick') || el.hasAttribute('tabindex')) return true;
+        if (el.hasAttribute && (el.hasAttribute('onclick') || el.hasAttribute('tabindex'))) return true;
         if (el.tagName === 'DIV' || el.tagName === 'SPAN') {
-            const style = window.getComputedStyle(el);
+            var style = window.getComputedStyle(el);
             if (style.cursor === 'pointer') return true;
         }
         return false;
     }
 
     function getRole(el) {
-        const explicit = el.getAttribute('role');
+        var explicit = el.getAttribute && el.getAttribute('role');
         if (explicit) return explicit.toLowerCase();
-        const tag = el.tagName;
+        var tag = el.tagName;
         if (tag === 'A') return 'link';
         if (tag === 'BUTTON') return 'button';
         if (tag === 'INPUT') {
-            const type = (el.type || 'text').toLowerCase();
+            var type = (el.type || 'text').toLowerCase();
             if (type === 'checkbox') return 'checkbox';
             if (type === 'radio') return 'radio';
             if (type === 'submit' || type === 'button') return 'button';
@@ -174,70 +274,177 @@ const SNAPSHOT_JS: &str = r#"
     }
 
     function getName(el) {
-        const ariaLabel = el.getAttribute('aria-label');
+        if (!el.getAttribute) return '';
+        var ariaLabel = el.getAttribute('aria-label');
         if (ariaLabel) return ariaLabel;
-        const labelledBy = el.getAttribute('aria-labelledby');
+        var labelledBy = el.getAttribute('aria-labelledby');
         if (labelledBy) {
-            const label = document.getElementById(labelledBy);
-            if (label) return label.textContent.trim().substring(0, 100);
+            var label = (el.getRootNode && el.getRootNode().getElementById)
+                ? el.getRootNode().getElementById(labelledBy)
+                : document.getElementById(labelledBy);
+            if (label) return (label.textContent || '').trim().substring(0, 100);
         }
         if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') {
-            const id = el.id;
+            var id = el.id;
             if (id) {
-                const label = document.querySelector('label[for="' + CSS.escape(id) + '"]');
-                if (label) return label.textContent.trim().substring(0, 100);
+                var root = el.getRootNode ? el.getRootNode() : document;
+                var assoc = root.querySelector ? root.querySelector('label[for="' + cssAttrEscape(id) + '"]') : null;
+                if (assoc) return (assoc.textContent || '').trim().substring(0, 100);
             }
-            const placeholder = el.getAttribute('placeholder');
+            var placeholder = el.getAttribute('placeholder');
             if (placeholder) return placeholder;
-            const title = el.getAttribute('title');
+            var title = el.getAttribute('title');
             if (title) return title;
         }
         if (el.tagName === 'IMG') return el.alt || '';
         if (el.tagName === 'A' || el.tagName === 'BUTTON') {
-            return el.textContent.trim().substring(0, 100);
+            return (el.textContent || '').trim().substring(0, 100);
         }
-        return el.textContent.trim().substring(0, 80);
+        return (el.textContent || '').trim().substring(0, 80);
     }
 
-    const results = [];
-    const MAX_DEPTH = arguments[0] || 10;
-    const INTERACTIVE_ONLY = arguments[1] || false;
-    const SCOPE_SELECTOR = arguments[2] || null;
+    // Visibility check: layout box, computed style, opacity, viewport overlap,
+    // and a center-point occlusion probe.
+    function isVisible(el) {
+        var style = window.getComputedStyle(el);
+        if (style.display === 'none' || style.visibility === 'hidden') return false;
+        if (parseFloat(style.opacity || '1') === 0) return false;
+        var rect = el.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return false;
+        // Off the document entirely (negative side, beyond doc) — keep, the
+        // page may scroll. We only filter purely degenerate cases above.
+        return true;
+    }
 
-    const root = SCOPE_SELECTOR ? document.querySelector(SCOPE_SELECTOR) : document.body;
-    if (!root) return JSON.stringify([]);
+    // Returns true if `el` is occluded at its center by a non-descendant node.
+    // Skipped for elements outside the viewport (we cannot probe those).
+    function isOccluded(el) {
+        var rect = el.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return true;
+        var vw = window.innerWidth || document.documentElement.clientWidth;
+        var vh = window.innerHeight || document.documentElement.clientHeight;
+        // If the center is outside the viewport, we cannot probe; consider visible.
+        var cx = rect.x + rect.width / 2;
+        var cy = rect.y + rect.height / 2;
+        if (cx < 0 || cy < 0 || cx > vw || cy > vh) return false;
+        var root = el.getRootNode ? el.getRootNode() : document;
+        var topEl = root.elementFromPoint ? root.elementFromPoint(cx, cy) : document.elementFromPoint(cx, cy);
+        if (!topEl) return false;
+        if (topEl === el) return false;
+        if (el.contains && el.contains(topEl)) return false;
+        if (topEl.contains && topEl.contains(el)) return false;
+        return true;
+    }
 
-    function walk(el, depth) {
+    var results = [];
+    var refCounter = 0;
+
+    var rootDoc = SCOPE_SELECTOR ? document.querySelector(SCOPE_SELECTOR) : document.body;
+    if (!rootDoc) return JSON.stringify({ elements: [], note: 'scope selector did not match' });
+
+    function walk(node, depth, chain) {
         if (depth > MAX_DEPTH) return;
-        if (el.nodeType !== 1) return;
-        const style = window.getComputedStyle(el);
-        if (style.display === 'none' || style.visibility === 'hidden') return;
+        if (!node) return;
+        // Element-like node.
+        if (node.nodeType !== 1) return;
 
-        const interactive = isInteractive(el);
-        if (!INTERACTIVE_ONLY || interactive) {
-            const rect = el.getBoundingClientRect();
-            const role = getRole(el);
-            if (role !== 'generic' || interactive) {
-                results.push({
-                    tag: el.tagName.toLowerCase(),
-                    role: role,
-                    name: getName(el),
-                    value: (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') ? (el.value || '') : null,
-                    selector: getSelector(el),
-                    interactive: interactive,
-                    bounds: [Math.round(rect.x), Math.round(rect.y), Math.round(rect.width), Math.round(rect.height)],
-                    depth: depth
-                });
+        if (!isVisible(node)) return;
+        // Skip occluded interactive candidates; non-interactive structural nodes
+        // we still descend into (their children may be visible).
+        var occluded = isOccluded(node);
+
+        var interactive = isInteractive(node);
+        var role = getRole(node);
+        var collect = (interactive || role !== 'generic') && !occluded;
+        if (INTERACTIVE_ONLY && !interactive) collect = false;
+
+        if (collect) {
+            var rect = node.getBoundingClientRect();
+            results.push({
+                node: node,
+                chain: chain.slice(),
+                tag: node.tagName.toLowerCase(),
+                role: role,
+                name: getName(node),
+                value: (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA' || node.tagName === 'SELECT') ? (node.value || '') : null,
+                selector: chainedSelector(node, chain),
+                interactive: interactive,
+                bounds: [Math.round(rect.x), Math.round(rect.y), Math.round(rect.width), Math.round(rect.height)],
+                depth: depth
+            });
+        }
+
+        // Descend into open shadow root, if any.
+        if (node.shadowRoot && node.shadowRoot.mode !== 'closed') {
+            var children = node.shadowRoot.children;
+            for (var i = 0; i < children.length; i++) {
+                walk(children[i], depth + 1, chain.concat([{ kind: 'shadow', host: node }]));
             }
         }
 
-        for (const child of el.children) {
-            walk(child, depth + 1);
+        // Descend into same-origin iframe contentDocument.
+        if (node.tagName === 'IFRAME') {
+            try {
+                var doc = node.contentDocument;
+                if (doc && doc.body) {
+                    var ic = doc.body.children;
+                    for (var j = 0; j < ic.length; j++) {
+                        walk(ic[j], depth + 1, chain.concat([{ kind: 'iframe', host: node }]));
+                    }
+                }
+            } catch (e) { /* cross-origin: cannot pierce */ }
+        }
+
+        // Light DOM children.
+        var lc = node.children;
+        for (var k = 0; k < lc.length; k++) {
+            walk(lc[k], depth + 1, chain);
         }
     }
 
-    walk(root, 0);
-    return JSON.stringify(results);
+    walk(rootDoc, 0, []);
+
+    // Optional highlight overlay: numbered boxes anchored in document space.
+    if (HIGHLIGHT) {
+        var overlay = document.createElement('div');
+        overlay.id = STALE_HIGHLIGHT_ID;
+        overlay.style.cssText = 'position:fixed;inset:0;pointer-events:none;z-index:2147483647;';
+        for (var r = 0; r < results.length; r++) {
+            var item = results[r];
+            // Only highlight elements visible in the current viewport.
+            var b = item.bounds;
+            if (!b) continue;
+            var box = document.createElement('div');
+            box.style.cssText =
+                'position:absolute;border:2px solid #ff3b30;outline:1px solid #fff;' +
+                'left:' + b[0] + 'px;top:' + b[1] + 'px;' +
+                'width:' + b[2] + 'px;height:' + b[3] + 'px;' +
+                'box-sizing:border-box;';
+            var label = document.createElement('div');
+            label.textContent = String(r + 1);
+            label.style.cssText =
+                'position:absolute;left:0;top:-16px;background:#ff3b30;color:#fff;' +
+                'font:600 11px/14px system-ui,sans-serif;padding:0 4px;border-radius:2px;';
+            box.appendChild(label);
+            overlay.appendChild(box);
+        }
+        (document.body || document.documentElement).appendChild(overlay);
+    }
+
+    // Strip non-serializable fields before returning.
+    var out = results.map(function(e) {
+        return {
+            tag: e.tag,
+            role: e.role,
+            name: e.name,
+            value: e.value,
+            selector: e.selector,
+            interactive: e.interactive,
+            bounds: e.bounds,
+            depth: e.depth
+        };
+    });
+    return JSON.stringify(out);
 })()
 "#;
 
@@ -269,9 +476,8 @@ pub async fn take_snapshot(
         .map(|s| serde_json::to_string(s).unwrap_or_else(|_| "null".to_string()))
         .unwrap_or_else(|| "null".to_string());
 
-    // Execute the snapshot JS with arguments
     let eval_js = format!(
-        "({SNAPSHOT_JS}).apply(null, [{}, {}, {}])",
+        "({SNAPSHOT_JS}).apply(null, [{}, {}, {}, {}])",
         options.max_depth,
         if options.interactive_only {
             "true"
@@ -279,6 +485,7 @@ pub async fn take_snapshot(
             "false"
         },
         selector_arg,
+        if options.highlight { "true" } else { "false" },
     );
 
     let result = page
@@ -352,6 +559,7 @@ pub async fn take_snapshot(
         "elements": output_elements,
         "count": ref_counter,
         "interactive_count": elements.iter().filter(|e| e.interactive).count(),
+        "highlight": options.highlight,
         "note": format!(
             "Use ref numbers with 'act' action to interact with elements (e.g., act click {}1)",
             if options.mode == SnapshotMode::Aria { "e" } else { "" }


### PR DESCRIPTION
Snapshot extractor now:
- Walks open shadow roots and same-origin iframes; chained selectors
  use ` >>> ` (shadow) and ` ||| ` (iframe) markers (resolved in a
  follow-up).
- Filters out occluded, zero-size, and fully transparent elements via
  computed style + elementFromPoint center probe.
- Prefers stable selectors: data-testid, data-qa, name=, aria-label
  before the nth-of-type structural fallback.
- Optional `highlight: true` paints numbered overlay boxes on each ref
  so a subsequent screenshot shows visual labels; auto-clears on the
  next snapshot.

https://claude.ai/code/session_019yWN89Ch7tUEZQ1TsKee1H