### PR TITLE
ci(release): build x86_64 linux on ubuntu-22.04 for glibc 2.35 compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,18 +91,28 @@ jobs:
 
   # ── Build release binaries ─────────────────────────────────────────
   build:
-    name: Build (${{ matrix.target }})
+    name: Build (${{ matrix.asset_name }})
     needs: bump
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
+          # Built on Ubuntu 22.04 (glibc 2.35) for broad compatibility:
+          # this binary runs on Ubuntu 22.04 and any newer glibc-based distro.
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
+            artifact: rustykrab-cli
+            asset_name: x86_64-unknown-linux-gnu-ubuntu22
+          # Built on the latest Ubuntu runner; requires the same or newer
+          # glibc on the host (currently 2.39 from Ubuntu 24.04).
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: rustykrab-cli
+            asset_name: x86_64-unknown-linux-gnu
           - target: aarch64-apple-darwin
             os: macos-14
             artifact: rustykrab-cli
+            asset_name: aarch64-apple-darwin
 
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +125,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          key: ${{ matrix.asset_name }}
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} -p rustykrab-cli
@@ -194,17 +204,17 @@ jobs:
           if [ -d "target/${{ matrix.target }}/release/RustyKrab.app" ]; then
             cp -R target/${{ matrix.target }}/release/RustyKrab.app dist/
             cd dist
-            tar czf rustykrab-${{ matrix.target }}.tar.gz RustyKrab.app
+            tar czf rustykrab-${{ matrix.asset_name }}.tar.gz RustyKrab.app
           else
             cp target/${{ matrix.target }}/release/${{ matrix.artifact }} dist/
             cd dist
-            tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+            tar czf rustykrab-${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact }}
           fi
 
       - uses: actions/upload-artifact@v4
         with:
-          name: rustykrab-${{ matrix.target }}
-          path: dist/rustykrab-${{ matrix.target }}.tar.gz
+          name: rustykrab-${{ matrix.asset_name }}
+          path: dist/rustykrab-${{ matrix.asset_name }}.tar.gz
 
   # ── Create GitHub Release ──────────────────────────────────────────
   release:


### PR DESCRIPTION
## Summary

- Add a second `x86_64-unknown-linux-gnu` entry to the release build matrix that runs on `ubuntu-22.04` (glibc 2.35), so users on Ubuntu 22.04 LTS and other older glibc-based distros have a compatible artifact. The existing `ubuntu-latest` build (currently glibc 2.39 from Ubuntu 24.04) stays untouched.
- Introduce a `matrix.asset_name` field to disambiguate the two Linux builds across cache key, tarball filename, and uploaded artifact name. The `ubuntu-latest` build keeps its original asset name so existing release-download URLs remain valid.

The next release will produce:

- `rustykrab-x86_64-unknown-linux-gnu-ubuntu22.tar.gz` (new, runs on Ubuntu 22.04+)
- `rustykrab-x86_64-unknown-linux-gnu.tar.gz` (unchanged, runs on Ubuntu 24.04+)
- `rustykrab-aarch64-apple-darwin.tar.gz` (unchanged)

> Note: GitHub Actions has deprecated the `ubuntu-22.04` runner image. It still works today but is on track for removal — when that lands, this matrix entry will need to migrate to a self-hosted 22.04 image or a manylinux-style container build.

## Test plan

- [ ] Trigger the Release workflow via `workflow_dispatch` on a non-prod tag and confirm the `Build (x86_64-unknown-linux-gnu-ubuntu22)` job succeeds on the `ubuntu-22.04` runner
- [ ] Download the new tarball and run the binary on an Ubuntu 22.04 host to confirm there are no `GLIBC_2.3x not found` errors
- [ ] Verify the existing `rustykrab-x86_64-unknown-linux-gnu.tar.gz` and `rustykrab-aarch64-apple-darwin.tar.gz` artifacts are still produced with their original names

https://claude.ai/code/session_01SGsamKwynuDoDFvtFbTAuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGsamKwynuDoDFvtFbTAuV)_