### PR TITLE
feat(prompt): inject current UTC date into system prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -45,8 +45,14 @@ async fn build_and_inject_system_prompt(
     tracing::info!(profile = %profile.name, "harness profile selected");
 
     // 2. Build the minimal system prompt.
+    //
+    // Date is rendered at day granularity so the system block stays
+    // cache-friendly: it only changes once per UTC day. Models that need
+    // sub-day precision should call a clock tool on demand.
+    let today = Utc::now().format("%Y-%m-%d").to_string();
     let mut builder = SystemPromptBuilder::new()
         .with_identity(&profile.agent_name)
+        .with_current_date(&today)
         .with_security_policy()
         .with_completion_protocol();
 

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -95,6 +95,18 @@ impl SystemPromptBuilder {
         self
     }
 
+    /// Add the current UTC date at day granularity.
+    ///
+    /// Day granularity (e.g. `2026-05-18`) is intentional: the resulting
+    /// system-prompt string only changes once per UTC day, so prompt
+    /// caching keeps hitting across iterations and across runs in the
+    /// same day. For sub-day precision, the agent should call a clock
+    /// tool on demand rather than burning the cache on every turn.
+    pub fn with_current_date(mut self, date: &str) -> Self {
+        self.sections.push(format!("Today's date is {date} (UTC)."));
+        self
+    }
+
     /// Add anti-injection security policy (simplified two-bullet version).
     pub fn with_security_policy(mut self) -> Self {
         self.sections.push(
@@ -266,6 +278,14 @@ mod tests {
             !prompt.contains("/var/lib/rustykrab/skills/local-skill"),
             "filesystem path leaked into prompt: {prompt}"
         );
+    }
+
+    #[test]
+    fn current_date_is_rendered_in_prompt() {
+        let prompt = SystemPromptBuilder::new()
+            .with_current_date("2026-05-18")
+            .build();
+        assert!(prompt.contains("Today's date is 2026-05-18 (UTC)."));
     }
 
     #[test]


### PR DESCRIPTION
Models have no inherent sense of "now", so they hallucinate when
reasoning about deadlines, freshness, or relative time. Inject the
date at day granularity so the system block changes only once per
UTC day — that keeps prompt caching hitting across iterations and
across runs. Sub-day precision is out of scope here; that's what a
clock tool would be for.