### PR TITLE
fix(browser): stop calling .apply on the snapshot IIFE's return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.0.1"
+version = "3.2.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/snapshot.rs
+++ b/crates/rustykrab-tools/src/browser/snapshot.rs
@@ -445,7 +445,7 @@ const SNAPSHOT_JS: &str = r#"
         };
     });
     return JSON.stringify(out);
-})()
+})
 "#;
 
 /// Raw element data from the JS snapshot.
@@ -477,7 +477,7 @@ pub async fn take_snapshot(
         .unwrap_or_else(|| "null".to_string());
 
     let eval_js = format!(
-        "({SNAPSHOT_JS}).apply(null, [{}, {}, {}, {}])",
+        "({SNAPSHOT_JS})({}, {}, {}, {})",
         options.max_depth,
         if options.interactive_only {
             "true"


### PR DESCRIPTION
SNAPSHOT_JS was self-invoking via `})()` and the evaluator then wrapped
it as `(JS).apply(null, [args])`, so `.apply` ran on the returned JSON
string and always threw `TypeError: (...).apply is not a function`.
As a side effect the snapshot also ignored its arguments, since the
inner IIFE was invoked with no args and silently used defaults.

Drop the auto-invocation and invoke the function directly with the
arguments instead of `.apply`, which also avoids depending on
`Function.prototype.apply` being present on the page.