### PR TITLE
fix(release): add multiarch lib path so zig lld finds libstdc++

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,11 @@ jobs:
           # needs that path to find `openssl/opensslconf.h`. Pass it
           # explicitly via CFLAGS only on the Linux cross-build leg.
           CFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-I/usr/include/x86_64-linux-gnu' || '' }}
+          # The ort-sys prebuilt onnxruntime archive references libstdc++
+          # symbols and expects the linker to resolve them dynamically via
+          # `-lstdc++`. zig's lld doesn't search Ubuntu's multiarch lib
+          # path on its own, so add it explicitly for the Linux leg.
+          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-L/usr/lib/x86_64-linux-gnu' || '' }}
         run: |
           if [ -n "${{ matrix.glibc }}" ]; then
             cargo zigbuild --release \


### PR DESCRIPTION
## Diagnosis

After the CFLAGS fix from #430, openssl-sys compiled cleanly and the build reached the final link step. The failure now is at the link with thousands of undefined libstdc++ symbols pulled in by the prebuilt onnxruntime archive bundled in ort-sys:

```
ld.lld: error: undefined symbol: vtable for std::basic_ios<char, std::char_traits<char>>
ld.lld: error: undefined symbol: std::__cxx11::basic_string<char, ...>::_M_replace(...)
... 5000+ more
```

The link command has `-lstdc++` and is using zig's lld:

```
"-Wl,-Bdynamic" "-lstdc++" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc"
"-fuse-ld=lld"
```

But lld only searches its own bundled sysroot and any explicitly added `-L` paths. Unlike real GCC, it doesn't auto-add `/usr/lib/x86_64-linux-gnu` (where Ubuntu's `libstdc++.so.6` actually lives), so `-lstdc++` can't be resolved.

## Fix

Add `-L/usr/lib/x86_64-linux-gnu` to RUSTFLAGS, gated to the Linux matrix entry only. The flag reaches the linker via `-C link-arg=`, lld picks up libstdc++.so.6 from the ubuntu-latest runner, and the resulting binary dynamically links against libstdc++ at runtime (which any glibc-2.35+ system already has).

The macOS leg is unaffected — the conditional yields an empty RUSTFLAGS there.

## Test plan

- [ ] Release workflow's `Build (x86_64-unknown-linux-gnu)` job links successfully
- [ ] Resulting `rustykrab-cli` runs on a fresh Ubuntu 22.04 box (target glibc 2.35)
- [ ] aarch64-apple-darwin leg still passes (no RUSTFLAGS applied)

## Follow-up risk

The runner is ubuntu-latest (currently 24/26-era), so the linked libstdc++ may reference newer `GLIBCXX_*` version tags than what's on Ubuntu 22.04. If the binary fails to load on 22.04 with "version GLIBCXX_3.4.30 not found" style errors, the next step is to install `libstdc++-11-dev` (the gcc-11 series, which is what 22.04 ships) on the runner and point `-L` at that path instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmQ5bvWik5RUUFnjjNY6Bm)_