### PR TITLE
fix(cron): inject skill body into system prompt and force tool use on iter 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1784,9 +1784,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1784,9 +1784,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2946,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.15"
+version = "2.10.20"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext, SESSION_TOOL_CONTEXT};
 use rustykrab_core::capability::Capability;
-use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent};
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, ToolChoice};
 use rustykrab_core::recall::RecallStore;
 use rustykrab_core::session::Session;
 use rustykrab_core::types::{
@@ -573,6 +573,11 @@ pub struct AgentConfig {
     pub compaction_threshold_pct: f64,
     /// Strategy for when to call the LLM after tool results start arriving.
     pub llm_trigger_strategy: LlmTriggerStrategy,
+    /// When `true`, the first LLM call of the run is made with
+    /// `tool_choice = "any"`, forcing the model to invoke a tool instead
+    /// of producing a greeting/acknowledgement. Set for scheduled tasks
+    /// where the first turn must be action, not chat.
+    pub force_tool_use_first_iteration: bool,
 }
 
 impl Default for AgentConfig {
@@ -585,6 +590,7 @@ impl Default for AgentConfig {
             max_context_tokens: 128_000,
             compaction_threshold_pct: 0.85,
             llm_trigger_strategy: LlmTriggerStrategy::Debounce(Duration::from_secs(2)),
+            force_tool_use_first_iteration: false,
         }
     }
 }
@@ -880,13 +886,29 @@ impl AgentRunner {
             // iteration are reflected in the next API call.
             let schemas = self.compute_schemas(session, session.conversation_id);
 
+            // Iteration-0 guard for scheduled tasks: force the model to
+            // call a tool on the first turn so it can't reply with a bare
+            // greeting like "I'm ready" and burn the slot. Only safe when
+            // we actually have tools to choose from.
+            let tool_choice = if iteration == 0
+                && self.config.force_tool_use_first_iteration
+                && !schemas.is_empty()
+            {
+                ToolChoice::Any
+            } else {
+                ToolChoice::Auto
+            };
+
             let llm_start = std::time::Instant::now();
             let ModelResponse {
                 message,
                 usage,
                 stop_reason,
                 ..
-            } = self.provider.chat(&conv.messages, &schemas).await?;
+            } = self
+                .provider
+                .chat_with_choice(&conv.messages, &schemas, tool_choice)
+                .await?;
             let llm_elapsed = llm_start.elapsed();
             tracing::info!(
                 iteration,
@@ -894,6 +916,7 @@ impl AgentRunner {
                 prompt_tokens = usage.prompt_tokens,
                 completion_tokens = usage.completion_tokens,
                 ?stop_reason,
+                ?tool_choice,
                 "LLM call completed"
             );
 
@@ -1233,6 +1256,16 @@ impl AgentRunner {
             // iteration are reflected in the next API call.
             let schemas = self.compute_schemas(session, session.conversation_id);
 
+            // Iteration-0 guard: see run_inner for rationale.
+            let tool_choice = if iteration == 0
+                && self.config.force_tool_use_first_iteration
+                && !schemas.is_empty()
+            {
+                ToolChoice::Any
+            } else {
+                ToolChoice::Auto
+            };
+
             let llm_start = std::time::Instant::now();
             let ModelResponse {
                 message,
@@ -1241,7 +1274,7 @@ impl AgentRunner {
                 ..
             } = self
                 .provider
-                .chat_stream(&conv.messages, &schemas, &stream_callback)
+                .chat_stream_with_choice(&conv.messages, &schemas, tool_choice, &stream_callback)
                 .await?;
             let llm_elapsed = llm_start.elapsed();
             tracing::info!(
@@ -1250,6 +1283,7 @@ impl AgentRunner {
                 prompt_tokens = usage.prompt_tokens,
                 completion_tokens = usage.completion_tokens,
                 ?stop_reason,
+                ?tool_choice,
                 "LLM call completed"
             );
 
@@ -3346,5 +3380,170 @@ mod response_classification_tests {
             Option A is the simplest because the integration surface is small \
             and the team already understands the moving parts.";
         assert_complete(text);
+    }
+}
+
+#[cfg(test)]
+mod tool_choice_guard_tests {
+    //! Tests for the iteration-0 force-tool-use guard used by cron tasks.
+    use super::*;
+
+    use async_trait::async_trait;
+    use rustykrab_core::capability::CapabilitySet;
+    use rustykrab_core::model::{ModelResponse, StopReason, Usage};
+    use rustykrab_core::types::ToolSchema;
+    use std::sync::Mutex;
+
+    use crate::sandbox::NoSandbox;
+
+    /// Provider that records the `ToolChoice` of every call so tests can
+    /// assert which iteration saw which choice.
+    struct RecordingProvider {
+        choices: Mutex<Vec<ToolChoice>>,
+    }
+
+    impl RecordingProvider {
+        fn new() -> Self {
+            Self {
+                choices: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for RecordingProvider {
+        fn name(&self) -> &str {
+            "recording-mock"
+        }
+
+        async fn chat(&self, _: &[Message], _: &[ToolSchema]) -> Result<ModelResponse> {
+            self.choices.lock().unwrap().push(ToolChoice::Auto);
+            Ok(canned_response())
+        }
+
+        async fn chat_with_choice(
+            &self,
+            _: &[Message],
+            _: &[ToolSchema],
+            choice: ToolChoice,
+        ) -> Result<ModelResponse> {
+            self.choices.lock().unwrap().push(choice);
+            Ok(canned_response())
+        }
+    }
+
+    fn canned_response() -> ModelResponse {
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text("Done.".into()),
+                created_at: Utc::now(),
+            },
+            usage: Usage::default(),
+            stop_reason: StopReason::EndTurn,
+            text: None,
+        }
+    }
+
+    /// Minimal no-op tool so `compute_schemas` returns a non-empty list —
+    /// the guard skips itself when there are no tools to choose from.
+    struct DummyTool;
+
+    #[async_trait]
+    impl Tool for DummyTool {
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn description(&self) -> &str {
+            "dummy tool for tests"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "dummy".into(),
+                description: "dummy".into(),
+                parameters: serde_json::json!({}),
+            }
+        }
+        async fn execute(&self, _args: serde_json::Value) -> Result<serde_json::Value> {
+            Ok(serde_json::json!({}))
+        }
+    }
+
+    fn make_conversation() -> Conversation {
+        Conversation {
+            id: Uuid::new_v4(),
+            messages: vec![Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text("Do the scheduled thing.".into()),
+                created_at: Utc::now(),
+            }],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            summary: None,
+            detected_profile: None,
+            channel_source: None,
+            channel_id: None,
+            channel_thread_id: None,
+        }
+    }
+
+    fn make_runner(provider: Arc<RecordingProvider>, force: bool) -> (AgentRunner, Session) {
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(DummyTool)];
+        let config = AgentConfig {
+            force_tool_use_first_iteration: force,
+            ..AgentConfig::default()
+        };
+        let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
+            .with_config(config)
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["dummy"]);
+        let caps = CapabilitySet::for_tools_permissive(&["dummy"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        (runner, session)
+    }
+
+    #[tokio::test]
+    async fn iteration_zero_forces_any_when_flag_set() {
+        let provider = Arc::new(RecordingProvider::new());
+        let (runner, session) = make_runner(provider.clone(), true);
+        let mut conv = make_conversation();
+        // Override conv.id to match the session's so capabilities apply.
+        conv.id = session.conversation_id;
+
+        runner
+            .run(&mut conv, &session)
+            .await
+            .expect("agent loop should complete");
+
+        let choices = provider.choices.lock().unwrap();
+        assert_eq!(
+            choices.first().copied(),
+            Some(ToolChoice::Any),
+            "iteration 0 must use ToolChoice::Any when flag is set; got {choices:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn iteration_zero_stays_auto_when_flag_unset() {
+        let provider = Arc::new(RecordingProvider::new());
+        let (runner, session) = make_runner(provider.clone(), false);
+        let mut conv = make_conversation();
+        conv.id = session.conversation_id;
+
+        runner
+            .run(&mut conv, &session)
+            .await
+            .expect("agent loop should complete");
+
+        let choices = provider.choices.lock().unwrap();
+        assert_eq!(
+            choices.first().copied(),
+            Some(ToolChoice::Auto),
+            "iteration 0 must use ToolChoice::Auto by default; got {choices:?}"
+        );
     }
 }

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -240,19 +240,20 @@ async fn execute_cron_task(
         }
     }
 
-    // If the task body is the bare name of a registered SKILL.md skill,
-    // inline its body into the prompt so the model executes the recipe
-    // directly instead of spinning through tool-discovery iterations to
-    // figure out it should call `skills.load`. Operators commonly schedule
-    // jobs with `task = "morning-briefing"`; that string alone gives the
-    // model nothing to do without a tool round-trip. With the body inlined,
-    // the first turn produces output.
+    // If the task body references a registered SKILL.md skill, resolve
+    // it so orchestrate.rs can inject the full recipe into the system
+    // prompt. The body in `system` is authoritative, cached across
+    // iterations, and clearly framed as guidance — versus stuffing it
+    // into the user message where the model treats it as conversational
+    // content. Operators commonly schedule jobs with `task = "morning-briefing"`,
+    // and without the body the model would have to make a tool round-trip
+    // before doing any real work.
     let resolved_skill = resolve_skill_for_task(&state.skill_registry, task_prompt);
     if let Some((ref name, _)) = resolved_skill {
         tracing::info!(
             job_id = %job_id,
             skill = %name,
-            "inlining SKILL.md body into scheduled-task prompt"
+            "injecting SKILL.md body into system prompt for scheduled task"
         );
     }
 
@@ -261,19 +262,30 @@ async fn execute_cron_task(
         job.last_run_at,
         effective_channel.as_deref(),
         effective_chat_id.as_deref(),
-        resolved_skill
-            .as_ref()
-            .map(|(n, b)| (n.as_str(), b.as_str())),
     );
+
+    let run_options = rustykrab_gateway::RunOptions {
+        active_skill: resolved_skill,
+        // Cron tasks must call a tool on iteration 0 — a bare "I'm ready"
+        // reply is never the deliverable, and the model would otherwise
+        // burn the slot.
+        force_tool_use_first_iteration: true,
+    };
 
     // Run the agent. Mint a fresh trace id per scheduled run so prompt-log
     // rows and agent logs for this job line up.
     let trace_id = Uuid::new_v4();
     tracing::info!(%trace_id, job_id = %job.id, "scheduled task starting");
     let no_op_event = |_event: AgentEvent| {};
-    let result =
-        rustykrab_gateway::run_agent_streaming(state, &mut conv, &prompt, &no_op_event, trace_id)
-            .await;
+    let result = rustykrab_gateway::run_agent_streaming_with_options(
+        state,
+        &mut conv,
+        &prompt,
+        &no_op_event,
+        trace_id,
+        &run_options,
+    )
+    .await;
 
     let (status, response_text) = match result {
         Ok(msg) => match &msg.content {
@@ -434,7 +446,6 @@ fn build_scheduled_prompt(
     last_run_at: Option<chrono::DateTime<chrono::Utc>>,
     channel: Option<&str>,
     chat_id: Option<&str>,
-    skill: Option<(&str, &str)>,
 ) -> String {
     let delivery = match (channel, chat_id) {
         (Some(c), Some(id)) => format!(
@@ -461,16 +472,7 @@ fn build_scheduled_prompt(
              Task: {task_prompt}"
         ),
     };
-    let skill_block = match skill {
-        Some((name, skill_body)) => format!(
-            "\n\nThe task names the skill `{name}`. Execute the recipe below for \
-             this turn — you do NOT need to call the `skills` tool to load it; the \
-             body is included here.\n\n\
-             <skill_instructions name=\"{name}\">\n{skill_body}\n</skill_instructions>"
-        ),
-        None => String::new(),
-    };
-    format!("{body}{skill_block}\n\n{delivery}")
+    format!("{body}\n\n{delivery}")
 }
 
 /// If `task_prompt` references a registered SKILL.md skill, return
@@ -686,7 +688,6 @@ mod tests {
             None,
             Some("telegram"),
             Some("12345"),
-            None,
         );
         assert!(prompt.contains("first time"));
         assert!(prompt.contains("Task: Write the daily briefing."));
@@ -697,7 +698,7 @@ mod tests {
     #[test]
     fn scheduled_prompt_recurring_includes_last_run() {
         let last = Utc.with_ymd_and_hms(2026, 4, 30, 9, 0, 0).unwrap();
-        let prompt = build_scheduled_prompt("Daily briefing.", Some(last), None, None, None);
+        let prompt = build_scheduled_prompt("Daily briefing.", Some(last), None, None);
         assert!(prompt.contains("due again"));
         assert!(prompt.contains("Last run was at 2026-04-30 09:00:00 UTC"));
         // No channel info → still tells the model the message IS the deliverable.
@@ -705,34 +706,14 @@ mod tests {
     }
 
     #[test]
-    fn scheduled_prompt_inlines_skill_body_when_provided() {
-        let body = "Step 1: gmail.search.\nStep 2: web_search.\nStep 3: assemble briefing.";
-        let prompt = build_scheduled_prompt(
-            "morning-briefing",
-            None,
-            Some("telegram"),
-            Some("99"),
-            Some(("morning-briefing", body)),
-        );
-        // The skill body must appear verbatim so the model can execute it
-        // without an extra `skills` tool round-trip.
-        assert!(
-            prompt.contains("<skill_instructions name=\"morning-briefing\">"),
-            "expected skill_instructions block in prompt: {prompt}"
-        );
-        assert!(prompt.contains("Step 1: gmail.search."));
-        assert!(prompt.contains("Step 3: assemble briefing."));
-        // And the prompt should explicitly tell the model NOT to call the
-        // skills tool — the body is already there.
-        assert!(prompt.contains("do NOT need to call the `skills` tool"));
-    }
-
-    #[test]
-    fn scheduled_prompt_omits_skill_block_when_none() {
-        let prompt = build_scheduled_prompt("Just do the thing", None, None, None, None);
+    fn scheduled_prompt_does_not_inline_skill_body() {
+        // Skill bodies are injected into the *system* prompt by
+        // orchestrate.rs::build_and_inject_system_prompt, not the user
+        // message. The user message stays small and uniform.
+        let prompt = build_scheduled_prompt("morning-briefing", None, Some("telegram"), Some("99"));
         assert!(
             !prompt.contains("<skill_instructions"),
-            "should not emit skill block when no skill resolved: {prompt}"
+            "user prompt should not embed skill_instructions: {prompt}"
         );
     }
 

--- a/crates/rustykrab-core/src/model.rs
+++ b/crates/rustykrab-core/src/model.rs
@@ -49,6 +49,20 @@ pub enum StreamEvent {
     Done(ModelResponse),
 }
 
+/// Constraint on whether the model must call a tool on this turn.
+///
+/// Providers that don't support a native tool_choice parameter fall back
+/// to the unconstrained behavior — the runner can still rely on a normal
+/// response and re-prompt on the next iteration if it wanted tool use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolChoice {
+    /// Model decides whether to call a tool.
+    #[default]
+    Auto,
+    /// Model MUST call at least one of the supplied tools (Anthropic: `{"type":"any"}`).
+    Any,
+}
+
 /// Trait implemented by every model provider (e.g. Anthropic, OpenAI).
 #[async_trait]
 pub trait ModelProvider: Send + Sync {
@@ -80,6 +94,20 @@ pub trait ModelProvider: Send + Sync {
     /// Send a conversation to the model and get back the next message.
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse>;
 
+    /// Send a conversation to the model with an explicit tool-choice constraint.
+    ///
+    /// Default implementation ignores the constraint and calls [`chat`].
+    /// Providers that natively support `tool_choice` (e.g. Anthropic)
+    /// should override this to forward the constraint to the API.
+    async fn chat_with_choice(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        _choice: ToolChoice,
+    ) -> Result<ModelResponse> {
+        self.chat(messages, tools).await
+    }
+
     /// Stream a response, sending chunks through the callback.
     ///
     /// Default implementation falls back to non-streaming `chat()`.
@@ -97,5 +125,18 @@ pub trait ModelProvider: Send + Sync {
         }
         on_event(StreamEvent::Done(response.clone()));
         Ok(response)
+    }
+
+    /// Stream a response with an explicit tool-choice constraint.
+    ///
+    /// Default implementation ignores the constraint and calls [`chat_stream`].
+    async fn chat_stream_with_choice(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        _choice: ToolChoice,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        self.chat_stream(messages, tools, on_event).await
     }
 }

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -10,7 +10,10 @@ mod telegram_webhook;
 mod webchat;
 
 pub use auth::generate_token;
-pub use orchestrate::{run_agent, run_agent_interactive, run_agent_streaming};
+pub use orchestrate::{
+    run_agent, run_agent_interactive, run_agent_streaming, run_agent_streaming_with_options,
+    run_agent_with_options, RunOptions,
+};
 pub use origin::OriginPolicy;
 pub use rate_limit::RateLimitConfig;
 pub use state::AppState;

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -16,11 +16,29 @@ use rustykrab_memory::types::{ConversationTurn, LifecycleStage, TurnMetadata};
 use rustykrab_memory::MemorySystem;
 use rustykrab_skills::SystemPromptBuilder;
 
+/// Optional knobs for an agent run. Most callers (HTTP, channels) use
+/// `RunOptions::default()`; the cron scheduler uses these to inject a
+/// SKILL.md body into the system prompt and force tool use on the first
+/// iteration.
+#[derive(Debug, Clone, Default)]
+pub struct RunOptions {
+    /// When set, `(name, body)` is wrapped in `<skill_instructions>` and
+    /// appended to the system prompt so the model has the full recipe
+    /// from turn 0 without a `skills`-tool round-trip.
+    pub active_skill: Option<(String, String)>,
+    /// When `true`, the runner makes its first LLM call with
+    /// `tool_choice = "any"`, forcing the model to invoke a tool. Used
+    /// for scheduled tasks so the model can't waste the slot on a
+    /// greeting.
+    pub force_tool_use_first_iteration: bool,
+}
+
 /// Build the system prompt and inject it as the first message in the conversation.
 async fn build_and_inject_system_prompt(
     state: &AppState,
     conv: &mut Conversation,
     user_content: &str,
+    options: &RunOptions,
 ) {
     // 1. Resolve the harness profile (for agent loop config, not prompt injection).
     let profile = state.profile_for(user_content).await;
@@ -63,6 +81,16 @@ async fn build_and_inject_system_prompt(
     if !satisfied.is_empty() {
         let refs: Vec<&rustykrab_skills::SkillMd> = satisfied.iter().map(|s| s.as_ref()).collect();
         builder = builder.with_available_skills(&refs);
+    }
+
+    // When the caller (cron) has pre-resolved a SKILL.md for this run,
+    // inline its full body into the system prompt. The skill recipe is
+    // instructions, not data — placing it in `system` rather than the
+    // user message keeps it cached across iterations and clearly framed
+    // as authoritative guidance for the model.
+    if let Some((name, body)) = options.active_skill.as_ref() {
+        tracing::info!(skill = %name, "injecting skill body into system prompt");
+        builder = builder.with_active_skill(name, body);
     }
 
     let mut system_prompt = builder.build();
@@ -206,8 +234,9 @@ async fn prepare_agent(
     state: &AppState,
     conv: &mut Conversation,
     user_content: &str,
+    options: &RunOptions,
 ) -> Result<(AgentRunner, Session), StatusCode> {
-    build_and_inject_system_prompt(state, conv, user_content).await;
+    build_and_inject_system_prompt(state, conv, user_content, options).await;
 
     // Create an ephemeral session with capabilities for available registered tools.
     let tool_names: Vec<&str> = state
@@ -227,12 +256,15 @@ async fn prepare_agent(
     // Resolve profile again for agent config (cheap — no LLM call on cache hit).
     let profile = state.profile_for(user_content).await;
 
+    let mut agent_config = profile.to_agent_config();
+    agent_config.force_tool_use_first_iteration = options.force_tool_use_first_iteration;
+
     let mut runner = AgentRunner::new(
         state.provider.clone(),
         state.tools.clone(),
         state.sandbox.clone(),
     )
-    .with_config(profile.to_agent_config())
+    .with_config(agent_config)
     .with_active_tools(state.active_tools.clone())
     .with_recall_store(state.recall.clone());
 
@@ -277,8 +309,19 @@ pub async fn run_agent(
     user_content: &str,
     trace_id: Uuid,
 ) -> Result<Message, StatusCode> {
+    run_agent_with_options(state, conv, user_content, trace_id, &RunOptions::default()).await
+}
+
+/// Like [`run_agent`] but accepts caller-supplied [`RunOptions`].
+pub async fn run_agent_with_options(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    trace_id: Uuid,
+    options: &RunOptions,
+) -> Result<Message, StatusCode> {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
-        let (runner, session) = prepare_agent(state, conv, user_content).await?;
+        let (runner, session) = prepare_agent(state, conv, user_content, options).await?;
 
         runner.run(conv, &session).await.map_err(|e| {
             tracing::error!(%trace_id, "agent error: {e}");
@@ -311,7 +354,8 @@ pub async fn run_agent_interactive(
     StatusCode,
 > {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
-        build_and_inject_system_prompt(state, &mut conv, user_content).await;
+        build_and_inject_system_prompt(state, &mut conv, user_content, &RunOptions::default())
+            .await;
 
         let tool_names: Vec<&str> = state
             .tools
@@ -349,8 +393,28 @@ pub async fn run_agent_streaming(
     on_event: &(dyn Fn(AgentEvent) + Send + Sync),
     trace_id: Uuid,
 ) -> Result<Message, StatusCode> {
+    run_agent_streaming_with_options(
+        state,
+        conv,
+        user_content,
+        on_event,
+        trace_id,
+        &RunOptions::default(),
+    )
+    .await
+}
+
+/// Like [`run_agent_streaming`] but accepts caller-supplied [`RunOptions`].
+pub async fn run_agent_streaming_with_options(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    trace_id: Uuid,
+    options: &RunOptions,
+) -> Result<Message, StatusCode> {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
-        let (runner, session) = prepare_agent(state, conv, user_content).await?;
+        let (runner, session) = prepare_agent(state, conv, user_content, options).await?;
 
         runner
             .run_streaming(conv, &session, on_event)

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 use chrono::Utc;
 use rustykrab_core::error::Result;
-use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
+use rustykrab_core::model::{
+    ModelProvider, ModelResponse, StopReason, StreamEvent, ToolChoice, Usage,
+};
 use rustykrab_core::types::{
     ContentBlock as CoreContentBlock, Message, MessageContent, Role, ToolCall, ToolSchema,
 };
@@ -284,37 +286,24 @@ impl AnthropicProvider {
         })
     }
 
-    /// Map an HTTP status code to a specific error variant (#186).
-    fn map_status_error(status: reqwest::StatusCode, body: &str) -> Error {
-        match status.as_u16() {
-            400 => Error::ModelBadRequest(format!("Anthropic API: {body}")),
-            401 | 403 => Error::ModelAuthError(format!("Anthropic API: {body}")),
-            429 => Error::ModelRateLimit(format!("Anthropic API: {body}")),
-            529 => Error::ModelOverloaded(format!("Anthropic API: {body}")),
-            _ => Error::ModelProvider(format!("Anthropic API returned {status}: {body}")),
+    /// Translate our `ToolChoice` into the JSON shape Anthropic expects.
+    ///
+    /// Returns `None` for `Auto` — omitting the field lets the model
+    /// decide, matching the API's default behavior.
+    fn tool_choice_json(choice: ToolChoice) -> Option<serde_json::Value> {
+        match choice {
+            ToolChoice::Auto => None,
+            ToolChoice::Any => Some(serde_json::json!({ "type": "any" })),
         }
     }
-}
 
-#[async_trait]
-impl ModelProvider for AnthropicProvider {
-    fn name(&self) -> &str {
-        "anthropic"
-    }
-
-    fn context_limit(&self) -> Option<usize> {
-        Some(self.context_limit)
-    }
-
-    fn supports_vision(&self) -> bool {
-        true
-    }
-
-    fn requires_paired_tool_results(&self) -> bool {
-        true
-    }
-
-    async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+    /// Underlying chat implementation shared by `chat` and `chat_with_choice`.
+    async fn chat_inner(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        tool_choice: ToolChoice,
+    ) -> Result<ModelResponse> {
         let (system, api_messages) = Self::build_messages(messages)?;
 
         // Fix #200: validate that the message list is not empty before calling the API.
@@ -338,11 +327,17 @@ impl ModelProvider for AnthropicProvider {
         }
         if !api_tools.is_empty() {
             body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
+            // tool_choice is only meaningful when tools are supplied; the API
+            // rejects the field otherwise.
+            if let Some(tc) = Self::tool_choice_json(tool_choice) {
+                body["tool_choice"] = tc;
+            }
         }
 
         tracing::debug!(
             model = %self.model,
             trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
+            ?tool_choice,
             "calling Anthropic Messages API"
         );
         rustykrab_core::prompt_trace::record_prompt(
@@ -437,11 +432,79 @@ impl ModelProvider for AnthropicProvider {
         Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
     }
 
+    /// Map an HTTP status code to a specific error variant (#186).
+    fn map_status_error(status: reqwest::StatusCode, body: &str) -> Error {
+        match status.as_u16() {
+            400 => Error::ModelBadRequest(format!("Anthropic API: {body}")),
+            401 | 403 => Error::ModelAuthError(format!("Anthropic API: {body}")),
+            429 => Error::ModelRateLimit(format!("Anthropic API: {body}")),
+            529 => Error::ModelOverloaded(format!("Anthropic API: {body}")),
+            _ => Error::ModelProvider(format!("Anthropic API returned {status}: {body}")),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProvider for AnthropicProvider {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    fn context_limit(&self) -> Option<usize> {
+        Some(self.context_limit)
+    }
+
+    fn supports_vision(&self) -> bool {
+        true
+    }
+
+    fn requires_paired_tool_results(&self) -> bool {
+        true
+    }
+
+    async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+        self.chat_inner(messages, tools, ToolChoice::Auto).await
+    }
+
+    async fn chat_with_choice(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        choice: ToolChoice,
+    ) -> Result<ModelResponse> {
+        self.chat_inner(messages, tools, choice).await
+    }
+
     /// Fix #175: streaming implementation using Anthropic SSE.
     async fn chat_stream(
         &self,
         messages: &[Message],
         tools: &[ToolSchema],
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        self.chat_stream_inner(messages, tools, ToolChoice::Auto, on_event)
+            .await
+    }
+
+    async fn chat_stream_with_choice(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        choice: ToolChoice,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        self.chat_stream_inner(messages, tools, choice, on_event)
+            .await
+    }
+}
+
+impl AnthropicProvider {
+    /// Streaming chat shared by `chat_stream` and `chat_stream_with_choice`.
+    async fn chat_stream_inner(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        tool_choice: ToolChoice,
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ModelResponse> {
         let (system, api_messages) = Self::build_messages(messages)?;
@@ -466,11 +529,16 @@ impl ModelProvider for AnthropicProvider {
         }
         if !api_tools.is_empty() {
             body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
+            // tool_choice requires at least one tool; skip otherwise.
+            if let Some(tc) = Self::tool_choice_json(tool_choice) {
+                body["tool_choice"] = tc;
+            }
         }
 
         tracing::debug!(
             model = %self.model,
             trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
+            ?tool_choice,
             "calling Anthropic Messages API (streaming)"
         );
         rustykrab_core::prompt_trace::record_prompt(
@@ -918,4 +986,20 @@ struct SseMessageDeltaInfo {
 #[derive(Deserialize)]
 struct SseDeltaUsage {
     output_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_choice_auto_emits_no_field() {
+        assert!(AnthropicProvider::tool_choice_json(ToolChoice::Auto).is_none());
+    }
+
+    #[test]
+    fn tool_choice_any_emits_any_type() {
+        let v = AnthropicProvider::tool_choice_json(ToolChoice::Any).expect("Any → Some");
+        assert_eq!(v, serde_json::json!({ "type": "any" }));
+    }
 }


### PR DESCRIPTION
Scheduled tasks that referenced a SKILL.md previously stuffed the recipe
into the user message, where the model treated it as conversational
content and often greeted the operator instead of executing. Move the
inlining into the system prompt via `SystemPromptBuilder::with_active_skill`,
and add an iteration-0 guard that forces `tool_choice: "any"` on the first
LLM call of a cron run so the model must invoke a tool rather than
producing an "I'm ready" reply.

- Add `ToolChoice` enum + `chat_with_choice`/`chat_stream_with_choice`
  on the `ModelProvider` trait (default impls delegate to existing
  methods; Anthropic overrides to set `tool_choice` in the request body).
- Add `force_tool_use_first_iteration` to `AgentConfig`; the runner sets
  `ToolChoice::Any` on iteration 0 when the flag is set and at least one
  tool is available.
- Add `RunOptions` and `run_agent{,_streaming}_with_options` in the
  gateway so callers can request the system-prompt skill injection and
  the iteration-0 guard.
- Wire both through the cron task queue.