### PR TITLE
fix(release): bootstrap rustup before build on macos-14 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,19 @@ jobs:
         with:
           ref: ${{ needs.bump.outputs.tag }}
 
+      # The macos-14 runner image ships Homebrew's `rustup-init` and a
+      # `cargo` shim that dispatches to it; calling `cargo build` then
+      # fails with "unexpected argument 'build'" because rustup-init is
+      # the installer, not the toolchain proxy. Bootstrap rustup via the
+      # official script so $HOME/.cargo/bin holds the real proxy binaries,
+      # and prepend it to PATH so subsequent steps pick them up.
+      - name: Bootstrap rustup (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain none --profile minimal --no-modify-path
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
The aarch64-apple-darwin release build started failing with:

    error: unexpected argument 'build' found
    Usage: rustup-init[EXE] [OPTIONS]

On the current macos-14 runner image, `cargo` resolves to Homebrew's
`rustup-init` installer rather than the real toolchain proxy, so
`cargo build` is interpreted as installer arguments and rejected.
`dtolnay/rust-toolchain@stable` doesn't override this PATH ordering.

Add an explicit step that runs the official rustup install script with
`--default-toolchain none --no-modify-path` and prepends
`$HOME/.cargo/bin` to GITHUB_PATH, so the real cargo proxy is picked up
for the subsequent build and codesign steps.