### PR TITLE
feat(agent): add recall_append for manual context stash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.9"
+version = "2.10.10"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/recall_tools.rs
+++ b/crates/rustykrab-agent/src/recall_tools.rs
@@ -35,15 +35,21 @@ use crate::rlm::RecursiveExecutor;
 /// the prompt on its own.
 const MAX_PEEK_CHARS: usize = 50_000;
 
-/// Build the four recall tools.  All four take no per-call construction
-/// arguments — they resolve the active conversation's archive at
-/// `execute()` time via [`with_session_context`], so the same instances
-/// can be registered globally and shared across conversations.
+/// Maximum bytes a single `recall_append` call may stash. Bounds memory
+/// growth from a model that tries to dump a huge blob in one shot;
+/// larger payloads should be appended in chunks.
+const MAX_APPEND_BYTES: usize = 4 * 1024 * 1024;
+
+/// Build the recall tools.  All take no per-call construction arguments —
+/// they resolve the active conversation's archive at `execute()` time via
+/// [`with_session_context`], so the same instances can be registered
+/// globally and shared across conversations.
 pub fn recall_tools(
     provider: Arc<dyn ModelProvider>,
     orchestration: OrchestrationConfig,
 ) -> Vec<Arc<dyn Tool>> {
     vec![
+        Arc::new(RecallAppendTool),
         Arc::new(RecallInfoTool),
         Arc::new(RecallPeekTool),
         Arc::new(RecallSearchTool),
@@ -70,6 +76,80 @@ fn empty_archive_response() -> Value {
         "empty": true,
         "note": "no compacted history is available for this conversation yet",
     })
+}
+
+// ── recall_append ───────────────────────────────────────────────────
+
+struct RecallAppendTool;
+
+#[async_trait]
+impl Tool for RecallAppendTool {
+    fn name(&self) -> &str {
+        "recall_append"
+    }
+
+    fn description(&self) -> &str {
+        "Stash a blob of text into this conversation's recall archive so \
+         you can come back to it later via `recall_info`, `recall_peek`, \
+         and `recall_search` without paying the token cost of carrying it \
+         in every turn. The archive is append-only — new text is joined \
+         with a blank-line separator to whatever is already there. Useful \
+         for large documents, long tool outputs, or chunks of context the \
+         user pasted that you only need to consult occasionally."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "The text to append to the archive. Maximum 4 MiB per call."
+                    }
+                },
+                "required": ["text"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let text = args["text"]
+            .as_str()
+            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing text".into()))?;
+
+        if text.len() > MAX_APPEND_BYTES {
+            return Err(rustykrab_core::Error::ToolExecution(
+                format!(
+                    "text too large: {} bytes exceeds {} byte limit; split into smaller appends",
+                    text.len(),
+                    MAX_APPEND_BYTES
+                )
+                .into(),
+            ));
+        }
+
+        let result = with_session_context(|ctx| {
+            ctx.recall.append(ctx.conversation_id, text);
+            ctx.recall
+                .get(ctx.conversation_id)
+                .map(|a| a.len())
+                .unwrap_or(0)
+        });
+
+        match result {
+            Some(archive_bytes) => Ok(json!({
+                "appended_bytes": text.len(),
+                "archive_bytes": archive_bytes,
+                "estimated_tokens": estimate_tokens(text),
+            })),
+            None => Err(rustykrab_core::Error::ToolExecution(
+                "recall_append called outside a session context".into(),
+            )),
+        }
+    }
 }
 
 // ── recall_info ─────────────────────────────────────────────────────
@@ -477,5 +557,101 @@ mod tests {
             })
             .await;
         assert!(result.is_err());
+    }
+
+    fn empty_ctx_with_store() -> (SessionToolContext, Uuid, Arc<RecallStore>) {
+        let conv = Uuid::new_v4();
+        let recall = Arc::new(RecallStore::new());
+        let ctx = SessionToolContext {
+            conversation_id: conv,
+            capabilities: Arc::new(CapabilitySet::none()),
+            all_tools: Arc::new(Vec::new()),
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+            recall: recall.clone(),
+        };
+        (ctx, conv, recall)
+    }
+
+    #[tokio::test]
+    async fn append_stashes_into_archive() {
+        let (ctx, conv, store) = empty_ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                RecallAppendTool
+                    .execute(json!({"text": "hello world"}))
+                    .await
+            })
+            .await
+            .unwrap();
+        assert_eq!(result["appended_bytes"], 11);
+        assert_eq!(result["archive_bytes"], 11);
+        assert_eq!(
+            store.get(conv).as_deref().map(String::as_str),
+            Some("hello world")
+        );
+    }
+
+    #[tokio::test]
+    async fn append_is_readable_via_info_and_peek() {
+        let (ctx, _, _) = empty_ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                RecallAppendTool
+                    .execute(json!({"text": "first chunk"}))
+                    .await?;
+                let info = RecallInfoTool.execute(json!({})).await?;
+                let peek = RecallPeekTool
+                    .execute(json!({"start": 0, "end": 5}))
+                    .await?;
+                Ok::<_, rustykrab_core::Error>(json!({"info": info, "peek": peek}))
+            })
+            .await
+            .unwrap();
+        assert_eq!(result["info"]["empty"], false);
+        assert_eq!(result["info"]["length_bytes"], 11);
+        assert_eq!(result["peek"]["text"], "first");
+    }
+
+    #[tokio::test]
+    async fn append_joins_with_blank_line_separator() {
+        let (ctx, conv, store) = empty_ctx_with_store();
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                RecallAppendTool
+                    .execute(json!({"text": "first"}))
+                    .await
+                    .unwrap();
+                RecallAppendTool
+                    .execute(json!({"text": "second"}))
+                    .await
+                    .unwrap();
+            })
+            .await;
+        assert_eq!(
+            store.get(conv).as_deref().map(String::as_str),
+            Some("first\n\nsecond")
+        );
+    }
+
+    #[tokio::test]
+    async fn append_rejects_oversize_payload() {
+        let (ctx, _, _) = empty_ctx_with_store();
+        let big = "x".repeat(MAX_APPEND_BYTES + 1);
+        let err = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                RecallAppendTool.execute(json!({"text": big})).await
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("text too large"));
+    }
+
+    #[tokio::test]
+    async fn append_errors_outside_session_scope() {
+        let err = RecallAppendTool
+            .execute(json!({"text": "x"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("outside a session context"));
     }
 }

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -20,12 +20,14 @@ use uuid::Uuid;
 /// Names of meta-tools that are always included in the schema sent to the
 /// model, regardless of the active tool set. The first two are how the
 /// model discovers and loads the rest of the catalog. The `recall_*`
-/// tools read the per-conversation compaction archive and need to be
+/// tools read and write the per-conversation archive and need to be
 /// always present — the model can't `tools_load` them after compaction
-/// has already dropped the detail it needs to recover.
+/// has already dropped the detail it needs to recover, and `recall_append`
+/// is the manual escape hatch for stashing content outside the prompt.
 const META_TOOL_NAMES: &[&str] = &[
     "tools_list",
     "tools_load",
+    "recall_append",
     "recall_info",
     "recall_peek",
     "recall_search",


### PR DESCRIPTION
## Summary

Adds `recall_append`, a small write-side companion to the existing `recall_info` / `recall_peek` / `recall_search` / `recall_sub_query` tools. Lets the model voluntarily stash content into the conversation's recall archive — e.g. a large document the user pasted or a long tool output it knows it'll need later — instead of carrying it in every turn.

## Why

The existing `recall_*` tools are read-only and only see content that `AgentRunner::compact_history` has displaced from the prompt. There's no path for the model to opt into stashing something itself. `recall_append` fills that gap by writing into the same `RecallStore` the read tools already use, so the model can store now and explore later via the existing primitives.

## Design notes

- New text joins the existing archive with a blank-line separator, matching how compaction batches accumulate.
- 4 MiB per-call cap on payload size to bound memory growth; larger blobs should be chunked.
- Registered in `META_TOOL_NAMES` so it's always sent in the schema — the manual stash is most valuable on small local models, which is exactly when `tools_load`-style discovery friction would hurt.
- No new state: piggybacks on the existing `Arc<RecallStore>` in `SessionToolContext`.

## Test plan

- [x] `cargo test -p rustykrab-agent` — 73 tests pass, 5 new for `recall_append`:
  - `append_stashes_into_archive`
  - `append_is_readable_via_info_and_peek` — round-trip via existing read tools
  - `append_joins_with_blank_line_separator`
  - `append_rejects_oversize_payload`
  - `append_errors_outside_session_scope`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rustykrab-agent --all-targets`

https://claude.ai/code/session_01NNHfd1XAwMDcVPBWKdR7BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHfd1XAwMDcVPBWKdR7BB)_