### PR TITLE
fix(browser): process tracking, health checks, and stealth at launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.10.21"
+version = "3.0.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -6,15 +6,43 @@
 //! - Tab management (list, open, close, focus) with targetId addressing
 //! - Browser lifecycle (start, stop, status)
 //! - Chrome profile symlink setup for cookie/session persistence
+//! - Process tracking (Child handles) so spawned Chromes can be killed
+//! - Health checks before reuse so dead browsers are auto-replaced
+//! - Best-effort kill of all spawned children on Drop
 
 use chromiumoxide::Browser;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
 
 use super::config::{BrowserConfig, DriverType};
 use rustykrab_core::{Error, Result};
+
+/// How long to wait for a launched Chrome to start serving CDP before giving
+/// up. Generous so cold launches on slow disks still succeed.
+const POST_LAUNCH_TIMEOUT_MS: u64 = 15_000;
+
+/// Cap on the per-probe HTTP timeout when polling `/json/version`.
+const HEALTH_PROBE_TIMEOUT_MS: u64 = 3_000;
+
+/// Stealth-oriented Chrome launch flags. These reduce the most obvious
+/// "this is a headed automation browser" signals — automation banner,
+/// `navigator.webdriver`, and the timer throttling that causes the macOS
+/// "Chrome went to sleep" pattern.
+const STEALTH_LAUNCH_ARGS: &[&str] = &[
+    "--disable-blink-features=AutomationControlled",
+    "--disable-features=IsolateOrigins,site-per-process",
+    "--window-size=1920,1080",
+    "--lang=en-US",
+    "--disable-background-timer-throttling",
+    "--disable-backgrounding-occluded-windows",
+    "--disable-renderer-backgrounding",
+    "--no-default-browser-check",
+    "--disable-infobars",
+    "--disable-default-apps",
+];
 
 /// State for a single browser profile instance.
 pub struct ProfileInstance {
@@ -31,14 +59,24 @@ pub struct BrowserManager {
     config: BrowserConfig,
     /// Active browser instances keyed by profile name.
     instances: Arc<Mutex<HashMap<String, ProfileInstance>>>,
+    /// Child process handles for browsers we launched ourselves.
+    /// Stored separately under a `std::sync::Mutex` so the `Drop` impl
+    /// (synchronous) can kill them even while the async `instances` lock
+    /// is held elsewhere.
+    children: Arc<std::sync::Mutex<HashMap<String, std::process::Child>>>,
 }
 
 impl BrowserManager {
     pub fn new(config: BrowserConfig) -> Self {
-        Self {
+        let mgr = Self {
             config,
             instances: Arc::new(Mutex::new(HashMap::new())),
+            children: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        };
+        if std::env::var("RUSTYKRAB_BROWSER_SWEEP").as_deref() == Ok("1") {
+            sweep_stale_processes();
         }
+        mgr
     }
 
     /// Load configuration and create a manager.
@@ -51,13 +89,31 @@ impl BrowserManager {
     }
 
     /// Get or create a browser instance for the given profile.
+    ///
+    /// Performs a liveness check on any cached instance: a dead Chrome
+    /// (process killed, OS crashed it, CDP stopped responding) is evicted
+    /// and replaced with a fresh launch.
     pub async fn get_browser(
         &self,
         profile_name: &str,
     ) -> Result<Arc<Mutex<HashMap<String, ProfileInstance>>>> {
         let mut instances = self.instances.lock().await;
 
-        if !instances.contains_key(profile_name) {
+        let needs_relaunch = match instances.get(profile_name) {
+            Some(inst) => !is_instance_alive(inst).await,
+            None => true,
+        };
+
+        if needs_relaunch {
+            if let Some(dead) = instances.remove(profile_name) {
+                tracing::warn!(
+                    profile = profile_name,
+                    "browser instance failed health check — relaunching"
+                );
+                dead._handler_task.abort();
+                self.kill_child(profile_name);
+                drop(dead.browser);
+            }
             let instance = self.connect_or_launch(profile_name).await?;
             instances.insert(profile_name.to_string(), instance);
         }
@@ -70,18 +126,19 @@ impl BrowserManager {
     pub async fn status(&self, profile_name: &str) -> serde_json::Value {
         let instances = self.instances.lock().await;
         if let Some(inst) = instances.get(profile_name) {
+            let alive = is_instance_alive(inst).await;
             let page_count = inst.browser.pages().await.map(|p| p.len()).unwrap_or(0);
             serde_json::json!({
-                "status": "running",
+                "status": if alive { "running" } else { "unresponsive" },
                 "profile": profile_name,
                 "cdp_url": inst.cdp_url,
                 "launched_by_us": inst.launched_by_us,
                 "tabs": page_count
             })
         } else {
-            // Try to probe the CDP endpoint
             let cdp_url = self.config.resolve_cdp_url(profile_name);
-            let reachable = probe_cdp(&cdp_url).await;
+            let probe_timeout = Duration::from_millis(self.health_probe_timeout_ms());
+            let reachable = probe_cdp(&cdp_url, probe_timeout).await;
             serde_json::json!({
                 "status": if reachable { "available" } else { "stopped" },
                 "profile": profile_name,
@@ -95,11 +152,23 @@ impl BrowserManager {
     /// Start a browser for the given profile (if not already running).
     pub async fn start(&self, profile_name: &str) -> Result<serde_json::Value> {
         let mut instances = self.instances.lock().await;
-        if instances.contains_key(profile_name) {
-            return Ok(serde_json::json!({
-                "status": "already_running",
-                "profile": profile_name
-            }));
+        if let Some(inst) = instances.get(profile_name) {
+            if is_instance_alive(inst).await {
+                return Ok(serde_json::json!({
+                    "status": "already_running",
+                    "profile": profile_name
+                }));
+            }
+            // Stale entry — fall through to relaunch.
+            tracing::warn!(
+                profile = profile_name,
+                "existing browser entry is unresponsive — replacing"
+            );
+            if let Some(dead) = instances.remove(profile_name) {
+                dead._handler_task.abort();
+                drop(dead.browser);
+            }
+            self.kill_child(profile_name);
         }
 
         let instance = self.connect_or_launch(profile_name).await?;
@@ -117,19 +186,37 @@ impl BrowserManager {
     pub async fn stop(&self, profile_name: &str) -> Result<serde_json::Value> {
         let mut instances = self.instances.lock().await;
         if let Some(inst) = instances.remove(profile_name) {
-            // Abort the handler task to clean up the CDP connection
             inst._handler_task.abort();
-            // Drop the browser — this closes the CDP connection
             drop(inst.browser);
+            let killed = self.kill_child(profile_name);
             Ok(serde_json::json!({
                 "status": "stopped",
-                "profile": profile_name
+                "profile": profile_name,
+                "process_killed": killed,
             }))
         } else {
             Ok(serde_json::json!({
                 "status": "not_running",
                 "profile": profile_name
             }))
+        }
+    }
+
+    /// Stop every running profile. Best-effort; errors are logged.
+    ///
+    /// This is the async, graceful counterpart to `Drop` (which only kills
+    /// child processes synchronously). Wire it into your shutdown sequence
+    /// if you want clean CDP disconnects before exit.
+    #[allow(dead_code)]
+    pub async fn shutdown_all(&self) {
+        let names: Vec<String> = {
+            let instances = self.instances.lock().await;
+            instances.keys().cloned().collect()
+        };
+        for name in names {
+            if let Err(e) = self.stop(&name).await {
+                tracing::warn!(profile = %name, error = %e, "failed to stop browser during shutdown");
+            }
         }
     }
 
@@ -199,13 +286,19 @@ impl BrowserManager {
             Error::ToolExecution(format!("browser not running for profile '{profile_name}'").into())
         })?;
 
-        let page = inst
-            .browser
-            .new_page(url)
+        let nav_timeout = Duration::from_millis(self.config.remote_cdp_timeout_ms.max(10_000));
+
+        let page = tokio::time::timeout(nav_timeout, inst.browser.new_page(url))
             .await
+            .map_err(|_| {
+                Error::ToolExecution(
+                    format!("open_tab timed out after {}ms", nav_timeout.as_millis()).into(),
+                )
+            })?
             .map_err(|e| Error::ToolExecution(format!("failed to open tab: {e}").into()))?;
 
-        let _ = page.wait_for_navigation().await;
+        // Bound wait_for_navigation so a slow page can't hang the call forever.
+        let _ = tokio::time::timeout(nav_timeout, page.wait_for_navigation()).await;
         let actual_url = page.url().await.ok().flatten().unwrap_or_default();
         let title = page.get_title().await.ok().flatten().unwrap_or_default();
         let pages = inst.browser.pages().await.map(|p| p.len()).unwrap_or(0);
@@ -214,7 +307,7 @@ impl BrowserManager {
             "status": "opened",
             "url": actual_url,
             "title": title,
-            "targetId": format!("tab_{}", pages - 1),
+            "targetId": format!("tab_{}", pages.saturating_sub(1)),
             "profile": profile_name
         }))
     }
@@ -231,7 +324,7 @@ impl BrowserManager {
         })?;
 
         let idx = parse_tab_index(target_id)?;
-        let pages = inst
+        let mut pages = inst
             .browser
             .pages()
             .await
@@ -243,12 +336,13 @@ impl BrowserManager {
             ));
         }
 
-        // Navigate to about:blank then close — close via dropping the page
-        let page = &pages[idx];
-        let _ = page.goto("about:blank").await;
-        // chromiumoxide doesn't have a direct close_page; we close by executing
-        // the CDP command
-        let _ = page.evaluate("window.close()").await;
+        // `Page::close` (the CDP `Target.closeTarget`) consumes self, so we
+        // take the page by value out of the Vec. This avoids `window.close()`
+        // which Chrome blocks for tabs not opened via script.
+        let page = pages.swap_remove(idx);
+        page.close()
+            .await
+            .map_err(|e| Error::ToolExecution(format!("close_tab failed: {e}").into()))?;
 
         Ok(serde_json::json!({
             "status": "closed",
@@ -344,14 +438,12 @@ impl BrowserManager {
     async fn connect_or_launch(&self, profile_name: &str) -> Result<ProfileInstance> {
         let cdp_url = self.config.resolve_cdp_url(profile_name);
         let attach_only = self.config.is_attach_only(profile_name);
-        let connect_timeout = std::time::Duration::from_millis(self.config.remote_cdp_timeout_ms);
+        let connect_timeout = Duration::from_millis(self.config.remote_cdp_timeout_ms);
 
         // Try connecting to an existing instance first
         match tokio::time::timeout(connect_timeout, Browser::connect(&cdp_url)).await {
             Ok(Ok((browser, handler))) => {
-                let mut handler = handler;
-                let handler_task =
-                    tokio::spawn(async move { while let Some(_event) = handler.next().await {} });
+                let handler_task = spawn_handler_task(handler, profile_name.to_string());
                 return Ok(ProfileInstance {
                     browser,
                     _handler_task: handler_task,
@@ -396,17 +488,50 @@ impl BrowserManager {
         // operations (fixes ASYNC-H3).
         let config = self.config.clone();
         let profile = profile_name.to_string();
-        tokio::task::spawn_blocking(move || launch_browser_blocking(&config, &profile))
+        let child = tokio::task::spawn_blocking(move || launch_browser_blocking(&config, &profile))
             .await
             .map_err(|e| Error::ToolExecution(format!("launch task failed: {e}").into()))??;
 
-        // Wait for it to start
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        // Track the child PID so `stop()` and Drop can kill it.
+        if let Ok(mut children) = self.children.lock() {
+            // If an old entry exists (somehow), drop it.
+            if let Some(mut old) = children.insert(profile_name.to_string(), child) {
+                let _ = old.kill();
+                let _ = old.wait();
+            }
+        }
+
+        // Wait for the freshly-launched Chrome to start serving CDP, instead
+        // of the old fixed 2-second sleep. Poll `/json/version` until we get
+        // a 200, with a generous overall budget.
+        let probe_timeout = Duration::from_millis(self.health_probe_timeout_ms());
+        let launch_deadline =
+            tokio::time::Instant::now() + Duration::from_millis(POST_LAUNCH_TIMEOUT_MS);
+        let mut became_ready = false;
+        while tokio::time::Instant::now() < launch_deadline {
+            if probe_cdp(&cdp_url, probe_timeout).await {
+                became_ready = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+        }
+        if !became_ready {
+            // Kill the child we just launched — it's not serving CDP.
+            self.kill_child(profile_name);
+            return Err(Error::ToolExecution(
+                format!(
+                    "browser launched but CDP never came up at {cdp_url} \
+                     within {POST_LAUNCH_TIMEOUT_MS}ms"
+                )
+                .into(),
+            ));
+        }
 
         let (browser, handler) =
             match tokio::time::timeout(connect_timeout, Browser::connect(&cdp_url)).await {
                 Ok(Ok(pair)) => pair,
                 Ok(Err(e)) => {
+                    self.kill_child(profile_name);
                     return Err(Error::ToolExecution(
                         format!(
                             "browser not reachable at {cdp_url} after launch attempt: {e}. \
@@ -417,6 +542,7 @@ impl BrowserManager {
                     ));
                 }
                 Err(_) => {
+                    self.kill_child(profile_name);
                     return Err(Error::ToolExecution(
                         format!(
                             "timed out connecting to browser at {cdp_url} \
@@ -430,9 +556,7 @@ impl BrowserManager {
                 }
             };
 
-        let mut handler = handler;
-        let handler_task =
-            tokio::spawn(async move { while let Some(_event) = handler.next().await {} });
+        let handler_task = spawn_handler_task(handler, profile_name.to_string());
 
         Ok(ProfileInstance {
             browser,
@@ -442,13 +566,99 @@ impl BrowserManager {
             launched_by_us: true,
         })
     }
+
+    fn health_probe_timeout_ms(&self) -> u64 {
+        self.config
+            .remote_cdp_timeout_ms
+            .min(HEALTH_PROBE_TIMEOUT_MS)
+    }
+
+    /// Kill the stored Child for the given profile. Returns true if a
+    /// process was killed.
+    fn kill_child(&self, profile_name: &str) -> bool {
+        let Ok(mut children) = self.children.lock() else {
+            return false;
+        };
+        let Some(mut child) = children.remove(profile_name) else {
+            return false;
+        };
+        let pid = child.id();
+        match child.kill() {
+            Ok(()) => {
+                let _ = child.wait();
+                tracing::info!(profile = profile_name, pid, "killed browser child");
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    profile = profile_name,
+                    pid,
+                    "failed to kill browser child: {e}"
+                );
+                false
+            }
+        }
+    }
 }
 
-/// Launch a Chrome/Chromium instance for the given profile.
-///
-/// This is a free function (not a method) so it can be called from
-/// `spawn_blocking` without lifetime issues (fixes ASYNC-H3).
-fn launch_browser_blocking(config: &BrowserConfig, profile_name: &str) -> Result<()> {
+impl Drop for BrowserManager {
+    fn drop(&mut self) {
+        // Best-effort: kill every Chrome we launched. We may be running
+        // outside any Tokio context here, so this stays synchronous and
+        // does not touch the async `instances` lock.
+        let Ok(mut children) = self.children.lock() else {
+            return;
+        };
+        for (name, mut child) in children.drain() {
+            let pid = child.id();
+            if let Err(e) = child.kill() {
+                tracing::warn!(
+                    profile = %name,
+                    pid,
+                    "failed to kill browser child during drop: {e}"
+                );
+                continue;
+            }
+            let _ = child.wait();
+            tracing::info!(profile = %name, pid, "killed browser child during drop");
+        }
+    }
+}
+
+/// Spawn the CDP event handler. The task drains events until the underlying
+/// connection closes, then logs the exit so an unexpected disconnect is
+/// visible in the logs.
+fn spawn_handler_task(
+    mut handler: chromiumoxide::Handler,
+    profile_name: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(event) = handler.next().await {
+            if let Err(e) = event {
+                tracing::debug!(profile = %profile_name, error = %e, "CDP handler event error");
+            }
+        }
+        tracing::info!(profile = %profile_name, "browser CDP handler task exited");
+    })
+}
+
+/// Health check for a cached `ProfileInstance`. We do a cheap CDP
+/// round-trip (`Browser.getVersion`) with a short timeout. A failure
+/// (timeout or CDP error) means the browser has gone away.
+async fn is_instance_alive(inst: &ProfileInstance) -> bool {
+    let probe_timeout = Duration::from_millis(HEALTH_PROBE_TIMEOUT_MS);
+    matches!(
+        tokio::time::timeout(probe_timeout, inst.browser.version()).await,
+        Ok(Ok(_))
+    )
+}
+
+/// Launch a Chrome/Chromium instance for the given profile and return the
+/// owning `Child`. The free-function shape keeps it `spawn_blocking`-safe.
+fn launch_browser_blocking(
+    config: &BrowserConfig,
+    profile_name: &str,
+) -> Result<std::process::Child> {
     let cdp_url = config.resolve_cdp_url(profile_name);
     let port = cdp_url
         .rsplit(':')
@@ -484,6 +694,12 @@ fn launch_browser_blocking(config: &BrowserConfig, profile_name: &str) -> Result
         args.push("--disable-setuid-sandbox".to_string());
     }
 
+    // Stealth + reliability flags. These are appended *before* user-supplied
+    // extra_args so explicit overrides win.
+    for flag in STEALTH_LAUNCH_ARGS {
+        args.push((*flag).to_string());
+    }
+
     // Extra args from config
     args.extend(config.extra_args.iter().cloned());
 
@@ -502,22 +718,63 @@ fn launch_browser_blocking(config: &BrowserConfig, profile_name: &str) -> Result
         )
     })?;
 
-    std::process::Command::new(&exe)
-        .args(&args)
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.args(&args)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| {
-            Error::ToolExecution(format!("failed to launch browser ({exe}): {e}").into())
-        })?;
+        .stderr(std::process::Stdio::null());
+
+    // macOS: prevent App Nap from suspending the headed browser's timers.
+    // Headed Chrome backgrounded on macOS will throttle its event loop and
+    // CDP can become unresponsive — disabling AppSleep keeps it lively.
+    #[cfg(target_os = "macos")]
+    {
+        cmd.env("NSAppSleepDisabled", "YES");
+    }
+
+    let child = cmd.spawn().map_err(|e| {
+        Error::ToolExecution(format!("failed to launch browser ({exe}): {e}").into())
+    })?;
 
     tracing::info!(
         port,
         profile = profile_name,
         %profile_dir_name,
+        pid = child.id(),
         "launched browser with remote debugging"
     );
-    Ok(())
+    Ok(child)
+}
+
+/// Best-effort kill of any Chromium-like process whose user-data-dir lives
+/// under `~/.rustykrab/browser/`. Opt-in via `RUSTYKRAB_BROWSER_SWEEP=1` —
+/// we won't touch unrelated browser processes, but startup sweeps are still
+/// destructive enough that they should be explicit.
+fn sweep_stale_processes() {
+    #[cfg(unix)]
+    {
+        // Match the user-data-dir we always pass on the command line.
+        let pattern = ".rustykrab/browser/";
+        match std::process::Command::new("pkill")
+            .args(["-f", &format!("user-data-dir=.*{pattern}")])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+        {
+            Ok(s) if s.success() => {
+                tracing::info!(pattern, "swept stale rustykrab browser processes");
+            }
+            Ok(_) => {
+                // pkill exit code 1 == no matches found, which is fine.
+            }
+            Err(e) => {
+                tracing::warn!("startup sweep skipped: pkill failed: {e}");
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // Not implemented on non-unix.
+    }
 }
 
 /// Detect the platform-specific Chrome data directory.
@@ -635,13 +892,17 @@ fn detect_chrome_executable() -> Option<String> {
     }
 }
 
-/// Probe a CDP URL to check if a browser is reachable.
-async fn probe_cdp(url: &str) -> bool {
+/// Probe a CDP URL to check if a browser is reachable, with a timeout.
+async fn probe_cdp(url: &str, timeout: Duration) -> bool {
     let version_url = format!("{}/json/version", url.trim_end_matches('/'));
-    reqwest::get(&version_url)
-        .await
-        .map(|r| r.status().is_success())
-        .unwrap_or(false)
+    let client = match reqwest::Client::builder().timeout(timeout).build() {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    matches!(
+        client.get(&version_url).send().await,
+        Ok(r) if r.status().is_success()
+    )
 }
 
 /// Parse a targetId like "tab_3" into an index.

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -476,6 +476,10 @@ impl Tool for BrowserTool {
                 // a no-op when their args are absent.
                 let stealth_opts = stealth::StealthOptions::from_args(&args);
                 let _ = stealth::apply_network_overrides(&page, &stealth_opts).await;
+                // Install DOM patches via evaluate_on_new_document so they
+                // run before the target page's own JS — this is what hides
+                // `navigator.webdriver` from frameworks that read it on load.
+                let _ = stealth::install_stealth_on_new_document(&page, &stealth_opts).await;
 
                 page.goto(url)
                     .await
@@ -883,6 +887,7 @@ impl Tool for BrowserTool {
 
                 let stealth_opts = stealth::StealthOptions::from_args(&args);
                 let _ = stealth::apply_network_overrides(&page, &stealth_opts).await;
+                let _ = stealth::install_stealth_on_new_document(&page, &stealth_opts).await;
 
                 page.goto(url)
                     .await

--- a/crates/rustykrab-tools/src/browser/stealth.rs
+++ b/crates/rustykrab-tools/src/browser/stealth.rs
@@ -104,6 +104,33 @@ pub async fn apply_stealth(page: &Page, opts: &StealthOptions) -> Result<()> {
     Ok(())
 }
 
+/// Install stealth patches via `Page.addScriptToEvaluateOnNewDocument` so
+/// they run *before* the page's own JavaScript on the next navigation.
+///
+/// This is the right hook for fingerprint patches: by the time
+/// `apply_stealth` runs (post-navigation), the site has already had a
+/// chance to read `navigator.webdriver` and friends. Calling this once
+/// per page is enough — the script persists across navigations on that
+/// page. Cheaper than re-injecting after every goto.
+pub async fn install_stealth_on_new_document(page: &Page, opts: &StealthOptions) -> Result<()> {
+    if !opts.any_patches() {
+        return Ok(());
+    }
+    let mut script = build_stealth_script(opts);
+    if let Some(ref ua) = opts.user_agent {
+        let lit = serde_json::to_string(ua).unwrap_or_else(|_| "\"\"".to_string());
+        script.push_str(&format!(
+            "\ntry{{Object.defineProperty(navigator,'userAgent',{{get:()=>{lit}}});}}catch(e){{}}"
+        ));
+    }
+    page.evaluate_on_new_document(script.as_str())
+        .await
+        .map_err(|e| {
+            Error::ToolExecution(format!("evaluate_on_new_document failed: {e}").into())
+        })?;
+    Ok(())
+}
+
 /// Build the combined stealth init script. Runs in the page context.
 /// Patches are wrapped in try/catch so a failure on one doesn't break
 /// the rest.


### PR DESCRIPTION
The browser manager assumed a Chrome instance, once cached, stayed alive
forever and was driven by an HTTP probe with no timeout. When Chrome
crashed, was killed by the OS, or App-Napped, the next tool call hung
on the 300s sandbox timeout. Restarting the CLI orphaned every Chrome
we'd ever spawned because the Child handle was dropped at launch.

This change:

- Stores std::process::Child handles per profile in a sync mutex so
  stop() and Drop can kill them. Drop kills all spawned children
  synchronously — no more orphaned Chromes after CLI restart.
- Adds a CDP-level liveness check (Browser.getVersion with 3s timeout)
  in get_browser/start/status. Dead instances are evicted, the child
  killed, and a fresh Chrome launched transparently.
- Replaces the fixed 2-second post-launch sleep with a polling loop
  against /json/version, capped at POST_LAUNCH_TIMEOUT_MS (15s) — cold
  launches succeed on slow disks, fast launches don't waste time.
- Wraps probe_cdp in a reqwest client with explicit timeout (was naked
  reqwest::get, could hang on a half-dead Chrome).
- Bounds open_tab navigation with a timeout so a slow page can't hang
  the call forever.
- Switches close_tab from window.close() (blocked for non-script tabs)
  to Page::close (Target.closeTarget).
- Appends stealth launch flags before user extra_args: disables the
  AutomationControlled blink feature, the macOS-style timer throttling
  that causes the zombie pattern, and sets a deterministic window
  size / lang. Sets NSAppSleepDisabled=YES in Chrome's env on macOS so
  AppSleep doesn't suspend the renderer.
- Adds install_stealth_on_new_document() and wires it into navigate /
  stealth_fetch before goto. Patches now run before page JS via
  evaluate_on_new_document instead of post-navigation evaluate, so
  navigator.webdriver is hidden by the time the site reads it.
- Logs CDP handler-task exits with the profile name so disconnects are
  visible.
- Opt-in startup sweep via RUSTYKRAB_BROWSER_SWEEP=1 — pkills Chrome
  whose user-data-dir lives under ~/.rustykrab/browser/.

https://claude.ai/code/session_01XNFqMr9SCS7ZXBrV37wen3