### PR TITLE
feat(sandbox): add NetDiscovery capability for raw-packet LAN scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,7 +3272,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.9.1"
+version = "2.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -2376,10 +2376,11 @@ async fn execute_single_tool(
         allow_fs_write: capabilities.has(&Capability::FileWrite),
         allow_net: capabilities.has(&Capability::HttpRequest),
         allow_spawn: capabilities.has(&Capability::ShellExec),
+        allow_net_discovery: capabilities.has(&Capability::NetDiscovery),
         // Network-using tools (e.g. `exec` running `nmap`, `curl`, `ssh`) can
         // take several minutes to sweep a subnet. Use a 5-minute timeout when
         // the tool actually needs network access; keep the default 30s otherwise.
-        timeout_secs: if requirements.needs_net {
+        timeout_secs: if requirements.needs_net || requirements.needs_net_discovery {
             300
         } else {
             SandboxPolicy::default().timeout_secs
@@ -2457,6 +2458,11 @@ fn enforce_sandbox_policy(
     if requirements.needs_net && !policy.allow_net {
         return Err(Error::Auth(format!(
             "tool '{tool_name}' requires network access, which is denied by policy"
+        )));
+    }
+    if requirements.needs_net_discovery && !policy.allow_net_discovery {
+        return Err(Error::Auth(format!(
+            "tool '{tool_name}' requires raw-packet network discovery, which is denied by policy"
         )));
     }
     Ok(())

--- a/crates/rustykrab-agent/src/sandbox.rs
+++ b/crates/rustykrab-agent/src/sandbox.rs
@@ -13,6 +13,11 @@ pub struct SandboxPolicy {
     pub allow_net: bool,
     /// Allow spawning child processes.
     pub allow_spawn: bool,
+    /// Allow raw-packet local-network discovery (ARP sweeps, mDNS,
+    /// broadcast probes). Off by default because the underlying tools
+    /// (e.g. `arp-scan`) typically need raw-socket privileges and the
+    /// blast radius is the operator's whole LAN.
+    pub allow_net_discovery: bool,
     /// Maximum execution time in seconds.
     pub timeout_secs: u64,
     /// Maximum memory in bytes (0 = unlimited).
@@ -26,6 +31,7 @@ impl Default for SandboxPolicy {
             allow_fs_write: false,
             allow_net: false,
             allow_spawn: false,
+            allow_net_discovery: false,
             timeout_secs: 30,
             max_memory_bytes: 256 * 1024 * 1024, // 256 MB
         }
@@ -40,6 +46,7 @@ impl SandboxPolicy {
             allow_fs_write: true,
             allow_net: true,
             allow_spawn: false,
+            allow_net_discovery: false,
             timeout_secs: 60,
             max_memory_bytes: 0,
         }
@@ -97,6 +104,11 @@ fn validate_tool_policy(
     if requirements.needs_net && !policy.allow_net {
         return Err(Error::Auth(format!(
             "sandbox denied tool '{tool_name}': network access not permitted"
+        )));
+    }
+    if requirements.needs_net_discovery && !policy.allow_net_discovery {
+        return Err(Error::Auth(format!(
+            "sandbox denied tool '{tool_name}': raw-packet network discovery not permitted"
         )));
     }
     Ok(())
@@ -204,6 +216,12 @@ mod tests {
     fn req_net() -> SandboxRequirements {
         SandboxRequirements {
             needs_net: true,
+            ..Default::default()
+        }
+    }
+    fn req_net_discovery() -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net_discovery: true,
             ..Default::default()
         }
     }
@@ -381,6 +399,47 @@ mod tests {
             .execute("notion", json!({}), &req_net(), &policy)
             .await
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn sandbox_denies_net_discovery_without_capability() {
+        let sandbox = ProcessSandbox::new();
+        // allow_net is on, but allow_net_discovery is not — the two
+        // are independent gates.
+        let policy = SandboxPolicy {
+            allow_net: true,
+            allow_spawn: true,
+            ..SandboxPolicy::default()
+        };
+        let result = sandbox
+            .execute(
+                "arp_scan",
+                json!({"interface": "eth0"}),
+                &req_net_discovery(),
+                &policy,
+            )
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("raw-packet network discovery not permitted"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_allows_net_discovery_with_capability() {
+        let sandbox = ProcessSandbox::new();
+        let policy = SandboxPolicy {
+            allow_net_discovery: true,
+            ..SandboxPolicy::default()
+        };
+        let args = json!({"interface": "eth0"});
+        let result = sandbox
+            .execute("arp_scan", args.clone(), &req_net_discovery(), &policy)
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), args);
     }
 
     #[tokio::test]

--- a/crates/rustykrab-core/src/capability.rs
+++ b/crates/rustykrab-core/src/capability.rs
@@ -18,6 +18,11 @@ pub enum Capability {
     ShellExec,
     /// Can make outbound HTTP requests.
     HttpRequest,
+    /// Can perform raw-packet network discovery on the local LAN
+    /// (e.g. ARP sweeps, mDNS browsing, broadcast probes). Distinct
+    /// from `HttpRequest` so a session can be allowed to fetch URLs
+    /// without also getting raw-socket discovery, and vice versa.
+    NetDiscovery,
     /// Can access a specific messaging channel by name.
     Channel(String),
     /// Can use a specific tool by name.

--- a/crates/rustykrab-core/src/tool.rs
+++ b/crates/rustykrab-core/src/tool.rs
@@ -19,13 +19,18 @@ pub struct SandboxRequirements {
     pub needs_net: bool,
     /// Tool spawns child processes.
     pub needs_spawn: bool,
+    /// Tool performs raw-packet network discovery on the local LAN
+    /// (ARP sweeps, mDNS, broadcast probes). Independent of `needs_net`
+    /// because outbound HTTP and raw-socket discovery are different
+    /// risk surfaces.
+    pub needs_net_discovery: bool,
 }
 
 impl SandboxRequirements {
     /// Returns true if this tool can cause external side effects
     /// (writes, network calls, or process spawning).
     pub fn has_side_effects(&self) -> bool {
-        self.needs_fs_write || self.needs_net || self.needs_spawn
+        self.needs_fs_write || self.needs_net || self.needs_spawn || self.needs_net_discovery
     }
 }
 

--- a/skills/network-recon/SKILL.md
+++ b/skills/network-recon/SKILL.md
@@ -20,8 +20,10 @@ command allowlist. Pick the right CLI for the job from the recipes below.
    `192.168.0.0/16`, `169.254.0.0/16`, `127.0.0.0/8`, `::1`, `fe80::/10`,
    `fc00::/7`. Refuse or push back if the user asks you to scan, probe, or SSH
    into a public IP or hostname that resolves to one.
-2. **Cap subnet scans at /20** (≤4094 hosts). Larger ranges waste time and may
-   trigger IDS alerts on managed networks.
+2. **Default cap on subnet scans is /20** (≤4094 hosts). Larger ranges waste
+   time and may trigger IDS alerts on managed networks. The user can ask to
+   loosen this — e.g. for a flat /16 office network — and you should comply
+   after warning about scan time and IDS noise.
 3. **SSH uses `BatchMode=yes -o StrictHostKeyChecking=accept-new`** so commands
    fail instead of hanging on prompts.
 4. **Confirm before destructive actions** over SSH (package install, service
@@ -36,6 +38,12 @@ nmap -sn 192.168.1.0/24                 # ICMP + ARP sweep
 arp-scan --interface=eth0 --localnet    # faster, needs root/cap_net_raw
 ip neigh show                           # cached MAC/IP (passive)
 ```
+
+`arp-scan` opens raw sockets, so it must run as root or with the binary
+setuid / `cap_net_raw+ep` set. If the agent is not running as root, expect
+`arp-scan` to fail with a permission error — fall back to `nmap -sn` (which
+uses the same ARP sweep on a local segment but degrades to ICMP without
+root) or `ip neigh show` for the cached entries.
 
 ### Open ports on a host
 ```


### PR DESCRIPTION
Splits raw-socket discovery (arp-scan, mDNS sweeps, broadcast probes) out
from the generic HttpRequest capability so a session can be granted one
without the other. Tools declare needs_net_discovery in
SandboxRequirements; the runner gates it with Capability::NetDiscovery
and the sandbox rejects the call when policy.allow_net_discovery is off.

Also clarifies the network-recon skill: arp-scan needs root or
cap_net_raw, and the /20 cap on subnet scans is a default the user can
loosen.