### PR TITLE
feat(mcp): connect to remote MCP servers and expose their tools natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,7 +3485,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.5"
+version = "2.10.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-channels/src/lib.rs
+++ b/crates/rustykrab-channels/src/lib.rs
@@ -1,5 +1,6 @@
 mod channel;
 pub mod mcp;
+pub mod mcp_http;
 pub mod signal;
 pub mod slack;
 pub mod telegram;
@@ -8,6 +9,7 @@ mod webchat;
 
 pub use channel::Channel;
 pub use mcp::McpClient;
+pub use mcp_http::McpHttpClient;
 pub use signal::{SignalChannel, SignalInboundMessage};
 pub use slack::{SlackChannel, SlackInboundMessage};
 pub use telegram::TelegramChannel;

--- a/crates/rustykrab-channels/src/mcp_http.rs
+++ b/crates/rustykrab-channels/src/mcp_http.rs
@@ -1,0 +1,316 @@
+//! MCP client over the Streamable HTTP transport (MCP spec rev 2025-03-26).
+//!
+//! Each request is a single HTTP POST whose body is one JSON-RPC 2.0 object.
+//! The server responds with either:
+//!   * `application/json`      — a single JSON-RPC response, or
+//!   * `text/event-stream`     — an SSE stream that includes the response.
+//!
+//! The transport is request/response only here: we do not open a server-push
+//! GET stream, since the connector use-case (initialize, `tools/list`,
+//! `tools/call`) never needs server-initiated requests.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tracing;
+
+use crate::mcp::{InitializeResult, McpToolDef, McpToolResult};
+
+/// Header used by the Streamable HTTP transport to track session continuity
+/// across requests. The server sets it on the `initialize` response and
+/// expects it echoed on every subsequent request.
+const MCP_SESSION_HEADER: &str = "mcp-session-id";
+
+/// MCP client speaking JSON-RPC over Streamable HTTP.
+pub struct McpHttpClient {
+    client: reqwest::Client,
+    url: String,
+    extra_headers: HeaderMap,
+    session_id: Mutex<Option<String>>,
+    next_id: AtomicU64,
+    tools: Mutex<Vec<McpToolDef>>,
+}
+
+impl McpHttpClient {
+    /// Connect to a remote MCP server and run the `initialize` handshake.
+    ///
+    /// `bearer_token`, if provided, is sent as `Authorization: Bearer <token>`
+    /// on every request. Per-server auth schemes other than bearer can be
+    /// added later by accepting a `HeaderMap` instead.
+    pub async fn connect(url: &str, bearer_token: Option<&str>) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+        let mut extra_headers = HeaderMap::new();
+        if let Some(token) = bearer_token {
+            let value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| format!("invalid bearer token: {e}"))?;
+            extra_headers.insert(AUTHORIZATION, value);
+        }
+
+        let this = Self {
+            client,
+            url: url.to_string(),
+            extra_headers,
+            session_id: Mutex::new(None),
+            next_id: AtomicU64::new(1),
+            tools: Mutex::new(Vec::new()),
+        };
+
+        let init_params = serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "rustykrab",
+                "version": env!("CARGO_PKG_VERSION"),
+            }
+        });
+        let init_result = this.request("initialize", Some(init_params)).await?;
+        let _init: InitializeResult = serde_json::from_value(init_result)
+            .map_err(|e| format!("failed to parse initialize result: {e}"))?;
+        this.notify("notifications/initialized", None).await?;
+
+        tracing::info!(url = %url, "MCP HTTP client initialized");
+        Ok(this)
+    }
+
+    /// Send a JSON-RPC request and return the matching response payload.
+    pub async fn request(&self, method: &str, params: Option<Value>) -> Result<Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params.unwrap_or(Value::Object(serde_json::Map::new())),
+        });
+
+        let mut req = self
+            .client
+            .post(&self.url)
+            .header(ACCEPT, "application/json, text/event-stream")
+            .header(CONTENT_TYPE, "application/json")
+            .headers(self.extra_headers.clone())
+            .json(&body);
+
+        if let Some(sid) = self.session_id.lock().await.clone() {
+            req = req.header(MCP_SESSION_HEADER, sid);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("HTTP {status}: {body}"));
+        }
+
+        if let Some(sid) = resp
+            .headers()
+            .get(MCP_SESSION_HEADER)
+            .and_then(|v| v.to_str().ok())
+        {
+            *self.session_id.lock().await = Some(sid.to_string());
+        }
+
+        let content_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_lowercase();
+
+        if content_type.starts_with("text/event-stream") {
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| format!("failed to read SSE body: {e}"))?;
+            extract_jsonrpc_from_sse(&body, id)
+        } else {
+            let value: Value = resp
+                .json()
+                .await
+                .map_err(|e| format!("failed to parse JSON response: {e}"))?;
+            extract_jsonrpc_from_value(&value, id)
+        }
+    }
+
+    /// Send a JSON-RPC notification (no `id`, no response expected).
+    pub async fn notify(&self, method: &str, params: Option<Value>) -> Result<(), String> {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params.unwrap_or(Value::Object(serde_json::Map::new())),
+        });
+
+        let mut req = self
+            .client
+            .post(&self.url)
+            .header(ACCEPT, "application/json, text/event-stream")
+            .header(CONTENT_TYPE, "application/json")
+            .headers(self.extra_headers.clone())
+            .json(&body);
+
+        if let Some(sid) = self.session_id.lock().await.clone() {
+            req = req.header(MCP_SESSION_HEADER, sid);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("HTTP notify failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("HTTP {status}: {body}"));
+        }
+        Ok(())
+    }
+
+    /// Fetch and cache the server's tool list.
+    pub async fn list_tools(&self) -> Result<Vec<McpToolDef>, String> {
+        let result = self.request("tools/list", None).await?;
+        #[derive(serde::Deserialize)]
+        struct ToolsList {
+            tools: Vec<McpToolDef>,
+        }
+        let list: ToolsList = serde_json::from_value(result)
+            .map_err(|e| format!("failed to parse tools/list: {e}"))?;
+        *self.tools.lock().await = list.tools.clone();
+        Ok(list.tools)
+    }
+
+    /// Invoke a tool on the remote server.
+    pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<McpToolResult, String> {
+        let params = serde_json::json!({ "name": name, "arguments": arguments });
+        let result = self.request("tools/call", Some(params)).await?;
+        serde_json::from_value(result)
+            .map_err(|e| format!("failed to parse tools/call result: {e}"))
+    }
+
+    /// Tool definitions captured by the most recent `list_tools` call.
+    pub async fn cached_tools(&self) -> Vec<McpToolDef> {
+        self.tools.lock().await.clone()
+    }
+}
+
+fn extract_jsonrpc_from_value(value: &Value, expected_id: u64) -> Result<Value, String> {
+    if let Some(arr) = value.as_array() {
+        for item in arr {
+            if let Some(v) = match_response(item, expected_id) {
+                return v;
+            }
+        }
+        return Err(format!("no JSON-RPC response found for id {expected_id}"));
+    }
+    match_response(value, expected_id)
+        .unwrap_or_else(|| Err("response missing id field".to_string()))
+}
+
+fn match_response(value: &Value, expected_id: u64) -> Option<Result<Value, String>> {
+    let id = value.get("id")?.as_u64()?;
+    if id != expected_id {
+        return None;
+    }
+    if let Some(err) = value.get("error") {
+        let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+        let msg = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown");
+        return Some(Err(format!("MCP error {code}: {msg}")));
+    }
+    Some(Ok(value.get("result").cloned().unwrap_or(Value::Null)))
+}
+
+fn extract_jsonrpc_from_sse(body: &str, expected_id: u64) -> Result<Value, String> {
+    for event in body.split("\n\n") {
+        let mut data = String::new();
+        for line in event.lines() {
+            let Some(rest) = line.strip_prefix("data:") else {
+                continue;
+            };
+            let payload = rest.strip_prefix(' ').unwrap_or(rest);
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(payload);
+        }
+        if data.is_empty() {
+            continue;
+        }
+        let parsed: Value = match serde_json::from_str(&data) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::trace!("SSE non-JSON data (parse error: {e}): {data}");
+                continue;
+            }
+        };
+        if let Some(result) = match_response(&parsed, expected_id) {
+            return result;
+        }
+    }
+    Err(format!(
+        "no JSON-RPC response in SSE stream for id {expected_id}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_sse_event() {
+        let body =
+            "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"ok\":true}}\n\n";
+        let v = extract_jsonrpc_from_sse(body, 7).unwrap();
+        assert_eq!(v["ok"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn skips_unrelated_events_and_finds_match() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n\
+                    : keep-alive\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"value\":42}}\n\n";
+        let v = extract_jsonrpc_from_sse(body, 2).unwrap();
+        assert_eq!(v["value"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn surfaces_jsonrpc_error() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\"id\":3,\"error\":{\"code\":-32601,\"message\":\"method not found\"}}\n\n";
+        let err = extract_jsonrpc_from_sse(body, 3).unwrap_err();
+        assert!(err.contains("-32601"));
+        assert!(err.contains("method not found"));
+    }
+
+    #[test]
+    fn parses_plain_json_object() {
+        let v: Value = serde_json::json!({"jsonrpc":"2.0","id":5,"result":{"x":1}});
+        let out = extract_jsonrpc_from_value(&v, 5).unwrap();
+        assert_eq!(out["x"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn parses_plain_json_array_response() {
+        let v: Value = serde_json::json!([
+            {"jsonrpc":"2.0","id":1,"result":{}},
+            {"jsonrpc":"2.0","id":9,"result":{"hit":true}}
+        ]);
+        let out = extract_jsonrpc_from_value(&v, 9).unwrap();
+        assert_eq!(out["hit"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn missing_response_is_error() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n";
+        assert!(extract_jsonrpc_from_sse(body, 99).is_err());
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -690,6 +690,16 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("video tool registered");
     }
 
+    // --- MCP connector (remote MCP servers as native tools) ---
+    // Registered before the sub-agent snapshot below so sub-agents also
+    // inherit MCP tools. Per-server connect failures are logged inside
+    // and never block startup.
+    let mcp_tools = rustykrab_tools::mcp_connector_tools().await;
+    if !mcp_tools.is_empty() {
+        tracing::info!(count = mcp_tools.len(), "MCP connector tools registered");
+        tools.extend(mcp_tools);
+    }
+
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");
 

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -86,6 +86,9 @@ mod skills;
 mod tools_list;
 mod tools_load;
 
+// MCP connector (remote MCP servers exposed as native tools)
+mod mcp_connector;
+
 // --- Public re-exports ---
 
 // Filesystem
@@ -166,6 +169,9 @@ pub use self::skills::{SkillTool, SkillsTool};
 // Meta tools
 pub use tools_list::ToolsListTool;
 pub use tools_load::ToolsLoadTool;
+
+// MCP connector
+pub use mcp_connector::{mcp_connector_tools, McpRemoteTool};
 
 /// Collect all built-in tools that require no external backend into a Vec.
 ///

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -1,0 +1,217 @@
+//! MCP connector — wraps tools served by remote MCP servers (Streamable HTTP
+//! transport) as native agent [`Tool`]s.
+//!
+//! Configuration (env vars only, per project convention):
+//!
+//! ```text
+//! RUSTYKRAB_MCP_SERVERS=name1,name2,...
+//! RUSTYKRAB_MCP_<NAME>_URL=https://...     # required, http(s) endpoint
+//! RUSTYKRAB_MCP_<NAME>_TOKEN=...           # optional Bearer token
+//! ```
+//!
+//! Server names are case-insensitive in env-var keys (we upper-case them
+//! before lookup) and appear verbatim — lower-cased — in the resulting
+//! tool name: `mcp__<server>__<remote-tool-name>`. The `mcp__` prefix
+//! mirrors how Claude Code surfaces MCP tools and prevents collisions
+//! with built-in tool names.
+//!
+//! Failures connecting to any single server are logged and skipped: a bad
+//! server config never blocks startup or other servers.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustykrab_channels::mcp::{McpContent, McpToolDef};
+use rustykrab_channels::McpHttpClient;
+use rustykrab_core::error::{ToolError, ToolErrorKind};
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
+use serde_json::{json, Value};
+
+/// A single tool exposed by a remote MCP server.
+pub struct McpRemoteTool {
+    name: String,
+    description: String,
+    parameters: Value,
+    server: String,
+    remote_tool: String,
+    client: Arc<McpHttpClient>,
+}
+
+impl McpRemoteTool {
+    pub fn new(server: &str, def: McpToolDef, client: Arc<McpHttpClient>) -> Self {
+        let prefixed = format!("mcp__{}__{}", server.to_lowercase(), def.name);
+        let description = def
+            .description
+            .unwrap_or_else(|| format!("MCP tool `{}` from server `{server}`", def.name));
+        // MCP tools advertise an `inputSchema` (JSON Schema). Pass it through
+        // as the agent's parameter schema; default to a permissive empty
+        // object when the server omits it.
+        let parameters = if def.input_schema.is_object() {
+            def.input_schema
+        } else {
+            json!({ "type": "object", "properties": {} })
+        };
+        Self {
+            name: prefixed,
+            description,
+            parameters,
+            server: server.to_string(),
+            remote_tool: def.name,
+            client,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpRemoteTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        SandboxRequirements {
+            needs_net: true,
+            ..SandboxRequirements::default()
+        }
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            parameters: self.parameters.clone(),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let result = self
+            .client
+            .call_tool(&self.remote_tool, args)
+            .await
+            .map_err(|e| {
+                Error::ToolExecution(ToolError {
+                    kind: ToolErrorKind::Transient,
+                    message: format!(
+                        "MCP server '{}' tool '{}' failed: {e}",
+                        self.server, self.remote_tool
+                    ),
+                })
+            })?;
+
+        let content = render_content(&result.content);
+        if result.is_error {
+            return Err(Error::ToolExecution(ToolError::internal(content)));
+        }
+        Ok(json!({ "content": content }))
+    }
+}
+
+fn render_content(content: &[McpContent]) -> String {
+    let mut out = String::new();
+    for block in content {
+        if let Some(text) = &block.text {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text);
+        }
+    }
+    out
+}
+
+/// Connect to every configured MCP server and return their tools.
+///
+/// Returns an empty Vec if `RUSTYKRAB_MCP_SERVERS` is unset or empty.
+/// Per-server failures are logged at WARN and do not propagate.
+pub async fn mcp_connector_tools() -> Vec<Arc<dyn Tool>> {
+    let raw = match std::env::var("RUSTYKRAB_MCP_SERVERS") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return Vec::new(),
+    };
+
+    let names: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut out: Vec<Arc<dyn Tool>> = Vec::new();
+    for name in names {
+        match connect_server(&name).await {
+            Ok(server_tools) => out.extend(server_tools),
+            Err(e) => tracing::warn!(
+                server = %name,
+                error = %e,
+                "MCP server connect failed; skipping"
+            ),
+        }
+    }
+    out
+}
+
+async fn connect_server(name: &str) -> std::result::Result<Vec<Arc<dyn Tool>>, String> {
+    let upper = name.to_uppercase();
+    let url_key = format!("RUSTYKRAB_MCP_{upper}_URL");
+    let token_key = format!("RUSTYKRAB_MCP_{upper}_TOKEN");
+
+    let url = std::env::var(&url_key).map_err(|_| format!("missing env var {url_key}"))?;
+    let token = std::env::var(&token_key).ok();
+
+    let client = McpHttpClient::connect(&url, token.as_deref())
+        .await
+        .map_err(|e| format!("connect: {e}"))?;
+    let defs = client
+        .list_tools()
+        .await
+        .map_err(|e| format!("list_tools: {e}"))?;
+    let client = Arc::new(client);
+
+    let tool_count = defs.len();
+    let tools: Vec<Arc<dyn Tool>> = defs
+        .into_iter()
+        .map(|d| Arc::new(McpRemoteTool::new(name, d, client.clone())) as Arc<dyn Tool>)
+        .collect();
+
+    tracing::info!(server = %name, tool_count, "MCP connector registered");
+    Ok(tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_tool_name_is_prefixed_and_lowercased() {
+        // We can't construct an McpRemoteTool here without a real client,
+        // but we can at least verify the rendering helper.
+        let blocks = vec![
+            McpContent {
+                content_type: "text".into(),
+                text: Some("hello".into()),
+                data: None,
+                mime_type: None,
+            },
+            McpContent {
+                content_type: "text".into(),
+                text: Some("world".into()),
+                data: None,
+                mime_type: None,
+            },
+        ];
+        assert_eq!(render_content(&blocks), "hello\nworld");
+    }
+
+    #[tokio::test]
+    async fn connector_returns_empty_when_unset() {
+        // Safety: the test uses a dedicated env var set/cleared in this
+        // process. No other test reads RUSTYKRAB_MCP_SERVERS.
+        std::env::remove_var("RUSTYKRAB_MCP_SERVERS");
+        let tools = mcp_connector_tools().await;
+        assert!(tools.is_empty());
+    }
+}


### PR DESCRIPTION
Add an MCP connector that, on startup, connects to MCP servers configured
via env vars and registers each remote tool as a native agent Tool. The
model invokes them via standard tool-use without any indirection — they
appear in `tools_list` like any built-in.

- `rustykrab-channels::mcp_http::McpHttpClient` speaks JSON-RPC over the
  Streamable HTTP transport (MCP 2025-03-26), handling both
  `application/json` and `text/event-stream` responses, and tracks the
  `Mcp-Session-Id` header across requests.
- `rustykrab-tools::McpRemoteTool` wraps a single (server, remote_tool)
  pair. Names are namespaced as `mcp__<server>__<tool>` to mirror Claude
  Code's convention and avoid collisions with built-ins.
- `rustykrab-tools::mcp_connector_tools()` reads `RUSTYKRAB_MCP_SERVERS`
  plus per-server `RUSTYKRAB_MCP_<NAME>_URL` and optional `_TOKEN`,
  connects, lists tools, and returns wrapped Tools. Per-server connect
  failures are logged and skipped.
- Wired into the CLI before the sub-agent snapshot so sub-agents inherit
  MCP tools too.