### PR TITLE
fix(tools): bound HttpSession, AdaptiveStore, and SnapshotStore caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/adaptive.rs
+++ b/crates/rustykrab-tools/src/browser/adaptive.rs
@@ -15,7 +15,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -154,10 +154,43 @@ fn tokenize(s: &str) -> std::collections::HashSet<String> {
         .collect()
 }
 
-/// Process-wide adaptive store keyed by `auto_save_id`.
+/// Upper bound on entries in the process-wide adaptive store. Each entry
+/// holds a `Vec<Fingerprint>` of tokenized element text, so an unbounded
+/// map would grow per unique `auto_save_id` an agent invents.
+const MAX_ADAPTIVE_ENTRIES: usize = 256;
+
+/// Process-wide adaptive store keyed by `auto_save_id`. LRU-bounded so
+/// long-running daemons don't accumulate fingerprints forever.
 #[derive(Default)]
 pub struct AdaptiveStore {
-    inner: Arc<Mutex<HashMap<String, Vec<Fingerprint>>>>,
+    inner: Arc<Mutex<AdaptiveInner>>,
+}
+
+#[derive(Default)]
+struct AdaptiveInner {
+    map: HashMap<String, Vec<Fingerprint>>,
+    /// Recency order: front = least-recently-used, back = most-recent.
+    order: VecDeque<String>,
+}
+
+impl AdaptiveInner {
+    fn touch(&mut self, id: &str) {
+        if let Some(pos) = self.order.iter().position(|k| k == id) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(id.to_string());
+    }
+
+    fn evict_to_capacity(&mut self) {
+        while self.map.len() > MAX_ADAPTIVE_ENTRIES {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.map.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
 }
 
 impl AdaptiveStore {
@@ -169,13 +202,19 @@ impl AdaptiveStore {
     pub async fn save(&self, id: &str, matches: &[Match]) {
         let prints: Vec<Fingerprint> = matches.iter().map(Fingerprint::from_match).collect();
         let mut g = self.inner.lock().await;
-        g.insert(id.to_string(), prints);
+        g.map.insert(id.to_string(), prints);
+        g.touch(id);
+        g.evict_to_capacity();
     }
 
     /// Look up saved fingerprints.
     pub async fn load(&self, id: &str) -> Option<Vec<Fingerprint>> {
-        let g = self.inner.lock().await;
-        g.get(id).cloned()
+        let mut g = self.inner.lock().await;
+        let hit = g.map.get(id).cloned();
+        if hit.is_some() {
+            g.touch(id);
+        }
+        hit
     }
 
     /// Find the best matching candidate from `candidates` for each saved
@@ -217,7 +256,7 @@ impl AdaptiveStore {
     pub async fn to_dump(&self) -> Value {
         let g = self.inner.lock().await;
         let mut out = Map::new();
-        for (id, prints) in g.iter() {
+        for (id, prints) in g.map.iter() {
             let arr: Vec<Value> = prints
                 .iter()
                 .map(|p| serde_json::to_value(p).unwrap_or(Value::Null))
@@ -325,5 +364,44 @@ mod tests {
             .match_against("never-saved", &[mk_match("a", "body > a", "x", &[])], 0.0)
             .await;
         assert!(scored.is_empty());
+    }
+
+    #[tokio::test]
+    async fn adaptive_evicts_lru_when_over_capacity() {
+        let store = AdaptiveStore::new();
+        let m = mk_match("a", "body > a", "x", &[("href", "/x")]);
+
+        for i in 0..(MAX_ADAPTIVE_ENTRIES + 10) {
+            store
+                .save(&format!("id-{i}"), std::slice::from_ref(&m))
+                .await;
+        }
+
+        let inner = store.inner.lock().await;
+        assert_eq!(inner.map.len(), MAX_ADAPTIVE_ENTRIES);
+        assert!(!inner.map.contains_key("id-0"));
+        assert!(inner
+            .map
+            .contains_key(&format!("id-{}", MAX_ADAPTIVE_ENTRIES + 9)));
+    }
+
+    #[tokio::test]
+    async fn adaptive_load_refreshes_recency() {
+        let store = AdaptiveStore::new();
+        let m = mk_match("a", "body > a", "x", &[("href", "/x")]);
+
+        for i in 0..MAX_ADAPTIVE_ENTRIES {
+            store
+                .save(&format!("id-{i}"), std::slice::from_ref(&m))
+                .await;
+        }
+        // Touch id-0 so it becomes most-recent; id-1 is now LRU.
+        let _ = store.load("id-0").await;
+        store.save("overflow", std::slice::from_ref(&m)).await;
+
+        let inner = store.inner.lock().await;
+        assert!(inner.map.contains_key("id-0"));
+        assert!(!inner.map.contains_key("id-1"));
+        assert!(inner.map.contains_key("overflow"));
     }
 }

--- a/crates/rustykrab-tools/src/browser/snapshot.rs
+++ b/crates/rustykrab-tools/src/browser/snapshot.rs
@@ -20,7 +20,7 @@
 use chromiumoxide::Page;
 use rustykrab_core::{Error, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -55,36 +55,81 @@ pub struct ElementRef {
     pub bounds: Option<[f64; 4]>,
 }
 
+/// Upper bound on cached snapshot keys. Each entry holds a full ref map
+/// (potentially hundreds of `ElementRef`s with selectors and bounds), so
+/// without a cap the store grows per `(profile, tab)` ever snapshotted.
+const MAX_SNAPSHOT_KEYS: usize = 64;
+
 /// Stores ref mappings from the most recent snapshot for each profile+tab.
+///
+/// LRU-bounded so closed tabs / stale profiles eventually drop out.
 pub struct SnapshotStore {
+    inner: Arc<Mutex<SnapshotInner>>,
+}
+
+struct SnapshotInner {
     /// Maps (profile, tab_key) -> { ref_id -> ElementRef }
-    refs: Arc<Mutex<HashMap<String, HashMap<String, ElementRef>>>>,
+    refs: HashMap<String, HashMap<String, ElementRef>>,
+    /// Recency order: front = least-recently-used, back = most-recent.
+    order: VecDeque<String>,
+}
+
+impl SnapshotInner {
+    fn touch(&mut self, key: &str) {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(key.to_string());
+    }
+
+    fn evict_to_capacity(&mut self) {
+        while self.refs.len() > MAX_SNAPSHOT_KEYS {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.refs.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
 }
 
 impl SnapshotStore {
     pub fn new() -> Self {
         Self {
-            refs: Arc::new(Mutex::new(HashMap::new())),
+            inner: Arc::new(Mutex::new(SnapshotInner {
+                refs: HashMap::new(),
+                order: VecDeque::new(),
+            })),
         }
     }
 
     /// Store refs from a snapshot.
     pub async fn store(&self, key: &str, refs: HashMap<String, ElementRef>) {
-        let mut store = self.refs.lock().await;
-        store.insert(key.to_string(), refs);
+        let mut g = self.inner.lock().await;
+        g.refs.insert(key.to_string(), refs);
+        g.touch(key);
+        g.evict_to_capacity();
     }
 
     /// Look up an element ref.
     pub async fn get_ref(&self, key: &str, ref_id: &str) -> Option<ElementRef> {
-        let store = self.refs.lock().await;
-        store.get(key).and_then(|m| m.get(ref_id)).cloned()
+        let mut g = self.inner.lock().await;
+        let hit = g.refs.get(key).and_then(|m| m.get(ref_id)).cloned();
+        if hit.is_some() {
+            g.touch(key);
+        }
+        hit
     }
 
     /// Clear refs for a key.
     #[allow(dead_code)]
     pub async fn clear(&self, key: &str) {
-        let mut store = self.refs.lock().await;
-        store.remove(key);
+        let mut g = self.inner.lock().await;
+        g.refs.remove(key);
+        if let Some(pos) = g.order.iter().position(|k| k == key) {
+            g.order.remove(pos);
+        }
     }
 }
 
@@ -577,5 +622,68 @@ fn truncate(s: &str, max: usize) -> String {
             end -= 1;
         }
         format!("{}...", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_ref(id: &str) -> ElementRef {
+        ElementRef {
+            ref_id: id.to_string(),
+            selector: "body > a".to_string(),
+            role: "link".to_string(),
+            name: "x".to_string(),
+            value: None,
+            interactive: true,
+            bounds: None,
+        }
+    }
+
+    fn mk_refs(id: &str) -> HashMap<String, ElementRef> {
+        let mut m = HashMap::new();
+        m.insert(id.to_string(), mk_ref(id));
+        m
+    }
+
+    #[tokio::test]
+    async fn snapshot_evicts_lru_when_over_capacity() {
+        let store = SnapshotStore::new();
+        for i in 0..(MAX_SNAPSHOT_KEYS + 5) {
+            store.store(&format!("k-{i}"), mk_refs("1")).await;
+        }
+        let inner = store.inner.lock().await;
+        assert_eq!(inner.refs.len(), MAX_SNAPSHOT_KEYS);
+        assert!(!inner.refs.contains_key("k-0"));
+        assert!(inner
+            .refs
+            .contains_key(&format!("k-{}", MAX_SNAPSHOT_KEYS + 4)));
+    }
+
+    #[tokio::test]
+    async fn snapshot_get_ref_refreshes_recency() {
+        let store = SnapshotStore::new();
+        for i in 0..MAX_SNAPSHOT_KEYS {
+            store.store(&format!("k-{i}"), mk_refs("1")).await;
+        }
+        // Bump k-0 to most-recent via a successful get_ref.
+        assert!(store.get_ref("k-0", "1").await.is_some());
+        store.store("overflow", mk_refs("1")).await;
+
+        let inner = store.inner.lock().await;
+        assert!(inner.refs.contains_key("k-0"));
+        assert!(!inner.refs.contains_key("k-1"));
+        assert!(inner.refs.contains_key("overflow"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_clear_removes_from_order() {
+        let store = SnapshotStore::new();
+        store.store("a", mk_refs("1")).await;
+        store.clear("a").await;
+        let inner = store.inner.lock().await;
+        assert!(!inner.refs.contains_key("a"));
+        assert!(!inner.order.iter().any(|k| k == "a"));
     }
 }

--- a/crates/rustykrab-tools/src/http_session.rs
+++ b/crates/rustykrab-tools/src/http_session.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -8,6 +8,11 @@ use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
 use crate::security;
+
+/// Upper bound on cached named sessions. Each `reqwest::Client` owns its
+/// own connection pool and cookie jar, so an unbounded map would leak
+/// sockets and FDs if a caller invents fresh session names.
+const MAX_SESSIONS: usize = 32;
 
 /// A cookie-aware HTTP client with named sessions.
 ///
@@ -21,30 +26,74 @@ use crate::security;
 /// Uses `tokio::sync::Mutex` to avoid blocking the async runtime
 /// (fixes ASYNC-H2).
 pub struct HttpSessionTool {
-    sessions: Arc<Mutex<HashMap<String, reqwest::Client>>>,
+    inner: Arc<Mutex<SessionCache>>,
+}
+
+/// LRU-bounded cache of `reqwest::Client`s keyed by session name.
+struct SessionCache {
+    clients: HashMap<String, reqwest::Client>,
+    /// Recency order: front = least-recently-used, back = most-recent.
+    order: VecDeque<String>,
+}
+
+impl SessionCache {
+    fn new() -> Self {
+        Self {
+            clients: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn touch(&mut self, key: &str) {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(key.to_string());
+    }
+
+    fn get_or_create(&mut self, name: &str) -> reqwest::Client {
+        if let Some(client) = self.clients.get(name).cloned() {
+            self.touch(name);
+            return client;
+        }
+        while self.clients.len() >= MAX_SESSIONS {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.clients.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+        let client = reqwest::Client::builder()
+            .cookie_store(true)
+            .user_agent("RustyKrab/0.1 (AI Agent)")
+            .timeout(std::time::Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        self.clients.insert(name.to_string(), client.clone());
+        self.order.push_back(name.to_string());
+        client
+    }
+
+    fn remove(&mut self, name: &str) {
+        self.clients.remove(name);
+        if let Some(pos) = self.order.iter().position(|k| k == name) {
+            self.order.remove(pos);
+        }
+    }
 }
 
 impl HttpSessionTool {
     pub fn new() -> Self {
         Self {
-            sessions: Arc::new(Mutex::new(HashMap::new())),
+            inner: Arc::new(Mutex::new(SessionCache::new())),
         }
     }
 
     async fn get_or_create_client(&self, session_name: &str) -> reqwest::Client {
-        let mut sessions = self.sessions.lock().await;
-        sessions
-            .entry(session_name.to_string())
-            .or_insert_with(|| {
-                reqwest::Client::builder()
-                    .cookie_store(true)
-                    .user_agent("RustyKrab/0.1 (AI Agent)")
-                    .timeout(std::time::Duration::from_secs(30))
-                    .redirect(reqwest::redirect::Policy::limited(10))
-                    .build()
-                    .unwrap_or_else(|_| reqwest::Client::new())
-            })
-            .clone()
+        let mut cache = self.inner.lock().await;
+        cache.get_or_create(session_name)
     }
 }
 
@@ -127,8 +176,8 @@ impl Tool for HttpSessionTool {
         let action = args["action"].as_str().unwrap_or("request");
 
         if action == "clear" {
-            let mut sessions = self.sessions.lock().await;
-            sessions.remove(session_name);
+            let mut cache = self.inner.lock().await;
+            cache.remove(session_name);
             return Ok(json!({
                 "status": "session_cleared",
                 "session": session_name,
@@ -217,5 +266,65 @@ impl Tool for HttpSessionTool {
             "body": body_out,
             "truncated": truncated,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn session_cache_evicts_lru_when_over_capacity() {
+        let tool = HttpSessionTool::new();
+        for i in 0..(MAX_SESSIONS + 5) {
+            tool.get_or_create_client(&format!("s-{i}")).await;
+        }
+        let cache = tool.inner.lock().await;
+        assert_eq!(cache.clients.len(), MAX_SESSIONS);
+        assert!(!cache.clients.contains_key("s-0"));
+        assert!(cache
+            .clients
+            .contains_key(&format!("s-{}", MAX_SESSIONS + 4)));
+    }
+
+    #[tokio::test]
+    async fn session_cache_reuses_existing_client() {
+        let tool = HttpSessionTool::new();
+        let a = tool.get_or_create_client("same").await;
+        let b = tool.get_or_create_client("same").await;
+        // reqwest::Client is cheap to clone and clones share the same inner pool.
+        // Verifying we didn't grow the map is the easier invariant.
+        let cache = tool.inner.lock().await;
+        assert_eq!(cache.clients.len(), 1);
+        drop(a);
+        drop(b);
+    }
+
+    #[tokio::test]
+    async fn session_cache_get_refreshes_recency() {
+        let tool = HttpSessionTool::new();
+        for i in 0..MAX_SESSIONS {
+            tool.get_or_create_client(&format!("s-{i}")).await;
+        }
+        // Re-accessing s-0 should bump it to most-recent so s-1 evicts next.
+        tool.get_or_create_client("s-0").await;
+        tool.get_or_create_client("overflow").await;
+
+        let cache = tool.inner.lock().await;
+        assert!(cache.clients.contains_key("s-0"));
+        assert!(!cache.clients.contains_key("s-1"));
+        assert!(cache.clients.contains_key("overflow"));
+    }
+
+    #[tokio::test]
+    async fn session_cache_remove_clears_order() {
+        let tool = HttpSessionTool::new();
+        tool.get_or_create_client("x").await;
+        {
+            let mut cache = tool.inner.lock().await;
+            cache.remove("x");
+            assert!(!cache.clients.contains_key("x"));
+            assert!(!cache.order.iter().any(|k| k == "x"));
+        }
     }
 }


### PR DESCRIPTION
These three process-wide HashMaps grew without limit as callers passed
distinct keys:

- HttpSessionTool sessions: each unique session name allocated a fresh
  reqwest::Client (own connection pool + cookie jar + DNS cache), so a
  caller inventing session names leaked FDs and sockets on top of heap.
- AdaptiveStore inner: keyed by arbitrary auto_save_id with no remove API.
- SnapshotStore refs: keyed by (profile, tab) with a clear() method
  that was marked dead_code and never called.

Each is now an LRU cache (32 / 256 / 64 entries) that touches on
read/write and evicts the least-recently-used entry on overflow. Adds
unit tests covering capacity bounds, recency refresh on read, and
removal cleanup.

https://claude.ai/code/session_01K97PBSRwMTvtEvNECHiotr