### PR TITLE
fix(deps): clear cargo-audit warnings and drop OpenSSL/native-tls

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,15 @@
+# cargo-audit / rustsec/audit-check configuration.
+#
+# Each ignored advisory must be re-evaluated whenever dependencies are
+# upgraded. Remove entries from this file as soon as an upstream fix lands.
+
+[advisories]
+ignore = [
+    # paste 1.0.15 is unmaintained (the original maintainer stepped away),
+    # but no security vulnerability has been reported against it. It is pulled
+    # in transitively only via `tokenizers` (HuggingFace) and
+    # `macro_rules_attribute`, both of which still depend on it. There is no
+    # actionable upstream fix available; revisit when tokenizers releases a
+    # version that drops the dependency.
+    "RUSTSEC-2024-0436",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,24 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,23 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,24 +100,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
+name = "async-channel"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
- "stable_deref_trait",
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-imap"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78dceaba06f029d8f4d7df20addd4b7370a30206e3926267ecda2915b0f3f66"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "imap-proto",
+ "log",
+ "nom 7.1.3",
+ "pin-project",
+ "pin-utils",
+ "self_cell",
+ "stop-token",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -194,49 +196,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec 0.7.6",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec 0.7.6",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec 0.7.6",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -331,31 +290,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bitstream-io"
-version = "4.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
-]
 
 [[package]]
 name = "blake2"
@@ -376,40 +314,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bufstream"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
-
-[[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -431,21 +345,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -475,7 +383,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -558,12 +466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,16 +491,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
+name = "compression-codecs"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -627,6 +553,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
+ "indexmap",
  "log",
  "publicsuffix",
  "serde",
@@ -634,16 +561,6 @@ dependencies = [
  "serde_json",
  "time",
  "url",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -726,12 +643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,14 +655,14 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.31.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
+ "phf",
  "smallvec",
 ]
 
@@ -838,18 +749,18 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -858,16 +769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -913,12 +814,22 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -1023,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.6.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1065,26 +976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,18 +998,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
-name = "exr"
-version = "1.74.0"
+name = "event-listener"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1135,13 +1038,12 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "5.13.2"
+version = "5.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f54fc1188b7f7eac8f47be2ab7b3a79ffd842cc8ff2e38316dd59ba4858890e"
+checksum = "a0112bd54a5d1903b19c85609c282949523bb8bb39f1614d4db0017e0ef3b0ff"
 dependencies = [
  "anyhow",
  "hf-hub",
- "image",
  "ndarray",
  "ort",
  "safetensors",
@@ -1155,35 +1057,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -1226,21 +1099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,16 +1112,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
 
 [[package]]
 name = "futures"
@@ -1360,15 +1208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,15 +1215,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1438,46 +1268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,23 +1318,22 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "http",
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
+ "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1564,16 +1353,12 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1631,7 +1416,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1656,22 +1440,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1692,11 +1461,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1830,78 +1597,22 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imap"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c617c55def8c42129e0dd503f11d7ee39d73f5c7e01eff55768b3879ff1d107d"
-dependencies = [
- "base64 0.13.1",
- "bufstream",
- "chrono",
- "imap-proto",
- "lazy_static",
- "native-tls",
- "nom 5.1.3",
- "regex",
-]
-
-[[package]]
 name = "imap-proto"
-version = "0.10.2"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a6def1d5ac8975d70b3fd101d57953fe3278ef2ee5d7816cba54b1d1dfc22f"
+checksum = "25f6af35c6a517aea5c72314abe90134980d2ae6a763809b50c208b3e429d71f"
 dependencies = [
- "nom 5.1.3",
+ "nom 7.1.3",
 ]
-
-[[package]]
-name = "imgref"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -1917,14 +1628,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1938,31 +1649,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1981,27 +1671,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -2035,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2056,12 +1751,6 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "lettre"
@@ -2091,33 +1780,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec 0.5.2",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -2173,15 +1839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,12 +1849,6 @@ name = "lzma-rust2"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
-
-[[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2226,16 +1877,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2261,16 +1909,6 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -2345,33 +1983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,26 +2004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "no_std_io2"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,28 +2023,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2472,33 +2047,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -2512,12 +2065,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,11 +2072,11 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2537,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2552,48 +2099,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -2603,27 +2112,33 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.3.0",
+ "ureq",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2666,21 +2181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,71 +2188,43 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.3",
+ "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "fastrand",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
@@ -2760,20 +2232,31 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
-name = "phf_shared"
-version = "0.11.3"
+name = "pin-project"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
- "siphasher 1.0.2",
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2783,12 +2266,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -2797,19 +2286,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.1",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "polyval"
@@ -2831,9 +2307,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2888,25 +2364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,27 +2378,6 @@ dependencies = [
  "idna",
  "psl-types",
 ]
-
-[[package]]
-name = "pxfm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -3086,56 +2522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec 0.7.6",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "simd_helpers",
- "thiserror 2.0.18",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,7 +2564,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3229,30 +2615,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3262,13 +2645,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3305,12 +2689,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,7 +2708,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3393,7 +2771,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3402,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3430,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3440,11 +2818,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3510,7 +2888,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustykrab-core",
  "serde",
  "serde_json",
@@ -3616,7 +2994,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustykrab-core",
  "secrecy",
  "serde",
@@ -3669,16 +3047,17 @@ dependencies = [
 name = "rustykrab-tools"
 version = "2.10.6"
 dependencies = [
+ "async-imap",
  "async-trait",
  "base64 0.22.1",
  "chromiumoxide",
- "imap",
+ "futures",
  "imap-proto",
  "lettre",
  "libc",
  "mail-parser",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "rustls-native-certs",
  "rustykrab-channels",
@@ -3690,6 +3069,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tracing",
  "url",
@@ -3739,16 +3119,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.20.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
+checksum = "f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526"
 dependencies = [
- "ahash",
  "cssparser",
  "ego-tree",
- "getopts",
  "html5ever",
- "once_cell",
+ "precomputed-hash",
  "selectors",
  "tendril",
 ]
@@ -3768,8 +3146,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3787,22 +3165,28 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.25.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cssparser",
  "derive_more",
- "fxhash",
  "log",
  "new_debug_unreachable",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -3887,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -3957,25 +3341,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_helpers"
-version = "0.1.0"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "quote",
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
+name = "simdutf8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4017,7 +3402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -4045,26 +3430,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
+name = "stop-token"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
+dependencies = [
+ "async-channel 1.9.0",
+ "cfg-if",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -4103,6 +3499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,27 +3536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,12 +3550,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -4225,20 +3605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
 ]
 
 [[package]]
@@ -4332,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -4356,16 +3722,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -4477,20 +3833,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4519,11 +3875,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -4624,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -4674,6 +4031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4691,40 +4054,23 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der 0.8.0",
+ "cookie_store",
+ "flate2",
  "log",
- "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4782,17 +4128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4837,11 +4172,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4850,14 +4185,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4868,9 +4203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4878,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4888,9 +4223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4901,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4949,7 +4284,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4957,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4976,37 +4311,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "which"
@@ -5120,27 +4452,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5161,21 +4475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5213,12 +4512,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5231,12 +4524,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5246,12 +4533,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5279,12 +4560,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5294,12 +4569,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5315,12 +4584,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5330,12 +4593,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5366,6 +4623,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5416,7 +4679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -5451,12 +4714,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -5580,27 +4837,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ secrecy = "0.10"
 chromiumoxide = "0.9"
 
 # Email (IMAP + SMTP)
-imap = "2"
+async-imap = { version = "0.11", default-features = false, features = ["runtime-tokio"] }
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls", "rustls-native-certs", "aws-lc-rs", "builder"] }
 mail-parser = "0.9"
 

--- a/crates/rustykrab-memory/Cargo.toml
+++ b/crates/rustykrab-memory/Cargo.toml
@@ -23,7 +23,7 @@ tracing.workspace = true
 thiserror.workspace = true
 regex = "1"
 rusqlite = { version = "0.34", features = ["bundled"] }
-fastembed = { version = "5", optional = true }
+fastembed = { version = "5", optional = true, default-features = false, features = ["ort-download-binaries-rustls-tls", "hf-hub-rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rustykrab-tools/Cargo.toml
+++ b/crates/rustykrab-tools/Cargo.toml
@@ -22,9 +22,11 @@ chromiumoxide.workspace = true
 tokio-stream.workspace = true
 url = "2"
 regex.workspace = true
-scraper = "0.20"
-imap.workspace = true
-imap-proto = "0.10"
+scraper = { version = "0.26", default-features = false }
+async-imap = { workspace = true }
+imap-proto = "0.16"
+tokio-rustls = "0.26"
+futures.workspace = true
 rustls.workspace = true
 rustls-native-certs.workspace = true
 lettre.workspace = true

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::TryStreamExt;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_store::SecretStore;
@@ -18,6 +19,8 @@ const KEY_APP_PASSWORD: &str = "gmail_app_password";
 
 /// Maximum messages to return from a search.
 const MAX_SEARCH_RESULTS: usize = 50;
+
+type ImapSession = async_imap::Session<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>;
 
 // ---------------------------------------------------------------------------
 // Tool struct
@@ -82,17 +85,8 @@ impl GmailTool {
             })?;
 
         // Verify credentials by connecting to IMAP.
-        // IMAP is blocking — run in spawn_blocking to avoid blocking the tokio worker.
-        let email_owned = email.to_string();
-        let password_owned = app_password.to_string();
-        tokio::task::spawn_blocking(move || {
-            let mut session = connect_imap_blocking(&email_owned, &password_owned)?;
-            let _ = session.logout();
-            Ok::<(), Error>(())
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("spawn_blocking failed: {e}").into()))?
-        .map_err(|e: Error| e)?;
+        let mut session = connect_imap(email, app_password).await?;
+        let _ = session.logout().await;
 
         Ok(json!({
             "status": "authenticated",
@@ -113,95 +107,97 @@ impl GmailTool {
             .min(MAX_SEARCH_RESULTS as u64) as usize;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        // IMAP is blocking, run in spawn_blocking.
-        let secrets = self.secrets.clone();
-        let query = query.to_string();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            session.select(&mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-            })?;
+        // Use Gmail's X-GM-RAW extension for full search syntax,
+        // falling back to standard IMAP SEARCH.
+        // Strip CRLF sequences to prevent IMAP command injection, then
+        // escape inner double quotes so the IMAP command parses correctly
+        // (e.g. query `from:"foo@bar.com"` becomes `X-GM-RAW "from:\"foo@bar.com\""`).
+        let sanitized_query = query.replace(['\r', '\n', '\0'], "");
+        let escaped_query = sanitized_query.replace('\\', "\\\\").replace('"', "\\\"");
+        let uids = match session
+            .uid_search(format!("X-GM-RAW \"{escaped_query}\""))
+            .await
+        {
+            Ok(set) => set,
+            Err(_) => session
+                .uid_search(query)
+                .await
+                .map_err(|e| Error::ToolExecution(format!("search failed: {e}").into()))?,
+        };
 
-            // Use Gmail's X-GM-RAW extension for full search syntax,
-            // falling back to standard IMAP SEARCH.
-            // Strip CRLF sequences to prevent IMAP command injection, then
-            // escape inner double quotes so the IMAP command parses correctly
-            // (e.g. query `from:"foo@bar.com"` becomes `X-GM-RAW "from:\"foo@bar.com\""`).
-            let sanitized_query = query.replace(['\r', '\n', '\0'], "");
-            let escaped_query = sanitized_query.replace('\\', "\\\\").replace('"', "\\\"");
-            let uids = session
-                .uid_search(format!("X-GM-RAW \"{escaped_query}\""))
-                .or_else(|_| session.uid_search(&query))
-                .map_err(|e| Error::ToolExecution(format!("search failed: {e}").into()))?;
+        // Take the most recent UIDs (highest numbers = newest).
+        let mut uid_list: Vec<u32> = uids.into_iter().collect();
+        uid_list.sort_unstable_by(|a, b| b.cmp(a));
+        uid_list.truncate(max_results);
 
-            // Take the most recent UIDs (highest numbers = newest).
-            let mut uid_list: Vec<u32> = uids.into_iter().collect();
-            uid_list.sort_unstable_by(|a, b| b.cmp(a));
-            uid_list.truncate(max_results);
+        if uid_list.is_empty() {
+            let _ = session.logout().await;
+            return Ok(json!({ "messages": [], "count": 0 }));
+        }
 
-            if uid_list.is_empty() {
-                let _ = session.logout();
-                return Ok(json!({ "messages": [], "count": 0 }));
-            }
+        let uid_set = uid_list
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
 
-            let uid_set = uid_list
-                .iter()
-                .map(|u| u.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+        let fetches: Vec<async_imap::types::Fetch> = session
+            .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS)")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch stream failed: {e}").into()))?;
 
-            let fetches = session
-                .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS)")
-                .map_err(|e| Error::ToolExecution(format!("fetch failed: {e}").into()))?;
+        let mut messages = Vec::new();
+        for fetch in &fetches {
+            let envelope = match fetch.envelope() {
+                Some(e) => e,
+                None => continue,
+            };
 
-            let mut messages = Vec::new();
-            for fetch in fetches.iter() {
-                let envelope = match fetch.envelope() {
-                    Some(e) => e,
-                    None => continue,
-                };
+            let subject = envelope
+                .subject
+                .as_ref()
+                .map(|s| decode_imap_string(s))
+                .unwrap_or_default();
+            let from = envelope
+                .from
+                .as_ref()
+                .and_then(|addrs| addrs.first())
+                .map(format_address)
+                .unwrap_or_default();
+            let date = envelope
+                .date
+                .as_ref()
+                .map(|d| decode_imap_string(d))
+                .unwrap_or_default();
 
-                let subject = envelope
-                    .subject
-                    .as_ref()
-                    .map(|s| decode_imap_string(s))
-                    .unwrap_or_default();
-                let from = envelope
-                    .from
-                    .as_ref()
-                    .and_then(|addrs| addrs.first())
-                    .map(|a| format_address(a))
-                    .unwrap_or_default();
-                let date = envelope
-                    .date
-                    .as_ref()
-                    .map(|d| decode_imap_string(d))
-                    .unwrap_or_default();
+            let flags: Vec<String> = fetch.flags().map(|f| format!("{f:?}")).collect();
 
-                let flags: Vec<String> = fetch.flags().iter().map(|f| format!("{f:?}")).collect();
+            messages.push(json!({
+                "uid": fetch.uid.unwrap_or(0),
+                "subject": subject,
+                "from": from,
+                "date": date,
+                "flags": flags,
+            }));
+        }
 
-                messages.push(json!({
-                    "uid": fetch.uid.unwrap_or(0),
-                    "subject": subject,
-                    "from": from,
-                    "date": date,
-                    "flags": flags,
-                }));
-            }
+        let _ = session.logout().await;
 
-            let _ = session.logout();
-
-            Ok(json!({
-                "messages": messages,
-                "count": messages.len(),
-            }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        Ok(json!({
+            "messages": messages,
+            "count": messages.len(),
+        }))
     }
 
     // -----------------------------------------------------------------------
@@ -215,152 +211,151 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let secrets = self.secrets.clone();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            session.select(&mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-            })?;
+        let fetches: Vec<async_imap::types::Fetch> = session
+            .uid_fetch(uid.to_string(), "(UID RFC822 FLAGS ENVELOPE)")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch stream failed: {e}").into()))?;
 
-            let fetches = session
-                .uid_fetch(uid.to_string(), "(UID RFC822 FLAGS ENVELOPE)")
-                .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?;
+        let fetch = fetches
+            .first()
+            .ok_or_else(|| Error::ToolExecution(format!("message uid {uid} not found").into()))?;
 
-            let fetch = fetches.iter().next().ok_or_else(|| {
-                Error::ToolExecution(format!("message uid {uid} not found").into())
-            })?;
+        let raw_body = fetch.body().unwrap_or_default();
+        let parsed = mail_parser::MessageParser::default()
+            .parse(raw_body)
+            .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
 
-            let raw_body = fetch.body().unwrap_or_default();
-            let parsed = mail_parser::MessageParser::default()
-                .parse(raw_body)
-                .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
-
-            let subject = parsed.subject().unwrap_or("").to_string();
-            let from = parsed
-                .from()
-                .and_then(|a| a.first())
-                .map(|a| {
-                    a.name()
-                        .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
-                        .unwrap_or_else(|| a.address().unwrap_or("").to_string())
-                })
-                .unwrap_or_default();
-            let to: Vec<String> = parsed
-                .to()
-                .map(|addrs| {
-                    addrs
-                        .iter()
-                        .map(|a| {
-                            a.name()
-                                .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
-                                .unwrap_or_else(|| a.address().unwrap_or("").to_string())
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            let cc: Vec<String> = parsed
-                .cc()
-                .map(|addrs| {
-                    addrs
-                        .iter()
-                        .map(|a| {
-                            a.name()
-                                .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
-                                .unwrap_or_else(|| a.address().unwrap_or("").to_string())
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            let date = parsed.date().map(|d| d.to_string()).unwrap_or_default();
-            let message_id = parsed.message_id().unwrap_or("").to_string();
-            let reply_to = parsed
-                .reply_to()
-                .and_then(|a| a.first())
-                .and_then(|a| a.address())
-                .unwrap_or("")
-                .to_string();
-            let body_text = parsed
-                .body_text(0)
-                .unwrap_or_else(|| {
-                    parsed
-                        .body_html(0)
-                        .map(|h| strip_html_tags(&h).into())
-                        .unwrap_or_default()
-                })
-                .to_string();
-
-            // Truncate very long bodies to avoid blowing up context.
-            let body_text = if body_text.len() > 8000 {
-                format!(
-                    "{}…\n[truncated, {} chars total]",
-                    &body_text[..body_text.floor_char_boundary(8000)],
-                    body_text.len()
-                )
-            } else {
-                body_text
-            };
-
-            // Attachment metadata
-            use mail_parser::MimeHeaders;
-            let attachments: Vec<Value> = parsed
-                .attachments()
-                .enumerate()
-                .map(|(i, part)| {
-                    let filename = part
-                        .content_disposition()
-                        .and_then(|cd| cd.attribute("filename"))
-                        .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
-                        .unwrap_or("unnamed")
-                        .to_string();
-                    let content_type = part
-                        .content_type()
-                        .map(|ct| {
-                            let sub = ct.subtype().unwrap_or("octet-stream");
-                            format!("{}/{sub}", ct.ctype())
-                        })
-                        .unwrap_or_else(|| "application/octet-stream".to_string());
-                    let size = part.contents().len();
-                    json!({
-                        "index": i,
-                        "filename": filename,
-                        "content_type": content_type,
-                        "size_bytes": size,
+        let subject = parsed.subject().unwrap_or("").to_string();
+        let from = parsed
+            .from()
+            .and_then(|a| a.first())
+            .map(|a| {
+                a.name()
+                    .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                    .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+            })
+            .unwrap_or_default();
+        let to: Vec<String> = parsed
+            .to()
+            .map(|addrs| {
+                addrs
+                    .iter()
+                    .map(|a| {
+                        a.name()
+                            .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                            .unwrap_or_else(|| a.address().unwrap_or("").to_string())
                     })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let cc: Vec<String> = parsed
+            .cc()
+            .map(|addrs| {
+                addrs
+                    .iter()
+                    .map(|a| {
+                        a.name()
+                            .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                            .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let date = parsed.date().map(|d| d.to_string()).unwrap_or_default();
+        let message_id = parsed.message_id().unwrap_or("").to_string();
+        let reply_to = parsed
+            .reply_to()
+            .and_then(|a| a.first())
+            .and_then(|a| a.address())
+            .unwrap_or("")
+            .to_string();
+        let body_text = parsed
+            .body_text(0)
+            .unwrap_or_else(|| {
+                parsed
+                    .body_html(0)
+                    .map(|h| strip_html_tags(&h).into())
+                    .unwrap_or_default()
+            })
+            .to_string();
+
+        // Truncate very long bodies to avoid blowing up context.
+        let body_text = if body_text.len() > 8000 {
+            format!(
+                "{}…\n[truncated, {} chars total]",
+                &body_text[..body_text.floor_char_boundary(8000)],
+                body_text.len()
+            )
+        } else {
+            body_text
+        };
+
+        // Attachment metadata
+        use mail_parser::MimeHeaders;
+        let attachments: Vec<Value> = parsed
+            .attachments()
+            .enumerate()
+            .map(|(i, part)| {
+                let filename = part
+                    .content_disposition()
+                    .and_then(|cd| cd.attribute("filename"))
+                    .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
+                    .unwrap_or("unnamed")
+                    .to_string();
+                let content_type = part
+                    .content_type()
+                    .map(|ct| {
+                        let sub = ct.subtype().unwrap_or("octet-stream");
+                        format!("{}/{sub}", ct.ctype())
+                    })
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let size = part.contents().len();
+                json!({
+                    "index": i,
+                    "filename": filename,
+                    "content_type": content_type,
+                    "size_bytes": size,
                 })
-                .collect();
+            })
+            .collect();
 
-            let flags: Vec<String> = fetch.flags().iter().map(|f| format!("{f:?}")).collect();
+        let flags: Vec<String> = fetch.flags().map(|f| format!("{f:?}")).collect();
 
-            let _ = session.logout();
+        let _ = session.logout().await;
 
-            let mut result = json!({
-                "uid": uid,
-                "subject": subject,
-                "from": from,
-                "to": to,
-                "date": date,
-                "body": body_text,
-                "flags": flags,
-                "message_id": message_id,
-            });
-            if !cc.is_empty() {
-                result["cc"] = json!(cc);
-            }
-            if !reply_to.is_empty() {
-                result["reply_to"] = json!(reply_to);
-            }
-            if !attachments.is_empty() {
-                result["attachments"] = json!(attachments);
-                result["attachment_count"] = json!(attachments.len());
-            }
-            Ok(result)
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        let mut result = json!({
+            "uid": uid,
+            "subject": subject,
+            "from": from,
+            "to": to,
+            "date": date,
+            "body": body_text,
+            "flags": flags,
+            "message_id": message_id,
+        });
+        if !cc.is_empty() {
+            result["cc"] = json!(cc);
+        }
+        if !reply_to.is_empty() {
+            result["reply_to"] = json!(reply_to);
+        }
+        if !attachments.is_empty() {
+            let count = attachments.len();
+            result["attachments"] = json!(attachments);
+            result["attachment_count"] = json!(count);
+        }
+        Ok(result)
     }
 
     // -----------------------------------------------------------------------
@@ -431,32 +426,30 @@ impl GmailTool {
     // -----------------------------------------------------------------------
 
     async fn action_labels(&self) -> Result<Value> {
-        let secrets = self.secrets.clone();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        let names: Vec<async_imap::types::Name> = session
+            .list(Some(""), Some("*"))
+            .await
+            .map_err(|e| Error::ToolExecution(format!("list mailboxes failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("list stream failed: {e}").into()))?;
 
-            let mailboxes = session
-                .list(Some(""), Some("*"))
-                .map_err(|e| Error::ToolExecution(format!("list mailboxes failed: {e}").into()))?;
-
-            let labels: Vec<Value> = mailboxes
-                .iter()
-                .map(|mb| {
-                    json!({
-                        "name": mb.name(),
-                        "delimiter": mb.delimiter().map(|c| c.to_string()),
-                    })
+        let labels: Vec<Value> = names
+            .iter()
+            .map(|mb| {
+                json!({
+                    "name": mb.name(),
+                    "delimiter": mb.delimiter(),
                 })
-                .collect();
+            })
+            .collect();
 
-            let _ = session.logout();
+        let _ = session.logout().await;
 
-            Ok(json!({ "labels": labels }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        Ok(json!({ "labels": labels }))
     }
 
     // -----------------------------------------------------------------------
@@ -468,38 +461,32 @@ impl GmailTool {
             .as_u64()
             .ok_or_else(|| Error::ToolExecution("missing 'uid'".into()))?
             as u32;
-        let from_mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
+        let from_mailbox = args["mailbox"].as_str().unwrap_or("INBOX").to_string();
         let to_mailbox = args["to_mailbox"]
             .as_str()
-            .ok_or_else(|| Error::ToolExecution("missing 'to_mailbox'".into()))?;
+            .ok_or_else(|| Error::ToolExecution("missing 'to_mailbox'".into()))?
+            .to_string();
 
-        let secrets = self.secrets.clone();
-        let from_mailbox = from_mailbox.to_string();
-        let to_mailbox = to_mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session.select(&from_mailbox).await.map_err(|e| {
+            Error::ToolExecution(format!("select {from_mailbox} failed: {e}").into())
+        })?;
 
-            session.select(&from_mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {from_mailbox} failed: {e}").into())
-            })?;
+        session
+            .uid_mv(uid.to_string(), &to_mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("move failed: {e}").into()))?;
 
-            session
-                .uid_mv(uid.to_string(), &to_mailbox)
-                .map_err(|e| Error::ToolExecution(format!("move failed: {e}").into()))?;
+        let _ = session.logout().await;
 
-            let _ = session.logout();
-
-            Ok(json!({
-                "status": "moved",
-                "uid": uid,
-                "from": from_mailbox,
-                "to": to_mailbox,
-            }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        Ok(json!({
+            "status": "moved",
+            "uid": uid,
+            "from": from_mailbox,
+            "to": to_mailbox,
+        }))
     }
 
     // -----------------------------------------------------------------------
@@ -513,27 +500,22 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let secrets = self.secrets.clone();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            session.select(&mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-            })?;
+        session
+            .uid_mv(uid.to_string(), "[Gmail]/Trash")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("trash failed: {e}").into()))?;
 
-            session
-                .uid_mv(uid.to_string(), "[Gmail]/Trash")
-                .map_err(|e| Error::ToolExecution(format!("trash failed: {e}").into()))?;
+        let _ = session.logout().await;
 
-            let _ = session.logout();
-
-            Ok(json!({ "status": "trashed", "uid": uid }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        Ok(json!({ "status": "trashed", "uid": uid }))
     }
 
     // -----------------------------------------------------------------------
@@ -547,35 +529,38 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let secrets = self.secrets.clone();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            session.select(&mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-            })?;
+        // uid_store returns a stream of FETCH responses; drain it so the server
+        // response is consumed before the next command.
+        let store_query = if read {
+            "+FLAGS (\\Seen)"
+        } else {
+            "-FLAGS (\\Seen)"
+        };
+        let _drain: Vec<async_imap::types::Fetch> = session
+            .uid_store(uid.to_string(), store_query)
+            .await
+            .map_err(|e| {
+                let action = if read { "mark read" } else { "mark unread" };
+                Error::ToolExecution(format!("{action} failed: {e}").into())
+            })?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("store stream failed: {e}").into()))?;
 
-            if read {
-                session
-                    .uid_store(uid.to_string(), "+FLAGS (\\Seen)")
-                    .map_err(|e| Error::ToolExecution(format!("mark read failed: {e}").into()))?;
-            } else {
-                session
-                    .uid_store(uid.to_string(), "-FLAGS (\\Seen)")
-                    .map_err(|e| Error::ToolExecution(format!("mark unread failed: {e}").into()))?;
-            }
+        let _ = session.logout().await;
 
-            let _ = session.logout();
-
-            let status = if read { "marked_read" } else { "marked_unread" };
-            Ok(json!({ "status": status, "uid": uid }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        let status = if read { "marked_read" } else { "marked_unread" };
+        Ok(json!({ "status": status, "uid": uid }))
     }
+
     // -----------------------------------------------------------------------
     // Action: thread (fetch full reply chain for a message)
     // -----------------------------------------------------------------------
@@ -587,179 +572,181 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let secrets = self.secrets.clone();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        // First, fetch the target message to get its References/In-Reply-To/Message-ID.
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            // First, fetch the target message to get its References/In-Reply-To/Message-ID.
-            session.select(&mailbox).map_err(|e| {
-                Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-            })?;
+        let fetches: Vec<async_imap::types::Fetch> = session
+            .uid_fetch(uid.to_string(), "(UID RFC822)")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch stream failed: {e}").into()))?;
 
-            let fetches = session
-                .uid_fetch(uid.to_string(), "(UID RFC822)")
-                .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?;
+        let fetch = fetches
+            .first()
+            .ok_or_else(|| Error::ToolExecution(format!("message uid {uid} not found").into()))?;
 
-            let fetch = fetches.iter().next().ok_or_else(|| {
-                Error::ToolExecution(format!("message uid {uid} not found").into())
-            })?;
+        let raw = fetch.body().unwrap_or_default();
+        let parsed = mail_parser::MessageParser::default()
+            .parse(raw)
+            .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
 
-            let raw = fetch.body().unwrap_or_default();
-            let parsed = mail_parser::MessageParser::default()
-                .parse(raw)
-                .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
-
-            // Collect all Message-IDs in the thread: this message + References header.
-            let mut msg_ids: Vec<String> = Vec::new();
-            if let Some(mid) = parsed.message_id() {
-                msg_ids.push(mid.to_string());
+        // Collect all Message-IDs in the thread: this message + References header.
+        let mut msg_ids: Vec<String> = Vec::new();
+        if let Some(mid) = parsed.message_id() {
+            msg_ids.push(mid.to_string());
+        }
+        // References header contains the full chain of Message-IDs.
+        let refs_header = parsed.header_raw("References").unwrap_or("");
+        for token in refs_header.split_whitespace() {
+            let id = token.trim_matches(|c| c == '<' || c == '>');
+            if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
+                msg_ids.push(id.to_string());
             }
-            // References header contains the full chain of Message-IDs.
-            let refs_header = parsed.header_raw("References").unwrap_or("");
-            for token in refs_header.split_whitespace() {
-                let id = token.trim_matches(|c| c == '<' || c == '>');
-                if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
-                    msg_ids.push(id.to_string());
-                }
+        }
+        if let Some(irt) = parsed.header_raw("In-Reply-To") {
+            let id = irt.trim().trim_matches(|c| c == '<' || c == '>');
+            if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
+                msg_ids.push(id.to_string());
             }
-            if let Some(irt) = parsed.header_raw("In-Reply-To") {
-                let id = irt.trim().trim_matches(|c| c == '<' || c == '>');
-                if !id.is_empty() && !msg_ids.contains(&id.to_string()) {
-                    msg_ids.push(id.to_string());
-                }
+        }
+
+        if msg_ids.is_empty() {
+            let _ = session.logout().await;
+            return Ok(json!({
+                "thread": [],
+                "count": 0,
+                "note": "no threading headers found on this message"
+            }));
+        }
+
+        // Search [Gmail]/All Mail for all messages matching any of these IDs.
+        session
+            .select("[Gmail]/All Mail")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select All Mail failed: {e}").into()))?;
+
+        let mut all_uids = std::collections::HashSet::new();
+        for mid in &msg_ids {
+            // Escape message IDs for IMAP query safety.
+            let escaped = mid.replace('\\', "\\\\").replace('"', "\\\"");
+            // Search for messages that reference this ID or have this ID.
+            let query = format!("X-GM-RAW \"rfc822msgid:{escaped} OR references:{escaped}\"");
+            if let Ok(uids) = session.uid_search(&query).await {
+                all_uids.extend(uids);
             }
-
-            if msg_ids.is_empty() {
-                let _ = session.logout();
-                return Ok(json!({
-                    "thread": [],
-                    "count": 0,
-                    "note": "no threading headers found on this message"
-                }));
+            // Also try standard HEADER search as fallback.
+            let query2 =
+                format!("OR HEADER Message-ID \"<{escaped}>\" HEADER References \"<{escaped}>\"");
+            if let Ok(uids) = session.uid_search(&query2).await {
+                all_uids.extend(uids);
             }
+        }
 
-            // Search [Gmail]/All Mail for all messages matching any of these IDs.
-            session
-                .select("[Gmail]/All Mail")
-                .map_err(|e| Error::ToolExecution(format!("select All Mail failed: {e}").into()))?;
+        if all_uids.is_empty() {
+            let _ = session.logout().await;
+            return Ok(json!({
+                "thread": [],
+                "count": 0,
+                "note": "could not find thread messages"
+            }));
+        }
 
-            let mut all_uids = std::collections::HashSet::new();
-            for mid in &msg_ids {
-                // Escape message IDs for IMAP query safety.
-                let escaped = mid.replace('\\', "\\\\").replace('"', "\\\"");
-                // Search for messages that reference this ID or have this ID.
-                let query = format!("X-GM-RAW \"rfc822msgid:{escaped} OR references:{escaped}\"");
-                if let Ok(uids) = session.uid_search(&query) {
-                    all_uids.extend(uids);
-                }
-                // Also try standard HEADER search as fallback.
-                let query2 = format!(
-                    "OR HEADER Message-ID \"<{escaped}>\" HEADER References \"<{escaped}>\""
-                );
-                if let Ok(uids) = session.uid_search(&query2) {
-                    all_uids.extend(uids);
-                }
-            }
+        // Fetch all thread messages.
+        let mut uid_list: Vec<u32> = all_uids.into_iter().collect();
+        uid_list.sort_unstable(); // chronological (oldest first)
 
-            if all_uids.is_empty() {
-                let _ = session.logout();
-                return Ok(json!({
-                    "thread": [],
-                    "count": 0,
-                    "note": "could not find thread messages"
-                }));
-            }
+        let uid_set = uid_list
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
 
-            // Fetch all thread messages.
-            let mut uid_list: Vec<u32> = all_uids.into_iter().collect();
-            uid_list.sort_unstable(); // chronological (oldest first)
+        let fetches: Vec<async_imap::types::Fetch> = session
+            .uid_fetch(&uid_set, "(UID RFC822 FLAGS)")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch thread failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch stream failed: {e}").into()))?;
 
-            let uid_set = uid_list
-                .iter()
-                .map(|u| u.to_string())
-                .collect::<Vec<_>>()
-                .join(",");
+        let mut messages = Vec::new();
+        for fetch in &fetches {
+            let raw_body = fetch.body().unwrap_or_default();
+            let msg = match mail_parser::MessageParser::default().parse(raw_body) {
+                Some(m) => m,
+                None => continue,
+            };
 
-            let fetches = session
-                .uid_fetch(&uid_set, "(UID RFC822 FLAGS)")
-                .map_err(|e| Error::ToolExecution(format!("fetch thread failed: {e}").into()))?;
+            let subject = msg.subject().unwrap_or("").to_string();
+            let from = msg
+                .from()
+                .and_then(|a| a.first())
+                .map(|a| {
+                    a.name()
+                        .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                        .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                })
+                .unwrap_or_default();
+            let to: Vec<String> = msg
+                .to()
+                .map(|addrs| {
+                    addrs
+                        .iter()
+                        .map(|a| {
+                            a.name()
+                                .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
+                                .unwrap_or_else(|| a.address().unwrap_or("").to_string())
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let date = msg.date().map(|d| d.to_string()).unwrap_or_default();
+            let message_id = msg.message_id().unwrap_or("").to_string();
+            let body_text = msg
+                .body_text(0)
+                .unwrap_or_else(|| {
+                    msg.body_html(0)
+                        .map(|h| strip_html_tags(&h).into())
+                        .unwrap_or_default()
+                })
+                .to_string();
 
-            let mut messages = Vec::new();
-            for fetch in fetches.iter() {
-                let raw_body = fetch.body().unwrap_or_default();
-                let msg = match mail_parser::MessageParser::default().parse(raw_body) {
-                    Some(m) => m,
-                    None => continue,
-                };
+            // Truncate long bodies.
+            let body_text = if body_text.len() > 4000 {
+                format!(
+                    "{}…\n[truncated, {} chars total]",
+                    &body_text[..body_text.floor_char_boundary(4000)],
+                    body_text.len()
+                )
+            } else {
+                body_text
+            };
 
-                let subject = msg.subject().unwrap_or("").to_string();
-                let from = msg
-                    .from()
-                    .and_then(|a| a.first())
-                    .map(|a| {
-                        a.name()
-                            .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
-                            .unwrap_or_else(|| a.address().unwrap_or("").to_string())
-                    })
-                    .unwrap_or_default();
-                let to: Vec<String> = msg
-                    .to()
-                    .map(|addrs| {
-                        addrs
-                            .iter()
-                            .map(|a| {
-                                a.name()
-                                    .map(|n| format!("{n} <{}>", a.address().unwrap_or("")))
-                                    .unwrap_or_else(|| a.address().unwrap_or("").to_string())
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let date = msg.date().map(|d| d.to_string()).unwrap_or_default();
-                let message_id = msg.message_id().unwrap_or("").to_string();
-                let body_text = msg
-                    .body_text(0)
-                    .unwrap_or_else(|| {
-                        msg.body_html(0)
-                            .map(|h| strip_html_tags(&h).into())
-                            .unwrap_or_default()
-                    })
-                    .to_string();
+            messages.push(json!({
+                "uid": fetch.uid.unwrap_or(0),
+                "subject": subject,
+                "from": from,
+                "to": to,
+                "date": date,
+                "message_id": message_id,
+                "body": body_text,
+            }));
+        }
 
-                // Truncate long bodies.
-                let body_text = if body_text.len() > 4000 {
-                    format!(
-                        "{}…\n[truncated, {} chars total]",
-                        &body_text[..body_text.floor_char_boundary(4000)],
-                        body_text.len()
-                    )
-                } else {
-                    body_text
-                };
+        let _ = session.logout().await;
 
-                messages.push(json!({
-                    "uid": fetch.uid.unwrap_or(0),
-                    "subject": subject,
-                    "from": from,
-                    "to": to,
-                    "date": date,
-                    "message_id": message_id,
-                    "body": body_text,
-                }));
-            }
-
-            let _ = session.logout();
-
-            Ok(json!({
-                "thread": messages,
-                "count": messages.len(),
-            }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        Ok(json!({
+            "thread": messages,
+            "count": messages.len(),
+        }))
     }
 
     // -----------------------------------------------------------------------
@@ -778,114 +765,103 @@ impl GmailTool {
         })? as usize;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let secrets = self.secrets.clone();
-        let mailbox = mailbox.to_string();
+        let (email, password) = self.get_credentials()?;
+        let mut session = connect_imap(&email, &password).await?;
 
-        tokio::task::spawn_blocking(move || {
-            let (email, password) = get_creds(&secrets)?;
-            let mut session = connect_imap_blocking(&email, &password)?;
+        session
+            .select(mailbox)
+            .await
+            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
 
-            session
-                .select(&mailbox)
-                .map_err(|e| {
-                    Error::ToolExecution(format!("select {mailbox} failed: {e}").into())
-                })?;
+        let fetches: Vec<async_imap::types::Fetch> = session
+            .uid_fetch(uid.to_string(), "(UID RFC822)")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into()))?
+            .try_collect()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("fetch stream failed: {e}").into()))?;
 
-            let fetches = session
-                .uid_fetch(uid.to_string(), "(UID RFC822)")
-                .map_err(|e| {
-                    Error::ToolExecution(format!("fetch uid {uid} failed: {e}").into())
-                })?;
+        let fetch = fetches
+            .first()
+            .ok_or_else(|| Error::ToolExecution(format!("message uid {uid} not found").into()))?;
 
-            let fetch = fetches
-                .iter()
-                .next()
-                .ok_or_else(|| {
-                    Error::ToolExecution(format!("message uid {uid} not found").into())
-                })?;
+        let raw_body = fetch.body().unwrap_or_default();
+        let parsed = mail_parser::MessageParser::default()
+            .parse(raw_body)
+            .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
 
-            let raw_body = fetch.body().unwrap_or_default();
-            let parsed = mail_parser::MessageParser::default()
-                .parse(raw_body)
-                .ok_or_else(|| Error::ToolExecution("failed to parse email".into()))?;
-
-            use mail_parser::MimeHeaders;
-            let part = parsed.attachment(attachment_index).ok_or_else(|| {
-                Error::ToolExecution(
-                    format!(
-                        "attachment index {attachment_index} not found (message has {} attachments)",
-                        parsed.attachment_count()
-                    )
-                    .into(),
+        use mail_parser::MimeHeaders;
+        let part = parsed.attachment(attachment_index).ok_or_else(|| {
+            Error::ToolExecution(
+                format!(
+                    "attachment index {attachment_index} not found (message has {} attachments)",
+                    parsed.attachment_count()
                 )
-            })?;
+                .into(),
+            )
+        })?;
 
-            let raw_filename = part
-                .content_disposition()
-                .and_then(|cd| cd.attribute("filename"))
-                .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
-                .unwrap_or("attachment.bin")
-                .to_string();
+        let raw_filename = part
+            .content_disposition()
+            .and_then(|cd| cd.attribute("filename"))
+            .or_else(|| part.content_type().and_then(|ct| ct.attribute("name")))
+            .unwrap_or("attachment.bin")
+            .to_string();
 
-            // Sanitize filename to prevent path traversal attacks.
-            // Strip path separators and parent-directory components,
-            // keeping only the final filename component.
-            let filename = {
-                let name = std::path::Path::new(&raw_filename)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("attachment.bin");
-                // Reject empty or dot-only filenames
-                if name.is_empty() || name == "." || name == ".." {
-                    "attachment.bin".to_string()
-                } else {
-                    // Prefix with a UUID to avoid collisions and ensure uniqueness
-                    format!("{}_{}", uuid::Uuid::new_v4(), name)
-                }
-            };
-
-            let contents = part.contents();
-
-            // Save to a temp directory
-            let download_dir = std::env::temp_dir().join("rustykrab-attachments");
-            std::fs::create_dir_all(&download_dir)
-                .map_err(|e| Error::ToolExecution(format!("create dir failed: {e}").into()))?;
-
-            let dest = download_dir.join(&filename);
-
-            // Final safety check: ensure the destination is within download_dir
-            if let Ok(canonical_dest) = dest.canonicalize().or_else(|_| {
-                // For new files, check parent
-                dest.parent()
-                    .and_then(|p| p.canonicalize().ok())
-                    .map(|p| p.join(dest.file_name().unwrap_or_default()))
-                    .ok_or(std::io::Error::other(
-                        "cannot resolve",
-                    ))
-            }) {
-                let canonical_dir = download_dir
-                    .canonicalize()
-                    .map_err(|e| Error::ToolExecution(format!("resolve dir failed: {e}").into()))?;
-                if !canonical_dest.starts_with(&canonical_dir) {
-                    return Err(Error::ToolExecution(
-                        "attachment filename escapes download directory".into(),
-                    ));
-                }
+        // Sanitize filename to prevent path traversal attacks.
+        // Strip path separators and parent-directory components,
+        // keeping only the final filename component.
+        let filename = {
+            let name = std::path::Path::new(&raw_filename)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("attachment.bin");
+            // Reject empty or dot-only filenames
+            if name.is_empty() || name == "." || name == ".." {
+                "attachment.bin".to_string()
+            } else {
+                // Prefix with a UUID to avoid collisions and ensure uniqueness
+                format!("{}_{}", uuid::Uuid::new_v4(), name)
             }
-            std::fs::write(&dest, contents)
-                .map_err(|e| Error::ToolExecution(format!("write failed: {e}").into()))?;
+        };
 
-            let _ = session.logout();
+        let contents = part.contents();
 
-            Ok(json!({
-                "status": "downloaded",
-                "filename": filename,
-                "path": dest.to_string_lossy(),
-                "size_bytes": contents.len(),
-            }))
-        })
-        .await
-        .map_err(|e| Error::ToolExecution(format!("task join failed: {e}").into()))?
+        // Save to a temp directory
+        let download_dir = std::env::temp_dir().join("rustykrab-attachments");
+        std::fs::create_dir_all(&download_dir)
+            .map_err(|e| Error::ToolExecution(format!("create dir failed: {e}").into()))?;
+
+        let dest = download_dir.join(&filename);
+
+        // Final safety check: ensure the destination is within download_dir
+        if let Ok(canonical_dest) = dest.canonicalize().or_else(|_| {
+            // For new files, check parent
+            dest.parent()
+                .and_then(|p| p.canonicalize().ok())
+                .map(|p| p.join(dest.file_name().unwrap_or_default()))
+                .ok_or(std::io::Error::other("cannot resolve"))
+        }) {
+            let canonical_dir = download_dir
+                .canonicalize()
+                .map_err(|e| Error::ToolExecution(format!("resolve dir failed: {e}").into()))?;
+            if !canonical_dest.starts_with(&canonical_dir) {
+                return Err(Error::ToolExecution(
+                    "attachment filename escapes download directory".into(),
+                ));
+            }
+        }
+        std::fs::write(&dest, contents)
+            .map_err(|e| Error::ToolExecution(format!("write failed: {e}").into()))?;
+
+        let _ = session.logout().await;
+
+        Ok(json!({
+            "status": "downloaded",
+            "filename": filename,
+            "path": dest.to_string_lossy(),
+            "size_bytes": contents.len(),
+        }))
     }
 }
 
@@ -1010,36 +986,8 @@ impl Tool for GmailTool {
 // Module-private helpers
 // ---------------------------------------------------------------------------
 
-/// Get credentials from SecretStore (for use in spawn_blocking closures).
-fn get_creds(secrets: &SecretStore) -> Result<(String, String)> {
-    let email = secrets.get(KEY_EMAIL).map_err(|e| {
-        Error::ToolExecution(
-            format!(
-                "gmail_email not available: {e}. Run gmail(action='setup') first. \
-                 If you already stored it, the master encryption key may have changed \
-                 (set RUSTYKRAB_MASTER_KEY for persistence across restarts)."
-            )
-            .into(),
-        )
-    })?;
-    let password = secrets.get(KEY_APP_PASSWORD).map_err(|e| {
-        Error::ToolExecution(
-            format!(
-                "gmail_app_password not available: {e}. Run gmail(action='setup') first. \
-                 If you already stored it, the master encryption key may have changed \
-                 (set RUSTYKRAB_MASTER_KEY for persistence across restarts)."
-            )
-            .into(),
-        )
-    })?;
-    Ok((email, password))
-}
-
-/// Connect to Gmail IMAP over rustls (blocking, for use in spawn_blocking).
-fn connect_imap_blocking(
-    email: &str,
-    password: &str,
-) -> Result<imap::Session<rustls::StreamOwned<rustls::ClientConnection, std::net::TcpStream>>> {
+/// Connect to Gmail IMAP over rustls and authenticate.
+async fn connect_imap(email: &str, password: &str) -> Result<ImapSession> {
     let native_certs = rustls_native_certs::load_native_certs();
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_parsable_certificates(native_certs.certs);
@@ -1053,15 +1001,30 @@ fn connect_imap_blocking(
         .to_string()
         .try_into()
         .map_err(|e| Error::ToolExecution(format!("invalid server name: {e}").into()))?;
-    let tls_conn = rustls::ClientConnection::new(config, server_name)
-        .map_err(|e| Error::ToolExecution(format!("TLS setup failed: {e}").into()))?;
-    let tcp = std::net::TcpStream::connect((IMAP_HOST, IMAP_PORT))
+
+    let tcp = tokio::net::TcpStream::connect((IMAP_HOST, IMAP_PORT))
+        .await
         .map_err(|e| Error::ToolExecution(format!("IMAP connect failed: {e}").into()))?;
-    let tls_stream = rustls::StreamOwned::new(tls_conn, tcp);
-    let client = imap::Client::new(tls_stream);
+    let connector = tokio_rustls::TlsConnector::from(config);
+    let tls_stream = connector
+        .connect(server_name, tcp)
+        .await
+        .map_err(|e| Error::ToolExecution(format!("TLS handshake failed: {e}").into()))?;
+
+    let mut client = async_imap::Client::new(tls_stream);
+    // Read the server greeting so the protocol stream stays in sync.
+    let _greeting = client
+        .read_response()
+        .await
+        .map_err(|e| Error::ToolExecution(format!("IMAP greeting read failed: {e}").into()))?
+        .ok_or_else(|| {
+            Error::ToolExecution("IMAP server closed connection before greeting".into())
+        })?;
+
     let session = client
         .login(email, password)
-        .map_err(|e| Error::ToolExecution(format!("IMAP login failed: {}", e.0).into()))?;
+        .await
+        .map_err(|(e, _client)| Error::ToolExecution(format!("IMAP login failed: {e}").into()))?;
     Ok(session)
 }
 
@@ -1071,7 +1034,7 @@ fn decode_imap_string(s: &[u8]) -> String {
 }
 
 /// Format an IMAP address into a readable string.
-fn format_address(addr: &imap_proto::types::Address) -> String {
+fn format_address(addr: &imap_proto::types::Address<'_>) -> String {
     let name = addr.name.as_ref().map(|n| decode_imap_string(n));
     let mailbox = addr.mailbox.as_ref().map(|m| decode_imap_string(m));
     let host = addr.host.as_ref().map(|h| decode_imap_string(h));


### PR DESCRIPTION
The security audit was flagging four advisories. Address each:

- RUSTSEC-2023-0086 (lexical-core 0.7, unsound): the sync `imap`
  2.4 crate was unmaintained and pinned `imap-proto` 0.10, which still
  pulled `nom` 5 and the unsound `lexical-core` 0.7. Migrate
  `crates/rustykrab-tools/src/gmail.rs` from blocking `imap` +
  `spawn_blocking` to `async-imap` 0.11 over `tokio-rustls`. The new
  client uses `imap-proto` 0.16 / `nom` 7 and removes ~1100 lines of
  blocking-bridge code while keeping the same Tool surface and
  Gmail-specific behaviors (X-GM-RAW search, thread reconstruction via
  References/In-Reply-To headers, attachment download path-traversal
  guards).
- RUSTSEC-2025-0057 (fxhash, unmaintained): bump `scraper` 0.20 -> 0.26;
  the new `selectors` 0.36 no longer depends on fxhash.
- RUSTSEC-2025-0119 (number_prefix, unmaintained): trim fastembed default
  features to drop hf-hub's progress-bar (indicatif/number_prefix) path,
  and switch to the rustls TLS variants to align with the workspace's
  rustls-only policy. This also removes `image`/`ravif`/`rav1e` and the
  `openssl`/`native-tls` chain from the dependency graph.
- RUSTSEC-2024-0436 (paste, unmaintained): no upstream fix available
  (still required by `tokenizers` and `macro_rules_attribute`). Document
  the rationale in `.cargo/audit.toml` so cargo-audit / rustsec
  audit-check pass cleanly; revisit when tokenizers releases a version
  that drops the dependency.

Net effect: cargo-audit reports zero advisories, the OpenSSL build-time
dependency is gone, and the lock file shrinks by ~80 crates.