### PR TITLE
feat: add prompt tracing with trace_id correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -699,6 +699,10 @@ impl AgentRunner {
         let active_tools = self.active_tools.clone();
         let recall = self.recall.clone();
 
+        // Carry the trace id from the calling task into the spawned agent
+        // task so prompt-log rows and agent-loop logs share the same id.
+        let trace_id = rustykrab_core::prompt_trace::current_trace_id();
+
         let join_handle = tokio::spawn(async move {
             let runner = AgentRunner {
                 provider,
@@ -710,9 +714,15 @@ impl AgentRunner {
                 active_tools,
                 recall,
             };
-            let result = runner
-                .run_event_loop(conv, &session, inbound_rx, outbound_tx)
-                .await;
+            let body = async move {
+                runner
+                    .run_event_loop(conv, &session, inbound_rx, outbound_tx)
+                    .await
+            };
+            let result = match trace_id {
+                Some(id) => rustykrab_core::prompt_trace::with_trace_id(id, body).await,
+                None => body.await,
+            };
             alive_clone.store(false, AtomicOrdering::Release);
             result
         });

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -467,6 +467,41 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => tracing::warn!(error = %e, "failed to scan skills directory"),
     }
 
+    // Aggregate startup audit: per-skill satisfaction state with the exact
+    // missing requirements. A skill whose `requires.env` or `requires.bins`
+    // is unmet at startup is filtered out of every system-prompt catalog
+    // and is therefore invisible to the agent — operators need to see
+    // that fact loudly at boot rather than wondering why the model never
+    // invokes it.
+    let all_md = skill_registry.md_skills();
+    if !all_md.is_empty() {
+        for s in &all_md {
+            if s.validation.is_satisfied() {
+                tracing::info!(
+                    name = %s.frontmatter.name,
+                    "skill ready"
+                );
+            } else {
+                tracing::warn!(
+                    name = %s.frontmatter.name,
+                    missing_env = ?s.validation.missing_env,
+                    missing_bins = ?s.validation.missing_bins,
+                    "skill UNAVAILABLE — requirements unmet, will be hidden from the agent"
+                );
+            }
+        }
+        let satisfied = all_md
+            .iter()
+            .filter(|s| s.validation.is_satisfied())
+            .count();
+        tracing::info!(
+            total = all_md.len(),
+            satisfied,
+            unsatisfied = all_md.len() - satisfied,
+            "skill registry audit complete"
+        );
+    }
+
     // --- Tools ---
     let mut tools = rustykrab_tools::builtin_tools(store.secrets());
     tools.extend(rustykrab_tools::memory_tools(memory_backend));

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod prompt_log;
 mod task_queue;
 
 use std::collections::{HashMap, HashSet};
@@ -168,6 +169,10 @@ async fn main() -> anyhow::Result<()> {
         .with(fmt::layer().with_writer(std::io::stdout))
         .with(fmt::layer().with_writer(non_blocking).with_ansi(false))
         .init();
+
+    // Optional prompt log (env-gated). Hold the guard for the process
+    // lifetime so the non-blocking worker keeps draining.
+    let _prompt_log_guard = prompt_log::init(&log_dir);
 
     tracing::info!("rustykrab {}", version_string());
 
@@ -1081,9 +1086,12 @@ async fn process_telegram_message(
         }
     });
 
-    // Start the event-driven agent loop.
+    // Start the event-driven agent loop. Mint a trace id per inbound
+    // Telegram message so the prompt log can be matched against this run.
+    let trace_id = Uuid::new_v4();
+    tracing::info!(%trace_id, chat_id, ?thread_id, "telegram agent run starting");
     let (handle, mut event_rx, join_handle) =
-        match rustykrab_gateway::run_agent_interactive(state, conv, user_text).await {
+        match rustykrab_gateway::run_agent_interactive(state, conv, user_text, trace_id).await {
             Ok(triple) => triple,
             Err(_status) => {
                 typing_active.store(false, std::sync::atomic::Ordering::Relaxed);
@@ -1443,7 +1451,10 @@ async fn process_slack_message(
         hb.store(epoch_millis(), Ordering::Relaxed);
     };
 
-    let agent_fut = rustykrab_gateway::run_agent_streaming(state, &mut conv, user_text, &on_event);
+    let trace_id = Uuid::new_v4();
+    tracing::info!(%trace_id, conv_id = %conv.id, "slack agent run starting");
+    let agent_fut =
+        rustykrab_gateway::run_agent_streaming(state, &mut conv, user_text, &on_event, trace_id);
 
     let timeout_millis = HEARTBEAT_TIMEOUT_SECS * 1000;
     let heartbeat_monitor = async {

--- a/crates/rustykrab-cli/src/prompt_log.rs
+++ b/crates/rustykrab-cli/src/prompt_log.rs
@@ -1,0 +1,68 @@
+//! File-backed [`PromptSink`] for the CLI.
+//!
+//! Writes one JSON object per line (JSONL) into a daily-rotated file under
+//! the data directory's `logs/` folder. Off by default; enable with
+//! `RUSTYKRAB_PROMPT_LOG=1`. Prompt content can include user secrets, so
+//! the operator opts in deliberately.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use rustykrab_core::prompt_trace::{set_sink, PromptRecord, PromptSink};
+use tracing_appender::non_blocking::WorkerGuard;
+
+/// Sink that serializes each [`PromptRecord`] as a single JSON line.
+///
+/// Wraps a [`tracing_appender::non_blocking::NonBlocking`] writer behind
+/// a mutex — `NonBlocking` is already MPSC under the hood, but its
+/// `Write` impl takes `&mut self`, so we serialize callers here.
+struct FilePromptSink {
+    writer: Mutex<tracing_appender::non_blocking::NonBlocking>,
+}
+
+impl PromptSink for FilePromptSink {
+    fn record(&self, record: PromptRecord) {
+        let line = match serde_json::to_string(&record) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("failed to serialize prompt record: {e}");
+                return;
+            }
+        };
+        let mut writer = match self.writer.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if let Err(e) = writeln!(*writer, "{line}") {
+            // Don't bring down the agent loop on a logging failure.
+            tracing::warn!("failed to write prompt record: {e}");
+        }
+    }
+}
+
+/// Init the prompt log when `RUSTYKRAB_PROMPT_LOG=1` is set.
+///
+/// Returns a [`WorkerGuard`] that must be kept alive for the lifetime of
+/// the process — dropping it flushes pending records and shuts the worker
+/// down. Returns `None` when the env var is unset, which is the default.
+pub fn init(log_dir: &Path) -> Option<WorkerGuard> {
+    let enabled = std::env::var("RUSTYKRAB_PROMPT_LOG")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+        .unwrap_or(false);
+    if !enabled {
+        return None;
+    }
+
+    let appender = tracing_appender::rolling::daily(log_dir, "prompts.log");
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let sink: Arc<dyn PromptSink> = Arc::new(FilePromptSink {
+        writer: Mutex::new(writer),
+    });
+    set_sink(sink);
+    tracing::info!(
+        log_dir = %log_dir.display(),
+        "prompt log enabled (RUSTYKRAB_PROMPT_LOG=1) — prompts will be written to prompts.log"
+    );
+    Some(guard)
+}

--- a/crates/rustykrab-cli/src/prompt_log.rs
+++ b/crates/rustykrab-cli/src/prompt_log.rs
@@ -1,32 +1,33 @@
-//! File-backed [`PromptSink`] for the CLI.
+//! File-backed [`TraceSink`] for the CLI.
 //!
 //! Writes one JSON object per line (JSONL) into a daily-rotated file under
 //! the data directory's `logs/` folder. Off by default; enable with
-//! `RUSTYKRAB_PROMPT_LOG=1`. Prompt content can include user secrets, so
-//! the operator opts in deliberately.
+//! `RUSTYKRAB_PROMPT_LOG=1`. Each record carries a `kind` discriminator
+//! so prompts and responses can be filtered downstream. The records can
+//! contain user secrets, so the operator opts in deliberately.
 
 use std::io::Write;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use rustykrab_core::prompt_trace::{set_sink, PromptRecord, PromptSink};
+use rustykrab_core::prompt_trace::{set_sink, TraceRecord, TraceSink};
 use tracing_appender::non_blocking::WorkerGuard;
 
-/// Sink that serializes each [`PromptRecord`] as a single JSON line.
+/// Sink that serializes each [`TraceRecord`] as a single JSON line.
 ///
 /// Wraps a [`tracing_appender::non_blocking::NonBlocking`] writer behind
 /// a mutex — `NonBlocking` is already MPSC under the hood, but its
 /// `Write` impl takes `&mut self`, so we serialize callers here.
-struct FilePromptSink {
+struct FileTraceSink {
     writer: Mutex<tracing_appender::non_blocking::NonBlocking>,
 }
 
-impl PromptSink for FilePromptSink {
-    fn record(&self, record: PromptRecord) {
+impl TraceSink for FileTraceSink {
+    fn record(&self, record: TraceRecord) {
         let line = match serde_json::to_string(&record) {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!("failed to serialize prompt record: {e}");
+                tracing::warn!("failed to serialize trace record: {e}");
                 return;
             }
         };
@@ -36,12 +37,12 @@ impl PromptSink for FilePromptSink {
         };
         if let Err(e) = writeln!(*writer, "{line}") {
             // Don't bring down the agent loop on a logging failure.
-            tracing::warn!("failed to write prompt record: {e}");
+            tracing::warn!("failed to write trace record: {e}");
         }
     }
 }
 
-/// Init the prompt log when `RUSTYKRAB_PROMPT_LOG=1` is set.
+/// Init the trace log when `RUSTYKRAB_PROMPT_LOG=1` is set.
 ///
 /// Returns a [`WorkerGuard`] that must be kept alive for the lifetime of
 /// the process — dropping it flushes pending records and shuts the worker
@@ -56,13 +57,13 @@ pub fn init(log_dir: &Path) -> Option<WorkerGuard> {
 
     let appender = tracing_appender::rolling::daily(log_dir, "prompts.log");
     let (writer, guard) = tracing_appender::non_blocking(appender);
-    let sink: Arc<dyn PromptSink> = Arc::new(FilePromptSink {
+    let sink: Arc<dyn TraceSink> = Arc::new(FileTraceSink {
         writer: Mutex::new(writer),
     });
     set_sink(sink);
     tracing::info!(
         log_dir = %log_dir.display(),
-        "prompt log enabled (RUSTYKRAB_PROMPT_LOG=1) — prompts will be written to prompts.log"
+        "trace log enabled (RUSTYKRAB_PROMPT_LOG=1) — prompts and responses will be written to prompts.log"
     );
     Some(guard)
 }

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -203,10 +203,14 @@ async fn execute_cron_task(
         effective_chat_id.as_deref(),
     );
 
-    // Run the agent.
+    // Run the agent. Mint a fresh trace id per scheduled run so prompt-log
+    // rows and agent logs for this job line up.
+    let trace_id = Uuid::new_v4();
+    tracing::info!(%trace_id, job_id = %job.id, "scheduled task starting");
     let no_op_event = |_event: AgentEvent| {};
     let result =
-        rustykrab_gateway::run_agent_streaming(state, &mut conv, &prompt, &no_op_event).await;
+        rustykrab_gateway::run_agent_streaming(state, &mut conv, &prompt, &no_op_event, trace_id)
+            .await;
 
     let (status, response_text) = match result {
         Ok(msg) => match &msg.content {

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod crypto;
 pub mod error;
 pub mod model;
 pub mod orchestration;
+pub mod prompt_trace;
 pub mod recall;
 pub mod session;
 pub mod tool;

--- a/crates/rustykrab-core/src/prompt_trace.rs
+++ b/crates/rustykrab-core/src/prompt_trace.rs
@@ -1,0 +1,149 @@
+//! Prompt tracing — correlate log lines with the prompts that produced them.
+//!
+//! Every agent invocation is tagged with a `trace_id` (UUID) that flows
+//! through the call stack via a task-local. Logs decorated with `trace_id`
+//! line up with rows in the prompt log file written by the registered
+//! [`PromptSink`].
+//!
+//! The sink is opt-in: until [`set_sink`] is called the [`record_prompt`]
+//! helper is a no-op. The CLI installs a file-backed sink when
+//! `RUSTYKRAB_PROMPT_LOG=1` is set, keeping prompts out of the log
+//! directory by default since they may contain user-secret material.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::types::{Message, ToolSchema};
+
+tokio::task_local! {
+    /// Trace id seeded at the entry point of an agent run.
+    static TRACE_ID: Uuid;
+}
+
+/// Returns the trace id active for the current task, if any.
+pub fn current_trace_id() -> Option<Uuid> {
+    TRACE_ID.try_with(|id| *id).ok()
+}
+
+/// Run `fut` with `trace_id` available to [`current_trace_id`] inside its
+/// task. Spawned child tasks do not inherit the value — re-scope inside the
+/// spawned future if you need it there.
+pub async fn with_trace_id<F>(trace_id: Uuid, fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    TRACE_ID.scope(trace_id, fut).await
+}
+
+/// One row in the prompt log: a single submission to a model provider.
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptRecord {
+    pub trace_id: Uuid,
+    pub timestamp: DateTime<Utc>,
+    pub provider: String,
+    pub model: String,
+    /// `true` for streaming submissions, `false` otherwise.
+    pub streaming: bool,
+    pub messages: Vec<Message>,
+    pub tools: Vec<ToolSchema>,
+}
+
+/// Sink that receives [`PromptRecord`] rows.
+pub trait PromptSink: Send + Sync {
+    fn record(&self, record: PromptRecord);
+}
+
+static SINK: OnceLock<Arc<dyn PromptSink>> = OnceLock::new();
+
+/// Install the global prompt sink. Only the first call wins — subsequent
+/// calls are silently ignored so re-init in tests doesn't panic.
+pub fn set_sink(sink: Arc<dyn PromptSink>) {
+    let _ = SINK.set(sink);
+}
+
+/// Write a prompt record to the global sink, tagged with the current
+/// trace id. No-op when no sink is installed or no trace id is set —
+/// callers don't need to guard the call.
+pub fn record_prompt(
+    provider: &str,
+    model: &str,
+    streaming: bool,
+    messages: &[Message],
+    tools: &[ToolSchema],
+) {
+    let Some(sink) = SINK.get() else { return };
+    let Some(trace_id) = current_trace_id() else {
+        return;
+    };
+    sink.record(PromptRecord {
+        trace_id,
+        timestamp: Utc::now(),
+        provider: provider.to_string(),
+        model: model.to_string(),
+        streaming,
+        messages: messages.to_vec(),
+        tools: tools.to_vec(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct CapturingSink {
+        records: Mutex<Vec<PromptRecord>>,
+    }
+
+    impl PromptSink for CapturingSink {
+        fn record(&self, record: PromptRecord) {
+            self.records.lock().unwrap().push(record);
+        }
+    }
+
+    #[tokio::test]
+    async fn current_trace_id_returns_none_without_scope() {
+        assert!(current_trace_id().is_none());
+    }
+
+    #[tokio::test]
+    async fn with_trace_id_makes_id_visible() {
+        let id = Uuid::new_v4();
+        with_trace_id(id, async move {
+            assert_eq!(current_trace_id(), Some(id));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn record_prompt_is_noop_without_trace_id() {
+        // No sink installed in this test, but we also can't install one
+        // (OnceLock) without affecting other tests. So just check the
+        // happy path: outside a scope the helper returns silently.
+        record_prompt("test", "test-model", false, &[], &[]);
+    }
+
+    #[test]
+    fn capturing_sink_collects_records() {
+        let sink = Arc::new(CapturingSink {
+            records: Mutex::new(Vec::new()),
+        });
+        let record = PromptRecord {
+            trace_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            provider: "test".into(),
+            model: "test-model".into(),
+            streaming: false,
+            messages: Vec::new(),
+            tools: Vec::new(),
+        };
+        sink.record(record.clone());
+        let stored = sink.records.lock().unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].trace_id, record.trace_id);
+    }
+}

--- a/crates/rustykrab-core/src/prompt_trace.rs
+++ b/crates/rustykrab-core/src/prompt_trace.rs
@@ -1,14 +1,16 @@
-//! Prompt tracing — correlate log lines with the prompts that produced them.
+//! Prompt and response tracing — correlate log lines with the prompts that
+//! produced them and the responses they returned.
 //!
 //! Every agent invocation is tagged with a `trace_id` (UUID) that flows
 //! through the call stack via a task-local. Logs decorated with `trace_id`
-//! line up with rows in the prompt log file written by the registered
-//! [`PromptSink`].
+//! line up with rows in the trace log file written by the registered
+//! [`TraceSink`].
 //!
 //! The sink is opt-in: until [`set_sink`] is called the [`record_prompt`]
-//! helper is a no-op. The CLI installs a file-backed sink when
-//! `RUSTYKRAB_PROMPT_LOG=1` is set, keeping prompts out of the log
-//! directory by default since they may contain user-secret material.
+//! and [`record_response`] helpers are no-ops. The CLI installs a
+//! file-backed sink when `RUSTYKRAB_PROMPT_LOG=1` is set, keeping prompts
+//! and responses out of the log directory by default since they may
+//! contain user-secret material.
 
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -17,6 +19,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use uuid::Uuid;
 
+use crate::model::{StopReason, Usage};
 use crate::types::{Message, ToolSchema};
 
 tokio::task_local! {
@@ -39,29 +42,51 @@ where
     TRACE_ID.scope(trace_id, fut).await
 }
 
-/// One row in the prompt log: a single submission to a model provider.
+/// One row in the trace log. Internally tagged via the `kind` field so a
+/// reader can distinguish prompt rows from response rows.
 #[derive(Debug, Clone, Serialize)]
-pub struct PromptRecord {
-    pub trace_id: Uuid,
-    pub timestamp: DateTime<Utc>,
-    pub provider: String,
-    pub model: String,
-    /// `true` for streaming submissions, `false` otherwise.
-    pub streaming: bool,
-    pub messages: Vec<Message>,
-    pub tools: Vec<ToolSchema>,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceRecord {
+    /// Outbound submission to the model.
+    Prompt {
+        trace_id: Uuid,
+        timestamp: DateTime<Utc>,
+        provider: String,
+        model: String,
+        /// `true` for streaming submissions, `false` otherwise.
+        streaming: bool,
+        messages: Vec<Message>,
+        tools: Vec<ToolSchema>,
+    },
+    /// Successful response from the model.
+    Response {
+        trace_id: Uuid,
+        timestamp: DateTime<Utc>,
+        provider: String,
+        model: String,
+        streaming: bool,
+        message: Message,
+        prompt_tokens: u32,
+        completion_tokens: u32,
+        cache_read_tokens: u32,
+        cache_creation_tokens: u32,
+        /// Stringified [`StopReason`] so consumers don't need the core
+        /// enum to parse the log.
+        stop_reason: String,
+        duration_ms: u64,
+    },
 }
 
-/// Sink that receives [`PromptRecord`] rows.
-pub trait PromptSink: Send + Sync {
-    fn record(&self, record: PromptRecord);
+/// Sink that receives [`TraceRecord`] rows.
+pub trait TraceSink: Send + Sync {
+    fn record(&self, record: TraceRecord);
 }
 
-static SINK: OnceLock<Arc<dyn PromptSink>> = OnceLock::new();
+static SINK: OnceLock<Arc<dyn TraceSink>> = OnceLock::new();
 
-/// Install the global prompt sink. Only the first call wins — subsequent
+/// Install the global trace sink. Only the first call wins — subsequent
 /// calls are silently ignored so re-init in tests doesn't panic.
-pub fn set_sink(sink: Arc<dyn PromptSink>) {
+pub fn set_sink(sink: Arc<dyn TraceSink>) {
     let _ = SINK.set(sink);
 }
 
@@ -79,7 +104,7 @@ pub fn record_prompt(
     let Some(trace_id) = current_trace_id() else {
         return;
     };
-    sink.record(PromptRecord {
+    sink.record(TraceRecord::Prompt {
         trace_id,
         timestamp: Utc::now(),
         provider: provider.to_string(),
@@ -90,17 +115,48 @@ pub fn record_prompt(
     });
 }
 
+/// Write a response record to the global sink, tagged with the current
+/// trace id. Same no-op semantics as [`record_prompt`].
+pub fn record_response(
+    provider: &str,
+    model: &str,
+    streaming: bool,
+    message: &Message,
+    usage: &Usage,
+    stop_reason: &StopReason,
+    duration_ms: u64,
+) {
+    let Some(sink) = SINK.get() else { return };
+    let Some(trace_id) = current_trace_id() else {
+        return;
+    };
+    sink.record(TraceRecord::Response {
+        trace_id,
+        timestamp: Utc::now(),
+        provider: provider.to_string(),
+        model: model.to_string(),
+        streaming,
+        message: message.clone(),
+        prompt_tokens: usage.prompt_tokens,
+        completion_tokens: usage.completion_tokens,
+        cache_read_tokens: usage.cache_read_tokens,
+        cache_creation_tokens: usage.cache_creation_tokens,
+        stop_reason: format!("{stop_reason:?}"),
+        duration_ms,
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::Mutex;
 
     struct CapturingSink {
-        records: Mutex<Vec<PromptRecord>>,
+        records: Mutex<Vec<TraceRecord>>,
     }
 
-    impl PromptSink for CapturingSink {
-        fn record(&self, record: PromptRecord) {
+    impl TraceSink for CapturingSink {
+        fn record(&self, record: TraceRecord) {
             self.records.lock().unwrap().push(record);
         }
     }
@@ -132,7 +188,7 @@ mod tests {
         let sink = Arc::new(CapturingSink {
             records: Mutex::new(Vec::new()),
         });
-        let record = PromptRecord {
+        let record = TraceRecord::Prompt {
             trace_id: Uuid::new_v4(),
             timestamp: Utc::now(),
             provider: "test".into(),
@@ -144,6 +200,24 @@ mod tests {
         sink.record(record.clone());
         let stored = sink.records.lock().unwrap();
         assert_eq!(stored.len(), 1);
-        assert_eq!(stored[0].trace_id, record.trace_id);
+        match &stored[0] {
+            TraceRecord::Prompt { provider, .. } => assert_eq!(provider, "test"),
+            _ => panic!("expected Prompt variant"),
+        }
+    }
+
+    #[test]
+    fn trace_record_serializes_with_kind_tag() {
+        let prompt = TraceRecord::Prompt {
+            trace_id: Uuid::nil(),
+            timestamp: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            provider: "p".into(),
+            model: "m".into(),
+            streaming: false,
+            messages: Vec::new(),
+            tools: Vec::new(),
+        };
+        let json = serde_json::to_string(&prompt).unwrap();
+        assert!(json.contains("\"kind\":\"prompt\""));
     }
 }

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod auth;
-mod logging;
+pub mod logging;
 mod orchestrate;
 pub mod origin;
 pub mod rate_limit;

--- a/crates/rustykrab-gateway/src/logging.rs
+++ b/crates/rustykrab-gateway/src/logging.rs
@@ -8,14 +8,23 @@ use axum::middleware::Next;
 use axum::response::Response;
 use uuid::Uuid;
 
+/// Newtype wrapper so handlers can extract the trace id from request
+/// extensions without colliding with bare `Uuid` extensions.
+#[derive(Debug, Clone, Copy)]
+pub struct TraceId(pub Uuid);
+
 /// HTTP request/response logging middleware.
 ///
 /// Logs method, path, status, latency, client IP, and content lengths
 /// for every request. Skips `/api/health` to reduce noise.
 /// Uses `info!` for successful responses and `warn!` for 4xx/5xx.
+///
+/// Generates a `trace_id` per request and stashes it in request extensions
+/// so downstream handlers can thread it into agent runs — prompt-log rows
+/// and agent-loop logs then share the same id as the HTTP completion log.
 pub async fn request_logging_middleware(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
     let path = request.uri().path().to_owned();
@@ -27,7 +36,8 @@ pub async fn request_logging_middleware(
 
     let method = request.method().clone();
     let query = request.uri().query().map(|q| q.to_owned());
-    let request_id = Uuid::new_v4();
+    let trace_id = Uuid::new_v4();
+    request.extensions_mut().insert(TraceId(trace_id));
     let client_ip = addr.ip();
     let user_agent = request
         .headers()
@@ -54,7 +64,7 @@ pub async fn request_logging_middleware(
 
     if status >= 400 {
         tracing::warn!(
-            %request_id,
+            %trace_id,
             %method,
             %path,
             ?query,
@@ -68,7 +78,7 @@ pub async fn request_logging_middleware(
         );
     } else {
         tracing::info!(
-            %request_id,
+            %trace_id,
             %method,
             %path,
             ?query,

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -244,19 +244,28 @@ fn extract_assistant_message(conv: &Conversation) -> Result<Message, StatusCode>
 }
 
 /// Run the agent loop on a conversation (non-streaming).
+///
+/// `trace_id` correlates every log line and prompt-log row produced by
+/// this run. Callers at HTTP boundaries thread the request's trace id in;
+/// channel/scheduler entry points should mint a fresh one with
+/// [`Uuid::new_v4`].
 pub async fn run_agent(
     state: &AppState,
     conv: &mut Conversation,
     user_content: &str,
+    trace_id: Uuid,
 ) -> Result<Message, StatusCode> {
-    let (runner, session) = prepare_agent(state, conv, user_content).await?;
+    rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
+        let (runner, session) = prepare_agent(state, conv, user_content).await?;
 
-    runner.run(conv, &session).await.map_err(|e| {
-        tracing::error!("agent error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        runner.run(conv, &session).await.map_err(|e| {
+            tracing::error!(%trace_id, "agent error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
-    extract_assistant_message(conv)
+        extract_assistant_message(conv)
+    })
+    .await
 }
 
 /// Start the event-driven agent loop, returning a handle for injecting
@@ -270,6 +279,7 @@ pub async fn run_agent_interactive(
     state: &AppState,
     mut conv: Conversation,
     user_content: &str,
+    trace_id: Uuid,
 ) -> std::result::Result<
     (
         AgentHandle,
@@ -278,26 +288,35 @@ pub async fn run_agent_interactive(
     ),
     StatusCode,
 > {
-    build_and_inject_system_prompt(state, &mut conv, user_content).await;
+    rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
+        build_and_inject_system_prompt(state, &mut conv, user_content).await;
 
-    let tool_names: Vec<&str> = state
-        .tools
-        .iter()
-        .filter(|t| t.available())
-        .map(|t| t.name())
-        .collect();
-    let caps = CapabilitySet::for_tools_permissive(&tool_names);
-    let session = Session::with_capabilities(conv.id, caps);
+        let tool_names: Vec<&str> = state
+            .tools
+            .iter()
+            .filter(|t| t.available())
+            .map(|t| t.name())
+            .collect();
+        let caps = CapabilitySet::for_tools_permissive(&tool_names);
+        let session = Session::with_capabilities(conv.id, caps);
 
-    let profile = state.profile_for(user_content).await;
-    let runner = AgentRunner::new(
-        state.provider.clone(),
-        state.tools.clone(),
-        state.sandbox.clone(),
-    )
-    .with_config(profile.to_agent_config());
+        let profile = state.profile_for(user_content).await;
+        let runner = AgentRunner::new(
+            state.provider.clone(),
+            state.tools.clone(),
+            state.sandbox.clone(),
+        )
+        .with_config(profile.to_agent_config());
 
-    Ok(runner.start(conv, session))
+        // The agent loop runs in a tokio::spawn'd task inside `start`, so
+        // the task-local trace id won't follow it. Re-scope the spawned
+        // future from inside the runner is not possible without changing
+        // the runner API; for the interactive path we accept that the
+        // agent task itself logs without trace_id. The caller can still
+        // correlate by the conversation id printed at start.
+        Ok(runner.start(conv, session))
+    })
+    .await
 }
 
 /// Run the agent loop with streaming events.
@@ -306,16 +325,20 @@ pub async fn run_agent_streaming(
     conv: &mut Conversation,
     user_content: &str,
     on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    trace_id: Uuid,
 ) -> Result<Message, StatusCode> {
-    let (runner, session) = prepare_agent(state, conv, user_content).await?;
+    rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
+        let (runner, session) = prepare_agent(state, conv, user_content).await?;
 
-    runner
-        .run_streaming(conv, &session, on_event)
-        .await
-        .map_err(|e| {
-            tracing::error!("agent error: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        runner
+            .run_streaming(conv, &session, on_event)
+            .await
+            .map_err(|e| {
+                tracing::error!(%trace_id, "agent error: {e}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
 
-    extract_assistant_message(conv)
+        extract_assistant_message(conv)
+    })
+    .await
 }

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -32,12 +32,34 @@ async fn build_and_inject_system_prompt(
         .with_security_policy();
 
     // Inject SKILL.md catalog (only satisfied skills).
-    let satisfied: Vec<_> = state
-        .skill_registry
-        .md_skills()
+    let all_md = state.skill_registry.md_skills();
+    let (satisfied, unsatisfied): (Vec<_>, Vec<_>) = all_md
         .into_iter()
-        .filter(|s| s.validation.is_satisfied())
+        .partition(|s| s.validation.is_satisfied());
+    let included: Vec<&str> = satisfied
+        .iter()
+        .map(|s| s.frontmatter.name.as_str())
         .collect();
+    let excluded: Vec<String> = unsatisfied
+        .iter()
+        .map(|s| {
+            let mut reasons = Vec::new();
+            if !s.validation.missing_env.is_empty() {
+                reasons.push(format!("missing_env={:?}", s.validation.missing_env));
+            }
+            if !s.validation.missing_bins.is_empty() {
+                reasons.push(format!("missing_bins={:?}", s.validation.missing_bins));
+            }
+            format!("{} ({})", s.frontmatter.name, reasons.join(", "))
+        })
+        .collect();
+    tracing::info!(
+        included_count = included.len(),
+        excluded_count = excluded.len(),
+        included = ?included,
+        excluded = ?excluded,
+        "SKILL.md catalog for system prompt"
+    );
     if !satisfied.is_empty() {
         let refs: Vec<&rustykrab_skills::SkillMd> = satisfied.iter().map(|s| s.as_ref()).collect();
         builder = builder.with_available_skills(&refs);

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use axum::extract::{Path, State};
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post};
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use rustykrab_agent::AgentEvent;
 use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
 
+use crate::logging::TraceId;
 use crate::AppState;
 
 /// Maximum allowed message size in bytes (100 KB).
@@ -107,6 +108,7 @@ async fn delete_conversation(
 /// Send a user message to a conversation and get an assistant response.
 async fn send_message(
     State(state): State<AppState>,
+    Extension(TraceId(trace_id)): Extension<TraceId>,
     Path(id): Path<Uuid>,
     Json(body): Json<SendMessageRequest>,
 ) -> Result<Json<Message>, StatusCode> {
@@ -135,7 +137,8 @@ async fn send_message(
     conv.updated_at = Utc::now();
 
     // Run the full agent pipeline.
-    let assistant_msg = crate::orchestrate::run_agent(&state, &mut conv, &user_content).await?;
+    let assistant_msg =
+        crate::orchestrate::run_agent(&state, &mut conv, &user_content, trace_id).await?;
 
     // Persist the full conversation (including intermediate tool call messages).
     conv.updated_at = Utc::now();
@@ -157,6 +160,7 @@ enum SsePayload {
 /// Send a user message and stream the assistant response as SSE events.
 async fn send_message_stream(
     State(state): State<AppState>,
+    Extension(TraceId(trace_id)): Extension<TraceId>,
     Path(id): Path<Uuid>,
     Json(body): Json<SendMessageRequest>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, StatusCode> {
@@ -245,6 +249,7 @@ async fn send_message_stream(
             &mut conv,
             &user_content,
             &on_event,
+            trace_id,
         );
 
         let result = tokio::select! {

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -340,7 +340,18 @@ impl ModelProvider for AnthropicProvider {
             body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
         }
 
-        tracing::debug!(model = %self.model, "calling Anthropic Messages API");
+        tracing::debug!(
+            model = %self.model,
+            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
+            "calling Anthropic Messages API"
+        );
+        rustykrab_core::prompt_trace::record_prompt(
+            self.name(),
+            &self.model,
+            false,
+            messages,
+            tools,
+        );
 
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
@@ -447,7 +458,18 @@ impl ModelProvider for AnthropicProvider {
             body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
         }
 
-        tracing::debug!(model = %self.model, "calling Anthropic Messages API (streaming)");
+        tracing::debug!(
+            model = %self.model,
+            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
+            "calling Anthropic Messages API (streaming)"
+        );
+        rustykrab_core::prompt_trace::record_prompt(
+            self.name(),
+            &self.model,
+            true,
+            messages,
+            tools,
+        );
 
         // Retry the initial connection with the same backoff as the non-streaming path.
         let mut last_err = None;

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -353,6 +353,7 @@ impl ModelProvider for AnthropicProvider {
             tools,
         );
 
+        let request_start = std::time::Instant::now();
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
@@ -411,6 +412,15 @@ impl ModelProvider for AnthropicProvider {
                     tracing::warn!(raw_body = %raw_body, "raw Anthropic API response");
                 }
 
+                rustykrab_core::prompt_trace::record_response(
+                    self.name(),
+                    &self.model,
+                    false,
+                    &response.message,
+                    &response.usage,
+                    &response.stop_reason,
+                    request_start.elapsed().as_millis() as u64,
+                );
                 return Ok(response);
             }
 
@@ -737,6 +747,15 @@ impl ModelProvider for AnthropicProvider {
             );
         }
 
+        rustykrab_core::prompt_trace::record_response(
+            self.name(),
+            &self.model,
+            true,
+            &response.message,
+            &response.usage,
+            &response.stop_reason,
+            stream_start.elapsed().as_millis() as u64,
+        );
         on_event(StreamEvent::Done(response.clone()));
         Ok(response)
     }

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -595,6 +595,7 @@ impl ModelProvider for OllamaProvider {
 
         let url = format!("{}/api/chat", self.base_url);
 
+        let request_start = std::time::Instant::now();
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
@@ -658,6 +659,15 @@ impl ModelProvider for OllamaProvider {
                     tracing::warn!(raw_body = %raw_body, "raw Ollama API response");
                 }
 
+                rustykrab_core::prompt_trace::record_response(
+                    self.name(),
+                    &self.model,
+                    false,
+                    &response.message,
+                    &response.usage,
+                    &response.stop_reason,
+                    request_start.elapsed().as_millis() as u64,
+                );
                 return Ok(response);
             }
 
@@ -938,6 +948,15 @@ impl ModelProvider for OllamaProvider {
             );
         }
 
+        rustykrab_core::prompt_trace::record_response(
+            self.name(),
+            &self.model,
+            true,
+            &response.message,
+            &response.usage,
+            &response.stop_reason,
+            stream_start.elapsed().as_millis() as u64,
+        );
         on_event(StreamEvent::Done(response.clone()));
         Ok(response)
     }

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -582,7 +582,15 @@ impl ModelProvider for OllamaProvider {
             base_url = %self.base_url,
             num_messages = ollama_messages.len(),
             num_ctx = ?self.config.num_ctx,
+            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
             "calling Ollama chat API"
+        );
+        rustykrab_core::prompt_trace::record_prompt(
+            self.name(),
+            &self.model,
+            false,
+            messages,
+            tools,
         );
 
         let url = format!("{}/api/chat", self.base_url);
@@ -722,7 +730,15 @@ impl ModelProvider for OllamaProvider {
             base_url = %self.base_url,
             num_messages = ollama_messages.len(),
             num_ctx = ?self.config.num_ctx,
+            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
             "calling Ollama chat API (streaming)"
+        );
+        rustykrab_core::prompt_trace::record_prompt(
+            self.name(),
+            &self.model,
+            true,
+            messages,
+            tools,
         );
 
         let url = format!("{}/api/chat", self.base_url);


### PR DESCRIPTION
Threads a per-run UUID `trace_id` from request entry points through the
agent loop into ModelProvider impls so log lines can be correlated with
the prompts that produced them.

- New `rustykrab_core::prompt_trace` module exposes a `tokio::task_local!`
  trace id, a `PromptSink` trait, and a `record_prompt(...)` helper that
  is a no-op when no sink or trace id is in scope.
- Anthropic and Ollama providers call `record_prompt` and include
  `trace_id` in their existing tracing calls, on both `chat` and
  `chat_stream`.
- Gateway logging middleware mints a `trace_id` per request, stashes it
  in request extensions, and renames the existing `request_id` log
  field to `trace_id` so HTTP completion logs share the id used
  downstream.
- `run_agent`, `run_agent_streaming`, and `run_agent_interactive` now
  take an explicit `trace_id` parameter and wrap their work in
  `with_trace_id` so providers can read it. The agent runner's `start()`
  re-scopes the task-local across its `tokio::spawn`.
- Routes extract the trace id from request extensions; CLI Telegram and
  Slack handlers and the cron task queue mint a fresh id per inbound
  message / scheduled run.
- `rustykrab-cli` gains a `prompt_log` module that installs a
  `FilePromptSink` writing JSONL records to a daily-rotated
  `prompts.log` under the data dir's `logs/`. Off by default; set
  `RUSTYKRAB_PROMPT_LOG=1` to opt in (prompts may contain user secrets).

Note: the CLI binary could not be built in the dev sandbox because
`ort-sys`'s prebuilt-binary host is firewalled, but `cargo check`,
`cargo clippy -D warnings`, `cargo fmt --check`, and `cargo test` all
pass for every other workspace crate, including the new prompt_trace
unit tests.

https://claude.ai/code/session_01UXVj4hkYUGLKFhVuVXEC6C