### PR TITLE
fix(gateway): handle Chrome DevTools well-known probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-gateway/src/webchat.rs
+++ b/crates/rustykrab-gateway/src/webchat.rs
@@ -13,7 +13,18 @@ struct StaticAssets;
 pub fn static_routes() -> Router<AppState> {
     Router::new()
         .route("/", get(index))
+        .route(
+            "/.well-known/appspecific/com.chrome.devtools.json",
+            get(chrome_devtools_probe),
+        )
         .route("/{*path}", get(serve_static))
+}
+
+// Chrome DevTools probes this path to discover a workspace project mapping
+// when DevTools is open. Returning 204 silences the "implementation does not
+// exist" / 404 noise without claiming to support a workspace.
+async fn chrome_devtools_probe() -> StatusCode {
+    StatusCode::NO_CONTENT
 }
 
 async fn index() -> impl IntoResponse {


### PR DESCRIPTION
Chrome DevTools probes /.well-known/appspecific/com.chrome.devtools.json
when open against a localhost server. The static handler's catch-all
returned 404, which Chrome surfaces as an "implementation does not
exist" error in the console. Return 204 No Content for that path so the
probe is acknowledged without claiming a workspace mapping.