### PR TITLE
fix(release): vendor openssl-sys for cargo-zigbuild Linux build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2196,7 @@ checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2975,7 +2985,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,12 +3090,13 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-trait",
  "chrono",
  "fastembed",
  "hex",
+ "openssl-sys",
  "regex",
  "rusqlite",
  "rustykrab-core",
@@ -3101,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.11"
+version = "2.10.14"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-memory/Cargo.toml
+++ b/crates/rustykrab-memory/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [features]
 default = []
-fastembed = ["dep:fastembed"]
+fastembed = ["dep:fastembed", "dep:openssl-sys"]
 
 [dependencies]
 rustykrab-core.workspace = true
@@ -40,6 +40,14 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 # posture (rustls everywhere via lettre/reqwest, per 7054b18) is
 # unaffected. Re-evaluate once pykeio/ort#523 is resolved upstream.
 fastembed = { version = "=5.8.0", optional = true, default-features = false, features = ["ort-download-binaries", "hf-hub-rustls-tls"] }
+# Cargo unifies features across the dep graph, so enabling `vendored` here
+# forces the openssl-sys pulled in by ureq → native-tls (above) to build
+# bundled OpenSSL instead of probing the host's headers. Without this,
+# cargo-zigbuild's CC wrapper for the glibc 2.35 cross build can't locate
+# Ubuntu's multiarch `openssl/opensslconf.h` and the build fails. Gated
+# behind the `fastembed` feature so we only pay the build cost when the
+# transitive openssl-sys is actually in the graph.
+openssl-sys = { version = "0.9", features = ["vendored"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
After #426 fixed the macOS leg, the `x86_64-unknown-linux-gnu` release build now fails on `openssl-sys`:

```
/usr/include/openssl/macros.h:14:10: fatal error: 'openssl/opensslconf.h' file not found
```

`openssl-sys` is in the dep graph because `ort-sys` (via `fastembed`'s `ort-download-binaries` feature) pulls in `ureq → native-tls → openssl-sys` in its build script, just to fetch the prebuilt ort tarball. cargo-zigbuild's CC wrapper for the glibc 2.35 cross-compile doesn't include Ubuntu's multiarch include path, so the host's `openssl/opensslconf.h` (which lives at `/usr/include/x86_64-linux-gnu/openssl/`) can't be resolved.

## Fix

Add an explicit `openssl-sys = { features = ["vendored"] }` dep to `rustykrab-memory`, gated behind the `fastembed` feature. Cargo unifies features across the dep graph, so this forces the transitive `openssl-sys` to build bundled OpenSSL from source — no host headers required.

This is build-time only, just like the existing native-tls dependency: the final binary doesn't link against OpenSSL (runtime TLS is rustls everywhere, per `7054b18`). The `openssl-src` cost is only paid when the `fastembed` feature is on, which is when `openssl-sys` is in the graph anyway.

## Test plan

- [ ] Release workflow's `Build (x86_64-unknown-linux-gnu)` job compiles past `openssl-sys`
- [ ] Release workflow's `Build (aarch64-apple-darwin)` job still passes
- [ ] `cargo check --workspace` on a normal Linux host still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmQ5bvWik5RUUFnjjNY6Bm)_