### PR TITLE
fix(agent): execute scheduled briefings instead of asking for tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.8.2"
+version = "2.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -182,7 +182,10 @@ fn classify_response(text: &str, _completion_tokens: u32) -> ResponseClass {
     if trimmed.is_empty() {
         return ResponseClass::Empty;
     }
-    if is_planning_only(trimmed) || is_progress_narration(trimmed) {
+    if is_planning_only(trimmed)
+        || is_progress_narration(trimmed)
+        || is_idle_acknowledgment(trimmed)
+    {
         return ResponseClass::PlanningOnly;
     }
     ResponseClass::Complete
@@ -353,6 +356,62 @@ fn is_progress_narration(text: &str) -> bool {
         .map(|p| lower.matches(p).count())
         .sum();
     intent_count >= 5
+}
+
+/// Heuristic: did the model respond with a generic idle acknowledgment
+/// instead of doing the requested work? Catches "I am ready. Please provide
+/// your first task.", "Standing by — let me know what you need.", "How can I
+/// help you today?". These responses look polite in a chat REPL but are
+/// failure modes inside a scheduled job: the conversation already contains
+/// the task, so asking for one is the model ignoring its instructions.
+///
+/// Distinct from the prior tiers:
+/// - `is_planning_only` catches "I'll do X next" (planning).
+/// - `is_progress_narration` catches "I'm currently doing X" (fake progress).
+/// - This catches "I'm waiting for you to tell me X" (idle).
+///
+/// Restricted to short responses (≤400 chars) without code blocks so a
+/// substantive answer that happens to end with "let me know if you need
+/// anything else" doesn't false-positive.
+fn is_idle_acknowledgment(text: &str) -> bool {
+    if text.contains("```") {
+        return false;
+    }
+    if text.len() > 400 {
+        return false;
+    }
+    let lower = text.to_lowercase();
+    let idle_markers = [
+        "i'm ready",
+        "i am ready",
+        "ready for your",
+        "ready when you",
+        "ready to assist",
+        "ready to help",
+        "ready to begin",
+        "ready to start",
+        "standing by",
+        "awaiting your",
+        "awaiting instructions",
+        "please provide",
+        "please give me",
+        "please tell me",
+        "please share",
+        "please specify",
+        "please let me know",
+        "what would you like",
+        "what can i help",
+        "how can i help",
+        "how may i help",
+        "how can i assist",
+        "how may i assist",
+        "your first task",
+        "your next task",
+        "what should i do",
+        "what do you want me to",
+        "what do you need me to",
+    ];
+    idle_markers.iter().any(|m| lower.contains(m))
 }
 
 /// Events emitted by the agent loop during streaming execution.
@@ -3174,6 +3233,37 @@ mod response_classification_tests {
             I am starting Phase 1, Step 1 (United Airlines) right now. \
             I will keep working through these steps until the data is complete.";
         assert_planning(text);
+    }
+
+    #[test]
+    fn idle_readiness_acknowledgment_is_planning() {
+        // The exact failure mode for scheduled briefings: the model treats
+        // the cron-triggered turn as a fresh REPL prompt and asks for work
+        // instead of executing the task already in the conversation.
+        assert_planning("I am ready. Please provide your first task.");
+        assert_planning("I'm ready. What would you like me to do?");
+        assert_planning("Standing by — let me know what you need.");
+        assert_planning("Ready to assist. How can I help you today?");
+        assert_planning("How may I assist you?");
+        assert_planning("Awaiting your instructions.");
+        assert_planning("Please tell me what you'd like to work on.");
+    }
+
+    #[test]
+    fn substantive_answer_with_trailing_offer_is_complete() {
+        // A real answer that ends with a polite "let me know" must NOT be
+        // flagged as idle — the body length keeps it above the 400-char
+        // threshold, and the response delivered actual content first.
+        let text = "The migration is safe under concurrent writes because the \
+            backfill runs inside an explicit transaction with statement-level \
+            locking on the affected rows. Postgres' MVCC keeps readers from \
+            blocking writers during the column add, and the NOT NULL \
+            constraint is added in a second pass after every row has a \
+            value. The only risk is long-running transactions that started \
+            before the migration: those will see a snapshot without the \
+            new column and may write rows that need a follow-up backfill. \
+            Let me know if you'd like the rollback plan as well.";
+        assert_complete(text);
     }
 
     #[test]

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -322,6 +322,32 @@ async fn main() -> anyhow::Result<()> {
             "soul path defaulted (set RUSTYKRAB_SOUL_PATH to override)"
         );
     }
+    // Seed the soul file if the configured path doesn't exist yet. Without
+    // this, the prompt loader silently falls back to the baked-in default
+    // and the operator has no visible file to edit. We only write when the
+    // file is missing — never overwrite a populated soul.
+    if let Some(path) = std::env::var_os(rustykrab_skills::prompt::SOUL_PATH_ENV) {
+        let soul_path = std::path::PathBuf::from(path);
+        if !soul_path.exists() {
+            if let Some(parent) = soul_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            match std::fs::write(
+                &soul_path,
+                rustykrab_skills::prompt::default_soul_template(),
+            ) {
+                Ok(()) => tracing::info!(
+                    path = %soul_path.display(),
+                    "seeded soul.md with default template — edit to customize"
+                ),
+                Err(e) => tracing::warn!(
+                    path = %soul_path.display(),
+                    error = %e,
+                    "could not seed soul.md — will use baked-in default at runtime"
+                ),
+            }
+        }
+    }
 
     // --- Memory system (hybrid retrieval: vector + BM25 + temporal + graph) ---
     let memory_db_path = data_dir.join("memory.db");

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -188,7 +188,20 @@ async fn execute_cron_task(
         }
     };
 
-    let prompt = build_scheduled_prompt(task_prompt, job.last_run_at);
+    // Resolve the delivery target. Precedence: job-specified > stored on the
+    // job's persistent conversation > operator-wide env defaults. The
+    // env defaults are the safety net for jobs created by older builds (or
+    // by the model without channel/chat_id) so their output isn't silently
+    // dropped on the floor.
+    let (effective_channel, effective_chat_id, effective_thread_id) =
+        resolve_delivery_target(channel, chat_id, thread_id, &conv);
+
+    let prompt = build_scheduled_prompt(
+        task_prompt,
+        job.last_run_at,
+        effective_channel.as_deref(),
+        effective_chat_id.as_deref(),
+    );
 
     // Run the agent.
     let no_op_event = |_event: AgentEvent| {};
@@ -213,37 +226,73 @@ async fn execute_cron_task(
     };
 
     // Route the response to the originating channel.
-    match channel {
+    match effective_channel.as_deref() {
         Some("telegram") => {
-            if let (Some(tg), Some(cid)) = (&state.telegram, chat_id) {
+            if let (Some(tg), Some(cid)) = (&state.telegram, effective_chat_id.as_deref()) {
                 if let Ok(chat_id_num) = cid.parse::<i64>() {
-                    let tg_thread = thread_id.and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
+                    let tg_thread = effective_thread_id
+                        .as_deref()
+                        .and_then(|s| s.parse::<i64>().ok())
+                        .unwrap_or(0);
                     if let Err(e) = tg.send_text(chat_id_num, &response_text, tg_thread).await {
                         tracing::error!(job_id = %job_id, "failed to send scheduled job result to Telegram: {e}");
                     }
                 } else {
                     tracing::error!(job_id = %job_id, chat_id = %cid, "invalid Telegram chat_id");
                 }
+            } else {
+                tracing::warn!(
+                    job_id = %job_id,
+                    has_telegram = state.telegram.is_some(),
+                    has_chat_id = effective_chat_id.is_some(),
+                    "telegram routing unavailable; result discarded: {response_text}"
+                );
             }
         }
         Some("slack") => {
-            if let (Some(sl), Some(channel_id)) = (&state.slack, chat_id) {
-                if let Err(e) = sl.send_text(channel_id, &response_text, thread_id).await {
+            if let (Some(sl), Some(channel_id)) = (&state.slack, effective_chat_id.as_deref()) {
+                if let Err(e) = sl
+                    .send_text(channel_id, &response_text, effective_thread_id.as_deref())
+                    .await
+                {
                     tracing::error!(job_id = %job_id, "failed to send scheduled job result to Slack: {e}");
                 }
+            } else {
+                tracing::warn!(
+                    job_id = %job_id,
+                    has_slack = state.slack.is_some(),
+                    has_chat_id = effective_chat_id.is_some(),
+                    "slack routing unavailable; result discarded: {response_text}"
+                );
             }
         }
         Some("signal") => {
-            if let (Some(sig), Some(number)) = (&state.signal, chat_id) {
+            if let (Some(sig), Some(number)) = (&state.signal, effective_chat_id.as_deref()) {
                 if let Err(e) = sig.send_text(number, &response_text).await {
                     tracing::error!(job_id = %job_id, "failed to send scheduled job result to Signal: {e}");
                 }
+            } else {
+                tracing::warn!(
+                    job_id = %job_id,
+                    has_signal = state.signal.is_some(),
+                    has_chat_id = effective_chat_id.is_some(),
+                    "signal routing unavailable; result discarded: {response_text}"
+                );
             }
         }
-        _ => {
-            tracing::info!(
+        Some(other) => {
+            tracing::warn!(
                 job_id = %job_id,
-                "scheduled job completed (no channel routing): {response_text}"
+                channel = %other,
+                "unknown channel for scheduled job; result discarded: {response_text}"
+            );
+        }
+        None => {
+            tracing::warn!(
+                job_id = %job_id,
+                "scheduled job has no delivery channel — set channel/chat_id on the \
+                 job, or set RUSTYKRAB_DEFAULT_CHANNEL + RUSTYKRAB_DEFAULT_CHAT_ID. \
+                 Result discarded: {response_text}"
             );
         }
     }
@@ -310,12 +359,27 @@ fn resume_or_create_conversation(
 
 /// Build the user message prepended to the agent's turn. On the first run
 /// there's no prior context, so we say so; on subsequent runs the prompt
-/// points the agent at the conversation history it already has.
+/// points the agent at the conversation history it already has. Also tells
+/// the model where its final response will be delivered, so it knows it's
+/// being asked to actually produce output (not chat about what it might do).
 fn build_scheduled_prompt(
     task_prompt: &str,
     last_run_at: Option<chrono::DateTime<chrono::Utc>>,
+    channel: Option<&str>,
+    chat_id: Option<&str>,
 ) -> String {
-    match last_run_at {
+    let delivery = match (channel, chat_id) {
+        (Some(c), Some(id)) => format!(
+            "Your final assistant message this turn will be delivered to {c} ({id}). \
+             Treat that final message as the briefing/answer the recipient will \
+             receive — do not ask for clarification, do not promise future updates."
+        ),
+        _ => "Your final assistant message this turn IS the deliverable for this \
+             scheduled task. Produce it directly — do not ask for clarification, \
+             do not promise future updates."
+            .to_string(),
+    };
+    let body = match last_run_at {
         Some(last) => format!(
             "[Scheduled task] Your scheduled task is due again. Earlier runs are in \
              this conversation — refer to them for any state, filenames, or \
@@ -328,5 +392,165 @@ fn build_scheduled_prompt(
              (filenames, conventions, summaries) can simply be written down here.\n\n\
              Task: {task_prompt}"
         ),
+    };
+    format!("{body}\n\n{delivery}")
+}
+
+/// Env vars that name a fallback delivery target for scheduled jobs that
+/// don't carry their own channel info. Set these on a single-user deploy so
+/// briefings always land somewhere instead of getting dropped to the log.
+const DEFAULT_CHANNEL_ENV: &str = "RUSTYKRAB_DEFAULT_CHANNEL";
+const DEFAULT_CHAT_ID_ENV: &str = "RUSTYKRAB_DEFAULT_CHAT_ID";
+const DEFAULT_THREAD_ID_ENV: &str = "RUSTYKRAB_DEFAULT_THREAD_ID";
+
+/// Resolve the channel/chat_id/thread_id triple to use for delivering this
+/// run's output. Precedence (first match wins):
+///   1. The job's stored fields (set when the job was created).
+///   2. The job's persistent conversation's `channel_*` fields (set when
+///      the conversation originated from a channel).
+///   3. Operator-wide env defaults.
+fn resolve_delivery_target(
+    job_channel: Option<&str>,
+    job_chat_id: Option<&str>,
+    job_thread_id: Option<&str>,
+    conv: &Conversation,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let channel = job_channel
+        .map(|s| s.to_string())
+        .or_else(|| conv.channel_source.clone())
+        .or_else(|| std::env::var(DEFAULT_CHANNEL_ENV).ok())
+        .filter(|s| !s.is_empty());
+    let chat_id = job_chat_id
+        .map(|s| s.to_string())
+        .or_else(|| conv.channel_id.clone())
+        .or_else(|| std::env::var(DEFAULT_CHAT_ID_ENV).ok())
+        .filter(|s| !s.is_empty());
+    let thread_id = job_thread_id
+        .map(|s| s.to_string())
+        .or_else(|| conv.channel_thread_id.clone())
+        .or_else(|| std::env::var(DEFAULT_THREAD_ID_ENV).ok())
+        .filter(|s| !s.is_empty());
+    (channel, chat_id, thread_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::sync::Mutex;
+
+    /// Env vars are process-global. Serialize tests that mutate them so they
+    /// don't race when run with `--test-threads > 1`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn empty_conv() -> Conversation {
+        Conversation {
+            id: Uuid::new_v4(),
+            messages: Vec::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            summary: None,
+            detected_profile: None,
+            channel_source: None,
+            channel_id: None,
+            channel_thread_id: None,
+        }
+    }
+
+    fn channel_conv(source: &str, id: &str, thread: Option<&str>) -> Conversation {
+        let mut c = empty_conv();
+        c.channel_source = Some(source.to_string());
+        c.channel_id = Some(id.to_string());
+        c.channel_thread_id = thread.map(|s| s.to_string());
+        c
+    }
+
+    #[test]
+    fn scheduled_prompt_first_run_includes_delivery_target() {
+        let prompt = build_scheduled_prompt(
+            "Write the daily briefing.",
+            None,
+            Some("telegram"),
+            Some("12345"),
+        );
+        assert!(prompt.contains("first time"));
+        assert!(prompt.contains("Task: Write the daily briefing."));
+        assert!(prompt.contains("delivered to telegram (12345)"));
+        assert!(prompt.contains("do not promise future updates"));
+    }
+
+    #[test]
+    fn scheduled_prompt_recurring_includes_last_run() {
+        let last = Utc.with_ymd_and_hms(2026, 4, 30, 9, 0, 0).unwrap();
+        let prompt = build_scheduled_prompt("Daily briefing.", Some(last), None, None);
+        assert!(prompt.contains("due again"));
+        assert!(prompt.contains("Last run was at 2026-04-30 09:00:00 UTC"));
+        // No channel info → still tells the model the message IS the deliverable.
+        assert!(prompt.contains("IS the deliverable"));
+    }
+
+    #[test]
+    fn delivery_target_prefers_job_fields() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let conv = channel_conv("telegram", "999", Some("7"));
+        let (ch, cid, tid) =
+            resolve_delivery_target(Some("slack"), Some("CABC"), Some("ts.1"), &conv);
+        assert_eq!(ch.as_deref(), Some("slack"));
+        assert_eq!(cid.as_deref(), Some("CABC"));
+        assert_eq!(tid.as_deref(), Some("ts.1"));
+    }
+
+    #[test]
+    fn delivery_target_falls_back_to_conversation() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        // Make sure no stray env defaults leak in from the surrounding env.
+        std::env::remove_var(DEFAULT_CHANNEL_ENV);
+        std::env::remove_var(DEFAULT_CHAT_ID_ENV);
+        std::env::remove_var(DEFAULT_THREAD_ID_ENV);
+        let conv = channel_conv("telegram", "42", Some("9"));
+        let (ch, cid, tid) = resolve_delivery_target(None, None, None, &conv);
+        assert_eq!(ch.as_deref(), Some("telegram"));
+        assert_eq!(cid.as_deref(), Some("42"));
+        assert_eq!(tid.as_deref(), Some("9"));
+    }
+
+    #[test]
+    fn delivery_target_falls_back_to_env_when_job_and_conv_empty() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var(DEFAULT_CHANNEL_ENV, "telegram");
+        std::env::set_var(DEFAULT_CHAT_ID_ENV, "55");
+        std::env::remove_var(DEFAULT_THREAD_ID_ENV);
+        let conv = empty_conv();
+        let (ch, cid, tid) = resolve_delivery_target(None, None, None, &conv);
+        std::env::remove_var(DEFAULT_CHANNEL_ENV);
+        std::env::remove_var(DEFAULT_CHAT_ID_ENV);
+        assert_eq!(ch.as_deref(), Some("telegram"));
+        assert_eq!(cid.as_deref(), Some("55"));
+        assert_eq!(tid, None);
+    }
+
+    #[test]
+    fn delivery_target_returns_none_when_nothing_configured() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(DEFAULT_CHANNEL_ENV);
+        std::env::remove_var(DEFAULT_CHAT_ID_ENV);
+        std::env::remove_var(DEFAULT_THREAD_ID_ENV);
+        let conv = empty_conv();
+        let (ch, cid, tid) = resolve_delivery_target(None, None, None, &conv);
+        assert!(ch.is_none());
+        assert!(cid.is_none());
+        assert!(tid.is_none());
+    }
+
+    #[test]
+    fn delivery_target_treats_empty_strings_as_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::remove_var(DEFAULT_CHANNEL_ENV);
+        std::env::remove_var(DEFAULT_CHAT_ID_ENV);
+        std::env::remove_var(DEFAULT_THREAD_ID_ENV);
+        let conv = empty_conv();
+        let (ch, cid, _) = resolve_delivery_target(Some(""), Some(""), None, &conv);
+        assert!(ch.is_none(), "empty channel should not satisfy the filter");
+        assert!(cid.is_none(), "empty chat_id should not satisfy the filter");
     }
 }

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -13,12 +13,24 @@ pub const SOUL_PATH_ENV: &str = "RUSTYKRAB_SOUL_PATH";
 /// Kept deliberately small: one mission, one persistence rule, one
 /// named exception. Anything more belongs in the soul.md file the
 /// operator ships.
-const DEFAULT_SOUL: &str = "You are {name}. Complete the user's task and any follow-on work that \
-should obviously be done. Keep going until everything reasonable is finished — don't ask \
+const DEFAULT_SOUL: &str = "You are {name}. Complete the user's task and any follow-on work \
+that should obviously be done. Keep going until everything reasonable is finished — don't ask \
 permission, don't enumerate options and wait for a pick, don't promise to do it later. If you \
 genuinely can't continue (missing tool, missing data, contradictory request), say so in one \
 sentence and ask one specific question.\n\n\
+Scheduled tasks are not chat: when you're invoked from a cron job, the conversation already \
+contains the task. Do not respond with 'I'm ready' or 'please provide a task' — execute the \
+task that's already there and produce the deliverable as your final message.\n\n\
 Use memory_save to persist important facts; context is limited.";
+
+/// Return the baked-in default soul template (with the literal `{name}`
+/// placeholder still in it). Exposed so `rustykrab-cli` can seed the
+/// configured soul path on first startup — if the file doesn't exist, the
+/// CLI writes this so the operator has a real file to edit instead of an
+/// invisible fallback.
+pub fn default_soul_template() -> &'static str {
+    DEFAULT_SOUL
+}
 
 /// Read the soul template, preferring a file at `RUSTYKRAB_SOUL_PATH`
 /// and falling back to [`DEFAULT_SOUL`].


### PR DESCRIPTION
Three bugs caused scheduled briefings to silently fail:

1. EndTurn/idle bug: the loop classifier only caught "I'll do X next"
   (planning) and "I'm currently doing X" (fake progress); it missed
   "I am ready, please provide your first task" — the model treating
   a cron-triggered turn as a fresh REPL prompt. Add a fourth detector
   for idle/readiness acknowledgments so the agent re-prompts and the
   model executes the task already in the conversation.

2. No channel routing: jobs without an explicit channel/chat_id had
   their output dropped to the log. Resolve a delivery target with
   precedence job > resumed conversation's channel_* fields >
   RUSTYKRAB_DEFAULT_CHANNEL/CHAT_ID/THREAD_ID env vars, and warn
   loudly (with the job_id) when nothing routes the result.

3. Missing soul.md: the configured path is platform-aware, but the
   file was never created, so the loader silently used the baked-in
   default and the operator had no visible file to edit. Seed
   soul.md with the default template on startup when missing, and
   extend the default to explicitly tell the model that scheduled
   tasks are not chat — execute the task in the conversation, do
   not ask for one.

Also tell the model in the scheduled prompt where its final message
will be delivered, so it treats that message as the deliverable.