### PR TITLE
feat(agent): add task_complete tool and gate EndTurn on it after tool use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -25,6 +25,9 @@ use uuid::Uuid;
 /// always present — the model can't `tools_load` them after compaction
 /// has already dropped the detail it needs to recover, and `recall_append`
 /// is the manual escape hatch for stashing content outside the prompt.
+/// `task_complete` is the explicit "I'm done" signal — the runner relies
+/// on it to disambiguate "model paused mid-task" from "model finished",
+/// so it must be callable from any iteration without a `tools_load` hop.
 const META_TOOL_NAMES: &[&str] = &[
     "tools_list",
     "tools_load",
@@ -33,6 +36,7 @@ const META_TOOL_NAMES: &[&str] = &[
     "recall_peek",
     "recall_search",
     "recall_sub_query",
+    "task_complete",
 ];
 
 fn is_meta_tool(name: &str) -> bool {
@@ -67,6 +71,13 @@ const EMPTY_RESPONSE_RETRY_LIMIT: usize = 1;
 /// Maximum retries for a planning-only response (model described intent
 /// without using tools).
 const PLANNING_ONLY_RETRY_LIMIT: usize = 2;
+/// Maximum number of times the runner will re-prompt the model to call
+/// `task_complete` after it stops with text-only output mid-task (i.e.
+/// after the agent has already invoked at least one tool this run).
+/// Past this cap the runner gives up and accepts the last text response
+/// rather than spinning until `max_iterations`. Small models that never
+/// learn to call `task_complete` thus degrade to the legacy behavior.
+const TASK_COMPLETE_RETRY_LIMIT: usize = 3;
 
 /// Default upper bound on the effective context window used when computing
 /// the compaction threshold. Keeps compaction aggressive even when the
@@ -168,6 +179,7 @@ fn compaction_summary_max_tokens() -> usize {
 }
 
 /// Classification of a model response that didn't include tool calls.
+#[derive(Debug)]
 enum ResponseClass {
     /// Substantive text — the model produced a real answer.
     Complete,
@@ -178,6 +190,32 @@ enum ResponseClass {
     /// (e.g. "I'll read the file…", "Let me search for…").
     PlanningOnly,
 }
+
+/// Extract the `summary` argument from a `task_complete` invocation if one
+/// is present in this batch of tool calls. Returns `None` when the model
+/// did not call `task_complete`, called it without a non-empty `summary`
+/// string, or called it with a malformed payload — in those cases the
+/// runner keeps looping rather than synthesizing a blank final answer.
+fn extract_task_complete_summary(calls: &[&ToolCall]) -> Option<String> {
+    calls
+        .iter()
+        .find(|c| c.name == "task_complete")
+        .and_then(|c| c.arguments.get("summary"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// User-role nudge injected when the model produces a text-only response
+/// after it has already invoked tools this run. Reminds the model that
+/// `task_complete` is the explicit completion signal — text alone no
+/// longer terminates the loop once work is in progress.
+const TASK_COMPLETE_REMINDER: &str =
+    "You produced text but did not call `task_complete`. If the user's request \
+     is fully handled, call `task_complete` now with a `summary` containing the \
+     final answer the user should see. If more work remains, call the next tool \
+     to keep going — text alone will not end the turn now that you've started \
+     working.";
 
 /// Classify a text-only assistant response.
 fn classify_response(text: &str, _completion_tokens: u32) -> ResponseClass {
@@ -954,9 +992,18 @@ impl AgentRunner {
         let mut empty_response_retries: usize = 0;
         let mut planning_only_retries: usize = 0;
         let mut empty_tool_use_retries: usize = 0;
+        // Cap re-prompts that nudge the model to call `task_complete` after
+        // it stops with text alone mid-task.
+        let mut task_complete_retries: usize = 0;
         // Track whether any side-effect tool has been executed this run,
         // so we can suppress retries that might duplicate externally-visible actions.
         let mut had_side_effects = false;
+        // Track whether the agent has called any tool this run. Used to
+        // gate the new "must call task_complete to stop" behavior: a
+        // text-only first response (greeting, direct Q&A) still ends the
+        // turn, but once the model has started using tools we expect an
+        // explicit completion signal.
+        let mut has_called_any_tool = false;
 
         // Per-run circuit breaker: a tool that fails repeatedly during this
         // run is disabled for the rest of the conversation so the model
@@ -1047,9 +1094,11 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
                 planning_only_retries = 0;
+                task_complete_retries = 0;
                 let calls = message.content.tool_calls();
                 let tool_names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
                 tracing::info!(
@@ -1058,6 +1107,12 @@ impl AgentRunner {
                     tools = ?tool_names,
                     "executing tool calls"
                 );
+
+                // Capture the `task_complete` summary up front so we can
+                // surface it as the final assistant message after the tool
+                // batch finishes — even if the call vector is moved into
+                // `execute_tools_parallel_traced` below.
+                let task_complete_summary = extract_task_complete_summary(&calls);
 
                 for call in &calls {
                     tracing::info!(tool = %call.name, call_id = %call.id, "tool call started");
@@ -1157,6 +1212,29 @@ impl AgentRunner {
                     consecutive_errors = 0;
                 }
 
+                // Explicit completion signal: the model called `task_complete`
+                // with a non-empty summary. Surface the summary as the final
+                // assistant message (so `extract_assistant_message` finds it)
+                // and exit the loop. We only break *after* tool results were
+                // pushed so the conversation history stays well-formed: every
+                // tool_call has a matching tool_result.
+                if let Some(summary) = task_complete_summary {
+                    tracing::info!(
+                        iteration,
+                        "task_complete invoked — terminating run with model-supplied summary"
+                    );
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::Assistant,
+                            content: MessageContent::Text(summary),
+                            created_at: Utc::now(),
+                        },
+                    );
+                    return Ok(());
+                }
+
                 continue;
             }
 
@@ -1177,6 +1255,41 @@ impl AgentRunner {
                 StopReason::EndTurn => {
                     let text = message.content.as_text().unwrap_or("");
                     let classification = classify_response(text, usage.completion_tokens);
+
+                    // If the agent has already called tools this run we no
+                    // longer trust an Ollama-style EndTurn as "task done":
+                    // the provider maps any text-only response to EndTurn
+                    // regardless of intent. Re-prompt the model to either
+                    // call `task_complete` with a final answer or continue
+                    // working. Cap by `TASK_COMPLETE_RETRY_LIMIT` so models
+                    // that never learn the protocol fall through to the
+                    // legacy accept-and-return behavior.
+                    if has_called_any_tool {
+                        task_complete_retries += 1;
+                        if task_complete_retries > TASK_COMPLETE_RETRY_LIMIT {
+                            tracing::warn!(
+                                retries = task_complete_retries,
+                                "task_complete reminder retries exhausted — accepting last response"
+                            );
+                            return Ok(());
+                        }
+                        tracing::warn!(
+                            iteration,
+                            retries = task_complete_retries,
+                            ?classification,
+                            "EndTurn without task_complete after tool use — re-prompting"
+                        );
+                        self.push_message(
+                            conv,
+                            Message {
+                                id: Uuid::new_v4(),
+                                role: Role::User,
+                                content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
+                                created_at: Utc::now(),
+                            },
+                        );
+                        continue;
+                    }
 
                     match classification {
                         ResponseClass::Complete => return Ok(()),
@@ -1353,7 +1466,9 @@ impl AgentRunner {
         let mut empty_response_retries: usize = 0;
         let mut planning_only_retries: usize = 0;
         let mut empty_tool_use_retries: usize = 0;
+        let mut task_complete_retries: usize = 0;
         let mut had_side_effects = false;
+        let mut has_called_any_tool = false;
         let mut breaker = ToolCircuitBreaker::new(self.config.circuit_breaker_threshold);
 
         for iteration in 0..self.config.max_iterations {
@@ -1437,9 +1552,11 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
                 planning_only_retries = 0;
+                task_complete_retries = 0;
                 let calls = message.content.tool_calls();
                 let tool_names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
                 tracing::info!(
@@ -1448,6 +1565,11 @@ impl AgentRunner {
                     tools = ?tool_names,
                     "executing tool calls"
                 );
+
+                // Capture the `task_complete` summary up front so we can
+                // surface it as the final assistant message after this
+                // tool batch finishes — see run_inner for rationale.
+                let task_complete_summary = extract_task_complete_summary(&calls);
 
                 for call in &calls {
                     tracing::info!(tool = %call.name, call_id = %call.id, "tool call started");
@@ -1567,6 +1689,29 @@ impl AgentRunner {
                     consecutive_errors = 0;
                 }
 
+                // Explicit completion signal — see run_inner. The synthesized
+                // final assistant message is also emitted as a TextDelta so
+                // streaming UIs render the deliverable just like a model-
+                // produced final answer.
+                if let Some(summary) = task_complete_summary {
+                    tracing::info!(
+                        iteration,
+                        "task_complete invoked — terminating run with model-supplied summary"
+                    );
+                    on_event(AgentEvent::TextDelta(summary.clone()));
+                    self.push_message(
+                        conv,
+                        Message {
+                            id: Uuid::new_v4(),
+                            role: Role::Assistant,
+                            content: MessageContent::Text(summary),
+                            created_at: Utc::now(),
+                        },
+                    );
+                    on_event(AgentEvent::Done);
+                    return Ok(());
+                }
+
                 continue;
             }
 
@@ -1587,6 +1732,38 @@ impl AgentRunner {
                 StopReason::EndTurn => {
                     let text = message.content.as_text().unwrap_or("");
                     let classification = classify_response(text, usage.completion_tokens);
+
+                    // Once the agent has called tools this run, an Ollama
+                    // EndTurn no longer terminates: re-prompt the model to
+                    // either call `task_complete` or keep working. See
+                    // run_inner for the full rationale.
+                    if has_called_any_tool {
+                        task_complete_retries += 1;
+                        if task_complete_retries > TASK_COMPLETE_RETRY_LIMIT {
+                            tracing::warn!(
+                                retries = task_complete_retries,
+                                "task_complete reminder retries exhausted — accepting last response"
+                            );
+                            on_event(AgentEvent::Done);
+                            return Ok(());
+                        }
+                        tracing::warn!(
+                            iteration,
+                            retries = task_complete_retries,
+                            ?classification,
+                            "EndTurn without task_complete after tool use — re-prompting"
+                        );
+                        self.push_message(
+                            conv,
+                            Message {
+                                id: Uuid::new_v4(),
+                                role: Role::User,
+                                content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
+                                created_at: Utc::now(),
+                            },
+                        );
+                        continue;
+                    }
 
                     match classification {
                         ResponseClass::Complete => {
@@ -3912,6 +4089,287 @@ mod tool_choice_guard_tests {
             Some(ToolChoice::Auto),
             "iteration 0 must use ToolChoice::Auto by default; got {choices:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod task_complete_tests {
+    //! End-to-end tests for the `task_complete` completion-signal protocol.
+
+    use super::*;
+
+    use async_trait::async_trait;
+    use rustykrab_core::capability::CapabilitySet;
+    use rustykrab_core::model::{ModelResponse, StopReason, Usage};
+    use rustykrab_core::types::{ToolCall, ToolSchema};
+    use std::sync::Mutex;
+
+    use crate::sandbox::NoSandbox;
+
+    /// Provider that returns a queued list of canned responses, one per
+    /// chat call, then panics if asked for more. Lets tests scenarios
+    /// scripted as "first turn is X, second is Y, third is Z."
+    struct ScriptedProvider {
+        script: Mutex<Vec<ModelResponse>>,
+        chat_count: Mutex<usize>,
+    }
+
+    impl ScriptedProvider {
+        fn new(script: Vec<ModelResponse>) -> Self {
+            Self {
+                script: Mutex::new(script),
+                chat_count: Mutex::new(0),
+            }
+        }
+
+        fn next(&self) -> ModelResponse {
+            let mut s = self.script.lock().unwrap();
+            *self.chat_count.lock().unwrap() += 1;
+            if s.is_empty() {
+                panic!("ScriptedProvider ran out of canned responses");
+            }
+            s.remove(0)
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for ScriptedProvider {
+        fn name(&self) -> &str {
+            "scripted-mock"
+        }
+        async fn chat(&self, _: &[Message], _: &[ToolSchema]) -> Result<ModelResponse> {
+            Ok(self.next())
+        }
+        async fn chat_with_choice(
+            &self,
+            _: &[Message],
+            _: &[ToolSchema],
+            _: ToolChoice,
+        ) -> Result<ModelResponse> {
+            Ok(self.next())
+        }
+    }
+
+    /// Pure-compute tool used to satisfy capabilities without triggering
+    /// the side-effect retry guard. The runner only needs a non-empty
+    /// tools vec for `compute_schemas` and capability checks.
+    struct NoopTool {
+        name: String,
+    }
+
+    #[async_trait]
+    impl Tool for NoopTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "test noop"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: self.name.clone(),
+                description: self.description().to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+        async fn execute(&self, _args: serde_json::Value) -> Result<serde_json::Value> {
+            Ok(serde_json::json!({"ok": true}))
+        }
+    }
+
+    fn tool_use_response(name: &str, args: serde_json::Value) -> ModelResponse {
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::ToolCall(ToolCall {
+                    id: Uuid::new_v4().to_string(),
+                    name: name.to_string(),
+                    arguments: args,
+                }),
+                created_at: Utc::now(),
+            },
+            usage: Usage::default(),
+            stop_reason: StopReason::ToolUse,
+            text: None,
+        }
+    }
+
+    fn text_response(text: &str) -> ModelResponse {
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text.to_string()),
+                created_at: Utc::now(),
+            },
+            usage: Usage::default(),
+            stop_reason: StopReason::EndTurn,
+            text: None,
+        }
+    }
+
+    fn make_conv() -> Conversation {
+        Conversation {
+            id: Uuid::new_v4(),
+            messages: vec![Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text("do the thing".into()),
+                created_at: Utc::now(),
+            }],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            summary: None,
+            detected_profile: None,
+            channel_source: None,
+            channel_id: None,
+            channel_thread_id: None,
+        }
+    }
+
+    fn make_runner(provider: Arc<ScriptedProvider>) -> (AgentRunner, Session, Uuid) {
+        use rustykrab_tools::TaskCompleteTool;
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "noop".into(),
+            }),
+            Arc::new(TaskCompleteTool::new()),
+        ];
+        let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["noop", "task_complete"]);
+        let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        (runner, session, conv_id)
+    }
+
+    #[tokio::test]
+    async fn task_complete_terminates_with_summary_as_final_message() {
+        // Model calls noop, then calls task_complete with a real summary.
+        // Loop must end and the conversation's last assistant text must
+        // be the summary string verbatim.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            tool_use_response(
+                "task_complete",
+                serde_json::json!({ "summary": "found 5 hotels with availability" }),
+            ),
+        ]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner
+            .run(&mut conv, &session)
+            .await
+            .expect("loop should terminate cleanly");
+
+        let last_assistant_text = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+            .and_then(|m| m.content.as_text())
+            .expect("final assistant text must be present");
+        assert_eq!(last_assistant_text, "found 5 hotels with availability");
+
+        // Provider should not be polled again after task_complete.
+        assert_eq!(*provider.chat_count.lock().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn endturn_after_tool_use_reprompts_for_task_complete() {
+        // Model calls noop, then ends with planning-only text (no
+        // task_complete). The runner must re-prompt rather than accept,
+        // even though Anthropic-style classification would have accepted
+        // the second message after side-effect equivalents.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            // EndTurn without task_complete → must trigger re-prompt.
+            text_response("I'll keep digging into this for you. Stay tuned!"),
+            // Now model calls task_complete properly.
+            tool_use_response(
+                "task_complete",
+                serde_json::json!({ "summary": "done at last" }),
+            ),
+        ]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let last_assistant_text = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+            .and_then(|m| m.content.as_text())
+            .expect("final assistant text must be present");
+        assert_eq!(last_assistant_text, "done at last");
+
+        // All three scripted turns must have been consumed.
+        assert_eq!(*provider.chat_count.lock().unwrap(), 3);
+
+        // The reminder must have been injected as a user-role message.
+        assert!(
+            conv.messages.iter().any(|m| m.role == Role::User
+                && m.content
+                    .as_text()
+                    .map(|t| t.contains("task_complete"))
+                    .unwrap_or(false)),
+            "expected re-prompt mentioning task_complete in the conversation"
+        );
+    }
+
+    #[tokio::test]
+    async fn iteration_zero_text_response_still_terminates() {
+        // No tools called yet — a substantive text response on iteration 0
+        // must still end the turn (greeting / direct Q&A path). This is
+        // the carve-out that keeps "what is 2+2?" → "4" from looping
+        // forever in models that don't know to call task_complete.
+        let provider = Arc::new(ScriptedProvider::new(vec![text_response(
+            "The answer is 42. Hitchhikers know.",
+        )]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+        assert_eq!(*provider.chat_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn task_complete_with_empty_summary_does_not_terminate() {
+        // Model calls noop, then calls task_complete with empty summary
+        // (the tool itself rejects it). The runner must NOT short-circuit
+        // on a failed task_complete — it should keep looping, hit the
+        // re-prompt path, then accept the next valid completion.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            tool_use_response("task_complete", serde_json::json!({ "summary": "   " })),
+            tool_use_response(
+                "task_complete",
+                serde_json::json!({ "summary": "real answer" }),
+            ),
+        ]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let last_assistant_text = conv
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant && m.content.as_text().is_some())
+            .and_then(|m| m.content.as_text())
+            .expect("final assistant text must be present");
+        assert_eq!(last_assistant_text, "real answer");
     }
 }
 

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -47,7 +47,8 @@ async fn build_and_inject_system_prompt(
     // 2. Build the minimal system prompt.
     let mut builder = SystemPromptBuilder::new()
         .with_identity(&profile.agent_name)
-        .with_security_policy();
+        .with_security_policy()
+        .with_completion_protocol();
 
     // Inject SKILL.md catalog (only satisfied skills).
     let all_md = state.skill_registry.md_skills();

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -109,6 +109,29 @@ impl SystemPromptBuilder {
         self
     }
 
+    /// Tell the model how to terminate a run. Once it has called any tool
+    /// this turn, the only accepted "I'm done" signal is the `task_complete`
+    /// tool — plain text (which providers like Ollama map to `EndTurn`
+    /// regardless of intent) will be treated as an interim progress update
+    /// and the runner will re-prompt the model to continue.
+    pub fn with_completion_protocol(mut self) -> Self {
+        self.sections.push(
+            "COMPLETION:\n\
+             - When the user's request is fully handled, call the \
+               `task_complete` tool. Pass the final answer the user should \
+               see as the `summary` argument — that string is delivered \
+               verbatim, so make it complete and self-contained.\n\
+             - Do not end your turn with text alone after you have started \
+               using tools. The runner treats text-without-task_complete as \
+               an interim update and will prompt you to keep working.\n\
+             - If more work remains, call the next tool. If you genuinely \
+               cannot continue, call `task_complete` with a summary that \
+               explains why."
+                .to_string(),
+        );
+        self
+    }
+
     /// Add a skill's system prompt fragment.
     pub fn with_skill(mut self, skill_prompt: &str) -> Self {
         self.sections.push(skill_prompt.to_string());

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -86,6 +86,10 @@ mod skills;
 mod tools_list;
 mod tools_load;
 
+// Completion signaling — explicit "I'm done" tool that lets the runner
+// distinguish "model paused mid-task" from "model finished the task."
+mod task_complete;
+
 // MCP connector (remote MCP servers exposed as native tools)
 mod mcp_connector;
 
@@ -170,6 +174,9 @@ pub use self::skills::{SkillTool, SkillsTool};
 pub use tools_list::ToolsListTool;
 pub use tools_load::ToolsLoadTool;
 
+// Completion signaling
+pub use task_complete::TaskCompleteTool;
+
 // MCP connector
 pub use mcp_connector::{mcp_connector_tools, McpRemoteTool};
 
@@ -184,6 +191,9 @@ pub fn builtin_tools(
         // Meta — tool discovery and lazy schema loading. Always registered.
         std::sync::Arc::new(ToolsListTool::new()),
         std::sync::Arc::new(ToolsLoadTool::new()),
+        // Completion signal — must always be reachable so the model can
+        // declare "task done" regardless of which dynamic tools are loaded.
+        std::sync::Arc::new(TaskCompleteTool::new()),
         // HTTP
         std::sync::Arc::new(HttpRequestTool::new()),
         std::sync::Arc::new(HttpSessionTool::new()),

--- a/crates/rustykrab-tools/src/task_complete.rs
+++ b/crates/rustykrab-tools/src/task_complete.rs
@@ -1,0 +1,111 @@
+use async_trait::async_trait;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Error, Result, Tool};
+use serde_json::{json, Value};
+
+/// Explicit "I'm done" signal the model emits when the user's request is
+/// fully handled. The runner watches for a successful call to this tool,
+/// surfaces the supplied `summary` as the assistant's final message, and
+/// then terminates the loop — so a text-only response (which Ollama maps
+/// to `StopReason::EndTurn` regardless of intent) no longer doubles as
+/// "task finished."
+pub struct TaskCompleteTool;
+
+impl TaskCompleteTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TaskCompleteTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for TaskCompleteTool {
+    fn name(&self) -> &str {
+        "task_complete"
+    }
+
+    fn description(&self) -> &str {
+        "Signal that the user's request is fully handled and you are ready to send \
+         your final answer. The `summary` you pass becomes the message the user sees, \
+         so make it complete and self-contained — the deliverable itself, not a \
+         meta-description of what you did. Call this ONLY when every step of the task \
+         is done; if work remains, call the next tool instead. The agent loop stops as \
+         soon as this call returns."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "description": "The final answer for the user — the deliverable itself, \
+                                        not a meta-description of what you did."
+                    }
+                },
+                "required": ["summary"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let summary = args
+            .get("summary")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
+        if summary.is_empty() {
+            return Err(Error::ToolExecution(
+                "task_complete requires a non-empty `summary` describing the final answer".into(),
+            ));
+        }
+        Ok(json!({ "ok": true, "summary": summary }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_missing_summary() {
+        let tool = TaskCompleteTool::new();
+        let err = tool.execute(json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("summary"));
+    }
+
+    #[tokio::test]
+    async fn rejects_empty_summary() {
+        let tool = TaskCompleteTool::new();
+        let err = tool.execute(json!({ "summary": "   " })).await.unwrap_err();
+        assert!(err.to_string().contains("summary"));
+    }
+
+    #[tokio::test]
+    async fn echoes_summary_back() {
+        let tool = TaskCompleteTool::new();
+        let out = tool
+            .execute(json!({ "summary": "found 3 hotels" }))
+            .await
+            .unwrap();
+        assert_eq!(out["ok"], json!(true));
+        assert_eq!(out["summary"], json!("found 3 hotels"));
+    }
+
+    #[test]
+    fn schema_advertises_required_summary() {
+        let schema = TaskCompleteTool::new().schema();
+        assert_eq!(schema.name, "task_complete");
+        let required = schema.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "summary"));
+    }
+}


### PR DESCRIPTION
Ollama (and similar providers) map any text-only response to
`StopReason::EndTurn`, so the agent's "I'm pausing to report progress" and
"I'm done" responses look identical. The runner used to accept either,
causing the model to narrate a plan, EndTurn, and drop the user's task
mid-flight.

Introduce a `task_complete` tool the model calls when it has finished the
user's request, passing the final answer as `summary`. The runner watches
for it after each tool batch, surfaces the summary as the assistant's
final message, and exits the loop. Until then, an EndTurn that arrives
after any tool has been invoked is treated as an interim update and
re-prompts the model (up to TASK_COMPLETE_RETRY_LIMIT) to either call
task_complete or continue. The iteration-0 / no-tools-yet path keeps the
legacy "text response ends the turn" behavior so direct Q&A and greetings
still terminate cleanly.

Wires the tool into builtin_tools and META_TOOL_NAMES so it is always
callable, and adds a `with_completion_protocol` section to the system
prompt builder documenting the protocol to the model.

https://claude.ai/code/session_01YML6UhhBAaQtdWN81TBenu