### PR TITLE
fix(cron): match skills referenced by natural-language task strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,7 +3485,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "axum",
  "chrono",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.4"
+version = "2.10.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -723,6 +723,32 @@ async fn main() -> anyhow::Result<()> {
     ));
     tracing::info!("recall tools registered");
 
+    // --- SKILL.md skills as first-class tools ---
+    // Each registered SKILL.md is also exposed as a tool whose name is the
+    // skill name and whose `execute()` returns the skill body verbatim.
+    // Why: small local models reach for native tools far more reliably than
+    // they consult the `<available_skills>` system-prompt catalog and call
+    // the meta `skills` tool with `action="load"`. Riding the trained
+    // tool-use prior turns a 30-50% discovery success rate into something
+    // closer to the natural function-calling rate.
+    //
+    // Registered last so collision detection sees the full real-tool set.
+    // Placed alongside recall_tools (after the subagent_runner snapshot)
+    // so sub-agents don't inherit skill-tools — sub-agents work on
+    // bounded sub-tasks and don't need the skill catalog.
+    let existing_tool_names: std::collections::HashSet<String> =
+        tools.iter().map(|t| t.name().to_string()).collect();
+    let skill_tool_count_before = tools.len();
+    tools.extend(rustykrab_tools::skill_md_as_tools(
+        &skill_registry,
+        &existing_tool_names,
+    ));
+    tracing::info!(
+        added = tools.len() - skill_tool_count_before,
+        registered_skills = skill_registry.md_skills().len(),
+        "skill-tools registered"
+    );
+
     // --- Harness router (auto-selects profile per message) ---
     // Reuses the main provider for classification to avoid model swapping.
     // The classification prompt is ~50 tokens — negligible overhead on any model.

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -473,20 +473,106 @@ fn build_scheduled_prompt(
     format!("{body}{skill_block}\n\n{delivery}")
 }
 
-/// If `task_prompt` is the bare name of a registered SKILL.md skill, return
+/// If `task_prompt` references a registered SKILL.md skill, return
 /// `(name, body)` so the runner can inline the recipe into the prompt.
 ///
-/// Matches conservatively: the trimmed task must equal the skill name
-/// exactly. Anything else (free-form natural-language tasks, tasks that
-/// reference a skill by sentence) is left untouched — those still rely on
-/// the model calling the `skills` tool.
+/// Matching tiers, tried in order:
+///   1. Exact (case-insensitive) match on the trimmed task body — `"daily_briefing"`,
+///      `"  Daily_Briefing\n"`.
+///   2. Whole-word substring match on any registered skill name —
+///      `"Run the daily_briefing skill"`, `"do daily_briefing now"`. "Whole word"
+///      means the skill name appears in the task with non-identifier chars on
+///      both sides, so `"daily_briefing-extended"` does NOT match the
+///      `daily_briefing` skill.
+///
+/// If multiple skills match by substring, the longest name wins (so a
+/// `"daily_briefing_v2"` skill beats a `"briefing"` skill when both appear),
+/// with alphabetical order as a deterministic tiebreaker.
+///
+/// Why loose matching: small local models reliably execute a recipe when its
+/// body is in the prompt, but improvise unreliably from a one-line description.
+/// Operators commonly schedule jobs with natural-language task strings rather
+/// than bare skill names; without substring matching, those tasks never get the
+/// body inlined and the model loops on tool-discovery before giving up.
 fn resolve_skill_for_task(registry: &SkillRegistry, task_prompt: &str) -> Option<(String, String)> {
     let trimmed = task_prompt.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let md = registry.get_md(trimmed)?;
+
+    let skills = registry.md_skills();
+    if skills.is_empty() {
+        return None;
+    }
+
+    let trimmed_lower = trimmed.to_ascii_lowercase();
+
+    // Tier 1: exact case-insensitive match on the whole task body.
+    if let Some(md) = skills
+        .iter()
+        .find(|s| s.frontmatter.name.eq_ignore_ascii_case(trimmed))
+    {
+        return Some((md.frontmatter.name.clone(), md.raw_body.clone()));
+    }
+
+    // Tier 2: whole-word substring match. Collect all candidates so we can
+    // pick the longest (most specific) one deterministically.
+    let mut candidates: Vec<&Arc<rustykrab_skills::skill_md::SkillMd>> = skills
+        .iter()
+        .filter(|s| {
+            let name = s.frontmatter.name.to_ascii_lowercase();
+            !name.is_empty() && contains_whole_word(&trimmed_lower, &name)
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // Longest name first; alphabetical as the tiebreak so the result is stable
+    // across runs even if the registry's HashMap iteration order changes.
+    candidates.sort_by(|a, b| {
+        b.frontmatter
+            .name
+            .len()
+            .cmp(&a.frontmatter.name.len())
+            .then_with(|| a.frontmatter.name.cmp(&b.frontmatter.name))
+    });
+    let md = candidates[0];
     Some((md.frontmatter.name.clone(), md.raw_body.clone()))
+}
+
+/// True if `needle` appears in `haystack` with non-identifier characters
+/// (or string boundaries) on both sides. Both inputs are expected to be
+/// already lowercased by the caller.
+///
+/// "Identifier character" here is `[A-Za-z0-9_-]`, matching the character
+/// set skill names are allowed to use. Hyphens count as part of a word so
+/// that `daily_briefing` doesn't spuriously match inside
+/// `daily_briefing-extended`.
+fn contains_whole_word(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    for (i, _) in haystack.match_indices(needle) {
+        let before_ok = haystack[..i]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_skill_name_char(c));
+        let end = i + needle.len();
+        let after_ok = haystack[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_skill_name_char(c));
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_skill_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-'
 }
 
 /// Stamp the resolved channel triple onto a conversation that doesn't carry
@@ -691,34 +777,36 @@ mod tests {
         assert!(conv.channel_thread_id.is_none());
     }
 
-    #[test]
-    fn resolve_skill_for_task_matches_bare_skill_name() {
+    fn make_skill(name: &str, body: &str) -> Arc<rustykrab_skills::skill_md::SkillMd> {
         use rustykrab_skills::skill_md::{
             RequirementValidation, SkillMd, SkillMdFrontmatter, SkillRequirements,
         };
         use std::collections::HashMap;
         use std::path::PathBuf;
-        use std::sync::Arc;
 
-        let registry = SkillRegistry::new();
-        let skill = Arc::new(SkillMd {
-            path: PathBuf::from("/skills/morning-briefing"),
+        Arc::new(SkillMd {
+            path: PathBuf::from(format!("/skills/{name}")),
             frontmatter: SkillMdFrontmatter {
-                name: "morning-briefing".to_string(),
-                description: "Daily briefing".to_string(),
+                name: name.to_string(),
+                description: format!("{name} description"),
                 version: "1.0".to_string(),
                 requires: SkillRequirements::default(),
                 user_invocable: true,
                 emoji: None,
                 extra: HashMap::new(),
             },
-            raw_body: "Step 1: do the thing.".to_string(),
+            raw_body: body.to_string(),
             validation: RequirementValidation {
                 missing_env: Vec::new(),
                 missing_bins: Vec::new(),
             },
-        });
-        registry.register_md(skill);
+        })
+    }
+
+    #[test]
+    fn resolve_skill_for_task_matches_bare_skill_name() {
+        let registry = SkillRegistry::new();
+        registry.register_md(make_skill("morning-briefing", "Step 1: do the thing."));
 
         // Trimmed bare match → resolves.
         let resolved = resolve_skill_for_task(&registry, "  morning-briefing\n");
@@ -731,12 +819,83 @@ mod tests {
             Some("Step 1: do the thing.")
         );
 
-        // Unrelated task → no resolution; the model still has to call
-        // `skills.load` if it wants the body.
-        assert!(resolve_skill_for_task(&registry, "do morning-briefing now").is_none());
+        // Case-insensitive bare match → still resolves.
+        let resolved = resolve_skill_for_task(&registry, "Morning-Briefing");
+        assert_eq!(
+            resolved.as_ref().map(|(n, _)| n.as_str()),
+            Some("morning-briefing")
+        );
 
         // Empty input → no resolution.
         assert!(resolve_skill_for_task(&registry, "   ").is_none());
+    }
+
+    #[test]
+    fn resolve_skill_for_task_matches_natural_language_reference() {
+        let registry = SkillRegistry::new();
+        registry.register_md(make_skill(
+            "daily_briefing",
+            "Step 1: gmail.\nStep 2: weather.\nStep 7: post to telegram.",
+        ));
+
+        // The bug this fix targets: operators commonly schedule jobs with
+        // sentence-shaped task strings, not bare skill names. These all need
+        // to resolve so the body gets inlined.
+        for task in [
+            "Run the daily_briefing skill",
+            "do daily_briefing now",
+            "DAILY_BRIEFING please",
+            "skill: daily_briefing",
+        ] {
+            let resolved = resolve_skill_for_task(&registry, task);
+            assert_eq!(
+                resolved.as_ref().map(|(n, _)| n.as_str()),
+                Some("daily_briefing"),
+                "expected daily_briefing to resolve for task {task:?}"
+            );
+            assert!(
+                resolved.unwrap().1.contains("Step 7"),
+                "body should be the full skill body, not just the name"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_skill_for_task_requires_whole_word_boundary() {
+        let registry = SkillRegistry::new();
+        registry.register_md(make_skill("briefing", "body"));
+
+        // Substring matches that aren't whole words must NOT resolve —
+        // otherwise a "briefing" skill would steal tasks meant for an
+        // unrelated "debriefing" or "briefings_v2" name.
+        assert!(resolve_skill_for_task(&registry, "do the debriefing").is_none());
+        assert!(resolve_skill_for_task(&registry, "open briefings_v2").is_none());
+        assert!(resolve_skill_for_task(&registry, "briefing-extended report").is_none());
+
+        // But a true word-boundary occurrence resolves.
+        assert!(resolve_skill_for_task(&registry, "send the briefing.").is_some());
+        assert!(resolve_skill_for_task(&registry, "(briefing) now").is_some());
+    }
+
+    #[test]
+    fn resolve_skill_for_task_picks_longest_match_when_multiple_skills_match() {
+        let registry = SkillRegistry::new();
+        registry.register_md(make_skill("briefing", "short body"));
+        registry.register_md(make_skill("daily_briefing", "long body"));
+
+        // Both names appear (briefing is a whole-word match next to the
+        // colon and the period). The more specific name wins so we don't
+        // run the wrong recipe.
+        let resolved =
+            resolve_skill_for_task(&registry, "Run daily_briefing: morning briefing.").unwrap();
+        assert_eq!(resolved.0, "daily_briefing");
+        assert_eq!(resolved.1, "long body");
+    }
+
+    #[test]
+    fn resolve_skill_for_task_no_skills_registered() {
+        let registry = SkillRegistry::new();
+        assert!(resolve_skill_for_task(&registry, "anything at all").is_none());
     }
 
     #[test]

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -23,8 +23,8 @@ contains the task — usually inside a message labeled '[Scheduled task]' follow
 Read that message and execute it. Never reply with 'I'm ready', 'please provide a task', \
 'I cannot perform any work because no task has been provided', or any other variant that \
 claims you have nothing to do — the task is in the conversation. If the task names a skill, \
-load that skill via the `skills` tool with action='load' and follow its instructions; do not \
-narrate that you would load it.\n\n\
+call the tool with that skill's name and follow the instructions it returns; do not narrate \
+that you would call it.\n\n\
 Use memory_save to persist important facts; context is limited.";
 
 /// Return the baked-in default soul template (with the literal `{name}`
@@ -134,9 +134,9 @@ impl SystemPromptBuilder {
     /// followed by an explicit instruction telling the model how to activate one.
     ///
     /// This is appended at prompt build time so the model knows which skills
-    /// exist without loading their full body. To USE a skill, the model must
-    /// call the `skills` tool with `action="load"` and the skill name; the
-    /// tool result returns the body, which the model then follows.
+    /// exist without loading their full body. Each skill listed here is also
+    /// exposed as a first-class tool with the same name — the model can call
+    /// the tool directly and receive the skill body as the tool result.
     pub fn with_available_skills(mut self, skills: &[&SkillMd]) -> Self {
         if skills.is_empty() {
             return self;
@@ -151,10 +151,10 @@ impl SystemPromptBuilder {
         }
         section.push_str("</available_skills>\n");
         section.push_str(
-            "To use a skill above, call the `skills` tool with \
-             action=\"load\" and the skill `name`. The tool result contains \
-             the skill body — follow those instructions for the rest of the \
-             turn. Do not claim to have a skill without loading it.",
+            "Each skill above is also a callable tool with the same name. \
+             To use a skill, call its tool — the tool result is the skill's \
+             instructions, which you then follow for the rest of the turn. \
+             Do not claim to have a skill without invoking it.",
         );
         self.sections.push(section);
         self
@@ -226,8 +226,11 @@ mod tests {
             .build();
         assert!(prompt.contains("<skill name=\"flight-monitor\""));
         assert!(prompt.contains("description=\"Watch flight prices\""));
-        assert!(prompt.contains("action=\"load\""));
-        assert!(prompt.contains("`skills` tool"));
+        // The instruction now points the model at calling the skill's tool
+        // directly (skills are exposed as first-class tools), rather than
+        // routing through the meta-`skills` tool with an action arg.
+        assert!(prompt.contains("callable tool with the same name"));
+        assert!(prompt.contains("follow"));
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -161,7 +161,7 @@ pub use credential_read::CredentialReadTool;
 pub use credential_write::CredentialWriteTool;
 
 // Skills
-pub use self::skills::SkillsTool;
+pub use self::skills::{SkillTool, SkillsTool};
 
 // Meta tools
 pub use tools_list::ToolsListTool;
@@ -266,6 +266,46 @@ pub fn skill_tools(
         None => std::sync::Arc::new(SkillsTool::new(skills_dir)),
     };
     vec![tool]
+}
+
+/// Wrap each currently-registered SKILL.md as its own first-class `Tool`.
+///
+/// Promotes skills from "catalog entries the model has to discover via
+/// `<available_skills>` and a meta-tool" to "tools that appear in the
+/// native function-calling schema." Models reach for native tools far
+/// more reliably than they consult a free-text catalog, especially small
+/// local ones, which is the whole point.
+///
+/// `existing_tool_names` is the set of names already taken in the tool
+/// schema (built-ins, backends, etc.). Skills whose name collides with a
+/// real tool are skipped with a warning rather than overwriting either
+/// side — collisions are rare in practice (skills get task-domain names
+/// like `daily_briefing`, tools get verb names like `web_search`) and a
+/// silent override would be the worst possible failure mode.
+///
+/// Snapshot semantics: this reads the registry once. Skills created at
+/// runtime via `SkillsTool::create` won't appear as tools until the next
+/// process restart. Hot-loading skill-tools live would require the
+/// agent's tool dispatcher to re-render the schema mid-conversation,
+/// which is out of scope here.
+pub fn skill_md_as_tools(
+    registry: &rustykrab_skills::SkillRegistry,
+    existing_tool_names: &std::collections::HashSet<String>,
+) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
+    let mut out: Vec<std::sync::Arc<dyn rustykrab_core::Tool>> = Vec::new();
+    for skill in registry.md_skills() {
+        let name = skill.frontmatter.name.clone();
+        if existing_tool_names.contains(&name) {
+            tracing::warn!(
+                skill = %name,
+                "skill name collides with an existing tool name; \
+                 skipping skill-tool registration. Rename the skill to expose it as a tool."
+            );
+            continue;
+        }
+        out.push(std::sync::Arc::new(SkillTool::new(skill)));
+    }
+    out
 }
 
 /// Collect automation tools that require backends into a Vec.

--- a/crates/rustykrab-tools/src/skills.rs
+++ b/crates/rustykrab-tools/src/skills.rs
@@ -248,6 +248,84 @@ fn load_response(name: &str, skill: &rustykrab_skills::SkillMd) -> Value {
     })
 }
 
+/// Adapter that exposes a single SKILL.md skill as a first-class `Tool`.
+///
+/// The point of this adapter is discoverability. A meta-tool like `SkillsTool`
+/// requires the model to (1) read the `<available_skills>` catalog in the
+/// system prompt, (2) realize a skill matches the task, (3) call `skills`
+/// with `action="load"` and the right `name`. Small local models are bad at
+/// step 3 — they're trained much harder on "call a tool" than on "consult a
+/// catalog and call a meta-tool with the right enum + arg." Promoting each
+/// skill to its own native tool replaces three inferences with one and rides
+/// the strong tool-use prior the model already has.
+///
+/// Execution semantics: calling the tool returns the SKILL.md body verbatim
+/// as the tool result (a JSON string). The model reads it as instructions and
+/// executes the recipe over subsequent tool calls in the same turn — same as
+/// today's `SkillsTool::action_load`, just delivered through a tool the model
+/// is far more likely to invoke unprompted.
+pub struct SkillTool {
+    skill: Arc<rustykrab_skills::SkillMd>,
+}
+
+impl SkillTool {
+    pub fn new(skill: Arc<rustykrab_skills::SkillMd>) -> Self {
+        Self { skill }
+    }
+
+    /// The skill name, used as the tool name. Constrained to `[a-z0-9_-]` by
+    /// the SKILL.md loader, so it's already a safe tool identifier.
+    fn skill_name(&self) -> &str {
+        &self.skill.frontmatter.name
+    }
+}
+
+#[async_trait]
+impl Tool for SkillTool {
+    fn name(&self) -> &str {
+        self.skill_name()
+    }
+
+    fn description(&self) -> &str {
+        // Use the SKILL.md description verbatim. We deliberately don't prepend
+        // a "[Skill]" tag or boilerplate about "calling this returns a recipe":
+        // the tool-result-is-instructions pattern is something models already
+        // handle natively (web_search, web_fetch, etc. all return text the
+        // model then acts on), and extra framing would just dilute the
+        // signal that picks this tool over neighbours in the schema.
+        &self.skill.frontmatter.description
+    }
+
+    fn schema(&self) -> ToolSchema {
+        // No parameters: the tool name *is* the routing. Activating the skill
+        // takes no args; the body is the same regardless of caller intent.
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn available(&self) -> bool {
+        // Hide skills whose declared requirements (env vars, binaries) aren't
+        // satisfied — calling one would just produce a recipe the agent
+        // can't execute anyway.
+        self.skill.validation.is_satisfied()
+    }
+
+    async fn execute(&self, _args: Value) -> Result<Value> {
+        // Return the body as a bare JSON string, not a structured object.
+        // Models read tool results as the next round of "input" and act on
+        // text directly; wrapping it in `{ "body": ... }` would force the
+        // model to do an extra parse step that small models routinely skip.
+        Ok(Value::String(self.skill.raw_body.clone()))
+    }
+}
+
 /// Validate that a skill name contains only `[a-z0-9_-]` and is 1–64 chars.
 /// Strict allowlist blocks path traversal.
 fn is_valid_name(name: &str) -> bool {
@@ -612,5 +690,129 @@ mod tests {
             .await;
         assert!(r.is_err());
         assert!(r.unwrap_err().to_string().contains("unknown action"));
+    }
+
+    fn make_skill_md(name: &str, description: &str, body: &str) -> Arc<rustykrab_skills::SkillMd> {
+        use rustykrab_skills::skill_md::{
+            RequirementValidation, SkillMd, SkillMdFrontmatter, SkillRequirements,
+        };
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        Arc::new(SkillMd {
+            path: PathBuf::from(format!("/skills/{name}")),
+            frontmatter: SkillMdFrontmatter {
+                name: name.to_string(),
+                description: description.to_string(),
+                version: "1.0".to_string(),
+                requires: SkillRequirements::default(),
+                user_invocable: true,
+                emoji: None,
+                extra: HashMap::new(),
+            },
+            raw_body: body.to_string(),
+            validation: RequirementValidation {
+                missing_env: Vec::new(),
+                missing_bins: Vec::new(),
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn skill_tool_uses_skill_name_and_description() {
+        let tool = SkillTool::new(make_skill_md(
+            "daily_briefing",
+            "Generate the daily briefing.",
+            "Step 1: do the thing.",
+        ));
+
+        // The tool's identity is the skill's identity — that's the whole
+        // point. If these ever drift, the model's schema view of the skill
+        // and the registry's view diverge.
+        assert_eq!(tool.name(), "daily_briefing");
+        assert_eq!(tool.description(), "Generate the daily briefing.");
+    }
+
+    #[tokio::test]
+    async fn skill_tool_execute_returns_body_as_bare_string() {
+        let body = "# Daily briefing\n\nStep 1: gmail.\nStep 2: weather.";
+        let tool = SkillTool::new(make_skill_md("daily_briefing", "desc", body));
+
+        let result = tool.execute(json!({})).await.unwrap();
+
+        // Bare string, not a JSON object: models receive tool results as
+        // text and act on them directly. Wrapping in { "body": ... } would
+        // force an extra parse step.
+        match result {
+            Value::String(s) => assert_eq!(s, body),
+            other => panic!("expected JSON string, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn skill_tool_execute_ignores_args() {
+        // The tool name is the routing — args don't change behavior.
+        // Defending against the model passing junk args.
+        let tool = SkillTool::new(make_skill_md("s", "d", "BODY"));
+        let r1 = tool.execute(json!({})).await.unwrap();
+        let r2 = tool.execute(json!({ "junk": "ignored" })).await.unwrap();
+        let r3 = tool.execute(Value::Null).await.unwrap();
+
+        assert_eq!(r1, r2);
+        assert_eq!(r2, r3);
+        assert_eq!(r1, Value::String("BODY".to_string()));
+    }
+
+    #[tokio::test]
+    async fn skill_tool_schema_has_empty_params() {
+        // Empty object schema is what we want: the model sees a tool that
+        // takes no args, and the schema rejects accidental extras.
+        let tool = SkillTool::new(make_skill_md("s", "d", "b"));
+        let schema = tool.schema();
+
+        assert_eq!(schema.name, "s");
+        assert_eq!(schema.description, "d");
+        assert_eq!(schema.parameters["type"], "object");
+        assert_eq!(schema.parameters["additionalProperties"], false);
+        assert!(
+            schema.parameters["properties"]
+                .as_object()
+                .unwrap()
+                .is_empty(),
+            "skill-tool schema must take no parameters"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_tool_unavailable_when_requirements_unsatisfied() {
+        use rustykrab_skills::skill_md::{
+            RequirementValidation, SkillMd, SkillMdFrontmatter, SkillRequirements,
+        };
+        use std::collections::HashMap;
+        use std::path::PathBuf;
+
+        // A skill whose required env var is missing should hide from the
+        // tool list — exposing it would just produce a recipe the agent
+        // can't actually execute.
+        let unsatisfied = Arc::new(SkillMd {
+            path: PathBuf::from("/skills/needs_env"),
+            frontmatter: SkillMdFrontmatter {
+                name: "needs_env".to_string(),
+                description: "Needs SOMETHING".to_string(),
+                version: "1.0".to_string(),
+                requires: SkillRequirements::default(),
+                user_invocable: true,
+                emoji: None,
+                extra: HashMap::new(),
+            },
+            raw_body: "body".to_string(),
+            validation: RequirementValidation {
+                missing_env: vec!["SOMETHING".to_string()],
+                missing_bins: Vec::new(),
+            },
+        });
+
+        let tool = SkillTool::new(unsatisfied);
+        assert!(!tool.available());
     }
 }


### PR DESCRIPTION
Cron tasks worded like "Run the daily_briefing skill" or "do
daily_briefing now" failed the bare-name check in
resolve_skill_for_task and so never had the SKILL.md body inlined into
the prompt. The model was left to improvise from the catalog
description alone, which small local models (e.g. gemma) get right
only ~30-50% of the time — it works at 1am, loops on tools_list and
gives up at 3am.

Loosen the matcher: try case-insensitive exact match first, then fall
back to whole-word substring match against any registered skill name.
Word boundaries use the [A-Za-z0-9_-] character class so
"daily_briefing-extended" doesn't spuriously match the daily_briefing
skill. When several skills appear in the task, the longest name wins
(alphabetical tiebreak) so the more specific recipe runs.