### PR TITLE
refactor(agent): share task_complete loop logic + retry-cap test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -220,6 +220,18 @@ const TASK_COMPLETE_REMINDER: &str =
      to keep going — text alone will not end the turn now that you've started \
      working.";
 
+/// Outcome of `AgentRunner::reprompt_for_task_complete`: tell the caller
+/// whether to keep looping or accept the last response. Lets the streaming
+/// and non-streaming run paths share the retry-cap bookkeeping while still
+/// emitting their own terminal events.
+enum CompletionReminderOutcome {
+    /// A reminder was injected — caller should `continue` the loop.
+    Continue,
+    /// Retry cap exceeded — caller should accept the last response and
+    /// return `Ok(())` (after emitting any provider-specific events).
+    GiveUp,
+}
+
 /// Classify a text-only assistant response.
 fn classify_response(text: &str, _completion_tokens: u32) -> ResponseClass {
     let trimmed = text.trim();
@@ -867,6 +879,63 @@ impl AgentRunner {
         }
     }
 
+    /// Push the `task_complete` summary as the final assistant message and
+    /// log the termination. Shared by the streaming and non-streaming run
+    /// paths; the caller is responsible for emitting any provider-specific
+    /// events (e.g. `AgentEvent::TextDelta` / `AgentEvent::Done`).
+    fn finalize_task_complete(&self, conv: &mut Conversation, iteration: usize, summary: String) {
+        tracing::info!(
+            iteration,
+            "task_complete invoked — terminating run with model-supplied summary"
+        );
+        self.push_message(
+            conv,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(summary),
+                created_at: Utc::now(),
+            },
+        );
+    }
+
+    /// Inject the `TASK_COMPLETE_REMINDER` as a user-role nudge after the
+    /// model produced a text-only EndTurn mid-task. Bumps `retries` and
+    /// returns `GiveUp` once the cap is exceeded so the caller can accept
+    /// the last response rather than spinning to `max_iterations`.
+    fn reprompt_for_task_complete(
+        &self,
+        conv: &mut Conversation,
+        iteration: usize,
+        retries: &mut usize,
+        classification: &ResponseClass,
+    ) -> CompletionReminderOutcome {
+        *retries += 1;
+        if *retries > TASK_COMPLETE_RETRY_LIMIT {
+            tracing::warn!(
+                retries = *retries,
+                "task_complete reminder retries exhausted — accepting last response"
+            );
+            return CompletionReminderOutcome::GiveUp;
+        }
+        tracing::warn!(
+            iteration,
+            retries = *retries,
+            ?classification,
+            "EndTurn without task_complete after tool use — re-prompting"
+        );
+        self.push_message(
+            conv,
+            Message {
+                id: Uuid::new_v4(),
+                role: Role::User,
+                content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
+                created_at: Utc::now(),
+            },
+        );
+        CompletionReminderOutcome::Continue
+    }
+
     /// Start the event-driven agent loop.
     ///
     /// Returns a handle for injecting events (user messages, cancellation),
@@ -1230,19 +1299,7 @@ impl AgentRunner {
                 // pushed so the conversation history stays well-formed: every
                 // tool_call has a matching tool_result.
                 if let Some(summary) = task_complete_summary {
-                    tracing::info!(
-                        iteration,
-                        "task_complete invoked — terminating run with model-supplied summary"
-                    );
-                    self.push_message(
-                        conv,
-                        Message {
-                            id: Uuid::new_v4(),
-                            role: Role::Assistant,
-                            content: MessageContent::Text(summary),
-                            created_at: Utc::now(),
-                        },
-                    );
+                    self.finalize_task_complete(conv, iteration, summary);
                     return Ok(());
                 }
 
@@ -1276,30 +1333,15 @@ impl AgentRunner {
                     // that never learn the protocol fall through to the
                     // legacy accept-and-return behavior.
                     if has_called_any_tool {
-                        task_complete_retries += 1;
-                        if task_complete_retries > TASK_COMPLETE_RETRY_LIMIT {
-                            tracing::warn!(
-                                retries = task_complete_retries,
-                                "task_complete reminder retries exhausted — accepting last response"
-                            );
-                            return Ok(());
-                        }
-                        tracing::warn!(
-                            iteration,
-                            retries = task_complete_retries,
-                            ?classification,
-                            "EndTurn without task_complete after tool use — re-prompting"
-                        );
-                        self.push_message(
+                        match self.reprompt_for_task_complete(
                             conv,
-                            Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
-                                created_at: Utc::now(),
-                            },
-                        );
-                        continue;
+                            iteration,
+                            &mut task_complete_retries,
+                            &classification,
+                        ) {
+                            CompletionReminderOutcome::Continue => continue,
+                            CompletionReminderOutcome::GiveUp => return Ok(()),
+                        }
                     }
 
                     match classification {
@@ -1711,20 +1753,8 @@ impl AgentRunner {
                 // streaming UIs render the deliverable just like a model-
                 // produced final answer.
                 if let Some(summary) = task_complete_summary {
-                    tracing::info!(
-                        iteration,
-                        "task_complete invoked — terminating run with model-supplied summary"
-                    );
                     on_event(AgentEvent::TextDelta(summary.clone()));
-                    self.push_message(
-                        conv,
-                        Message {
-                            id: Uuid::new_v4(),
-                            role: Role::Assistant,
-                            content: MessageContent::Text(summary),
-                            created_at: Utc::now(),
-                        },
-                    );
+                    self.finalize_task_complete(conv, iteration, summary);
                     on_event(AgentEvent::Done);
                     return Ok(());
                 }
@@ -1755,31 +1785,18 @@ impl AgentRunner {
                     // either call `task_complete` or keep working. See
                     // run_inner for the full rationale.
                     if has_called_any_tool {
-                        task_complete_retries += 1;
-                        if task_complete_retries > TASK_COMPLETE_RETRY_LIMIT {
-                            tracing::warn!(
-                                retries = task_complete_retries,
-                                "task_complete reminder retries exhausted — accepting last response"
-                            );
-                            on_event(AgentEvent::Done);
-                            return Ok(());
-                        }
-                        tracing::warn!(
-                            iteration,
-                            retries = task_complete_retries,
-                            ?classification,
-                            "EndTurn without task_complete after tool use — re-prompting"
-                        );
-                        self.push_message(
+                        match self.reprompt_for_task_complete(
                             conv,
-                            Message {
-                                id: Uuid::new_v4(),
-                                role: Role::User,
-                                content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
-                                created_at: Utc::now(),
-                            },
-                        );
-                        continue;
+                            iteration,
+                            &mut task_complete_retries,
+                            &classification,
+                        ) {
+                            CompletionReminderOutcome::Continue => continue,
+                            CompletionReminderOutcome::GiveUp => {
+                                on_event(AgentEvent::Done);
+                                return Ok(());
+                            }
+                        }
                     }
 
                     match classification {
@@ -4513,6 +4530,50 @@ mod task_complete_tests {
             .and_then(|m| m.content.as_text())
             .expect("final assistant text must be present");
         assert_eq!(last_assistant_text, "real answer");
+    }
+
+    #[tokio::test]
+    async fn task_complete_retry_limit_exhaustion_accepts_last_response() {
+        // After one real tool call the model narrates `TASK_COMPLETE_RETRY_LIMIT + 1`
+        // consecutive text-only EndTurns instead of ever calling
+        // `task_complete`. The runner must re-prompt up to the cap and then
+        // fall through to `Ok(())` — degrading gracefully to legacy
+        // behavior — rather than spinning until `max_iterations`.
+        let mut script = vec![tool_use_response("noop", serde_json::json!({}))];
+        // One more text response than the limit so the cap is exceeded.
+        for i in 0..=TASK_COMPLETE_RETRY_LIMIT {
+            script.push(text_response(&format!("still working on it ({i})")));
+        }
+        let total_provider_calls = script.len();
+        let provider = Arc::new(ScriptedProvider::new(script));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner
+            .run(&mut conv, &session)
+            .await
+            .expect("loop should fall through gracefully after retries exhausted");
+
+        // Provider polled exactly once per scripted response — the loop
+        // stopped at the cap, not earlier and not later.
+        assert_eq!(*provider.chat_count.lock().unwrap(), total_provider_calls);
+
+        // The reminder must have been injected exactly `TASK_COMPLETE_RETRY_LIMIT`
+        // times: each text response below the cap triggers one reminder;
+        // the response that exceeds the cap returns without injecting.
+        let reminder_count = conv
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == Role::User
+                    && m.content
+                        .as_text()
+                        .map(|t| t.contains("did not call `task_complete`"))
+                        .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(reminder_count, TASK_COMPLETE_RETRY_LIMIT);
     }
 }
 

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -25,9 +25,13 @@ use uuid::Uuid;
 /// always present — the model can't `tools_load` them after compaction
 /// has already dropped the detail it needs to recover, and `recall_append`
 /// is the manual escape hatch for stashing content outside the prompt.
-/// `task_complete` is the explicit "I'm done" signal — the runner relies
-/// on it to disambiguate "model paused mid-task" from "model finished",
-/// so it must be callable from any iteration without a `tools_load` hop.
+///
+/// `task_complete` is *not* listed here on purpose: exposing the
+/// completion signal from turn 0 tempts the model to call it for simple
+/// Q&A and greetings. The runner instead activates it via
+/// `self.active_tools` the first time the model uses any tool this run,
+/// so it appears in the schema exactly when the runner starts requiring
+/// it.
 const META_TOOL_NAMES: &[&str] = &[
     "tools_list",
     "tools_load",
@@ -36,7 +40,6 @@ const META_TOOL_NAMES: &[&str] = &[
     "recall_peek",
     "recall_search",
     "recall_sub_query",
-    "task_complete",
 ];
 
 fn is_meta_tool(name: &str) -> bool {
@@ -1094,6 +1097,14 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                // First tool call this run — make `task_complete` visible
+                // in the schema from the next iteration onward. We hide it
+                // on no-tool turns (greetings, direct Q&A) so the model
+                // isn't tempted to use it as a chatty turn-ender.
+                if !has_called_any_tool {
+                    self.active_tools
+                        .activate(session.conversation_id, ["task_complete"]);
+                }
                 has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
@@ -1552,6 +1563,12 @@ impl AgentRunner {
 
             // Handle tool calls.
             if message.content.has_tool_calls() {
+                // First tool call this run — reveal `task_complete` in the
+                // schema from here on. See run_inner for rationale.
+                if !has_called_any_tool {
+                    self.active_tools
+                        .activate(session.conversation_id, ["task_complete"]);
+                }
                 has_called_any_tool = true;
                 empty_tool_use_retries = 0;
                 empty_response_retries = 0;
@@ -4240,7 +4257,10 @@ mod task_complete_tests {
         let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
             .with_active_tools(active.clone());
         let conv_id = Uuid::new_v4();
-        active.activate(conv_id, ["noop", "task_complete"]);
+        // Pre-activate only `noop`: the runner should auto-reveal
+        // `task_complete` after the first tool call, so leaving it out
+        // here also exercises that activation path.
+        active.activate(conv_id, ["noop"]);
         let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
         let session = Session::with_capabilities(conv_id, caps);
         (runner, session, conv_id)
@@ -4340,6 +4360,129 @@ mod task_complete_tests {
 
         runner.run(&mut conv, &session).await.unwrap();
         assert_eq!(*provider.chat_count.lock().unwrap(), 1);
+    }
+
+    /// Provider that records the *names* of tools in each call's schema
+    /// so a test can assert which iterations saw `task_complete` exposed.
+    struct SchemaRecordingProvider {
+        script: Mutex<Vec<ModelResponse>>,
+        schema_names_per_call: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl SchemaRecordingProvider {
+        fn new(script: Vec<ModelResponse>) -> Self {
+            Self {
+                script: Mutex::new(script),
+                schema_names_per_call: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn next(&self, tools: &[ToolSchema]) -> ModelResponse {
+            self.schema_names_per_call
+                .lock()
+                .unwrap()
+                .push(tools.iter().map(|t| t.name.clone()).collect());
+            let mut s = self.script.lock().unwrap();
+            if s.is_empty() {
+                panic!("SchemaRecordingProvider ran out of canned responses");
+            }
+            s.remove(0)
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for SchemaRecordingProvider {
+        fn name(&self) -> &str {
+            "schema-recording-mock"
+        }
+        async fn chat(&self, _: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+            Ok(self.next(tools))
+        }
+        async fn chat_with_choice(
+            &self,
+            _: &[Message],
+            tools: &[ToolSchema],
+            _: ToolChoice,
+        ) -> Result<ModelResponse> {
+            Ok(self.next(tools))
+        }
+    }
+
+    #[tokio::test]
+    async fn task_complete_is_hidden_until_first_tool_call() {
+        // Iteration 0 schema must not contain `task_complete`. After the
+        // model uses any tool, iteration 1's schema must include it.
+        use rustykrab_tools::TaskCompleteTool;
+        let provider = Arc::new(SchemaRecordingProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            tool_use_response("task_complete", serde_json::json!({ "summary": "ok" })),
+        ]));
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "noop".into(),
+            }),
+            Arc::new(TaskCompleteTool::new()),
+        ];
+        let runner = AgentRunner::new(provider.clone(), tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["noop"]);
+        let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let schemas = provider.schema_names_per_call.lock().unwrap();
+        assert_eq!(schemas.len(), 2, "expected 2 chat calls");
+        assert!(
+            !schemas[0].iter().any(|n| n == "task_complete"),
+            "iteration 0 schema must not expose task_complete; got {:?}",
+            schemas[0]
+        );
+        assert!(
+            schemas[1].iter().any(|n| n == "task_complete"),
+            "iteration 1 schema must expose task_complete after tool use; got {:?}",
+            schemas[1]
+        );
+    }
+
+    #[tokio::test]
+    async fn task_complete_hidden_for_direct_qa_path() {
+        // A user asks something the model can answer in one turn with no
+        // tools. `task_complete` must never appear in the schema, so the
+        // model isn't tempted to invoke it as a chatty turn-ender.
+        use rustykrab_tools::TaskCompleteTool;
+        let provider = Arc::new(SchemaRecordingProvider::new(vec![text_response(
+            "The answer is 42.",
+        )]));
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "noop".into(),
+            }),
+            Arc::new(TaskCompleteTool::new()),
+        ];
+        let runner = AgentRunner::new(provider.clone(), tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["noop"]);
+        let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        let schemas = provider.schema_names_per_call.lock().unwrap();
+        for (i, names) in schemas.iter().enumerate() {
+            assert!(
+                !names.iter().any(|n| n == "task_complete"),
+                "iteration {i} should not expose task_complete on direct-Q&A path; got {names:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -47,8 +47,7 @@ async fn build_and_inject_system_prompt(
     // 2. Build the minimal system prompt.
     let mut builder = SystemPromptBuilder::new()
         .with_identity(&profile.agent_name)
-        .with_security_policy()
-        .with_completion_protocol();
+        .with_security_policy();
 
     // Inject SKILL.md catalog (only satisfied skills).
     let all_md = state.skill_registry.md_skills();

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -109,29 +109,6 @@ impl SystemPromptBuilder {
         self
     }
 
-    /// Tell the model how to terminate a run. Once it has called any tool
-    /// this turn, the only accepted "I'm done" signal is the `task_complete`
-    /// tool — plain text (which providers like Ollama map to `EndTurn`
-    /// regardless of intent) will be treated as an interim progress update
-    /// and the runner will re-prompt the model to continue.
-    pub fn with_completion_protocol(mut self) -> Self {
-        self.sections.push(
-            "COMPLETION:\n\
-             - When the user's request is fully handled, call the \
-               `task_complete` tool. Pass the final answer the user should \
-               see as the `summary` argument — that string is delivered \
-               verbatim, so make it complete and self-contained.\n\
-             - Do not end your turn with text alone after you have started \
-               using tools. The runner treats text-without-task_complete as \
-               an interim update and will prompt you to keep working.\n\
-             - If more work remains, call the next tool. If you genuinely \
-               cannot continue, call `task_complete` with a summary that \
-               explains why."
-                .to_string(),
-        );
-        self
-    }
-
     /// Add a skill's system prompt fragment.
     pub fn with_skill(mut self, skill_prompt: &str) -> Self {
         self.sections.push(skill_prompt.to_string());


### PR DESCRIPTION
## Summary

Follow-up to #441 / #442. Two small things on top of the existing `task_complete` work:

1. **Factor out the duplicated loop plumbing.** `run_inner` and the streaming variant carried two near-identical copies of the success path (push summary as the final assistant message) and the re-prompt path (bump retry counter, inject reminder, give up at the cap). The streaming variant added two `AgentEvent` emissions but was otherwise the same, and the duplication had already drifted once.

   Extracted onto `AgentRunner`:
   - `finalize_task_complete(conv, iteration, summary)` — pushes the summary as the final assistant message and logs. Callers emit any streaming events around the call.
   - `reprompt_for_task_complete(conv, iteration, retries, classification)` — bumps the retry counter, injects the reminder, returns a `CompletionReminderOutcome::{Continue, GiveUp}` so each caller applies its own terminal-event behavior at the cap.

   No behavior change — net ~60 fewer duplicated lines across the two loops.

2. **Add the missing retry-cap fallthrough test.** `task_complete_retry_limit_exhaustion_accepts_last_response` scripts one tool call followed by `TASK_COMPLETE_RETRY_LIMIT + 1` consecutive text-only EndTurns and asserts the runner injects exactly the limit's worth of reminders, then returns `Ok(())` instead of spinning to `max_iterations`. Pins down the graceful-degradation contract for models that never learn the protocol.

## Stacking

Based on #442 (`claude/hide-task-complete-until-first-tool`), which is itself based on #441 / `main`. Merge after #442 lands and this rebases onto `main` cleanly.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p rustykrab-agent --all-targets` clean
- [x] `cargo test -p rustykrab-agent` — 92 passed, 0 failed
- [x] All 7 `runner::task_complete_tests` pass, including the new retry-exhaustion case

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsWSxwtP6Xo9x4Ws78NRnd)_