### PR TITLE
fix(release): pass multiarch CFLAGS for openssl-sys zigbuild probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,14 @@ jobs:
         run: cargo install --locked cargo-zigbuild
 
       - name: Build release binary
+        env:
+          # cargo-zigbuild's zigcc wrapper doesn't include Ubuntu's
+          # multiarch include path (/usr/include/x86_64-linux-gnu) that
+          # GCC adds automatically. openssl-sys's build-script probe
+          # (a transitive build-dep of ort-sys via ureq → native-tls)
+          # needs that path to find `openssl/opensslconf.h`. Pass it
+          # explicitly via CFLAGS only on the Linux cross-build leg.
+          CFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-I/usr/include/x86_64-linux-gnu' || '' }}
         run: |
           if [ -n "${{ matrix.glibc }}" ]; then
             cargo zigbuild --release \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,15 +2180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,7 +2187,6 @@ checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2985,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3002,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3023,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3052,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3066,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "axum",
  "chrono",
@@ -3090,13 +3080,12 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-trait",
  "chrono",
  "fastembed",
  "hex",
- "openssl-sys",
  "regex",
  "rusqlite",
  "rustykrab-core",
@@ -3112,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3129,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3145,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3168,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.14"
+version = "2.10.15"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-memory/Cargo.toml
+++ b/crates/rustykrab-memory/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [features]
 default = []
-fastembed = ["dep:fastembed", "dep:openssl-sys"]
+fastembed = ["dep:fastembed"]
 
 [dependencies]
 rustykrab-core.workspace = true
@@ -40,14 +40,6 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 # posture (rustls everywhere via lettre/reqwest, per 7054b18) is
 # unaffected. Re-evaluate once pykeio/ort#523 is resolved upstream.
 fastembed = { version = "=5.8.0", optional = true, default-features = false, features = ["ort-download-binaries", "hf-hub-rustls-tls"] }
-# Cargo unifies features across the dep graph, so enabling `vendored` here
-# forces the openssl-sys pulled in by ureq → native-tls (above) to build
-# bundled OpenSSL instead of probing the host's headers. Without this,
-# cargo-zigbuild's CC wrapper for the glibc 2.35 cross build can't locate
-# Ubuntu's multiarch `openssl/opensslconf.h` and the build fails. Gated
-# behind the `fastembed` feature so we only pay the build cost when the
-# transitive openssl-sys is actually in the graph.
-openssl-sys = { version = "0.9", features = ["vendored"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Why the previous fix didn't work

PR #429 tried to fix the Linux build by declaring `openssl-sys` as a normal-dep of `rustykrab-memory` with the `vendored` feature. Cargo did download `openssl-src`, but the build still failed in the same spot, because **under resolver v2, normal-deps and build-deps don't share features**. The failing `openssl-sys` is in the build-deps graph (`ort-sys → ureq → native-tls → openssl-sys`), so the `vendored` feature declared on the normal-deps copy never reached the build-script copy.

## Actual problem

cargo-zigbuild's `zigcc` wrapper invokes its own clang-based driver, which does not include Ubuntu's multiarch include path that real GCC adds automatically:

```
"-I" "/usr/include" -E build/expando.c
/usr/include/openssl/macros.h:14:10: fatal error: 'openssl/opensslconf.h' file not found
```

On Ubuntu, `opensslconf.h` lives at `/usr/include/x86_64-linux-gnu/openssl/opensslconf.h`, not under `/usr/include/openssl/`. Real GCC searches `/usr/include/x86_64-linux-gnu` as part of its multiarch resolution; zigcc doesn't.

## Fix

1. Revert the ineffective `openssl-sys` normal-dep with `vendored` from `rustykrab-memory/Cargo.toml`.
2. In the release workflow's `Build release binary` step, set `CFLAGS=-I/usr/include/x86_64-linux-gnu` only on the `x86_64-unknown-linux-gnu` matrix entry. The `cc` crate picks up `CFLAGS`, so all C probes (including `openssl-sys`'s `expando.c`) get the multiarch path.

This keeps the runtime TLS posture (rustls everywhere) untouched — the workaround is purely a build-time include-path hint scoped to the Linux release leg.

## Test plan

- [ ] Release workflow's `Build (x86_64-unknown-linux-gnu)` job compiles past `openssl-sys`
- [ ] Release workflow's `Build (aarch64-apple-darwin)` job still passes (no CFLAGS applied)
- [ ] Normal `cargo build` on Linux dev hosts remains unaffected (CFLAGS only set in CI step)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmQ5bvWik5RUUFnjjNY6Bm)_