### PR TITLE
feat(mcp): credential refs + chat REPL with no-echo secret onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -998,7 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2072,7 +2072,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2815,6 +2815,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a57a69104632d64deb0df2e09a69945cd7a6eab4070fc9b1d7e50cf6c3edc"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,7 +2908,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2946,7 +2967,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2975,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2992,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,13 +3034,15 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "chrono",
  "dirs",
+ "reqwest 0.13.3",
+ "rpassword",
  "rustls",
  "rustykrab-agent",
  "rustykrab-channels",
@@ -3042,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3056,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3080,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3101,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3118,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3134,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3157,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.3.3"
+version = "3.4.0"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -3499,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3674,7 +3697,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4519,7 +4542,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -257,6 +257,71 @@ cargo run --release -p rustykrab-cli
 
 Open `http://127.0.0.1:3000` in a browser for the embedded WebChat interface.
 
+### Terminal chat (`chat` subcommand)
+
+A small REPL client that talks to the running daemon over loopback. Useful
+when no messaging channel is configured, and as the safest path for
+onboarding new credentials.
+
+```bash
+rustykrab-cli chat
+```
+
+Slash commands:
+
+- `/set <name>` — prompt for a value with no echo and store it in the
+  encrypted local secret store. The value is sent straight to
+  `POST /api/secrets` and never enters the model's context, the
+  conversation history, or any messaging channel.
+- `/set <name> --keychain <service>/<account>` — store in the macOS
+  Keychain instead.
+- `/list` — list stored secret names (no values).
+- `/delete <name>` — delete a secret.
+- `/help`, `/quit`.
+
+Anything that isn't a slash command is sent to the agent as a normal
+chat turn. The client uses `RUSTYKRAB_AUTH_TOKEN` (or the OS keychain /
+encrypted store fallbacks) and `RUSTYKRAB_GATEWAY_URL` (default
+`http://127.0.0.1:3000`).
+
+### MCP servers: credential refs
+
+Any `RUSTYKRAB_MCP_<NAME>_TOKEN`, `_HEADER_<K>`, or `_ENV_<K>` value may be
+either a literal or a reference resolved at connect time:
+
+```bash
+# Encrypted local SecretStore (namespaced to the server)
+export RUSTYKRAB_MCP_GITHUB_TOKEN=ref:store:mcp.github.token
+export RUSTYKRAB_MCP_DATADOG_HEADER_DD_API_KEY=ref:store:mcp.datadog.api_key
+
+# macOS Keychain (operator-chosen service / account)
+export RUSTYKRAB_MCP_NOTION_TOKEN=ref:keychain:Notion/api-token
+```
+
+Store refs are namespaced: server `github` can only resolve store keys
+that begin with `mcp.github.`, so a misconfigured env var can't pull
+another server's credentials. Keychain refs are not namespaced — the
+operator's choice of env var is the gate.
+
+Onboarding a token end-to-end:
+
+```text
+$ rustykrab-cli chat
+> /set mcp.github.token
+  value for mcp.github.token (hidden): ***
+  ✓ stored in encrypted local store as `mcp.github.token`
+  (MCP servers pick up new credentials at next daemon restart.)
+> /quit
+
+$ export RUSTYKRAB_MCP_SERVERS=github
+$ export RUSTYKRAB_MCP_GITHUB_URL=https://api.githubcopilot.com/mcp/
+$ export RUSTYKRAB_MCP_GITHUB_TOKEN=ref:store:mcp.github.token
+$ rustykrab-cli   # restart the daemon
+```
+
+The resolver runs entirely inside the connector — the model never sees
+the resolved values, and they are not surfaced through any tool.
+
 ## Architecture
 
 A Cargo workspace of 10 crates under `crates/`:

--- a/crates/rustykrab-cli/Cargo.toml
+++ b/crates/rustykrab-cli/Cargo.toml
@@ -29,3 +29,5 @@ anyhow.workspace = true
 rustls.workspace = true
 dirs = "6"
 toml.workspace = true
+reqwest.workspace = true
+rpassword = "7"

--- a/crates/rustykrab-cli/src/chat.rs
+++ b/crates/rustykrab-cli/src/chat.rs
@@ -1,0 +1,436 @@
+//! `rustykrab-cli chat` — a small REPL that talks to a running daemon over
+//! the loopback gateway.
+//!
+//! Two purposes:
+//! 1. Have a conversation with the agent from the terminal (handy when
+//!    the messaging channels aren't configured or you don't want to use
+//!    one for ad-hoc tasks).
+//! 2. Onboard credentials via the slash-command `/set <name>`, which
+//!    prompts for the value with no echo and `POST`s it directly to
+//!    `/api/secrets`. The value never enters the model's context, never
+//!    transits a third-party messaging server, and is not persisted in
+//!    the conversation history.
+//!
+//! The chat client always talks to a daemon that's already running. It
+//! does not touch the SQLite store directly to avoid lock contention and
+//! a double trust path. Secret onboarding without a running daemon is
+//! still supported via the existing `keychain` subcommand or by writing
+//! to the SecretStore directly from a one-off process.
+
+use std::io::{self, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use uuid::Uuid;
+
+const DEFAULT_GATEWAY_URL: &str = "http://127.0.0.1:3000";
+
+pub async fn run(data_dir: &Path, _args: &[String]) -> anyhow::Result<()> {
+    let gateway_url =
+        std::env::var("RUSTYKRAB_GATEWAY_URL").unwrap_or_else(|_| DEFAULT_GATEWAY_URL.to_string());
+
+    let token = resolve_auth_token(data_dir)?;
+
+    let mut auth_headers = HeaderMap::new();
+    auth_headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|e| anyhow::anyhow!("invalid auth token: {e}"))?,
+    );
+
+    let client = reqwest::Client::builder()
+        .default_headers(auth_headers)
+        .timeout(Duration::from_secs(600))
+        .build()?;
+
+    // Probe the daemon and start a conversation before printing anything,
+    // so a failure mode is obvious.
+    health_check(&client, &gateway_url).await?;
+    let conv_id = create_conversation(&client, &gateway_url).await?;
+
+    print_banner(&gateway_url, conv_id);
+
+    let stdin = io::stdin();
+    loop {
+        print!("> ");
+        io::stdout().flush().ok();
+
+        let mut line = String::new();
+        let n = stdin.read_line(&mut line)?;
+        if n == 0 {
+            // EOF (e.g. Ctrl-D).
+            println!();
+            return Ok(());
+        }
+        let input = line.trim();
+        if input.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = input.strip_prefix('/') {
+            match handle_slash(&client, &gateway_url, rest).await {
+                Ok(ControlFlow::Continue) => continue,
+                Ok(ControlFlow::Quit) => return Ok(()),
+                Err(e) => {
+                    eprintln!("  error: {e}");
+                    continue;
+                }
+            }
+        }
+
+        match send_message(&client, &gateway_url, conv_id, input).await {
+            Ok(reply) => println!("{reply}\n"),
+            Err(e) => eprintln!("  error: {e}\n"),
+        }
+    }
+}
+
+enum ControlFlow {
+    Continue,
+    Quit,
+}
+
+async fn handle_slash(
+    client: &reqwest::Client,
+    base: &str,
+    rest: &str,
+) -> anyhow::Result<ControlFlow> {
+    let mut parts = rest.split_whitespace();
+    let cmd = parts.next().unwrap_or("");
+    let rest_args: Vec<&str> = parts.collect();
+
+    match cmd {
+        "quit" | "exit" | "q" => Ok(ControlFlow::Quit),
+        "help" | "?" => {
+            print_help();
+            Ok(ControlFlow::Continue)
+        }
+        "list" | "ls" => {
+            list_secrets(client, base).await?;
+            Ok(ControlFlow::Continue)
+        }
+        "set" => {
+            let name = rest_args.first().ok_or_else(|| {
+                anyhow::anyhow!("usage: /set <name> [--keychain <service>/<account>]")
+            })?;
+            let keychain_target = parse_keychain_flag(&rest_args[1..])?;
+            set_secret_interactive(client, base, name, keychain_target).await?;
+            Ok(ControlFlow::Continue)
+        }
+        "delete" | "rm" => {
+            let name = rest_args
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("usage: /delete <name>"))?;
+            delete_secret(client, base, name).await?;
+            Ok(ControlFlow::Continue)
+        }
+        other => {
+            eprintln!("  unknown command `/{other}` (try /help)");
+            Ok(ControlFlow::Continue)
+        }
+    }
+}
+
+fn parse_keychain_flag(args: &[&str]) -> anyhow::Result<Option<(String, String)>> {
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        if *a == "--keychain" {
+            let target = iter
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("--keychain requires <service>/<account>"))?;
+            let (s, acc) = target.split_once('/').ok_or_else(|| {
+                anyhow::anyhow!("--keychain target must be <service>/<account>, got `{target}`")
+            })?;
+            return Ok(Some((s.to_string(), acc.to_string())));
+        }
+    }
+    Ok(None)
+}
+
+fn print_banner(gateway_url: &str, conv_id: Uuid) {
+    println!();
+    println!("rustykrab chat — connected to {gateway_url}");
+    println!("conversation: {conv_id}");
+    println!("type /help for slash commands, /quit to exit.");
+    println!();
+}
+
+fn print_help() {
+    println!("  /set <name>                    Store a secret in the encrypted local store.");
+    println!("                                 Value is prompted for with no echo.");
+    println!("                                 Convention: mcp.<server>.<field>");
+    println!("  /set <name> --keychain S/A     Store in the macOS Keychain instead");
+    println!("                                 (service=S, account=A).");
+    println!("  /list                          List the names of stored secrets.");
+    println!("  /delete <name>                 Delete a secret from the local store.");
+    println!("  /help, /quit");
+    println!();
+    println!("  Anything else is sent to the agent as a chat message. Secrets pasted");
+    println!("  via /set never enter the model's context.");
+    println!("  MCP servers re-read their credentials at daemon startup — restart");
+    println!("  rustykrab after onboarding a new MCP secret for it to take effect.");
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+async fn health_check(client: &reqwest::Client, base: &str) -> anyhow::Result<()> {
+    let url = format!("{base}/api/health");
+    let resp = client.get(&url).send().await.map_err(|e| {
+        anyhow::anyhow!(
+            "could not reach daemon at {base}: {e}. \
+             Is `rustykrab-cli` (the daemon) running?"
+        )
+    })?;
+    if !resp.status().is_success() {
+        anyhow::bail!("daemon health check failed: HTTP {}", resp.status());
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct ConversationResp {
+    id: Uuid,
+}
+
+async fn create_conversation(client: &reqwest::Client, base: &str) -> anyhow::Result<Uuid> {
+    let url = format!("{base}/api/conversations");
+    let resp = client.post(&url).send().await?;
+    if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+        anyhow::bail!(
+            "401 Unauthorized — check RUSTYKRAB_AUTH_TOKEN matches the running daemon. \
+             You can rotate via POST /api/logout."
+        );
+    }
+    let resp = resp.error_for_status()?;
+    let conv: ConversationResp = resp.json().await?;
+    Ok(conv.id)
+}
+
+#[derive(Deserialize)]
+struct AssistantMessage {
+    content: serde_json::Value,
+}
+
+async fn send_message(
+    client: &reqwest::Client,
+    base: &str,
+    conv_id: Uuid,
+    content: &str,
+) -> anyhow::Result<String> {
+    let url = format!("{base}/api/conversations/{conv_id}/messages");
+    let resp = client
+        .post(&url)
+        .json(&json!({ "content": content }))
+        .send()
+        .await?
+        .error_for_status()?;
+    let msg: AssistantMessage = resp.json().await?;
+    Ok(render_content(&msg.content))
+}
+
+/// Extract a human-readable string from a `MessageContent` JSON value.
+/// `MessageContent::Text(s)` serialises as `{"Text": "..."}`; any other
+/// variant is dumped as JSON.
+fn render_content(value: &serde_json::Value) -> String {
+    if let Some(text) = value.get("Text").and_then(|v| v.as_str()) {
+        return text.to_string();
+    }
+    if let Some(text) = value.as_str() {
+        return text.to_string();
+    }
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+#[derive(Serialize)]
+struct SetSecretBody<'a> {
+    name: &'a str,
+    value: &'a str,
+    dest: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account: Option<&'a str>,
+}
+
+async fn set_secret_interactive(
+    client: &reqwest::Client,
+    base: &str,
+    name: &str,
+    keychain_target: Option<(String, String)>,
+) -> anyhow::Result<()> {
+    // `rpassword` reads /dev/tty (or the Windows console) directly,
+    // bypassing stdin redirection. The buffer is dropped before this
+    // function returns; the network send moves it through a borrow only.
+    let value = rpassword::prompt_password(format!("  value for {name} (hidden): "))?;
+    if value.is_empty() {
+        anyhow::bail!("empty value — not stored");
+    }
+
+    let body = match &keychain_target {
+        Some((service, account)) => SetSecretBody {
+            name,
+            value: &value,
+            dest: "keychain",
+            service: Some(service.as_str()),
+            account: Some(account.as_str()),
+        },
+        None => SetSecretBody {
+            name,
+            value: &value,
+            dest: "store",
+            service: None,
+            account: None,
+        },
+    };
+
+    let url = format!("{base}/api/secrets");
+    let resp = client.post(&url).json(&body).send().await?;
+    drop(value); // be explicit about it
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("set failed: HTTP {status} {text}");
+    }
+
+    match keychain_target {
+        Some((s, a)) => println!("  ✓ stored in keychain (service={s}, account={a})"),
+        None => println!("  ✓ stored in encrypted local store as `{name}`"),
+    }
+    println!("  (MCP servers pick up new credentials at next daemon restart.)");
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct ListSecretsResp {
+    names: Vec<String>,
+    keychain_available: bool,
+}
+
+async fn list_secrets(client: &reqwest::Client, base: &str) -> anyhow::Result<()> {
+    let url = format!("{base}/api/secrets");
+    let resp = client.get(&url).send().await?.error_for_status()?;
+    let list: ListSecretsResp = resp.json().await?;
+    if list.names.is_empty() {
+        println!("  (no secrets stored)");
+    } else {
+        for n in &list.names {
+            println!("  {n}");
+        }
+    }
+    println!(
+        "  keychain: {}",
+        if list.keychain_available {
+            "available"
+        } else {
+            "not available on this platform"
+        }
+    );
+    Ok(())
+}
+
+async fn delete_secret(client: &reqwest::Client, base: &str, name: &str) -> anyhow::Result<()> {
+    let url = format!("{base}/api/secrets/{name}");
+    let resp = client.delete(&url).send().await?;
+    if !resp.status().is_success() {
+        anyhow::bail!("delete failed: HTTP {}", resp.status());
+    }
+    println!("  ✓ deleted `{name}`");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Auth-token resolution
+// ---------------------------------------------------------------------------
+//
+// The chat client must hold the same bearer token the daemon accepts.
+// We use the same registry chain the daemon does: env → keychain → store.
+// If the store is locked (daemon holds it), we fall back to env/keychain
+// only; the user can also set RUSTYKRAB_AUTH_TOKEN explicitly.
+
+fn resolve_auth_token(data_dir: &Path) -> anyhow::Result<String> {
+    if let Ok(v) = std::env::var("RUSTYKRAB_AUTH_TOKEN") {
+        let v = v.trim();
+        if !v.is_empty() {
+            return Ok(v.to_string());
+        }
+    }
+
+    let spec = rustykrab_store::registry::lookup("rustykrab_auth_token")
+        .ok_or_else(|| anyhow::anyhow!("auth-token spec missing from registry"))?;
+
+    if rustykrab_store::keychain::keychain_available() {
+        if let Ok(Some(cred)) = rustykrab_store::keychain::get_credential(
+            rustykrab_store::registry::keychain_service(),
+            spec.keychain_account,
+        ) {
+            return Ok(cred.value);
+        }
+    }
+
+    // Last resort: try opening the store. Will fail if the daemon holds
+    // an exclusive lock on it — that's fine, we already told the user
+    // to set RUSTYKRAB_AUTH_TOKEN above.
+    let db_path = data_dir.join("db");
+    if db_path.exists() {
+        if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
+            if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
+                if let Ok(v) = store.secrets().get(spec.store_name) {
+                    return Ok(v);
+                }
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "could not resolve auth token. Set RUSTYKRAB_AUTH_TOKEN to the value \
+         the daemon printed at startup, or run `rustykrab-cli keychain status` \
+         to inspect what's stored."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_keychain_flag_extracts_target() {
+        let args = vec!["--keychain", "Foo/bar"];
+        let got = parse_keychain_flag(&args).unwrap();
+        assert_eq!(got, Some(("Foo".to_string(), "bar".to_string())));
+    }
+
+    #[test]
+    fn parse_keychain_flag_returns_none_when_absent() {
+        let args: Vec<&str> = vec![];
+        assert!(parse_keychain_flag(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_keychain_flag_rejects_missing_target() {
+        let args = vec!["--keychain"];
+        assert!(parse_keychain_flag(&args).is_err());
+    }
+
+    #[test]
+    fn parse_keychain_flag_rejects_missing_slash() {
+        let args = vec!["--keychain", "no-slash"];
+        assert!(parse_keychain_flag(&args).is_err());
+    }
+
+    #[test]
+    fn render_content_extracts_text_variant() {
+        let v = serde_json::json!({ "Text": "hello world" });
+        assert_eq!(render_content(&v), "hello world");
+    }
+
+    #[test]
+    fn render_content_handles_plain_string() {
+        let v = serde_json::json!("hello");
+        assert_eq!(render_content(&v), "hello");
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -344,7 +344,7 @@ async fn main() -> anyhow::Result<()> {
         return handle_keychain_subcommand(&data_dir, &args[2..]);
     }
     if args.len() >= 2 && args[1] == "chat" {
-        return chat::run(&data_dir, &args[2..]).await.map_err(Into::into);
+        return chat::run(&data_dir, &args[2..]).await;
     }
 
     // --- Harness profile ---

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod chat;
 mod prompt_log;
 mod task_queue;
 
@@ -341,6 +342,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if args.len() >= 2 && args[1] == "keychain" {
         return handle_keychain_subcommand(&data_dir, &args[2..]);
+    }
+    if args.len() >= 2 && args[1] == "chat" {
+        return chat::run(&data_dir, &args[2..]).await.map_err(Into::into);
     }
 
     // --- Harness profile ---
@@ -694,7 +698,7 @@ async fn main() -> anyhow::Result<()> {
     // Registered before the sub-agent snapshot below so sub-agents also
     // inherit MCP tools. Per-server connect failures are logged inside
     // and never block startup.
-    let mcp_tools = rustykrab_tools::mcp_connector_tools().await;
+    let mcp_tools = rustykrab_tools::mcp_connector_tools(&store.secrets()).await;
     if !mcp_tools.is_empty() {
         tracing::info!(count = mcp_tools.len(), "MCP connector tools registered");
         tools.extend(mcp_tools);

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -34,6 +34,9 @@ pub fn api_routes() -> Router<AppState> {
             "/api/conversations/{id}/messages/stream",
             post(send_message_stream),
         )
+        .route("/api/secrets", get(list_secrets))
+        .route("/api/secrets", post(set_secret))
+        .route("/api/secrets/{name}", axum::routing::delete(delete_secret))
         .route("/api/health", get(health))
         .route("/api/logout", post(logout))
 }
@@ -370,4 +373,118 @@ async fn send_message_stream(
             .interval(std::time::Duration::from_secs(15))
             .text("ping"),
     ))
+}
+
+// ---------------------------------------------------------------------------
+// Secrets management
+// ---------------------------------------------------------------------------
+//
+// These endpoints let a trusted caller (the local `rustykrab chat` CLI, or
+// future settings UI) write credentials directly into the encrypted store
+// or the OS keychain without the value passing through the model.
+//
+// All `/api/*` endpoints are already gated by the bearer-token middleware,
+// so callers must hold `RUSTYKRAB_AUTH_TOKEN`.
+
+const MAX_SECRET_VALUE_SIZE: usize = 64 * 1024;
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum SecretDest {
+    #[default]
+    Store,
+    Keychain,
+}
+
+#[derive(Deserialize)]
+struct SetSecretRequest {
+    /// Identifier in the encrypted store. For MCP credentials, by
+    /// convention `mcp.<server>.<field>`.
+    name: String,
+    value: String,
+    #[serde(default)]
+    dest: SecretDest,
+    /// macOS Keychain service name (required when `dest == "keychain"`).
+    #[serde(default)]
+    service: Option<String>,
+    /// macOS Keychain account name (required when `dest == "keychain"`).
+    #[serde(default)]
+    account: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+struct ListSecretsResponse {
+    names: Vec<String>,
+    keychain_available: bool,
+}
+
+async fn list_secrets(
+    State(state): State<AppState>,
+) -> Result<Json<ListSecretsResponse>, StatusCode> {
+    let names = state.store.secrets().list_names().map_err(|e| {
+        tracing::error!(error = %e, "list_secrets failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    Ok(Json(ListSecretsResponse {
+        names,
+        keychain_available: rustykrab_store::keychain::keychain_available(),
+    }))
+}
+
+async fn set_secret(
+    State(state): State<AppState>,
+    Json(body): Json<SetSecretRequest>,
+) -> Result<StatusCode, StatusCode> {
+    if body.value.len() > MAX_SECRET_VALUE_SIZE {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    if body.value.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    match body.dest {
+        SecretDest::Store => {
+            state
+                .store
+                .secrets()
+                .set(&body.name, &body.value)
+                .map_err(|e| {
+                    tracing::warn!(error = %e, name = %body.name, "set_secret: store write failed");
+                    StatusCode::BAD_REQUEST
+                })?;
+            tracing::info!(name = %body.name, dest = "store", "secret stored");
+        }
+        SecretDest::Keychain => {
+            if !rustykrab_store::keychain::keychain_available() {
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
+            }
+            let service = body.service.as_deref().ok_or(StatusCode::BAD_REQUEST)?;
+            let account = body.account.as_deref().ok_or(StatusCode::BAD_REQUEST)?;
+            rustykrab_store::keychain::set_credential(service, account, &body.value).map_err(
+                |e| {
+                    tracing::error!(error = %e, "set_secret: keychain write failed");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                },
+            )?;
+            tracing::info!(
+                service = %service,
+                account = %account,
+                dest = "keychain",
+                "secret stored"
+            );
+        }
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn delete_secret(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    state.store.secrets().delete(&name).map_err(|e| {
+        tracing::error!(error = %e, "delete_secret failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    tracing::info!(name = %name, "secret deleted");
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -32,6 +32,21 @@
 //! mirrors how Claude Code surfaces MCP tools and prevents collisions
 //! with built-in tool names.
 //!
+//! ## Credential refs
+//!
+//! Any value (`_TOKEN`, `_HEADER_<K>`, `_ENV_<K>`) may be either a literal
+//! or a reference resolved at connect time:
+//!
+//! ```text
+//! ref:store:mcp.<server>.<field>           # encrypted local SecretStore
+//! ref:keychain:<service>/<account>         # macOS Keychain (no-op elsewhere)
+//! ```
+//!
+//! Store refs are namespaced — server `github` can only resolve store keys
+//! beginning with `mcp.github.`, preventing cross-server credential leakage
+//! via a misconfigured env var. Keychain refs are not namespaced; the
+//! operator's choice of env var IS the gate.
+//!
 //! Failures connecting to any single server are logged and skipped: a bad
 //! server config never blocks startup or other servers.
 
@@ -44,6 +59,7 @@ use rustykrab_channels::{McpClient, McpHttpClient};
 use rustykrab_core::error::{ToolError, ToolErrorKind};
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
+use rustykrab_store::SecretStore;
 use serde_json::{json, Value};
 
 /// Transport-agnostic handle to an MCP server. Both variants expose the
@@ -167,7 +183,10 @@ fn render_content(content: &[McpContent]) -> String {
 ///
 /// Returns an empty Vec if `RUSTYKRAB_MCP_SERVERS` is unset or empty.
 /// Per-server failures are logged at WARN and do not propagate.
-pub async fn mcp_connector_tools() -> Vec<Arc<dyn Tool>> {
+///
+/// `secrets` is used to resolve `ref:store:...` values; pass the daemon's
+/// shared [`SecretStore`].
+pub async fn mcp_connector_tools(secrets: &SecretStore) -> Vec<Arc<dyn Tool>> {
     let raw = match std::env::var("RUSTYKRAB_MCP_SERVERS") {
         Ok(v) if !v.trim().is_empty() => v,
         _ => return Vec::new(),
@@ -181,7 +200,7 @@ pub async fn mcp_connector_tools() -> Vec<Arc<dyn Tool>> {
 
     let mut out: Vec<Arc<dyn Tool>> = Vec::new();
     for name in names {
-        match connect_server(&name).await {
+        match connect_server(&name, secrets).await {
             Ok(server_tools) => out.extend(server_tools),
             Err(e) => tracing::warn!(
                 server = %name,
@@ -193,7 +212,10 @@ pub async fn mcp_connector_tools() -> Vec<Arc<dyn Tool>> {
     out
 }
 
-async fn connect_server(name: &str) -> std::result::Result<Vec<Arc<dyn Tool>>, String> {
+async fn connect_server(
+    name: &str,
+    secrets: &SecretStore,
+) -> std::result::Result<Vec<Arc<dyn Tool>>, String> {
     let upper = name.to_uppercase();
     let transport_key = format!("RUSTYKRAB_MCP_{upper}_TRANSPORT");
     let transport_raw = std::env::var(&transport_key)
@@ -202,8 +224,8 @@ async fn connect_server(name: &str) -> std::result::Result<Vec<Arc<dyn Tool>>, S
         .to_lowercase();
 
     let (transport, defs) = match transport_raw.as_str() {
-        "http" | "" => connect_http(&upper).await?,
-        "stdio" => connect_stdio(&upper).await?,
+        "http" | "" => connect_http(name, &upper, secrets).await?,
+        "stdio" => connect_stdio(name, &upper, secrets).await?,
         other => {
             return Err(format!(
                 "unknown transport `{other}` for MCP server `{name}`"
@@ -222,11 +244,15 @@ async fn connect_server(name: &str) -> std::result::Result<Vec<Arc<dyn Tool>>, S
     Ok(tools)
 }
 
-async fn connect_http(upper: &str) -> std::result::Result<(McpTransport, Vec<McpToolDef>), String> {
+async fn connect_http(
+    server: &str,
+    upper: &str,
+    secrets: &SecretStore,
+) -> std::result::Result<(McpTransport, Vec<McpToolDef>), String> {
     let url_key = format!("RUSTYKRAB_MCP_{upper}_URL");
     let url = std::env::var(&url_key).map_err(|_| format!("missing env var {url_key}"))?;
 
-    let headers = build_http_headers(upper)?;
+    let headers = build_http_headers(server, upper, secrets)?;
     let client = McpHttpClient::connect(&url, headers)
         .await
         .map_err(|e| format!("connect: {e}"))?;
@@ -238,7 +264,9 @@ async fn connect_http(upper: &str) -> std::result::Result<(McpTransport, Vec<Mcp
 }
 
 async fn connect_stdio(
+    server: &str,
     upper: &str,
+    secrets: &SecretStore,
 ) -> std::result::Result<(McpTransport, Vec<McpToolDef>), String> {
     let command_key = format!("RUSTYKRAB_MCP_{upper}_COMMAND");
     let command =
@@ -253,8 +281,14 @@ async fn connect_stdio(
         .collect();
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
-    let env_pairs = collect_prefixed(upper, "ENV_");
-    let env_refs: Vec<(&str, &str)> = env_pairs
+    // Resolve ENV_ entries — values may be `ref:` references.
+    let mut resolved_env: Vec<(String, String)> = Vec::new();
+    for (key, raw_value) in collect_prefixed(upper, "ENV_") {
+        let value = resolve_value_ref(server, &raw_value, secrets)
+            .map_err(|e| format!("ENV_{key}: {e}"))?;
+        resolved_env.push((key, value));
+    }
+    let env_refs: Vec<(&str, &str)> = resolved_env
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
@@ -270,21 +304,29 @@ async fn connect_stdio(
 }
 
 /// Assemble HTTP headers from `RUSTYKRAB_MCP_<NAME>_TOKEN` (bearer shorthand)
-/// plus every `RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>` entry.
-fn build_http_headers(upper: &str) -> std::result::Result<HeaderMap, String> {
+/// plus every `RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>` entry. Values may be
+/// `ref:` references resolved via `secrets`.
+fn build_http_headers(
+    server: &str,
+    upper: &str,
+    secrets: &SecretStore,
+) -> std::result::Result<HeaderMap, String> {
     let mut headers = HeaderMap::new();
 
-    if let Ok(token) = std::env::var(format!("RUSTYKRAB_MCP_{upper}_TOKEN")) {
+    if let Ok(raw) = std::env::var(format!("RUSTYKRAB_MCP_{upper}_TOKEN")) {
+        let token = resolve_value_ref(server, &raw, secrets).map_err(|e| format!("TOKEN: {e}"))?;
         let value = HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|e| format!("invalid bearer token: {e}"))?;
         headers.insert(AUTHORIZATION, value);
     }
 
-    for (key, value) in collect_prefixed(upper, "HEADER_") {
+    for (key, raw_value) in collect_prefixed(upper, "HEADER_") {
         let header_name = key.replace('_', "-").to_lowercase();
         let name = HeaderName::from_bytes(header_name.as_bytes())
             .map_err(|e| format!("invalid header name `{header_name}`: {e}"))?;
-        let value = HeaderValue::from_str(&value)
+        let resolved = resolve_value_ref(server, &raw_value, secrets)
+            .map_err(|e| format!("HEADER_{key}: {e}"))?;
+        let value = HeaderValue::from_str(&resolved)
             .map_err(|e| format!("invalid header value for `{header_name}`: {e}"))?;
         headers.insert(name, value);
     }
@@ -306,6 +348,91 @@ fn collect_prefixed(upper: &str, prefix: &str) -> Vec<(String, String)> {
         }
     }
     out
+}
+
+/// Resolve a raw env-var value, expanding `ref:` references if present.
+///
+/// Recognised forms:
+/// - Literal value (no `ref:` prefix) → returned as-is.
+/// - `ref:store:<name>` → looked up in the encrypted SecretStore. `<name>`
+///   must begin with `mcp.<server-lowercase>.` to prevent one server's
+///   config from pulling another server's credentials.
+/// - `ref:keychain:<service>/<account>` → looked up via the macOS
+///   Keychain. Not namespaced — the operator's choice of env var is the
+///   trust boundary.
+///
+/// Errors carry the ref kind but never the looked-up value. Audit logs
+/// emitted by this function never log the resolved value either.
+fn resolve_value_ref(
+    server: &str,
+    raw: &str,
+    secrets: &SecretStore,
+) -> std::result::Result<String, String> {
+    let rest = match raw.strip_prefix("ref:") {
+        Some(r) => r,
+        None => return Ok(raw.to_string()),
+    };
+
+    let (kind, target) = rest
+        .split_once(':')
+        .ok_or_else(|| format!("malformed credential ref `{raw}`: expected `ref:<kind>:...`"))?;
+
+    match kind {
+        "store" => {
+            let name = target.trim();
+            let expected_prefix = format!("mcp.{}.", server.to_lowercase());
+            if !name.starts_with(&expected_prefix) {
+                return Err(format!(
+                    "store ref `{name}` is outside server `{server}`'s namespace \
+                     (must begin with `{expected_prefix}`)"
+                ));
+            }
+            let value = secrets.get(name).map_err(|e| match e {
+                rustykrab_core::Error::NotFound(_) => {
+                    format!("store ref `{name}` not found in SecretStore")
+                }
+                other => format!("store ref `{name}`: {other}"),
+            })?;
+            tracing::info!(
+                server = %server,
+                ref_kind = "store",
+                ref_name = %name,
+                "resolved credential ref"
+            );
+            Ok(value)
+        }
+        "keychain" => {
+            let (service, account) = target.split_once('/').ok_or_else(|| {
+                format!(
+                    "malformed keychain ref `{raw}`: expected \
+                     `ref:keychain:<service>/<account>`"
+                )
+            })?;
+            if !rustykrab_store::keychain::keychain_available() {
+                return Err(format!(
+                    "keychain ref `{service}/{account}` requested but \
+                     OS credential store is unavailable on this platform"
+                ));
+            }
+            let cred = rustykrab_store::keychain::get_credential(service, account)
+                .map_err(|e| format!("keychain ref `{service}/{account}`: {e}"))?
+                .ok_or_else(|| {
+                    format!("keychain ref `{service}/{account}` not found in OS keychain")
+                })?;
+            tracing::info!(
+                server = %server,
+                ref_kind = "keychain",
+                ref_service = %service,
+                ref_account = %account,
+                "resolved credential ref"
+            );
+            Ok(cred.value)
+        }
+        other => Err(format!(
+            "unknown credential ref kind `{other}` in `{raw}` \
+             (expected `store` or `keychain`)"
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -336,16 +463,107 @@ mod tests {
         // Safety: the test uses a dedicated env var set/cleared in this
         // process. No other test reads RUSTYKRAB_MCP_SERVERS.
         std::env::remove_var("RUSTYKRAB_MCP_SERVERS");
-        let tools = mcp_connector_tools().await;
+        let secrets = make_test_secrets();
+        let tools = mcp_connector_tools(&secrets).await;
         assert!(tools.is_empty());
+    }
+
+    /// Open a SecretStore backed by a fresh on-disk SQLite database in a
+    /// tempdir. The tempdir is leaked so the file survives for the test;
+    /// the OS reclaims `/tmp` on process exit.
+    fn make_test_secrets() -> SecretStore {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = rustykrab_store::Store::open(dir.path(), vec![0u8; 32]).expect("open store");
+        std::mem::forget(dir);
+        store.secrets()
+    }
+
+    #[test]
+    fn resolve_value_ref_passes_through_literals() {
+        let secrets = make_test_secrets();
+        let v = resolve_value_ref("github", "ghp_literaltoken", &secrets).unwrap();
+        assert_eq!(v, "ghp_literaltoken");
+    }
+
+    #[test]
+    fn resolve_value_ref_store_lookup_succeeds_in_namespace() {
+        let secrets = make_test_secrets();
+        secrets
+            .set("mcp.github.token", "stored-token-value")
+            .unwrap();
+        let v = resolve_value_ref("github", "ref:store:mcp.github.token", &secrets).unwrap();
+        assert_eq!(v, "stored-token-value");
+    }
+
+    #[test]
+    fn resolve_value_ref_store_lookup_is_case_insensitive_on_server() {
+        let secrets = make_test_secrets();
+        secrets
+            .set("mcp.github.token", "stored-token-value")
+            .unwrap();
+        let v = resolve_value_ref("GitHub", "ref:store:mcp.github.token", &secrets).unwrap();
+        assert_eq!(v, "stored-token-value");
+    }
+
+    #[test]
+    fn resolve_value_ref_store_rejects_cross_server_lookup() {
+        let secrets = make_test_secrets();
+        secrets
+            .set("mcp.notion.token", "other-server-token")
+            .unwrap();
+        let err = resolve_value_ref("github", "ref:store:mcp.notion.token", &secrets).unwrap_err();
+        assert!(
+            err.contains("outside server"),
+            "expected namespace error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_value_ref_store_rejects_unnamespaced_keys() {
+        let secrets = make_test_secrets();
+        secrets.set("global_secret", "x").unwrap();
+        let err = resolve_value_ref("github", "ref:store:global_secret", &secrets).unwrap_err();
+        assert!(err.contains("outside server"));
+    }
+
+    #[test]
+    fn resolve_value_ref_store_missing_key_errors() {
+        let secrets = make_test_secrets();
+        let err =
+            resolve_value_ref("github", "ref:store:mcp.github.missing", &secrets).unwrap_err();
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_value_ref_rejects_unknown_kind() {
+        let secrets = make_test_secrets();
+        let err = resolve_value_ref("github", "ref:vault:foo", &secrets).unwrap_err();
+        assert!(err.contains("unknown credential ref kind"));
+    }
+
+    #[test]
+    fn resolve_value_ref_rejects_malformed_ref() {
+        let secrets = make_test_secrets();
+        let err = resolve_value_ref("github", "ref:store", &secrets).unwrap_err();
+        assert!(err.contains("malformed"));
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn resolve_value_ref_keychain_unavailable_on_non_mac() {
+        let secrets = make_test_secrets();
+        let err =
+            resolve_value_ref("github", "ref:keychain:Service/account", &secrets).unwrap_err();
+        assert!(err.contains("unavailable"), "got: {err}");
     }
 
     #[test]
     fn build_http_headers_token_becomes_bearer() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTTOKEN";
+        let secrets = make_test_secrets();
         std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"), "abc123");
-        let headers = build_http_headers(upper).unwrap();
+        let headers = build_http_headers("testtoken", upper, &secrets).unwrap();
         assert_eq!(headers.get("authorization").unwrap(), "Bearer abc123");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
     }
@@ -354,6 +572,7 @@ mod tests {
     fn build_http_headers_supports_arbitrary_headers() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTDD";
+        let secrets = make_test_secrets();
         std::env::set_var(
             format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_API_KEY"),
             "key-aaa",
@@ -362,11 +581,59 @@ mod tests {
             format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"),
             "key-bbb",
         );
-        let headers = build_http_headers(upper).unwrap();
+        let headers = build_http_headers("testdd", upper, &secrets).unwrap();
         assert_eq!(headers.get("dd-api-key").unwrap(), "key-aaa");
         assert_eq!(headers.get("dd-application-key").unwrap(), "key-bbb");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_API_KEY"));
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"));
+    }
+
+    #[test]
+    fn build_http_headers_resolves_token_ref() {
+        // Safety: unique prefix; no other test reads these.
+        let upper = "TESTREF";
+        let secrets = make_test_secrets();
+        secrets.set("mcp.testref.token", "resolved-bearer").unwrap();
+        std::env::set_var(
+            format!("RUSTYKRAB_MCP_{upper}_TOKEN"),
+            "ref:store:mcp.testref.token",
+        );
+        let headers = build_http_headers("testref", upper, &secrets).unwrap();
+        assert_eq!(
+            headers.get("authorization").unwrap(),
+            "Bearer resolved-bearer"
+        );
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
+    }
+
+    #[test]
+    fn build_http_headers_resolves_header_ref() {
+        // Safety: unique prefix; no other test reads these.
+        let upper = "TESTHDRREF";
+        let secrets = make_test_secrets();
+        secrets.set("mcp.testhdrref.api_key", "secret-key").unwrap();
+        std::env::set_var(
+            format!("RUSTYKRAB_MCP_{upper}_HEADER_X_API_KEY"),
+            "ref:store:mcp.testhdrref.api_key",
+        );
+        let headers = build_http_headers("testhdrref", upper, &secrets).unwrap();
+        assert_eq!(headers.get("x-api-key").unwrap(), "secret-key");
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_X_API_KEY"));
+    }
+
+    #[test]
+    fn build_http_headers_rejects_cross_server_ref() {
+        // Safety: unique prefix; no other test reads these.
+        let upper = "TESTXSERVER";
+        let secrets = make_test_secrets();
+        secrets.set("mcp.notion.token", "wrong-server").unwrap();
+        std::env::set_var(
+            format!("RUSTYKRAB_MCP_{upper}_TOKEN"),
+            "ref:store:mcp.notion.token",
+        );
+        let err = build_http_headers("testxserver", upper, &secrets).unwrap_err();
+        assert!(err.contains("outside server"), "got: {err}");
+        std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
     }
 
     #[test]


### PR DESCRIPTION
MCP server env vars (TOKEN, HEADER_*, ENV_*) now accept
`ref:store:mcp.<server>.<field>` and `ref:keychain:<service>/<account>`
references resolved at connect time. Store refs are namespaced per
server so a misconfigured env var cannot pull another server's
credentials; resolution happens inside the connector so the model
never sees the values.

A new `rustykrab-cli chat` subcommand provides a terminal REPL against
the running daemon. Its `/set <name>` slash-command prompts for a value
with no echo and POSTs directly to a new `/api/secrets` endpoint, so
secrets never enter model context or the conversation table. `/list`
and `/delete` are also wired through the gateway. MCP servers re-read
credentials at startup, so the chat help text reminds users to
restart the daemon after onboarding.