### PR TITLE
fix(browser): apply remote_cdp_timeout_ms to Browser::connect calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.20"
+version = "2.10.21"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -344,10 +344,11 @@ impl BrowserManager {
     async fn connect_or_launch(&self, profile_name: &str) -> Result<ProfileInstance> {
         let cdp_url = self.config.resolve_cdp_url(profile_name);
         let attach_only = self.config.is_attach_only(profile_name);
+        let connect_timeout = std::time::Duration::from_millis(self.config.remote_cdp_timeout_ms);
 
         // Try connecting to an existing instance first
-        match Browser::connect(&cdp_url).await {
-            Ok((browser, handler)) => {
+        match tokio::time::timeout(connect_timeout, Browser::connect(&cdp_url)).await {
+            Ok(Ok((browser, handler))) => {
                 let mut handler = handler;
                 let handler_task =
                     tokio::spawn(async move { while let Some(_event) = handler.next().await {} });
@@ -359,7 +360,7 @@ impl BrowserManager {
                     launched_by_us: false,
                 });
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 if attach_only {
                     return Err(Error::ToolExecution(
                         format!("cannot connect to browser at {cdp_url} (attach-only mode): {e}")
@@ -369,6 +370,23 @@ impl BrowserManager {
                 tracing::info!(
                     profile = profile_name,
                     "browser not reachable at {cdp_url}, launching..."
+                );
+            }
+            Err(_) => {
+                if attach_only {
+                    return Err(Error::ToolExecution(
+                        format!(
+                            "timed out connecting to browser at {cdp_url} \
+                             after {}ms (attach-only mode)",
+                            connect_timeout.as_millis()
+                        )
+                        .into(),
+                    ));
+                }
+                tracing::info!(
+                    profile = profile_name,
+                    "browser CDP connect at {cdp_url} timed out after {}ms, launching...",
+                    connect_timeout.as_millis()
                 );
             }
         }
@@ -385,16 +403,32 @@ impl BrowserManager {
         // Wait for it to start
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-        let (browser, handler) = Browser::connect(&cdp_url).await.map_err(|e| {
-            Error::ToolExecution(
-                format!(
-                    "browser not reachable at {cdp_url} after launch attempt: {e}. \
-                     If a browser is already running without remote debugging, \
-                     quit it first so a new instance can start."
-                )
-                .into(),
-            )
-        })?;
+        let (browser, handler) =
+            match tokio::time::timeout(connect_timeout, Browser::connect(&cdp_url)).await {
+                Ok(Ok(pair)) => pair,
+                Ok(Err(e)) => {
+                    return Err(Error::ToolExecution(
+                        format!(
+                            "browser not reachable at {cdp_url} after launch attempt: {e}. \
+                         If a browser is already running without remote debugging, \
+                         quit it first so a new instance can start."
+                        )
+                        .into(),
+                    ));
+                }
+                Err(_) => {
+                    return Err(Error::ToolExecution(
+                        format!(
+                            "timed out connecting to browser at {cdp_url} \
+                         after {}ms (post-launch). \
+                         If a browser is already running without remote debugging, \
+                         quit it first so a new instance can start.",
+                            connect_timeout.as_millis()
+                        )
+                        .into(),
+                    ));
+                }
+            };
 
         let mut handler = handler;
         let handler_task =


### PR DESCRIPTION
The config field defaulted to 5000ms but was never wired up, so stale
CDP endpoints (App-Nap-suspended Chrome, dead DevTools sockets) blocked
connect_or_launch for the underlying chromiumoxide default (~300s).
Wrap both Browser::connect calls in tokio::time::timeout so connection
attempts fail fast and the launch fallback (or attach-only error) runs
within the configured budget.