### PR TITLE
chore: sync Cargo.lock with v2.10.7 workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,7 +2863,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "axum",
  "chrono",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.6"
+version = "2.10.7"
 dependencies = [
  "async-imap",
  "async-trait",


### PR DESCRIPTION
The release: v2.10.7 commit bumped workspace.package.version in
Cargo.toml but did not regenerate Cargo.lock. Any cargo invocation
rewrites the lock, leaving a dirty tree. Sync it.

https://claude.ai/code/session_01SGsamKwynuDoDFvtFbTAuV