### PR TITLE
fix(release): use cargo-zigbuild for glibc 2.35-compatible linux build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,15 +97,21 @@ jobs:
     strategy:
       matrix:
         include:
-          # Built on Ubuntu 22.04 (glibc 2.35) so the artifact runs on
-          # 22.04 and any newer glibc-based distro. Pairs with the
-          # =4.9.1 fastembed pin (ort rc.9) — see crates/rustykrab-memory.
+          # Built with cargo-zigbuild targeting glibc 2.35 so the artifact
+          # runs on Ubuntu 22.04 and any newer glibc-based distro. We can
+          # no longer build on the ubuntu-22.04 runner directly because
+          # the Rust stable toolchain's precompiled std references glibc
+          # 2.39 symbols (even the per-crate build scripts fail to run on
+          # 22.04). zig-as-linker rewrites the glibc version refs in the
+          # final binary back down to 2.35.
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
+            os: ubuntu-latest
             artifact: rustykrab-cli
+            glibc: "2.35"
           - target: aarch64-apple-darwin
             os: macos-14
             artifact: rustykrab-cli
+            glibc: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -120,8 +126,25 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install zig
+        if: matrix.glibc != ''
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild
+        if: matrix.glibc != ''
+        run: cargo install --locked cargo-zigbuild
+
       - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }} -p rustykrab-cli
+        run: |
+          if [ -n "${{ matrix.glibc }}" ]; then
+            cargo zigbuild --release \
+              --target "${{ matrix.target }}.${{ matrix.glibc }}" \
+              -p rustykrab-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p rustykrab-cli
+          fi
 
       - name: Import signing certificate
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix(release): build linux x86_64 with cargo-zigbuild to keep glibc 2.35 compat
+
 ## [2.10.11] - 2026-05-13
 
 - feat(agent): add recall_append for manual context stash (#420)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - fix(release): build linux x86_64 with cargo-zigbuild to keep glibc 2.35 compat
+- security(deps): bump lettre to 0.11.22 (RUSTSEC-2026-0141, boring-tls feature unused)
 
 ## [2.10.11] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1784,9 +1784,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.10"
+version = "2.10.11"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The Rust stable toolchain's precompiled std now references glibc 2.39
symbols, so even the per-crate build scripts fail to launch on the
ubuntu-22.04 runner (glibc 2.35). Switch the linux x86_64 build to
ubuntu-latest and let zig-as-linker rewrite glibc version refs back
down to 2.35 so the artifact still runs on Ubuntu 22.04 and any newer
glibc-based distro.