### PR TITLE
fix(release): install gcc-11 and link against its libstdc++

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,18 @@ jobs:
         if: matrix.glibc != ''
         run: cargo install --locked cargo-zigbuild
 
+      # Install gcc-11's libstdc++ dev symlink so zig's lld can resolve
+      # `-lstdc++` (it needs the unversioned libstdc++.so, which only the
+      # libstdc++-N-dev packages provide — Ubuntu's multiarch path only
+      # has the versioned libstdc++.so.6). Picking gcc-11 matches the
+      # libstdc++ that ships with Ubuntu 22.04 / glibc 2.35, so the final
+      # binary's GLIBCXX symbol references stay backward-compatible.
+      - name: Install gcc-11 toolchain (Linux)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-11
+
       - name: Build release binary
         env:
           # cargo-zigbuild's zigcc wrapper doesn't include Ubuntu's
@@ -169,9 +181,10 @@ jobs:
           CFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-I/usr/include/x86_64-linux-gnu' || '' }}
           # The ort-sys prebuilt onnxruntime archive references libstdc++
           # symbols and expects the linker to resolve them dynamically via
-          # `-lstdc++`. zig's lld doesn't search Ubuntu's multiarch lib
-          # path on its own, so add it explicitly for the Linux leg.
-          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-L/usr/lib/x86_64-linux-gnu' || '' }}
+          # `-lstdc++`. Point zig's lld at the gcc-11 toolchain dir, which
+          # contains the unversioned `libstdc++.so` symlink it needs to
+          # resolve that name.
+          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-L/usr/lib/gcc/x86_64-linux-gnu/11' || '' }}
         run: |
           if [ -n "${{ matrix.glibc }}" ]; then
             cargo zigbuild --release \


### PR DESCRIPTION
## Diagnosis

After #431 merged, the link line now correctly includes `-L/usr/lib/x86_64-linux-gnu`, but the link still fails with thousands of undefined libstdc++ symbols (`std::basic_ios`, `std::__cxx11::basic_string`, etc.) from the prebuilt onnxruntime archive.

The reason: lld's `-l stdc++` resolves the **unversioned** name `libstdc++.so` first (then `.a`). Ubuntu's multiarch path `/usr/lib/x86_64-linux-gnu/` only contains the **versioned** `libstdc++.so.6` — the unversioned symlink lives at `/usr/lib/gcc/x86_64-linux-gnu/<N>/libstdc++.so` and only ships with the `libstdc++-N-dev` packages (i.e., when `g++-N` is installed). The ubuntu-latest runner has `g++-13` pre-installed by default, but `-L` was pointed at the wrong directory.

## Fix

1. Install `g++-11` on the Linux runner. This puts the unversioned symlink at `/usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so`.
2. Change `-L` to that path.

**Why gcc-11 specifically:** ubuntu-latest is gcc-13/14, which means a libstdc++ with newer `GLIBCXX_*` symbol versions. If we linked against that, the resulting binary could reference `GLIBCXX_3.4.30+` symbols that don't exist on Ubuntu 22.04 (which has `GLIBCXX_3.4.29`). gcc-11 matches the libstdc++ that ships with Ubuntu 22.04 / glibc 2.35, keeping the binary backward-compatible with our target baseline. This pre-empts the GLIBCXX version-mismatch risk I flagged on #431.

## Test plan

- [ ] Release workflow's `Build (x86_64-unknown-linux-gnu)` job links successfully
- [ ] Final binary runs on a fresh Ubuntu 22.04 host (target glibc 2.35 / GLIBCXX_3.4.29 baseline)
- [ ] aarch64-apple-darwin leg still passes (gcc-11 install and RUSTFLAGS are gated to Linux)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmQ5bvWik5RUUFnjjNY6Bm)_