### PR TITLE
feat(security): gate subagent tools behind env var + capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1784,9 +1784,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1784,9 +1784,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -706,22 +706,37 @@ async fn main() -> anyhow::Result<()> {
     // --- Orchestration config (used by RLM module and subagent throttle) ---
     let orchestration_config = load_orchestration_config(&data_dir)?;
 
-    // --- Sub-agent tools (subagents, agents_list) ---
-    // Snapshot the tool list as it stands now so the sub-agent can call
-    // every parent tool except the session/subagent meta-tools we are
-    // about to add — that prevents a sub-agent from re-spawning itself
-    // through the same registry. The per-tool depth guard inside
-    // `SubagentsTool` is the second line of defence.
-    let agent_registry = Arc::new(AgentRegistry::with_defaults());
-    let subagent_runner: Arc<dyn rustykrab_tools::SessionManager> = Arc::new(SubagentRunner::new(
-        provider.clone(),
-        tools.clone(),
-        Arc::new(ProcessSandbox::new()),
-        agent_registry,
-        orchestration_config.max_concurrent_tasks,
-    ));
-    tools.extend(rustykrab_tools::session_tools(subagent_runner));
-    tracing::info!("subagent tools registered");
+    // --- Sub-agent tools (subagents, agents_list, sessions_*) ---
+    // Gated behind `RUSTYKRAB_ENABLE_SUBAGENTS=true`. Sub-agents can spawn
+    // nested agent loops with the same toolset, which is a real
+    // amplification of any prompt-injection blast radius — keep it
+    // opt-in. Even when registered, sessions also need
+    // `Capability::Subagent` (granted by the gateway via
+    // `AppState::subagents_enabled`) before the model can actually call
+    // them.
+    let subagents_enabled = std::env::var("RUSTYKRAB_ENABLE_SUBAGENTS")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+        .unwrap_or(false);
+    if subagents_enabled {
+        // Snapshot the tool list as it stands now so the sub-agent can call
+        // every parent tool except the session/subagent meta-tools we are
+        // about to add — that prevents a sub-agent from re-spawning itself
+        // through the same registry. The per-tool depth guard inside
+        // `SubagentsTool` is the second line of defence.
+        let agent_registry = Arc::new(AgentRegistry::with_defaults());
+        let subagent_runner: Arc<dyn rustykrab_tools::SessionManager> =
+            Arc::new(SubagentRunner::new(
+                provider.clone(),
+                tools.clone(),
+                Arc::new(ProcessSandbox::new()),
+                agent_registry,
+                orchestration_config.max_concurrent_tasks,
+            ));
+        tools.extend(rustykrab_tools::session_tools(subagent_runner));
+        tracing::info!("subagent tools registered (RUSTYKRAB_ENABLE_SUBAGENTS=true)");
+    } else {
+        tracing::info!("subagent tools disabled — set RUSTYKRAB_ENABLE_SUBAGENTS=true to enable");
+    }
 
     // --- Recall tools (read compaction-displaced history) ---
     // The store backing these tools lives on AppState and is threaded
@@ -773,7 +788,8 @@ async fn main() -> anyhow::Result<()> {
         .with_harness_router(router)
         .with_orchestration_config(orchestration_config)
         .with_skill_registry(skill_registry)
-        .with_memory(Arc::clone(&memory_system), agent_id);
+        .with_memory(Arc::clone(&memory_system), agent_id)
+        .with_subagents_enabled(subagents_enabled);
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-core/src/capability.rs
+++ b/crates/rustykrab-core/src/capability.rs
@@ -1,6 +1,32 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+/// Names of the sub-agent / session-management tools that, in addition to
+/// a matching [`Capability::Tool`] grant, require [`Capability::Subagent`]
+/// to use. Centralising this list keeps [`CapabilitySet::can_use_tool`]
+/// and any consumer that filters tool schemas in sync.
+///
+/// These tools can spawn nested agent loops or coordinate other
+/// sessions, so they get an extra gate beyond the per-tool capability
+/// — they are off-by-default in `for_tools_permissive` and only granted
+/// when the runtime explicitly opts in.
+pub const SUBAGENT_TOOL_NAMES: &[&str] = &[
+    "subagents",
+    "agents_list",
+    "sessions_list",
+    "sessions_history",
+    "sessions_send",
+    "sessions_spawn",
+    "sessions_yield",
+    "session_status",
+];
+
+/// Returns whether `tool_name` is one of the sub-agent / session-management
+/// tools that require [`Capability::Subagent`].
+pub fn is_subagent_tool(tool_name: &str) -> bool {
+    SUBAGENT_TOOL_NAMES.contains(&tool_name)
+}
+
 /// A capability that can be granted to a conversation session.
 ///
 /// Capabilities follow the principle of least privilege — each
@@ -29,6 +55,11 @@ pub enum Capability {
     Tool(String),
     /// Can read/write secrets.
     SecretAccess,
+    /// Can use the sub-agent / session-management tool family
+    /// (`subagents`, `agents_list`, `sessions_*`). Required in addition
+    /// to [`Capability::Tool`] for those tools so spawning nested agent
+    /// loops is opt-in even when the tools are registered.
+    Subagent,
     /// Administrative — can manage other sessions.
     Admin,
 }
@@ -77,8 +108,19 @@ impl CapabilitySet {
     /// Normalises the tool name before lookup: trims whitespace and, if
     /// the name contains a colon separator (e.g. `"some_tool:subaction"`
     /// emitted by some models), checks the base name as well.
+    ///
+    /// For tools in [`SUBAGENT_TOOL_NAMES`] this additionally requires
+    /// [`Capability::Subagent`] — see that constant for rationale.
     pub fn can_use_tool(&self, tool_name: &str) -> bool {
         let trimmed = tool_name.trim();
+        let base = trimmed.split(':').next().unwrap_or(trimmed);
+
+        // Two-layer gate for the sub-agent family: even if `Tool(name)`
+        // is granted, the session also needs `Subagent`.
+        if is_subagent_tool(base) && !self.capabilities.contains(&Capability::Subagent) {
+            return false;
+        }
+
         if self
             .capabilities
             .contains(&Capability::Tool(trimmed.to_string()))
@@ -86,12 +128,10 @@ impl CapabilitySet {
             return true;
         }
         // Fall back to the base name before any colon separator.
-        if let Some(base) = trimmed.split(':').next() {
-            if base != trimmed {
-                return self
-                    .capabilities
-                    .contains(&Capability::Tool(base.to_string()));
-            }
+        if base != trimmed {
+            return self
+                .capabilities
+                .contains(&Capability::Tool(base.to_string()));
         }
         false
     }
@@ -178,5 +218,54 @@ mod tests {
         let caps = CapabilitySet::default_safe();
         assert!(!caps.can_use_tool("example_tool"));
         assert!(caps.has(&Capability::HttpRequest));
+    }
+
+    #[test]
+    fn subagent_tools_blocked_without_subagent_capability() {
+        // Even with `Tool("subagents")` granted, the session still needs
+        // `Subagent` to actually use it.
+        let caps = CapabilitySet::for_tools_permissive(&["subagents", "agents_list", "read"]);
+        assert!(!caps.can_use_tool("subagents"));
+        assert!(!caps.can_use_tool("agents_list"));
+        assert!(caps.can_use_tool("read"));
+    }
+
+    #[test]
+    fn subagent_tools_allowed_when_subagent_capability_granted() {
+        let mut caps = CapabilitySet::for_tools_permissive(&["subagents", "agents_list"]);
+        caps.grant(Capability::Subagent);
+        assert!(caps.can_use_tool("subagents"));
+        assert!(caps.can_use_tool("agents_list"));
+    }
+
+    #[test]
+    fn subagent_capability_alone_does_not_grant_other_tools() {
+        let mut caps = CapabilitySet::none();
+        caps.grant(Capability::Subagent);
+        // No `Tool(...)` grant, so still denied.
+        assert!(!caps.can_use_tool("subagents"));
+        assert!(!caps.can_use_tool("read"));
+    }
+
+    #[test]
+    fn all_session_tools_gated_by_subagent_capability() {
+        let names: Vec<&str> = SUBAGENT_TOOL_NAMES.to_vec();
+        let caps = CapabilitySet::for_tools_permissive(&names);
+        // Without Capability::Subagent, every tool in the family is denied.
+        for name in &names {
+            assert!(!caps.can_use_tool(name), "{name} should be denied");
+        }
+        // After granting, all are allowed.
+        let mut caps = caps;
+        caps.grant(Capability::Subagent);
+        for name in &names {
+            assert!(caps.can_use_tool(name), "{name} should be allowed");
+        }
+    }
+
+    #[test]
+    fn for_tools_permissive_does_not_grant_subagent() {
+        let caps = CapabilitySet::for_tools_permissive(&["subagents"]);
+        assert!(!caps.has(&Capability::Subagent));
     }
 }

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -16,7 +16,7 @@ pub use active_tools::{
     with_session_context, ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT,
 };
 pub use agent_def::{AgentDefinition, AgentRegistry};
-pub use capability::{Capability, CapabilitySet};
+pub use capability::{is_subagent_tool, Capability, CapabilitySet, SUBAGENT_TOOL_NAMES};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;
 pub use orchestration::{OrchestrationConfig, RecursiveCall, TaskComplexity, VoteResult};

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::AppState;
 use rustykrab_agent::{AgentEvent, AgentHandle, AgentRunner, OnMessageCallback};
-use rustykrab_core::capability::CapabilitySet;
+use rustykrab_core::capability::{Capability, CapabilitySet};
 use rustykrab_core::session::Session;
 use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
 use rustykrab_memory::types::{ConversationTurn, LifecycleStage, TurnMetadata};
@@ -230,6 +230,19 @@ fn build_memory_callback(state: &AppState, conv: &Conversation) -> Option<OnMess
 
 /// Shared setup: build system prompt, inject it, create session and runner.
 /// Returns `(AgentRunner, Session)`.
+/// Build the permissive capability set for an ephemeral session, honoring
+/// the gateway's `subagents_enabled` policy. Sub-agent tools require
+/// `Capability::Subagent` in addition to the per-tool grant, so we only
+/// add it when the gateway has been opted in (see
+/// `AppState::with_subagents_enabled`).
+fn build_session_capabilities(state: &AppState, tool_names: &[&str]) -> CapabilitySet {
+    let mut caps = CapabilitySet::for_tools_permissive(tool_names);
+    if state.subagents_enabled {
+        caps.grant(Capability::Subagent);
+    }
+    caps
+}
+
 async fn prepare_agent(
     state: &AppState,
     conv: &mut Conversation,
@@ -248,9 +261,10 @@ async fn prepare_agent(
     tracing::debug!(
         tool_count = tool_names.len(),
         tools = ?tool_names,
+        subagents_enabled = state.subagents_enabled,
         "granting session capabilities for available tools"
     );
-    let caps = CapabilitySet::for_tools_permissive(&tool_names);
+    let caps = build_session_capabilities(state, &tool_names);
     let session = Session::with_capabilities(conv.id, caps);
 
     // Resolve profile again for agent config (cheap — no LLM call on cache hit).
@@ -363,7 +377,7 @@ pub async fn run_agent_interactive(
             .filter(|t| t.available())
             .map(|t| t.name())
             .collect();
-        let caps = CapabilitySet::for_tools_permissive(&tool_names);
+        let caps = build_session_capabilities(state, &tool_names);
         let session = Session::with_capabilities(conv.id, caps);
 
         let profile = state.profile_for(user_content).await;

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -52,6 +52,11 @@ pub struct AppState {
     /// the `recall_*` tools so the agent can recover detail dropped by
     /// summarisation.
     pub recall: Arc<RecallStore>,
+    /// Whether sub-agent / session-management tools should be granted to
+    /// sessions created by this gateway. Default `false`. Driven by the
+    /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var at startup; threaded through
+    /// here so `prepare_agent` knows whether to grant `Capability::Subagent`.
+    pub subagents_enabled: bool,
 }
 
 impl AppState {
@@ -81,7 +86,16 @@ impl AppState {
             agent_id: None,
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall: Arc::new(RecallStore::new()),
+            subagents_enabled: false,
         }
+    }
+
+    /// Enable the sub-agent / session-management tool family for every
+    /// session created by this gateway. Driven by the
+    /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var in the CLI; off by default.
+    pub fn with_subagents_enabled(mut self, enabled: bool) -> Self {
+        self.subagents_enabled = enabled;
+        self
     }
 
     /// Attach the memory system and the agent identifier used for writes.


### PR DESCRIPTION
## Summary

Gates the `subagents` / `agents_list` / `sessions_*` tool family behind two independent layers, off by default. Today the family ships open to every session built by `prepare_agent` because `for_tools_permissive` grants `Capability::Tool(name)` for every registered tool indiscriminately — that's a real prompt-injection amplifier.

## Two layers

1. **Registration gate (env var).** The CLI reads `RUSTYKRAB_ENABLE_SUBAGENTS` at startup. Default is off — `session_tools(...)` is never called, `SubagentRunner` is never constructed, the schema is never sent.
2. **Capability gate (in-code).** A new `Capability::Subagent` variant is required *in addition to* the per-tool `Capability::Tool` grant for any name in the new `SUBAGENT_TOOL_NAMES` constant. `CapabilitySet::for_tools_permissive` deliberately does not grant it; the gateway's `prepare_agent` grants it only when `AppState::subagents_enabled` is true, which the CLI mirrors from the env var.

Single env var drives both layers today, but the capability layer gives us a seam for per-channel policy later (e.g. allow subagents on Telegram but not the WebChat REST API) without re-plumbing.

## Files

- `crates/rustykrab-core/src/capability.rs` — `Capability::Subagent`, `SUBAGENT_TOOL_NAMES`, `is_subagent_tool`, two-layer `can_use_tool` enforcement, 5 new tests.
- `crates/rustykrab-core/src/lib.rs` — re-export new symbols.
- `crates/rustykrab-gateway/src/state.rs` — `AppState::subagents_enabled` field + `with_subagents_enabled` builder.
- `crates/rustykrab-gateway/src/orchestrate.rs` — `build_session_capabilities` helper applied at both grant sites.
- `crates/rustykrab-cli/src/main.rs` — env-var read, conditional registration, plumb flag into `AppState`.

## Test plan

- [x] `cargo test -p rustykrab-core capability` — 10 tests pass, 5 new covering the gate:
  - `subagent_tools_blocked_without_subagent_capability`
  - `subagent_tools_allowed_when_subagent_capability_granted`
  - `subagent_capability_alone_does_not_grant_other_tools`
  - `all_session_tools_gated_by_subagent_capability` (covers every name in `SUBAGENT_TOOL_NAMES`)
  - `for_tools_permissive_does_not_grant_subagent`
- [x] `cargo test -p rustykrab-agent subagent` — existing 4 subagent tests untouched and pass.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rustykrab-core -p rustykrab-agent -p rustykrab-gateway --all-targets` — clean.
- [ ] Full workspace build — CI will validate; my local sandbox couldn't link `ort-sys` (network-blocked CDN, unrelated). Non-CLI crates all build.

## Behavior

- **Default** (env var unset): subagent tools are not registered, capability is not granted, model sees no subagent schemas. Tracing log says so at startup.
- **Enabled** (`RUSTYKRAB_ENABLE_SUBAGENTS=true`): tools registered, capability granted by `prepare_agent`, model can use them as before.
- **Half-on** (env var set but capability somehow missing): tools registered but `can_use_tool` filter denies them. Defense in depth.

https://claude.ai/code/session_01NNHfd1XAwMDcVPBWKdR7BB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHfd1XAwMDcVPBWKdR7BB)_