### PR TITLE
feat(gateway): exempt valid service-token requests from Origin requirement

### DIFF
--- a/crates/rustykrab-gateway/src/auth.rs
+++ b/crates/rustykrab-gateway/src/auth.rs
@@ -1,5 +1,5 @@
 use axum::extract::Request;
-use axum::http::{header, StatusCode};
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
 use rustykrab_core::crypto::constant_time_eq;
@@ -34,20 +34,11 @@ pub async fn require_auth(
         return Ok(next.run(request).await);
     }
 
-    // All /api/ endpoints require Bearer token.
-    let token = request
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "));
-
-    // Hold the read guard during comparison to prevent TOCTOU race
-    // with token rotation. The guard is dropped before the await point
-    // (next.run) to avoid holding the lock across an async boundary.
-    let is_valid = {
-        let token_guard = state.auth_token.read().unwrap_or_else(|e| e.into_inner());
-        token.is_some_and(|t| constant_time_eq(t, &token_guard))
-    };
+    // All /api/ endpoints require Bearer token. The token is compared
+    // under the read lock and the guard released before the await point
+    // (next.run), so the lock is never held across an async boundary and
+    // there is no TOCTOU race with token rotation.
+    let is_valid = has_valid_bearer_token(&state.0, request.headers());
 
     if is_valid {
         Ok(next.run(request).await)
@@ -68,4 +59,72 @@ pub fn generate_token() -> String {
         .try_fill_bytes(&mut bytes)
         .expect("OS RNG failed");
     hex::encode(bytes)
+}
+
+/// Returns true if `headers` carries an `Authorization: Bearer <token>`
+/// matching `expected`, compared in constant time.
+pub fn bearer_matches(headers: &HeaderMap, expected: &str) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|t| constant_time_eq(t, expected))
+}
+
+/// Returns true if the request bears a valid service token for this server.
+///
+/// Reads the configured token under the lock and compares before returning,
+/// so the guard is never held across an await point.
+pub fn has_valid_bearer_token(state: &AppState, headers: &HeaderMap) -> bool {
+    let guard = state.auth_token.read().unwrap_or_else(|e| e.into_inner());
+    bearer_matches(headers, &guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_auth(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::AUTHORIZATION, HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn matches_correct_bearer_token() {
+        assert!(bearer_matches(
+            &headers_with_auth("Bearer secret123"),
+            "secret123"
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_token() {
+        assert!(!bearer_matches(
+            &headers_with_auth("Bearer wrong"),
+            "secret123"
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_header() {
+        assert!(!bearer_matches(&HeaderMap::new(), "secret123"));
+    }
+
+    #[test]
+    fn rejects_missing_bearer_prefix() {
+        assert!(!bearer_matches(
+            &headers_with_auth("secret123"),
+            "secret123"
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_scheme() {
+        assert!(!bearer_matches(
+            &headers_with_auth("Basic secret123"),
+            "secret123"
+        ));
+    }
 }

--- a/crates/rustykrab-gateway/src/origin.rs
+++ b/crates/rustykrab-gateway/src/origin.rs
@@ -80,11 +80,20 @@ pub async fn origin_check_middleware(
             Some(origin_str.to_string())
         }
         None if is_sensitive => {
-            tracing::warn!(
-                path = %path,
-                "rejected request without Origin header on sensitive endpoint"
-            );
-            return Err(StatusCode::FORBIDDEN);
+            // Server-to-server clients (e.g. the Apollo BFF) do not send an
+            // Origin header. Permit them only when they present a valid
+            // bearer service token: possession of the secret proves
+            // authorization, and a cross-origin browser cannot forge it
+            // (it can't set Authorization without a CORS preflight we reject).
+            if crate::auth::has_valid_bearer_token(&state.0, request.headers()) {
+                None
+            } else {
+                tracing::warn!(
+                    path = %path,
+                    "rejected request without Origin header on sensitive endpoint"
+                );
+                return Err(StatusCode::FORBIDDEN);
+            }
         }
         None => None,
     };


### PR DESCRIPTION
The origin middleware requires an Origin header on /api/ and /webhook/
endpoints, which rejects server-to-server callers that legitimately omit
it. The forthcoming Apollo BFF calls the agent over /api/ with a bearer
service token and no browser Origin header.

Allow an Origin-less request through only when it carries a valid bearer
token: possession of the secret proves authorization, and a cross-origin
browser cannot forge it (it can't set Authorization without a CORS
preflight we reject). Unauthenticated Origin-less requests are still
rejected, so the protection against browserless tools is preserved.

Extracts the bearer-token check into reusable helpers (bearer_matches,
has_valid_bearer_token) shared by the auth and origin middleware, and
adds unit tests for the comparison.

https://claude.ai/code/session_01L8Yt2X8gVVQRBJ4Wrqp7NL