### PR TITLE
fix(tools): make credential_read/write keychain params conditional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -32,12 +32,13 @@ impl Tool for CredentialReadTool {
         "Read a stored credential/secret by name, or list all stored credential names. \
          Use this to retrieve API keys, passwords, or tokens needed to authenticate \
          with external services. Credentials are stored encrypted at rest.\n\n\
-         Set source to 'keychain' to read credentials directly from the macOS Keychain. \
-         When using keychain source, you MUST provide both 'service' and 'account' \
-         parameters.\n\n\
+         Only 'action' is always required. 'source' defaults to 'store' (the encrypted \
+         local store). 'name' is required for 'get'/'read' against the store. 'service' \
+         and 'account' are required ONLY when source is 'keychain' — do not pass them \
+         (or pass empty strings) for the local store.\n\n\
          Examples:\n\
-         - List secrets from local store: {\"action\": \"list\", \"source\": \"store\"}\n\
-         - Read from local store: {\"action\": \"get\", \"source\": \"store\", \"name\": \"my_api_key\"}\n\
+         - List local secrets: {\"action\": \"list\"}\n\
+         - Read from local store: {\"action\": \"get\", \"name\": \"my_api_key\"}\n\
          - Read from keychain: {\"action\": \"get\", \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
     }
 
@@ -55,24 +56,30 @@ impl Tool for CredentialReadTool {
                     },
                     "name": {
                         "type": "string",
-                        "description": "The name/key of the secret to retrieve (required for 'get' action when source is 'store')"
+                        "description": "The name/key of the secret to retrieve. Required for 'get'/'read' when source is 'store' (the default)."
                     },
                     "source": {
                         "type": "string",
                         "enum": ["store", "keychain"],
                         "default": "store",
-                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
+                        "description": "Where to read from: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain). Omit to use 'store'."
                     },
                     "service": {
                         "type": "string",
-                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). REQUIRED — provide the service name associated with the keychain entry."
+                        "description": "macOS Keychain service name (the 'Where' field in Keychain Access). Required ONLY when source is 'keychain'; omit for source 'store'."
                     },
                     "account": {
                         "type": "string",
-                        "description": "macOS Keychain account name. REQUIRED — provide the account name associated with the keychain entry (e.g. 'deploy_token', 'api_key', 'rustykrab')."
+                        "description": "macOS Keychain account name (e.g. 'deploy_token', 'api_key'). Required ONLY when source is 'keychain'; omit for source 'store'."
                     }
                 },
-                "required": ["action", "source", "service", "account"]
+                "required": ["action"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "source": { "const": "keychain" } }, "required": ["source"] },
+                        "then": { "required": ["service", "account"] }
+                    }
+                ]
             }),
         }
     }

--- a/crates/rustykrab-tools/src/credential_write.rs
+++ b/crates/rustykrab-tools/src/credential_write.rs
@@ -30,16 +30,18 @@ impl Tool for CredentialWriteTool {
         "Store, update, or delete a credential/secret. Use this to save API keys, \
          passwords, or tokens so they can be retrieved later with credential_read. \
          All credentials are encrypted at rest.\n\n\
-         Set source to 'keychain' to write to the macOS Keychain. When using keychain \
-         source, you MUST provide both 'service' and 'account' parameters. The \
-         'import_from_keychain' action also requires 'service' and 'account'.\n\n\
+         Required: 'action' and 'name'. 'value' is required for 'set'. 'source' \
+         defaults to 'store' (the encrypted local store) — omit it for normal usage. \
+         'service' and 'account' are required ONLY when source is 'keychain' or when \
+         using 'import_from_keychain'; do not pass them (or pass empty strings) for \
+         the local store.\n\n\
          Examples:\n\
-         - Store in local store: {\"action\": \"set\", \"name\": \"my_api_key\", \"value\": \"sk-123\", \
-         \"source\": \"store\", \"service\": \"\", \"account\": \"\"}\n\
+         - Store locally: {\"action\": \"set\", \"name\": \"my_api_key\", \"value\": \"sk-123\"}\n\
+         - Delete locally: {\"action\": \"delete\", \"name\": \"my_api_key\"}\n\
          - Store in keychain: {\"action\": \"set\", \"name\": \"deploy_key\", \"value\": \"sk-123\", \
          \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}\n\
          - Import from keychain: {\"action\": \"import_from_keychain\", \"name\": \"local_copy\", \
-         \"source\": \"keychain\", \"service\": \"myapp\", \"account\": \"deploy_token\"}"
+         \"service\": \"myapp\", \"account\": \"deploy_token\"}"
     }
 
     fn schema(&self) -> ToolSchema {
@@ -66,18 +68,32 @@ impl Tool for CredentialWriteTool {
                         "type": "string",
                         "enum": ["store", "keychain"],
                         "default": "store",
-                        "description": "Where to write: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain)"
+                        "description": "Where to write: 'store' (default, encrypted local store) or 'keychain' (macOS Keychain). Omit to use 'store'."
                     },
                     "service": {
                         "type": "string",
-                        "description": "macOS Keychain service name. REQUIRED — provide the service name for the keychain entry."
+                        "description": "macOS Keychain service name. Required ONLY when source is 'keychain' or action is 'import_from_keychain'; omit for source 'store'."
                     },
                     "account": {
                         "type": "string",
-                        "description": "macOS Keychain account name. REQUIRED — provide the account name for the keychain entry (e.g. 'deploy_token', 'api_key')."
+                        "description": "macOS Keychain account name (e.g. 'deploy_token', 'api_key'). Required ONLY when source is 'keychain' or action is 'import_from_keychain'; omit for source 'store'."
                     }
                 },
-                "required": ["action", "name", "source", "service", "account"]
+                "required": ["action", "name"],
+                "allOf": [
+                    {
+                        "if": { "properties": { "source": { "const": "keychain" } }, "required": ["source"] },
+                        "then": { "required": ["service", "account"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "import_from_keychain" } }, "required": ["action"] },
+                        "then": { "required": ["service", "account"] }
+                    },
+                    {
+                        "if": { "properties": { "action": { "const": "set" } }, "required": ["action"] },
+                        "then": { "required": ["value"] }
+                    }
+                ]
             }),
         }
     }


### PR DESCRIPTION
The schemas declared `service` and `account` as top-level required
parameters, but they only apply when `source == "keychain"` (or for
`import_from_keychain`). The agent runner's flat schema validator
enforced them on every call, so plain local-store usage like
`{action: "list"}` or `{action: "get", name: "x"}` failed with
"missing required parameter 'service'/'account'", causing the model to
loop on guesses.

Slim the top-level `required` lists to just the genuinely-always-needed
fields and express the conditional requirements via JSON Schema
`if/then` for model guidance. Update parameter descriptions and tool
examples to match — including dropping the misleading empty
`service: ""`, `account: ""` placeholders from the credential_write
example.

Runtime validation in the tools themselves was already correct and is
unchanged.