### PR TITLE
feat(mcp): support stdio transport and arbitrary HTTP headers per server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3118,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-channels/src/mcp_http.rs
+++ b/crates/rustykrab-channels/src/mcp_http.rs
@@ -11,7 +11,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{HeaderMap, ACCEPT, CONTENT_TYPE};
 use serde_json::Value;
 use tokio::sync::Mutex;
 use tracing;
@@ -36,21 +36,14 @@ pub struct McpHttpClient {
 impl McpHttpClient {
     /// Connect to a remote MCP server and run the `initialize` handshake.
     ///
-    /// `bearer_token`, if provided, is sent as `Authorization: Bearer <token>`
-    /// on every request. Per-server auth schemes other than bearer can be
-    /// added later by accepting a `HeaderMap` instead.
-    pub async fn connect(url: &str, bearer_token: Option<&str>) -> Result<Self, String> {
+    /// `extra_headers` are sent on every request — use this to express
+    /// per-server auth (bearer tokens, `x-api-key`, multi-credential schemes
+    /// like Datadog's `DD-API-KEY` + `DD-APPLICATION-KEY`, etc.).
+    pub async fn connect(url: &str, extra_headers: HeaderMap) -> Result<Self, String> {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(120))
             .build()
             .map_err(|e| format!("failed to build HTTP client: {e}"))?;
-
-        let mut extra_headers = HeaderMap::new();
-        if let Some(token) = bearer_token {
-            let value = HeaderValue::from_str(&format!("Bearer {token}"))
-                .map_err(|e| format!("invalid bearer token: {e}"))?;
-            extra_headers.insert(AUTHORIZATION, value);
-        }
 
         let this = Self {
             client,

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -1,13 +1,30 @@
-//! MCP connector — wraps tools served by remote MCP servers (Streamable HTTP
-//! transport) as native agent [`Tool`]s.
+//! MCP connector — wraps tools served by remote MCP servers as native agent
+//! [`Tool`]s. Supports both Streamable HTTP and stdio transports.
 //!
 //! Configuration (env vars only, per project convention):
 //!
 //! ```text
 //! RUSTYKRAB_MCP_SERVERS=name1,name2,...
-//! RUSTYKRAB_MCP_<NAME>_URL=https://...     # required, http(s) endpoint
-//! RUSTYKRAB_MCP_<NAME>_TOKEN=...           # optional Bearer token
+//!
+//! # Per-server, common:
+//! RUSTYKRAB_MCP_<NAME>_TRANSPORT=http|stdio          # default: http
+//!
+//! # HTTP transport:
+//! RUSTYKRAB_MCP_<NAME>_URL=https://...               # required for http
+//! RUSTYKRAB_MCP_<NAME>_TOKEN=...                     # shorthand for `Authorization: Bearer <token>`
+//! RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>=<value>          # arbitrary header, repeatable
+//!
+//! # stdio transport:
+//! RUSTYKRAB_MCP_<NAME>_COMMAND=npx                   # required for stdio
+//! RUSTYKRAB_MCP_<NAME>_ARGS=-y,@scope/pkg,mcp        # comma-separated, optional
+//! RUSTYKRAB_MCP_<NAME>_ENV_<KEY>=<value>             # child env var, repeatable
 //! ```
+//!
+//! `HEADER_<KEY>` translates `_` to `-` and lowercases the key — so
+//! `RUSTYKRAB_MCP_DATADOG_HEADER_DD_API_KEY` becomes the `dd-api-key`
+//! header (HTTP headers are case-insensitive). `ENV_<KEY>` is passed
+//! through verbatim as the child process's env var, e.g.
+//! `RUSTYKRAB_MCP_DATADOG_ENV_DD_API_KEY` sets `DD_API_KEY` for the child.
 //!
 //! Server names are case-insensitive in env-var keys (we upper-case them
 //! before lookup) and appear verbatim — lower-cased — in the resulting
@@ -21,12 +38,34 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rustykrab_channels::mcp::{McpContent, McpToolDef};
-use rustykrab_channels::McpHttpClient;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
+use rustykrab_channels::mcp::{McpContent, McpToolDef, McpToolResult};
+use rustykrab_channels::{McpClient, McpHttpClient};
 use rustykrab_core::error::{ToolError, ToolErrorKind};
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use serde_json::{json, Value};
+
+/// Transport-agnostic handle to an MCP server. Both variants expose the
+/// same `call_tool` / `list_tools` surface; we branch here so the tool
+/// wrapper doesn't have to.
+enum McpTransport {
+    Http(Arc<McpHttpClient>),
+    Stdio(Arc<McpClient>),
+}
+
+impl McpTransport {
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Value,
+    ) -> std::result::Result<McpToolResult, String> {
+        match self {
+            McpTransport::Http(c) => c.call_tool(name, arguments).await,
+            McpTransport::Stdio(c) => c.call_tool(name, arguments).await,
+        }
+    }
+}
 
 /// A single tool exposed by a remote MCP server.
 pub struct McpRemoteTool {
@@ -35,11 +74,11 @@ pub struct McpRemoteTool {
     parameters: Value,
     server: String,
     remote_tool: String,
-    client: Arc<McpHttpClient>,
+    transport: Arc<McpTransport>,
 }
 
 impl McpRemoteTool {
-    pub fn new(server: &str, def: McpToolDef, client: Arc<McpHttpClient>) -> Self {
+    fn new(server: &str, def: McpToolDef, transport: Arc<McpTransport>) -> Self {
         let prefixed = format!("mcp__{}__{}", server.to_lowercase(), def.name);
         let description = def
             .description
@@ -58,7 +97,7 @@ impl McpRemoteTool {
             parameters,
             server: server.to_string(),
             remote_tool: def.name,
-            client,
+            transport,
         }
     }
 }
@@ -90,7 +129,7 @@ impl Tool for McpRemoteTool {
 
     async fn execute(&self, args: Value) -> Result<Value> {
         let result = self
-            .client
+            .transport
             .call_tool(&self.remote_tool, args)
             .await
             .map_err(|e| {
@@ -156,29 +195,117 @@ pub async fn mcp_connector_tools() -> Vec<Arc<dyn Tool>> {
 
 async fn connect_server(name: &str) -> std::result::Result<Vec<Arc<dyn Tool>>, String> {
     let upper = name.to_uppercase();
+    let transport_key = format!("RUSTYKRAB_MCP_{upper}_TRANSPORT");
+    let transport_raw = std::env::var(&transport_key)
+        .unwrap_or_else(|_| "http".to_string())
+        .trim()
+        .to_lowercase();
+
+    let (transport, defs) = match transport_raw.as_str() {
+        "http" | "" => connect_http(&upper).await?,
+        "stdio" => connect_stdio(&upper).await?,
+        other => {
+            return Err(format!(
+                "unknown transport `{other}` for MCP server `{name}`"
+            ))
+        }
+    };
+
+    let transport = Arc::new(transport);
+    let tool_count = defs.len();
+    let tools: Vec<Arc<dyn Tool>> = defs
+        .into_iter()
+        .map(|d| Arc::new(McpRemoteTool::new(name, d, transport.clone())) as Arc<dyn Tool>)
+        .collect();
+
+    tracing::info!(server = %name, transport = %transport_raw, tool_count, "MCP connector registered");
+    Ok(tools)
+}
+
+async fn connect_http(upper: &str) -> std::result::Result<(McpTransport, Vec<McpToolDef>), String> {
     let url_key = format!("RUSTYKRAB_MCP_{upper}_URL");
-    let token_key = format!("RUSTYKRAB_MCP_{upper}_TOKEN");
-
     let url = std::env::var(&url_key).map_err(|_| format!("missing env var {url_key}"))?;
-    let token = std::env::var(&token_key).ok();
 
-    let client = McpHttpClient::connect(&url, token.as_deref())
+    let headers = build_http_headers(upper)?;
+    let client = McpHttpClient::connect(&url, headers)
         .await
         .map_err(|e| format!("connect: {e}"))?;
     let defs = client
         .list_tools()
         .await
         .map_err(|e| format!("list_tools: {e}"))?;
-    let client = Arc::new(client);
+    Ok((McpTransport::Http(Arc::new(client)), defs))
+}
 
-    let tool_count = defs.len();
-    let tools: Vec<Arc<dyn Tool>> = defs
-        .into_iter()
-        .map(|d| Arc::new(McpRemoteTool::new(name, d, client.clone())) as Arc<dyn Tool>)
+async fn connect_stdio(
+    upper: &str,
+) -> std::result::Result<(McpTransport, Vec<McpToolDef>), String> {
+    let command_key = format!("RUSTYKRAB_MCP_{upper}_COMMAND");
+    let command =
+        std::env::var(&command_key).map_err(|_| format!("missing env var {command_key}"))?;
+
+    let args_key = format!("RUSTYKRAB_MCP_{upper}_ARGS");
+    let args_raw = std::env::var(&args_key).unwrap_or_default();
+    let args: Vec<String> = args_raw
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+
+    let env_pairs = collect_prefixed(upper, "ENV_");
+    let env_refs: Vec<(&str, &str)> = env_pairs
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
 
-    tracing::info!(server = %name, tool_count, "MCP connector registered");
-    Ok(tools)
+    let client = McpClient::spawn(&command, &arg_refs, &env_refs)
+        .await
+        .map_err(|e| format!("spawn: {e}"))?;
+    let defs = client
+        .list_tools()
+        .await
+        .map_err(|e| format!("list_tools: {e}"))?;
+    Ok((McpTransport::Stdio(Arc::new(client)), defs))
+}
+
+/// Assemble HTTP headers from `RUSTYKRAB_MCP_<NAME>_TOKEN` (bearer shorthand)
+/// plus every `RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>` entry.
+fn build_http_headers(upper: &str) -> std::result::Result<HeaderMap, String> {
+    let mut headers = HeaderMap::new();
+
+    if let Ok(token) = std::env::var(format!("RUSTYKRAB_MCP_{upper}_TOKEN")) {
+        let value = HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|e| format!("invalid bearer token: {e}"))?;
+        headers.insert(AUTHORIZATION, value);
+    }
+
+    for (key, value) in collect_prefixed(upper, "HEADER_") {
+        let header_name = key.replace('_', "-").to_lowercase();
+        let name = HeaderName::from_bytes(header_name.as_bytes())
+            .map_err(|e| format!("invalid header name `{header_name}`: {e}"))?;
+        let value = HeaderValue::from_str(&value)
+            .map_err(|e| format!("invalid header value for `{header_name}`: {e}"))?;
+        headers.insert(name, value);
+    }
+
+    Ok(headers)
+}
+
+/// Collect every env var matching `RUSTYKRAB_MCP_<UPPER>_<PREFIX><KEY>` and
+/// return `(<KEY>, value)` pairs. `<KEY>` preserves the original casing of
+/// the env var (env vars are conventionally upper-case, but we don't enforce).
+fn collect_prefixed(upper: &str, prefix: &str) -> Vec<(String, String)> {
+    let full_prefix = format!("RUSTYKRAB_MCP_{upper}_{prefix}");
+    let mut out = Vec::new();
+    for (k, v) in std::env::vars() {
+        if let Some(rest) = k.strip_prefix(&full_prefix) {
+            if !rest.is_empty() {
+                out.push((rest.to_string(), v));
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -186,9 +313,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remote_tool_name_is_prefixed_and_lowercased() {
-        // We can't construct an McpRemoteTool here without a real client,
-        // but we can at least verify the rendering helper.
+    fn render_content_joins_text_blocks_with_newlines() {
         let blocks = vec![
             McpContent {
                 content_type: "text".into(),
@@ -213,5 +338,54 @@ mod tests {
         std::env::remove_var("RUSTYKRAB_MCP_SERVERS");
         let tools = mcp_connector_tools().await;
         assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn build_http_headers_token_becomes_bearer() {
+        // Safety: unique prefix; no other test reads these.
+        let upper = "TESTTOKEN";
+        std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"), "abc123");
+        let headers = build_http_headers(upper).unwrap();
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer abc123");
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
+    }
+
+    #[test]
+    fn build_http_headers_supports_arbitrary_headers() {
+        // Safety: unique prefix; no other test reads these.
+        let upper = "TESTDD";
+        std::env::set_var(
+            format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_API_KEY"),
+            "key-aaa",
+        );
+        std::env::set_var(
+            format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"),
+            "key-bbb",
+        );
+        let headers = build_http_headers(upper).unwrap();
+        assert_eq!(headers.get("dd-api-key").unwrap(), "key-aaa");
+        assert_eq!(headers.get("dd-application-key").unwrap(), "key-bbb");
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_API_KEY"));
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"));
+    }
+
+    #[test]
+    fn collect_prefixed_returns_matching_keys_only() {
+        let upper = "TESTCOLLECT";
+        std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_ENV_FOO"), "1");
+        std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_ENV_BAR"), "2");
+        std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_BAZ"), "3");
+        let mut got = collect_prefixed(upper, "ENV_");
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("BAR".to_string(), "2".to_string()),
+                ("FOO".to_string(), "1".to_string())
+            ]
+        );
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_ENV_FOO"));
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_ENV_BAR"));
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_BAZ"));
     }
 }


### PR DESCRIPTION
The MCP connector previously accepted only a URL and an optional bearer
token per server, which is insufficient for real-world MCP servers that
either run over stdio (most npx-based servers) or need multi-credential
auth (Datadog's DD-API-KEY + DD-APPLICATION-KEY, x-api-key, etc.).

Adds two per-server env-var families and a transport switch:

  RUSTYKRAB_MCP_<NAME>_TRANSPORT=http|stdio          (default: http)
  RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>=<value>          (http, repeatable)
  RUSTYKRAB_MCP_<NAME>_COMMAND=<bin>                 (stdio)
  RUSTYKRAB_MCP_<NAME>_ARGS=<csv>                    (stdio, optional)
  RUSTYKRAB_MCP_<NAME>_ENV_<KEY>=<value>             (stdio, repeatable)

The existing TOKEN shorthand still expands to `Authorization: Bearer`.
HEADER_<KEY> lowercases and converts `_` to `-` so e.g. DD_API_KEY ->
dd-api-key. McpHttpClient::connect now takes a HeaderMap instead of an
Option<&str> bearer.

Internally the tool wrapper now holds an McpTransport enum so it can
dispatch to either McpHttpClient or the previously-unused-by-the-connector
McpClient (stdio).