### PR TITLE
ci(release): amend merge commit on PR-merge release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '0' }}
           BUMP_TYPE: ${{ steps.bump-type.outputs.bump }}
         run: |
+          # Fold the bump into the merge commit on the PR path so we don't
+          # add an extra "release: vX" commit. Manual dispatch keeps the
+          # separate commit since HEAD belongs to someone else's work.
+          AMEND_FLAG=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            AMEND_FLAG="--amend"
+          fi
           ./scripts/release.sh "$BUMP_TYPE" \
-            --ci \
+            --ci $AMEND_FLAG \
             --pr-title "$PR_TITLE" \
             --pr-number "$PR_NUMBER"
           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -87,7 +94,12 @@ jobs:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git"
-          git push origin main --tags
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git push --force-with-lease origin main
+            git push origin --tags
+          else
+            git push origin main --tags
+          fi
 
   # ── Build release binaries ─────────────────────────────────────────
   build:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,13 +11,17 @@
 # Usage (CI — called by GitHub Actions on PR merge):
 #   ./scripts/release.sh patch --ci --pr-title "Add foo" --pr-number 42
 #
+# Pass --amend to fold the version bump into HEAD instead of creating a new
+# commit. Used by the PR-merge release path so the merge commit absorbs the
+# bump and the tag points at it directly. Requires a force-with-lease push.
+#
 # What it does:
 #   1. Validates the working tree is clean (skipped in --ci mode)
 #   2. Computes the next version (or uses the one you gave)
 #   3. Updates workspace version in Cargo.toml
 #   4. Moves "Unreleased" entries in CHANGELOG.md under a new version heading
 #   5. Runs `cargo check` to regenerate Cargo.lock (skipped in --ci mode)
-#   6. Commits and tags as v<version>
+#   6. Commits (or amends HEAD with --amend) and tags as v<version>
 #
 # After running locally, push with:
 #   git push origin main --tags
@@ -33,12 +37,14 @@ die() { echo "error: $*" >&2; exit 1; }
 # --- Parse arguments ---
 BUMP=""
 CI_MODE=false
+AMEND=false
 PR_TITLE=""
 PR_NUMBER=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --ci)       CI_MODE=true; shift ;;
+        --amend)    AMEND=true; shift ;;
         --pr-title) PR_TITLE="$2"; shift 2 ;;
         --pr-number) PR_NUMBER="$2"; shift 2 ;;
         -*)         die "unknown flag: $1" ;;
@@ -118,7 +124,11 @@ fi
 # --- Commit and tag ---
 cd "$REPO_ROOT"
 git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "release: v$NEXT"
+if [ "$AMEND" = true ]; then
+    git commit --amend --no-edit
+else
+    git commit -m "release: v$NEXT"
+fi
 git tag -a "v$NEXT" -m "v$NEXT"
 
 echo ""


### PR DESCRIPTION
Fold the version bump into the PR's merge commit on main instead of
appending a separate "release: vX" commit. Manual dispatch keeps the
extra commit since HEAD belongs to unrelated work.