### PR TITLE
fix(release): explicit versioned libstdc++ link + install diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,15 @@ jobs:
       - name: Install gcc-11 toolchain (Linux)
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
+          set -euxo pipefail
           sudo apt-get update
-          sudo apt-get install -y g++-11
+          sudo apt-get install -y g++-11 libstdc++-11-dev
+          # Fail fast if the symlinks lld needs aren't where we expect them.
+          # The next step's `-L` path assumes /usr/lib/gcc/x86_64-linux-gnu/11/.
+          ls -la /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
+          ls -la /usr/lib/gcc/x86_64-linux-gnu/11/libgcc_s.so
+          readlink -f /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so
+          readlink -f /usr/lib/gcc/x86_64-linux-gnu/11/libgcc_s.so
 
       - name: Build release binary
         env:
@@ -193,10 +200,16 @@ jobs:
           CFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-I/usr/include/x86_64-linux-gnu' || '' }}
           # The ort-sys prebuilt onnxruntime archive references libstdc++
           # symbols and expects the linker to resolve them dynamically via
-          # `-lstdc++`. Point zig's lld at the gcc-11 toolchain dir, which
-          # contains the unversioned `libstdc++.so` symlink it needs to
-          # resolve that name.
-          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-L/usr/lib/gcc/x86_64-linux-gnu/11' || '' }}
+          # `-lstdc++`. Adding `-L /usr/lib/gcc/x86_64-linux-gnu/11` alone
+          # wasn't enough: zig's lld doesn't always pick up the unversioned
+          # libstdc++.so symlink through it. Pass three things together:
+          #   1. -L for both the gcc-11 dir and the multiarch dir
+          #   2. an explicit `-l:libstdc++.so.6` so resolution targets the
+          #      versioned name directly (no symlink lookup required)
+          #   3. ditto for libgcc_s.so.1
+          # Rustc still emits its own `-lstdc++` / `-lgcc_s` after these,
+          # but with the search paths in place lld can resolve those too.
+          RUSTFLAGS: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && '-C link-arg=-L/usr/lib/gcc/x86_64-linux-gnu/11 -C link-arg=-L/usr/lib/x86_64-linux-gnu -C link-arg=-l:libstdc++.so.6 -C link-arg=-l:libgcc_s.so.1' || '' }}
         run: |
           if [ -n "${{ matrix.glibc }}" ]; then
             cargo zigbuild --release \


### PR DESCRIPTION
## Diagnosis

After #433 merged we have the gcc-11 install step and `-L /usr/lib/gcc/x86_64-linux-gnu/11` in RUSTFLAGS, but the next run hit the **same identical** ~thousand undefined libstdc++ symbol errors. The link command in the log confirms `-L/usr/lib/gcc/x86_64-linux-gnu/11` is being passed, so the link-arg is reaching lld.

Two candidate causes:
1. The unversioned `libstdc++.so` symlink isn't actually where we assume it is after `apt-get install g++-11` on this Ubuntu image.
2. zig's lld doesn't pick up the unversioned symlink through `-L` (its cross-compile sysroot logic may shadow host paths in some cases).

## Fix

Two changes, designed to either diagnose case 1 fast or sidestep case 2 entirely:

**Install step (`set -euxo pipefail` + verification):**
- Pin `libstdc++-11-dev` explicitly alongside `g++-11`.
- `ls -la` and `readlink -f` the expected symlinks immediately after install. If they aren't where we think, the build dies at the install step with a clear error instead of producing 50k lines of cryptic lld output.

**Build step (explicit versioned link):**
- Add `-L /usr/lib/x86_64-linux-gnu` as a second search path (where the versioned `libstdc++.so.6` lives).
- Pass `-l:libstdc++.so.6` and `-l:libgcc_s.so.1` explicitly so resolution targets the versioned soname directly — no symlink lookup required. Rustc still emits its own `-lstdc++` and `-lgcc_s` after these, but with both `-L` paths in place lld can resolve those too.

## Test plan

- [ ] Install step succeeds and prints valid symlink paths (or dies clearly if the layout is wrong)
- [ ] Linux build links the binary
- [ ] aarch64-apple-darwin leg still passes (everything is gated to `runner.os` / matrix target)

## If this still fails

The verbose install output will tell us whether the symlinks exist. If they do and lld still can't find libstdc++, the next move is to abandon cargo-zigbuild for this leg — likely switching to building on `ubuntu-22.04` directly (which natively has glibc 2.35 and a working libstdc++ setup) or using `cross` with a manylinux container.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmQ5bvWik5RUUFnjjNY6Bm)_