### PR TITLE
feat(agent): enable subagent delegation via agents_list/subagents tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,13 +3272,14 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
  "regex",
  "rustykrab-core",
+ "rustykrab-tools",
  "serde",
  "serde_json",
  "tokio",
@@ -3288,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3336,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "axum",
  "chrono",
@@ -3373,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3394,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3410,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3450,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-agent/Cargo.toml
+++ b/crates/rustykrab-agent/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 rustykrab-core.workspace = true
+rustykrab-tools.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 serde_json.workspace = true

--- a/crates/rustykrab-agent/src/lib.rs
+++ b/crates/rustykrab-agent/src/lib.rs
@@ -3,6 +3,7 @@ pub mod rlm;
 pub mod router;
 mod runner;
 pub mod sandbox;
+pub mod subagent;
 pub mod trace;
 pub mod voting;
 
@@ -11,5 +12,6 @@ pub use rlm::RecursiveExecutor;
 pub use router::HarnessRouter;
 pub use runner::{AgentConfig, AgentEvent, AgentRunner, OnMessageCallback};
 pub use sandbox::{NoSandbox, ProcessSandbox, Sandbox, SandboxPolicy};
+pub use subagent::SubagentRunner;
 pub use trace::{ExecutionTracer, ToolStats, ToolTrace};
 pub use voting::ConsistencyVoter;

--- a/crates/rustykrab-agent/src/rlm/context_store.rs
+++ b/crates/rustykrab-agent/src/rlm/context_store.rs
@@ -1,0 +1,85 @@
+//! Per-conversation context store for the RLM REPL tools.
+//!
+//! The four context tools (`context_info`, `context_peek`,
+//! `context_search`, `context_set`) operate on a string blob keyed by
+//! the active conversation's id. The blob lives outside the prompt so
+//! a small model can explore it via tool calls instead of paying the
+//! token cost of having it in every turn.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use uuid::Uuid;
+
+/// Maximum bytes a single context blob may hold. Caps memory growth from
+/// runaway `context_set` calls; the model gets an error if it tries to
+/// stash something larger.
+pub const MAX_CONTEXT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Thread-safe map of conversation id → context blob.
+#[derive(Debug, Default)]
+pub struct ContextStore {
+    inner: RwLock<HashMap<Uuid, Arc<String>>>,
+}
+
+impl ContextStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the context blob for `conv_id`, replacing any existing entry.
+    /// Returns the byte length stored.
+    pub fn set(&self, conv_id: Uuid, text: String) -> usize {
+        let len = text.len();
+        let mut map = self.inner.write().expect("ContextStore poisoned");
+        map.insert(conv_id, Arc::new(text));
+        len
+    }
+
+    /// Look up the context blob for `conv_id`.
+    pub fn get(&self, conv_id: Uuid) -> Option<Arc<String>> {
+        let map = self.inner.read().expect("ContextStore poisoned");
+        map.get(&conv_id).cloned()
+    }
+
+    /// Remove the entry for `conv_id`. Returns `true` if one existed.
+    pub fn clear(&self, conv_id: Uuid) -> bool {
+        let mut map = self.inner.write().expect("ContextStore poisoned");
+        map.remove(&conv_id).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_and_get_roundtrip() {
+        let store = ContextStore::new();
+        let id = Uuid::new_v4();
+        let n = store.set(id, "hello".into());
+        assert_eq!(n, 5);
+        assert_eq!(store.get(id).as_deref().map(String::as_str), Some("hello"));
+    }
+
+    #[test]
+    fn entries_are_per_conversation() {
+        let store = ContextStore::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        store.set(a, "for a".into());
+        store.set(b, "for b".into());
+        assert_eq!(store.get(a).as_deref().map(String::as_str), Some("for a"));
+        assert_eq!(store.get(b).as_deref().map(String::as_str), Some("for b"));
+    }
+
+    #[test]
+    fn clear_removes_entry() {
+        let store = ContextStore::new();
+        let id = Uuid::new_v4();
+        store.set(id, "x".into());
+        assert!(store.clear(id));
+        assert!(store.get(id).is_none());
+        assert!(!store.clear(id));
+    }
+}

--- a/crates/rustykrab-agent/src/rlm/mod.rs
+++ b/crates/rustykrab-agent/src/rlm/mod.rs
@@ -9,8 +9,11 @@
 //! - No single call handles the full context — the tool layer manages it
 
 pub mod context_manager;
+pub mod context_store;
 pub mod recursive_call;
 pub mod repl_tools;
 
 pub use context_manager::estimate_tokens;
+pub use context_store::ContextStore;
 pub use recursive_call::RecursiveExecutor;
+pub use repl_tools::context_tools;

--- a/crates/rustykrab-agent/src/rlm/repl_tools.rs
+++ b/crates/rustykrab-agent/src/rlm/repl_tools.rs
@@ -4,11 +4,24 @@
 //! externally and give the model tools to peek, search, and delegate
 //! sub-queries — mirroring the foundational RLM paper's Python REPL
 //! approach (Zhang, Kraska, Khattab — arXiv 2512.24601).
+//!
+//! Two binding modes are supported:
+//!
+//! - **Fixed**: a pre-built `Arc<String>`, used by [`RecursiveExecutor`]
+//!   for a single call against a known blob.
+//! - **Store**: an [`Arc<ContextStore>`] keyed by the active
+//!   conversation's id. This is what [`context_tools`] returns — the
+//!   tools resolve their context lazily from the
+//!   `SESSION_TOOL_CONTEXT::conversation_id` task-local on every call,
+//!   so the same registered tool instances work for every session.
+//!
+//! [`RecursiveExecutor`]: super::recursive_call::RecursiveExecutor
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use regex::Regex;
+use rustykrab_core::active_tools::SESSION_TOOL_CONTEXT;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::tool::Tool;
@@ -17,11 +30,43 @@ use serde_json::{json, Value};
 use tokio::sync::Semaphore;
 
 use super::context_manager::estimate_tokens;
+use super::context_store::{ContextStore, MAX_CONTEXT_BYTES};
 
 /// Maximum characters returned by a single `context_peek` call.
 const MAX_PEEK_CHARS: usize = 50_000;
 
-/// Build the set of REPL tools for a given recursion level.
+/// How a [`ContextInfoTool`] / [`ContextPeekTool`] / [`ContextSearchTool`]
+/// finds the blob it should operate on.
+#[derive(Clone)]
+enum ContextSource {
+    /// Use the same fixed blob for every call (the
+    /// [`RecursiveExecutor`] path).
+    Fixed(Arc<String>),
+    /// Look the blob up in a [`ContextStore`] by the active
+    /// conversation id read from `SESSION_TOOL_CONTEXT`.
+    Store(Arc<ContextStore>),
+}
+
+impl ContextSource {
+    fn resolve(&self) -> Option<Arc<String>> {
+        match self {
+            ContextSource::Fixed(s) => Some(s.clone()),
+            ContextSource::Store(store) => SESSION_TOOL_CONTEXT
+                .try_with(|ctx| store.get(ctx.conversation_id))
+                .ok()
+                .flatten(),
+        }
+    }
+}
+
+fn no_context_error() -> rustykrab_core::Error {
+    rustykrab_core::Error::ToolExecution(
+        "no context bound for this conversation; call `context_set` first".into(),
+    )
+}
+
+/// Build the set of REPL tools for a given recursion level. Used by
+/// [`RecursiveExecutor`] with a fixed context blob.
 ///
 /// At `depth >= max_recursion_depth - 1` the `sub_query` tool is
 /// omitted so the model must answer directly from peek/search results.
@@ -32,16 +77,15 @@ pub fn repl_tools(
     depth: usize,
     semaphore: Arc<Semaphore>,
 ) -> Vec<Arc<dyn Tool>> {
+    let source = ContextSource::Fixed(context.clone());
     let mut tools: Vec<Arc<dyn Tool>> = vec![
         Arc::new(ContextInfoTool {
-            context: context.clone(),
+            source: source.clone(),
         }),
         Arc::new(ContextPeekTool {
-            context: context.clone(),
+            source: source.clone(),
         }),
-        Arc::new(ContextSearchTool {
-            context: context.clone(),
-        }),
+        Arc::new(ContextSearchTool { source }),
     ];
 
     if depth < config.max_recursion_depth.saturating_sub(1) {
@@ -57,10 +101,98 @@ pub fn repl_tools(
     tools
 }
 
+/// Build the always-on context tools backed by a per-conversation
+/// [`ContextStore`]. Returns four tools: `context_set`, `context_info`,
+/// `context_peek`, `context_search`. `sub_query` is intentionally not
+/// included in this builder — wiring recursive sub-calls into the main
+/// agent runner is a separate change.
+pub fn context_tools(store: Arc<ContextStore>) -> Vec<Arc<dyn Tool>> {
+    let source = ContextSource::Store(store.clone());
+    vec![
+        Arc::new(ContextSetTool { store }),
+        Arc::new(ContextInfoTool {
+            source: source.clone(),
+        }),
+        Arc::new(ContextPeekTool {
+            source: source.clone(),
+        }),
+        Arc::new(ContextSearchTool { source }),
+    ]
+}
+
+// ── context_set ─────────────────────────────────────────────────────
+
+struct ContextSetTool {
+    store: Arc<ContextStore>,
+}
+
+#[async_trait]
+impl Tool for ContextSetTool {
+    fn name(&self) -> &str {
+        "context_set"
+    }
+
+    fn description(&self) -> &str {
+        "Stash a large blob of text outside the prompt for the current \
+         conversation. After calling this you can use `context_info`, \
+         `context_peek`, and `context_search` to explore the blob \
+         without paying the token cost of having it in every turn. \
+         Replaces any previously stashed context for this conversation."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "The blob to stash. Maximum 4 MiB."
+                    }
+                },
+                "required": ["text"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let text = args["text"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing text".into()))?;
+
+        if text.len() > MAX_CONTEXT_BYTES {
+            return Err(rustykrab_core::Error::ToolExecution(
+                format!(
+                    "context too large: {} bytes exceeds {} byte limit",
+                    text.len(),
+                    MAX_CONTEXT_BYTES
+                )
+                .into(),
+            ));
+        }
+
+        let conv_id = SESSION_TOOL_CONTEXT
+            .try_with(|ctx| ctx.conversation_id)
+            .map_err(|_| {
+                rustykrab_core::Error::ToolExecution(
+                    "context_set called outside a session context".into(),
+                )
+            })?;
+
+        let bytes = self.store.set(conv_id, text.to_string());
+        Ok(json!({
+            "stored_bytes": bytes,
+            "estimated_tokens": estimate_tokens(text),
+        }))
+    }
+}
+
 // ── context_info ────────────────────────────────────────────────────
 
 struct ContextInfoTool {
-    context: Arc<String>,
+    source: ContextSource,
 }
 
 #[async_trait]
@@ -88,18 +220,18 @@ impl Tool for ContextInfoTool {
     }
 
     async fn execute(&self, _args: Value) -> rustykrab_core::Result<Value> {
-        let length_bytes = self.context.len();
-        let length_chars = self.context.chars().count();
-        let estimated_tokens = estimate_tokens(&self.context);
-        let line_count = self.context.lines().count();
-        let preview_end = self
-            .context
+        let context = self.source.resolve().ok_or_else(no_context_error)?;
+        let length_bytes = context.len();
+        let length_chars = context.chars().count();
+        let estimated_tokens = estimate_tokens(&context);
+        let line_count = context.lines().count();
+        let preview_end = context
             .char_indices()
             .take_while(|(i, _)| *i < 500)
             .last()
             .map(|(i, c)| i + c.len_utf8())
             .unwrap_or(length_bytes.min(500));
-        let preview = &self.context[..preview_end];
+        let preview = &context[..preview_end];
 
         Ok(json!({
             "length_bytes": length_bytes,
@@ -114,7 +246,7 @@ impl Tool for ContextInfoTool {
 // ── context_peek ────────────────────────────────────────────────────
 
 struct ContextPeekTool {
-    context: Arc<String>,
+    source: ContextSource,
 }
 
 #[async_trait]
@@ -152,22 +284,23 @@ impl Tool for ContextPeekTool {
     }
 
     async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let context = self.source.resolve().ok_or_else(no_context_error)?;
         let start = args["start"].as_u64().unwrap_or(0) as usize;
         let end = args["end"].as_u64().unwrap_or(0) as usize;
 
-        let ctx_len = self.context.len();
+        let ctx_len = context.len();
         let start = start.min(ctx_len);
         let end = end.min(ctx_len).max(start);
 
         // Snap to char boundaries.
-        let start = snap_to_char_boundary(&self.context, start);
-        let end = snap_to_char_boundary(&self.context, end);
+        let start = snap_to_char_boundary(&context, start);
+        let end = snap_to_char_boundary(&context, end);
 
         // Enforce safety limit.
         let effective_end = end.min(start + MAX_PEEK_CHARS);
-        let effective_end = snap_to_char_boundary(&self.context, effective_end);
+        let effective_end = snap_to_char_boundary(&context, effective_end);
 
-        let slice = &self.context[start..effective_end];
+        let slice = &context[start..effective_end];
         let truncated = effective_end < end;
 
         Ok(json!({
@@ -182,7 +315,7 @@ impl Tool for ContextPeekTool {
 // ── context_search ──────────────────────────────────────────────────
 
 struct ContextSearchTool {
-    context: Arc<String>,
+    source: ContextSource,
 }
 
 #[async_trait]
@@ -219,6 +352,7 @@ impl Tool for ContextSearchTool {
     }
 
     async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let context = self.source.resolve().ok_or_else(no_context_error)?;
         let pattern = args["pattern"]
             .as_str()
             .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing pattern".into()))?;
@@ -232,9 +366,9 @@ impl Tool for ContextSearchTool {
         let mut total_count = 0usize;
         // Track byte offset by pointer arithmetic against the original
         // string so we handle both \n and \r\n correctly.
-        let ctx_start = self.context.as_ptr() as usize;
+        let ctx_start = context.as_ptr() as usize;
 
-        for (line_num, line) in self.context.lines().enumerate() {
+        for (line_num, line) in context.lines().enumerate() {
             if re.is_match(line) {
                 let byte_offset = line.as_ptr() as usize - ctx_start;
                 total_count += 1;
@@ -378,10 +512,19 @@ mod tests {
         assert_eq!(snap_to_char_boundary(s, 100), 12);
     }
 
+    use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext};
+    use rustykrab_core::CapabilitySet;
+    use uuid::Uuid;
+
+    fn fixed(text: &str) -> ContextSource {
+        ContextSource::Fixed(Arc::new(text.to_string()))
+    }
+
     #[tokio::test]
     async fn test_context_info() {
-        let ctx = Arc::new("Line one\nLine two\nLine three".to_string());
-        let tool = ContextInfoTool { context: ctx };
+        let tool = ContextInfoTool {
+            source: fixed("Line one\nLine two\nLine three"),
+        };
         let result = tool.execute(json!({})).await.unwrap();
         assert_eq!(result["line_count"], 3);
         assert_eq!(result["length_bytes"], 28);
@@ -391,8 +534,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_context_peek_basic() {
-        let ctx = Arc::new("Hello, world! This is a test.".to_string());
-        let tool = ContextPeekTool { context: ctx };
+        let tool = ContextPeekTool {
+            source: fixed("Hello, world! This is a test."),
+        };
         let result = tool.execute(json!({"start": 0, "end": 13})).await.unwrap();
         assert_eq!(result["text"], "Hello, world!");
         assert_eq!(result["truncated"], false);
@@ -400,8 +544,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_context_peek_clamps_bounds() {
-        let ctx = Arc::new("short".to_string());
-        let tool = ContextPeekTool { context: ctx };
+        let tool = ContextPeekTool {
+            source: fixed("short"),
+        };
         let result = tool
             .execute(json!({"start": 0, "end": 99999}))
             .await
@@ -411,13 +556,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_context_search_finds_matches() {
-        let ctx = Arc::new(
-            "The temperature in Tokyo is 25C.\n\
-             Rain expected in London.\n\
-             Tokyo will be sunny tomorrow."
-                .to_string(),
-        );
-        let tool = ContextSearchTool { context: ctx };
+        let tool = ContextSearchTool {
+            source: fixed(
+                "The temperature in Tokyo is 25C.\n\
+                 Rain expected in London.\n\
+                 Tokyo will be sunny tomorrow.",
+            ),
+        };
         let result = tool
             .execute(json!({"pattern": "tokyo", "max_results": 10}))
             .await
@@ -433,16 +578,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_context_search_invalid_regex() {
-        let ctx = Arc::new("test".to_string());
-        let tool = ContextSearchTool { context: ctx };
+        let tool = ContextSearchTool {
+            source: fixed("test"),
+        };
         let result = tool.execute(json!({"pattern": "[invalid"})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_context_search_respects_max_results() {
-        let ctx = Arc::new("match\nmatch\nmatch\nmatch\nmatch".to_string());
-        let tool = ContextSearchTool { context: ctx };
+        let tool = ContextSearchTool {
+            source: fixed("match\nmatch\nmatch\nmatch\nmatch"),
+        };
         let result = tool
             .execute(json!({"pattern": "match", "max_results": 2}))
             .await
@@ -457,12 +604,96 @@ mod tests {
     #[tokio::test]
     async fn test_context_search_crlf_offsets() {
         // \r\n line endings — byte offsets must account for 2-byte separators
-        let ctx = Arc::new("first\r\nsecond\r\nthird".to_string());
-        let tool = ContextSearchTool { context: ctx };
+        let tool = ContextSearchTool {
+            source: fixed("first\r\nsecond\r\nthird"),
+        };
         let result = tool.execute(json!({"pattern": "third"})).await.unwrap();
         let matches = result["matches"].as_array().unwrap();
         assert_eq!(matches.len(), 1);
         // "first\r\n" = 7 bytes, "second\r\n" = 8 bytes → "third" starts at byte 15
         assert_eq!(matches[0]["byte_offset"], 15);
+    }
+
+    fn session_ctx(conv_id: Uuid) -> SessionToolContext {
+        SessionToolContext {
+            conversation_id: conv_id,
+            capabilities: Arc::new(CapabilitySet::default_safe()),
+            all_tools: Arc::new(Vec::new()),
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_source_resolves_via_session_context() {
+        let store = Arc::new(ContextStore::new());
+        let conv_id = Uuid::new_v4();
+        store.set(conv_id, "stored text".into());
+
+        let tool = ContextInfoTool {
+            source: ContextSource::Store(store),
+        };
+        let result = SESSION_TOOL_CONTEXT
+            .scope(session_ctx(conv_id), tool.execute(json!({})))
+            .await
+            .unwrap();
+        assert_eq!(result["length_bytes"], 11);
+    }
+
+    #[tokio::test]
+    async fn store_source_errors_when_no_context_bound() {
+        let store = Arc::new(ContextStore::new());
+        let conv_id = Uuid::new_v4(); // never set
+        let tool = ContextInfoTool {
+            source: ContextSource::Store(store),
+        };
+        let result = SESSION_TOOL_CONTEXT
+            .scope(session_ctx(conv_id), tool.execute(json!({})))
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no context bound"));
+    }
+
+    #[tokio::test]
+    async fn context_set_stashes_into_store() {
+        let store = Arc::new(ContextStore::new());
+        let conv_id = Uuid::new_v4();
+        let tool = ContextSetTool {
+            store: store.clone(),
+        };
+
+        let result = SESSION_TOOL_CONTEXT
+            .scope(
+                session_ctx(conv_id),
+                tool.execute(json!({"text": "hello world"})),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["stored_bytes"], 11);
+        assert_eq!(
+            store.get(conv_id).as_deref().map(String::as_str),
+            Some("hello world")
+        );
+    }
+
+    #[tokio::test]
+    async fn context_set_rejects_oversize_blob() {
+        let store = Arc::new(ContextStore::new());
+        let conv_id = Uuid::new_v4();
+        let tool = ContextSetTool { store };
+
+        let big = "x".repeat(MAX_CONTEXT_BYTES + 1);
+        let err = SESSION_TOOL_CONTEXT
+            .scope(session_ctx(conv_id), tool.execute(json!({"text": big})))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("context too large"));
+    }
+
+    #[tokio::test]
+    async fn context_set_errors_outside_session_scope() {
+        let store = Arc::new(ContextStore::new());
+        let tool = ContextSetTool { store };
+        let err = tool.execute(json!({"text": "x"})).await.unwrap_err();
+        assert!(err.to_string().contains("outside a session context"));
     }
 }

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -16,7 +16,19 @@ use uuid::Uuid;
 /// Names of meta-tools that are always included in the schema sent to the
 /// model, regardless of the active tool set. These are how the model
 /// discovers and loads the rest of the catalog.
-const META_TOOL_NAMES: &[&str] = &["tools_list", "tools_load"];
+/// Tools that are always sent to the model regardless of the
+/// per-conversation active set. The `tools_*` meta-tools let the model
+/// discover/load other tools; the `context_*` tools let the model
+/// stash and explore large blobs outside the prompt — useful even on
+/// small models that struggle to fit context inline.
+const META_TOOL_NAMES: &[&str] = &[
+    "tools_list",
+    "tools_load",
+    "context_set",
+    "context_info",
+    "context_peek",
+    "context_search",
+];
 
 fn is_meta_tool(name: &str) -> bool {
     META_TOOL_NAMES.contains(&name)

--- a/crates/rustykrab-agent/src/subagent.rs
+++ b/crates/rustykrab-agent/src/subagent.rs
@@ -1,0 +1,364 @@
+//! Sub-agent delegation runtime.
+//!
+//! [`SubagentRunner`] implements [`rustykrab_tools::SessionManager`] and
+//! is wired up via `rustykrab_tools::session_tools(...)`. The model calls
+//! the `agents_list` and `subagents` tools; this struct turns those calls
+//! into a fresh nested [`AgentRunner`] invocation against a
+//! [`AgentDefinition`] from the registry.
+//!
+//! The full multi-session API (`sessions_spawn` / `sessions_send` /
+//! `sessions_yield` / etc.) is intentionally stubbed — those tools are
+//! a separate feature and will be wired up in a follow-up.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rustykrab_core::active_tools::SESSION_TOOL_CONTEXT;
+use rustykrab_core::model::ModelProvider;
+use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
+use rustykrab_core::{AgentRegistry, CapabilitySet, Error, Result, Session, Tool};
+use rustykrab_tools::SessionManager;
+use serde_json::{json, Value};
+use tokio::sync::Semaphore;
+use uuid::Uuid;
+
+use crate::harness::HarnessProfile;
+use crate::runner::AgentRunner;
+use crate::sandbox::Sandbox;
+
+/// Runs sub-agents against an [`AgentRegistry`] using a fresh
+/// [`AgentRunner`] per call.
+///
+/// A semaphore serialises concurrent calls so that a model emitting
+/// parallel `subagents` tool calls in one turn does not stack multiple
+/// nested loops on top of a local Ollama provider. The default permit
+/// count is taken from `OrchestrationConfig::max_concurrent_tasks`.
+pub struct SubagentRunner {
+    provider: Arc<dyn ModelProvider>,
+    tools: Vec<Arc<dyn Tool>>,
+    sandbox: Arc<dyn Sandbox>,
+    registry: Arc<AgentRegistry>,
+    concurrency: Arc<Semaphore>,
+}
+
+impl SubagentRunner {
+    pub fn new(
+        provider: Arc<dyn ModelProvider>,
+        tools: Vec<Arc<dyn Tool>>,
+        sandbox: Arc<dyn Sandbox>,
+        registry: Arc<AgentRegistry>,
+        concurrency: usize,
+    ) -> Self {
+        let permits = concurrency.max(1);
+        Self {
+            provider,
+            tools,
+            sandbox,
+            registry,
+            concurrency: Arc::new(Semaphore::new(permits)),
+        }
+    }
+
+    /// Build a session whose capabilities are the intersection of the
+    /// parent session's capabilities and the agent definition's
+    /// `allowed_tools` list. If `allowed_tools` is `None`, the parent's
+    /// capabilities pass through unchanged.
+    fn derive_capabilities(&self, allowed_tools: Option<&[String]>) -> CapabilitySet {
+        let parent = SESSION_TOOL_CONTEXT
+            .try_with(|ctx| (*ctx.capabilities).clone())
+            .ok();
+
+        match (parent, allowed_tools) {
+            (Some(parent_caps), Some(allowed)) => {
+                let names: Vec<&str> = allowed
+                    .iter()
+                    .filter(|name| parent_caps.can_use_tool(name))
+                    .map(|s| s.as_str())
+                    .collect();
+                CapabilitySet::for_tools(&names)
+            }
+            (Some(parent_caps), None) => parent_caps,
+            (None, Some(allowed)) => {
+                let names: Vec<&str> = allowed.iter().map(|s| s.as_str()).collect();
+                CapabilitySet::for_tools(&names)
+            }
+            (None, None) => CapabilitySet::default_safe(),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionManager for SubagentRunner {
+    async fn list_sessions(&self) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_list is not implemented yet".into(),
+        ))
+    }
+
+    async fn get_session_history(&self, _session_id: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_history is not implemented yet".into(),
+        ))
+    }
+
+    async fn send_to_session(&self, _session_id: &str, _message: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_send is not implemented yet".into(),
+        ))
+    }
+
+    async fn spawn_session(
+        &self,
+        _system_prompt: Option<&str>,
+        _capabilities: Option<Vec<String>>,
+    ) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_spawn is not implemented yet".into(),
+        ))
+    }
+
+    async fn yield_session(&self, _result: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "sessions_yield is not implemented yet".into(),
+        ))
+    }
+
+    async fn get_session_status(&self, _session_id: &str) -> Result<Value> {
+        Err(Error::ToolExecution(
+            "session_status is not implemented yet".into(),
+        ))
+    }
+
+    async fn list_agents(&self) -> Result<Value> {
+        let defs = self.registry.list();
+        let agents: Vec<Value> = defs
+            .iter()
+            .map(|d| {
+                json!({
+                    "id": d.id,
+                    "description": d.description,
+                    "profile": d.profile,
+                    "allowed_tools": d.allowed_tools,
+                })
+            })
+            .collect();
+        Ok(json!({ "agents": agents }))
+    }
+
+    async fn run_subagent(&self, agent_id: &str, task: &str) -> Result<Value> {
+        let def = self
+            .registry
+            .get(agent_id)
+            .ok_or_else(|| Error::ToolExecution(format!("unknown agent_id: {agent_id}").into()))?;
+
+        // Serialise nested runs so a parallel-tool-call burst from the
+        // model doesn't fan out into multiple concurrent local-model
+        // loops.
+        let _permit = self
+            .concurrency
+            .acquire()
+            .await
+            .map_err(|_| Error::Internal("subagent semaphore closed".into()))?;
+
+        let profile = match def.profile.as_str() {
+            "coding" => HarnessProfile::coding(),
+            "research" => HarnessProfile::research(),
+            "creative" => HarnessProfile::creative(),
+            _ => HarnessProfile::default(),
+        };
+
+        let caps = self.derive_capabilities(def.allowed_tools.as_deref());
+        let conv_id = Uuid::new_v4();
+        let session = Session::with_capabilities(conv_id, caps);
+
+        let now = Utc::now();
+        let mut conv = Conversation {
+            id: conv_id,
+            messages: vec![
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::System,
+                    content: MessageContent::Text(def.system_prompt.clone()),
+                    created_at: now,
+                },
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::User,
+                    content: MessageContent::Text(task.to_string()),
+                    created_at: now,
+                },
+            ],
+            created_at: now,
+            updated_at: now,
+            summary: None,
+            detected_profile: Some(def.profile.clone()),
+            channel_source: Some("subagent".into()),
+            channel_id: Some(def.id.clone()),
+            channel_thread_id: None,
+        };
+
+        let runner = AgentRunner::new(
+            self.provider.clone(),
+            self.tools.clone(),
+            self.sandbox.clone(),
+        )
+        .with_config(profile.to_agent_config());
+
+        runner.run(&mut conv, &session).await.map_err(|e| {
+            Error::ToolExecution(format!("subagent '{}' failed: {e}", def.id).into())
+        })?;
+
+        let answer = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+            .and_then(|m| m.content.as_text())
+            .unwrap_or("")
+            .to_string();
+
+        let iterations = conv
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Assistant)
+            .count();
+
+        Ok(json!({
+            "agent_id": def.id,
+            "result": answer,
+            "iterations": iterations,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use rustykrab_core::model::{ModelResponse, StopReason, StreamEvent, Usage};
+    use rustykrab_core::types::ToolSchema;
+    use std::sync::Mutex;
+
+    use crate::sandbox::NoSandbox;
+
+    struct ScriptedProvider {
+        responses: Mutex<Vec<ModelResponse>>,
+    }
+
+    impl ScriptedProvider {
+        fn new(responses: Vec<ModelResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> Result<ModelResponse> {
+            let mut q = self.responses.lock().unwrap();
+            if q.is_empty() {
+                Ok(text_response("(no more responses)"))
+            } else {
+                Ok(q.remove(0))
+            }
+        }
+
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+            _on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+        ) -> Result<ModelResponse> {
+            self.chat(messages, tools).await
+        }
+    }
+
+    fn text_response(text: &str) -> ModelResponse {
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+                created_at: Utc::now(),
+            },
+            usage: Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                ..Default::default()
+            },
+            stop_reason: StopReason::EndTurn,
+            text: Some(text.to_string()),
+        }
+    }
+
+    fn make_runner(provider: Arc<dyn ModelProvider>) -> SubagentRunner {
+        SubagentRunner::new(
+            provider,
+            Vec::new(),
+            Arc::new(NoSandbox),
+            Arc::new(AgentRegistry::with_defaults()),
+            1,
+        )
+    }
+
+    #[tokio::test]
+    async fn list_agents_returns_registered_defs() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        let v = runner.list_agents().await.unwrap();
+        let agents = v.get("agents").and_then(|a| a.as_array()).unwrap();
+        let ids: Vec<&str> = agents
+            .iter()
+            .filter_map(|a| a.get("id").and_then(|i| i.as_str()))
+            .collect();
+        assert_eq!(ids, vec!["coder", "planner", "researcher"]);
+    }
+
+    #[tokio::test]
+    async fn run_subagent_unknown_id_errors() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        let err = runner.run_subagent("nope", "do a thing").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown agent_id"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_subagent_returns_assistant_text() {
+        let provider = Arc::new(ScriptedProvider::new(vec![text_response("done")]));
+        let runner = make_runner(provider);
+
+        let v = runner
+            .run_subagent("planner", "plan something")
+            .await
+            .unwrap();
+        assert_eq!(v.get("agent_id").and_then(|i| i.as_str()), Some("planner"));
+        assert_eq!(v.get("result").and_then(|r| r.as_str()), Some("done"));
+    }
+
+    #[tokio::test]
+    async fn sessions_apis_return_not_implemented() {
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = make_runner(provider);
+
+        assert!(runner.list_sessions().await.is_err());
+        assert!(runner.spawn_session(None, None).await.is_err());
+        assert!(runner.yield_session("x").await.is_err());
+        assert!(runner.get_session_status("x").await.is_err());
+        assert!(runner.send_to_session("x", "y").await.is_err());
+        assert!(runner.get_session_history("x").await.is_err());
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -15,6 +15,7 @@ const BUILD_DATE: &str = env!("RUSTYKRAB_BUILD_DATE");
 fn version_string() -> String {
     format!("{VERSION} ({GIT_HASH}{GIT_DIRTY}, {BUILD_DATE})")
 }
+use rustykrab_agent::rlm::{context_tools, ContextStore};
 use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter, ProcessSandbox, SubagentRunner};
 use rustykrab_channels::telegram::ChannelMessage;
 use rustykrab_channels::{TelegramChannel, VideoChannel, VideoConfig};
@@ -441,6 +442,14 @@ async fn main() -> anyhow::Result<()> {
         tools.extend(rustykrab_tools::video_tools(video_backend));
         tracing::info!("video tool registered");
     }
+
+    // --- Context tools (RLM REPL: context_set / info / peek / search) ---
+    // Always available regardless of `tools_load` state — registered as
+    // meta-tools in the runner so small models can stash and explore
+    // large blobs without paying token cost on every turn.
+    let context_store = Arc::new(ContextStore::new());
+    tools.extend(context_tools(context_store.clone()));
+    tracing::info!("context tools registered");
 
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -15,12 +15,13 @@ const BUILD_DATE: &str = env!("RUSTYKRAB_BUILD_DATE");
 fn version_string() -> String {
     format!("{VERSION} ({GIT_HASH}{GIT_DIRTY}, {BUILD_DATE})")
 }
-use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter};
+use rustykrab_agent::{AgentEvent, HarnessProfile, HarnessRouter, ProcessSandbox, SubagentRunner};
 use rustykrab_channels::telegram::ChannelMessage;
 use rustykrab_channels::{TelegramChannel, VideoChannel, VideoConfig};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::types::MessageContent;
+use rustykrab_core::AgentRegistry;
 use rustykrab_gateway::AppState;
 use rustykrab_memory::backend::HybridMemoryBackend;
 use rustykrab_memory::embedding::FastEmbedder;
@@ -444,15 +445,32 @@ async fn main() -> anyhow::Result<()> {
     // --- Log provider status ---
     tracing::info!(provider = provider.name(), "model provider configured");
 
+    // --- Orchestration config (used by RLM module and subagent throttle) ---
+    let orchestration_config = load_orchestration_config(&data_dir)?;
+
+    // --- Sub-agent tools (subagents, agents_list) ---
+    // Snapshot the tool list as it stands now so the sub-agent can call
+    // every parent tool except the session/subagent meta-tools we are
+    // about to add — that prevents a sub-agent from re-spawning itself
+    // through the same registry. The per-tool depth guard inside
+    // `SubagentsTool` is the second line of defence.
+    let agent_registry = Arc::new(AgentRegistry::with_defaults());
+    let subagent_runner: Arc<dyn rustykrab_tools::SessionManager> = Arc::new(SubagentRunner::new(
+        provider.clone(),
+        tools.clone(),
+        Arc::new(ProcessSandbox::new()),
+        agent_registry,
+        orchestration_config.max_concurrent_tasks,
+    ));
+    tools.extend(rustykrab_tools::session_tools(subagent_runner));
+    tracing::info!("subagent tools registered");
+
     // --- Harness router (auto-selects profile per message) ---
     // Reuses the main provider for classification to avoid model swapping.
     // The classification prompt is ~50 tokens — negligible overhead on any model.
     let classifier: Arc<dyn ModelProvider> = provider.clone();
 
     let router = Arc::new(HarnessRouter::new(classifier).with_base(profile));
-
-    // --- Orchestration config (used by RLM module) ---
-    let orchestration_config = load_orchestration_config(&data_dir)?;
 
     // --- Build gateway state ---
     // Clone store handle so we can flush it after the server shuts down.

--- a/crates/rustykrab-core/src/agent_def.rs
+++ b/crates/rustykrab-core/src/agent_def.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+/// A named sub-agent definition: system prompt, harness profile, and the
+/// tool subset the sub-agent is allowed to use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDefinition {
+    /// Stable identifier referenced by the `subagents` tool.
+    pub id: String,
+    /// Short description shown in `agents_list`.
+    pub description: String,
+    /// System prompt prepended to the sub-agent's conversation.
+    pub system_prompt: String,
+    /// Harness profile name: `coding`, `research`, `creative`, or `default`.
+    pub profile: String,
+    /// Tools the sub-agent may call. `None` means inherit the parent's
+    /// active capability set unchanged.
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+/// Read-only catalog of [`AgentDefinition`]s.
+#[derive(Debug, Default, Clone)]
+pub struct AgentRegistry {
+    by_id: HashMap<String, Arc<AgentDefinition>>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, def: AgentDefinition) {
+        self.by_id.insert(def.id.clone(), Arc::new(def));
+    }
+
+    pub fn get(&self, id: &str) -> Option<Arc<AgentDefinition>> {
+        self.by_id.get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<Arc<AgentDefinition>> {
+        let mut defs: Vec<_> = self.by_id.values().cloned().collect();
+        defs.sort_by(|a, b| a.id.cmp(&b.id));
+        defs
+    }
+
+    /// Built-in catalog: researcher, coder, planner.
+    pub fn with_defaults() -> Self {
+        let mut reg = Self::new();
+        reg.insert(AgentDefinition {
+            id: "researcher".into(),
+            description: "Investigates a question using web/search/memory tools and returns a synthesized answer.".into(),
+            system_prompt: "You are a focused research sub-agent. Answer the user's question by gathering evidence with the available tools, then return a concise synthesis with citations or sources where applicable. Do not ask follow-up questions; produce a final answer in one turn loop.".into(),
+            profile: "research".into(),
+            allowed_tools: None,
+        });
+        reg.insert(AgentDefinition {
+            id: "coder".into(),
+            description: "Reads, edits, and runs code to implement a change or diagnose a bug.".into(),
+            system_prompt: "You are a focused coding sub-agent. Implement the requested change end-to-end: read relevant files, apply edits, and verify with tests or a build. Return a short summary of what you changed.".into(),
+            profile: "coding".into(),
+            allowed_tools: None,
+        });
+        reg.insert(AgentDefinition {
+            id: "planner".into(),
+            description: "Drafts a step-by-step implementation plan without making changes.".into(),
+            system_prompt: "You are a planning sub-agent. Read enough of the codebase to ground your reasoning, then produce a concrete, ordered plan with file paths and named functions. Do not modify any files.".into(),
+            profile: "default".into(),
+            allowed_tools: None,
+        });
+        reg
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_contain_three_agents() {
+        let reg = AgentRegistry::with_defaults();
+        let ids: Vec<String> = reg.list().iter().map(|d| d.id.clone()).collect();
+        assert_eq!(ids, vec!["coder", "planner", "researcher"]);
+    }
+
+    #[test]
+    fn get_returns_definition_by_id() {
+        let reg = AgentRegistry::with_defaults();
+        let def = reg.get("coder").expect("coder agent exists");
+        assert_eq!(def.profile, "coding");
+    }
+
+    #[test]
+    fn unknown_id_returns_none() {
+        let reg = AgentRegistry::with_defaults();
+        assert!(reg.get("nonexistent").is_none());
+    }
+}

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod active_tools;
+pub mod agent_def;
 pub mod capability;
 pub mod crypto;
 pub mod error;
@@ -11,6 +12,7 @@ pub mod types;
 pub use active_tools::{
     with_session_context, ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT,
 };
+pub use agent_def::{AgentDefinition, AgentRegistry};
 pub use capability::{Capability, CapabilitySet};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;


### PR DESCRIPTION
Adds an `AgentRegistry` of named sub-agent definitions in
`rustykrab-core` and a `SubagentRunner` in `rustykrab-agent` that
implements `rustykrab_tools::SessionManager` for the `agents_list`
and `subagents` tools (the rest of the session API stays stubbed).

Each `subagents` call spins up a fresh `AgentRunner` against a chosen
`HarnessProfile`, with capabilities derived from the parent session's
capabilities intersected with the agent's `allowed_tools` list. A
semaphore sized to `OrchestrationConfig::max_concurrent_tasks`
serialises nested runs so a model emitting parallel `subagents` calls
does not stack concurrent loops on a local provider.

Ships three built-in agents: researcher, coder, planner.