### PR TITLE
refactor(agent): hide task_complete until the model uses its first tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -25,9 +25,13 @@ use uuid::Uuid;
 /// always present — the model can't `tools_load` them after compaction
 /// has already dropped the detail it needs to recover, and `recall_append`
 /// is the manual escape hatch for stashing content outside the prompt.
-/// `task_complete` is the explicit "I'm done" signal — the runner relies
-/// on it to disambiguate "model paused mid-task" from "model finished",
-/// so it must be callable from any iteration without a `tools_load` hop.
+///
+/// `task_complete` is *not* listed here on purpose: exposing the
+/// completion signal from turn 0 tempts the model to call it for simple
+/// Q&A and greetings. The runner instead activates it via
+/// `self.active_tools` the first time the model uses any tool this run,
+/// so it appears in the schema exactly when the runner starts requiring
+/// it.
 const META_TOOL_NAMES: &[&str] = &[
     "tools_list",
     "tools_load",
@@ -36,7 +40,6 @@ const META_TOOL_NAMES: &[&str] = &[
     "recall_peek",
     "recall_search",
     "recall_sub_query",
-    "task_complete",
 ];
 
 fn is_meta_tool(name: &str) -> bool {
@@ -1094,6 +1097,14 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                // First tool call this run — make `task_complete` visible
+                // in the schema from the next iteration onward. We hide it
+                // on no-tool turns (greetings, direct Q&A) so the model
+                // isn't tempted to use it as a chatty turn-ender.
+                if !has_called_any_tool {
+                    self.active_tools
+                        .activate(session.conversation_id, ["task_complete"]);
+                }
                 has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
@@ -1552,6 +1563,12 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                // First tool call this run — reveal `task_complete` in the
+                // schema from here on. See run_inner for rationale.
+                if !has_called_any_tool {
+                    self.active_tools
+                        .activate(session.conversation_id, ["task_complete"]);
+                }
                 has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
@@ -4240,7 +4257,10 @@ mod task_complete_tests {
         let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
             .with_active_tools(active.clone());
         let conv_id = Uuid::new_v4();
-        active.activate(conv_id, ["noop", "task_complete"]);
+        // Pre-activate only `noop`: the runner should auto-reveal
+        // `task_complete` after the first tool call, so leaving it out
+        // here also exercises that activation path.
+        active.activate(conv_id, ["noop"]);
         let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
         let session = Session::with_capabilities(conv_id, caps);
         (runner, session, conv_id)
@@ -4340,6 +4360,129 @@ mod task_complete_tests {
 
         runner.run(&mut conv, &session).await.unwrap();
         assert_eq!(*provider.chat_count.lock().unwrap(), 1);
+    }
+
+    /// Provider that records the *names* of tools in each call's schema
+    /// so a test can assert which iterations saw `task_complete` exposed.
+    struct SchemaRecordingProvider {
+        script: Mutex<Vec<ModelResponse>>,
+        schema_names_per_call: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl SchemaRecordingProvider {
+        fn new(script: Vec<ModelResponse>) -> Self {
+            Self {
+                script: Mutex::new(script),
+                schema_names_per_call: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn next(&self, tools: &[ToolSchema]) -> ModelResponse {
+            self.schema_names_per_call
+                .lock()
+                .unwrap()
+                .push(tools.iter().map(|t| t.name.clone()).collect());
+            let mut s = self.script.lock().unwrap();
+            if s.is_empty() {
+                panic!("SchemaRecordingProvider ran out of canned responses");
+            }
+            s.remove(0)
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for SchemaRecordingProvider {
+        fn name(&self) -> &str {
+            "schema-recording-mock"
+        }
+        async fn chat(&self, _: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+            Ok(self.next(tools))
+        }
+        async fn chat_with_choice(
+            &self,
+            _: &[Message],
+            tools: &[ToolSchema],
+            _: ToolChoice,
+        ) -> Result<ModelResponse> {
+            Ok(self.next(tools))
+        }
+    }
+
+    #[tokio::test]
+    async fn task_complete_is_hidden_until_first_tool_call() {
+        // Iteration 0 schema must not contain `task_complete`. After the
+        // model uses any tool, iteration 1's schema must include it.
+        use rustykrab_tools::TaskCompleteTool;
+        let provider = Arc::new(SchemaRecordingProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            tool_use_response("task_complete", serde_json::json!({ "summary": "ok" })),
+        ]));
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "noop".into(),
+            }),
+            Arc::new(TaskCompleteTool::new()),
+        ];
+        let runner = AgentRunner::new(provider.clone(), tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["noop"]);
+        let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let schemas = provider.schema_names_per_call.lock().unwrap();
+        assert_eq!(schemas.len(), 2, "expected 2 chat calls");
+        assert!(
+            !schemas[0].iter().any(|n| n == "task_complete"),
+            "iteration 0 schema must not expose task_complete; got {:?}",
+            schemas[0]
+        );
+        assert!(
+            schemas[1].iter().any(|n| n == "task_complete"),
+            "iteration 1 schema must expose task_complete after tool use; got {:?}",
+            schemas[1]
+        );
+    }
+
+    #[tokio::test]
+    async fn task_complete_hidden_for_direct_qa_path() {
+        // A user asks something the model can answer in one turn with no
+        // tools. `task_complete` must never appear in the schema, so the
+        // model isn't tempted to invoke it as a chatty turn-ender.
+        use rustykrab_tools::TaskCompleteTool;
+        let provider = Arc::new(SchemaRecordingProvider::new(vec![text_response(
+            "The answer is 42.",
+        )]));
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "noop".into(),
+            }),
+            Arc::new(TaskCompleteTool::new()),
+        ];
+        let runner = AgentRunner::new(provider.clone(), tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["noop"]);
+        let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let schemas = provider.schema_names_per_call.lock().unwrap();
+        for (i, names) in schemas.iter().enumerate() {
+            assert!(
+                !names.iter().any(|n| n == "task_complete"),
+                "iteration {i} should not expose task_complete on direct-Q&A path; got {names:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -53,8 +53,7 @@ async fn build_and_inject_system_prompt(
     let mut builder = SystemPromptBuilder::new()
         .with_identity(&profile.agent_name)
         .with_current_date(&today)
-        .with_security_policy()
-        .with_completion_protocol();
+        .with_security_policy();
 
     // Inject SKILL.md catalog (only satisfied skills).
     let all_md = state.skill_registry.md_skills();

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -121,29 +121,6 @@ impl SystemPromptBuilder {
         self
     }
 
-    /// Tell the model how to terminate a run. Once it has called any tool
-    /// this turn, the only accepted "I'm done" signal is the `task_complete`
-    /// tool — plain text (which providers like Ollama map to `EndTurn`
-    /// regardless of intent) will be treated as an interim progress update
-    /// and the runner will re-prompt the model to continue.
-    pub fn with_completion_protocol(mut self) -> Self {
-        self.sections.push(
-            "COMPLETION:\n\
-             - When the user's request is fully handled, call the \
-               `task_complete` tool. Pass the final answer the user should \
-               see as the `summary` argument — that string is delivered \
-               verbatim, so make it complete and self-contained.\n\
-             - Do not end your turn with text alone after you have started \
-               using tools. The runner treats text-without-task_complete as \
-               an interim update and will prompt you to keep working.\n\
-             - If more work remains, call the next tool. If you genuinely \
-               cannot continue, call `task_complete` with a summary that \
-               explains why."
-                .to_string(),
-        );
-        self
-    }
-
     /// Add a skill's system prompt fragment.
     pub fn with_skill(mut self, skill_prompt: &str) -> Self {
         self.sections.push(skill_prompt.to_string());


### PR DESCRIPTION
## Summary

Follow-up to #441. Listing `task_complete` in `META_TOOL_NAMES` exposed the completion signal from turn 0, which dangled it in front of the model on simple Q&A and greeting turns. The result was overuse — any text-ender could turn into a chatty `task_complete("hi back!")` call.

This change drops `task_complete` from the meta list and instead activates it via `self.active_tools` the first time `has_called_any_tool` flips to true this run. The tool is now in the schema exactly when the runner starts requiring it — no earlier — and disappears entirely for direct-answer turns. The system-prompt `with_completion_protocol` section also goes away: the tool's own description teaches the protocol once it appears.

## Behavior

- **No-tool turns** (greetings, direct Q&A): zero `task_complete` overhead — it never appears in the schema, ~140 schema tokens saved per call.
- **After first tool call**: `task_complete` becomes visible from the next iteration, exactly when the runner starts enforcing it as the termination signal.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p rustykrab-{tools,agent,skills,gateway} --all-targets` clean
- [x] `cargo test` on the affected crates: 155 passed, 0 failed
- [x] New tests added in `runner::task_complete_tests`:
  - `task_complete_is_hidden_until_first_tool_call` — uses a `SchemaRecordingProvider` to assert `task_complete` is absent on iteration 0 and present on iteration 1 after a tool call.
  - `task_complete_hidden_for_direct_qa_path` — asserts `task_complete` never appears in the schema across a no-tool turn.

https://claude.ai/code/session_01YML6UhhBAaQtdWN81TBenu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YML6UhhBAaQtdWN81TBenu)_