### PR TITLE
fix(browser): self-heal stale refs in act instead of relying on the model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/actions.rs
+++ b/crates/rustykrab-tools/src/browser/actions.rs
@@ -5,10 +5,10 @@
 //! wait, evaluate.
 
 use chromiumoxide::Page;
-use rustykrab_core::{Error, Result};
+use rustykrab_core::{Error, Result, ToolError, ToolErrorKind};
 use serde_json::{json, Value};
 
-use super::snapshot::SnapshotStore;
+use super::snapshot::{take_snapshot, ElementRef, SnapshotOptions, SnapshotStore};
 
 /// Encode a string as a safe JavaScript string literal (including quotes).
 /// Uses serde_json serialization which properly escapes backslashes, quotes,
@@ -19,8 +19,22 @@ fn js_string_literal(s: &str) -> String {
 
 /// Execute a ref-based action on the page.
 ///
-/// The `ref_id` comes from a previous snapshot. The action is performed on
-/// the element identified by that ref's stored CSS selector.
+/// The `ref_id` comes from a previous snapshot. The action is performed on the
+/// element identified by that ref's stored CSS selector.
+///
+/// Refs go stale whenever the page re-renders or navigates. Rather than relying
+/// on the model to notice the failure and decide to re-snapshot (a decision a
+/// weaker model makes inconsistently), `act` recovers deterministically:
+///
+/// - **Heal** — if the action fails because the element is gone, re-snapshot
+///   and re-resolve the *same logical element* by role+name. When exactly one
+///   element matches and the page hasn't navigated, retry the action once.
+/// - **Escalate** — if the page navigated, the element is gone, or several now
+///   match (ambiguous), return a `stale_ref` payload carrying a fresh snapshot
+///   so the model can re-pick a ref in the same turn.
+///
+/// Healing is only attempted for pre-action "element not found" failures, where
+/// nothing happened yet — so a retry can't double-fire a click or a submit.
 pub async fn execute_act(
     page: &Page,
     store: &SnapshotStore,
@@ -29,17 +43,58 @@ pub async fn execute_act(
     ref_id: &str,
     args: &Value,
 ) -> Result<Value> {
-    let element_ref = store.get_ref(store_key, ref_id).await.ok_or_else(|| {
-        Error::ToolExecution(
-            format!(
-                "ref '{ref_id}' not found. Take a new snapshot first to get current element refs."
+    let element_ref = match store.get_ref(store_key, ref_id).await {
+        Some(r) => r,
+        None => {
+            // No stored identity to re-resolve (ref never captured for this
+            // tab, LRU-evicted, or the tab navigated). Hand back a fresh
+            // snapshot rather than a bare error so the model can re-pick.
+            return Ok(escalate(
+                page,
+                store,
+                store_key,
+                action,
+                ref_id,
+                "ref not found in the latest snapshot for this tab",
             )
-            .into(),
-        )
-    })?;
+            .await);
+        }
+    };
 
-    let selector = &element_ref.selector;
+    let url_before = current_url(page).await;
 
+    match dispatch_act(page, store, store_key, action, &element_ref.selector, args).await {
+        Ok(v) => Ok(v),
+        // A pre-action "element not found" (typed NotFound) means a stale ref —
+        // recover. Genuine failures after the element resolved (click/type
+        // errored) propagate unchanged: retrying those risks a double side
+        // effect.
+        Err(e) if is_stale_element(&e) => {
+            heal_or_escalate(
+                page,
+                store,
+                store_key,
+                &element_ref,
+                action,
+                ref_id,
+                args,
+                url_before.as_deref(),
+            )
+            .await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Run a single ref-based action against an explicit CSS selector.
+async fn dispatch_act(
+    page: &Page,
+    store: &SnapshotStore,
+    store_key: &str,
+    action: &str,
+    selector: &str,
+    args: &Value,
+) -> Result<Value> {
     match action {
         "click" => act_click(page, selector).await,
         "type" | "fill" => {
@@ -84,12 +139,138 @@ pub async fn execute_act(
     }
 }
 
+/// True when the error is a stale-ref failure (the element wasn't found before
+/// the action ran), as opposed to a genuine failure mid-action.
+fn is_stale_element(e: &Error) -> bool {
+    matches!(e, Error::ToolExecution(te) if te.kind == ToolErrorKind::NotFound)
+}
+
+async fn current_url(page: &Page) -> Option<String> {
+    page.url().await.ok().flatten()
+}
+
+/// A stale-ref action failed. Re-snapshot, then either silently re-resolve the
+/// same logical element (unique role+name match, same page) and retry once, or
+/// escalate a fresh snapshot back to the model.
+#[allow(clippy::too_many_arguments)]
+async fn heal_or_escalate(
+    page: &Page,
+    store: &SnapshotStore,
+    store_key: &str,
+    stale: &ElementRef,
+    action: &str,
+    ref_id: &str,
+    args: &Value,
+    url_before: Option<&str>,
+) -> Result<Value> {
+    // Re-snapshot first: this refreshes the store (so find_by_identity sees the
+    // current DOM) and gives us a payload to embed if we escalate.
+    let snapshot = take_snapshot(page, &SnapshotOptions::default(), store, store_key)
+        .await
+        .ok();
+    let url_after = current_url(page).await;
+
+    // Guard 1 — navigation. A changed URL means the page is semantically
+    // different; never silently re-target, hand control back to the model.
+    if url_before != url_after.as_deref() {
+        return Ok(escalation_payload(
+            action,
+            ref_id,
+            "the tab navigated to a different URL since the snapshot",
+            snapshot,
+            url_after.as_deref(),
+        ));
+    }
+
+    // Guard 2 — unique identity. Heal only when exactly one element still
+    // matches the stale ref's role+name; none or several means escalate.
+    let matches = store
+        .find_by_identity(store_key, &stale.role, &stale.name)
+        .await;
+    match matches.as_slice() {
+        [only] => match dispatch_act(page, store, store_key, action, &only.selector, args).await {
+            Ok(mut v) => {
+                if let Value::Object(ref mut o) = v {
+                    o.insert("recovered".into(), Value::Bool(true));
+                }
+                Ok(v)
+            }
+            Err(_) => Ok(escalation_payload(
+                action,
+                ref_id,
+                "the re-resolved element could still not be actioned",
+                snapshot,
+                url_after.as_deref(),
+            )),
+        },
+        [] => Ok(escalation_payload(
+            action,
+            ref_id,
+            "the element is no longer present after the page changed",
+            snapshot,
+            url_after.as_deref(),
+        )),
+        _ => Ok(escalation_payload(
+            action,
+            ref_id,
+            "several elements now match the same role/name — ambiguous, cannot auto-recover",
+            snapshot,
+            url_after.as_deref(),
+        )),
+    }
+}
+
+/// Re-snapshot and build a stale-ref escalation payload without attempting a
+/// heal (used when there's no stored identity to re-resolve).
+async fn escalate(
+    page: &Page,
+    store: &SnapshotStore,
+    store_key: &str,
+    action: &str,
+    ref_id: &str,
+    reason: &str,
+) -> Value {
+    let snapshot = take_snapshot(page, &SnapshotOptions::default(), store, store_key)
+        .await
+        .ok();
+    let url = current_url(page).await;
+    escalation_payload(action, ref_id, reason, snapshot, url.as_deref())
+}
+
+/// Build the `stale_ref` payload returned to the model. Returned as `Ok` (not
+/// `Err`) on purpose: the runner blindly retries failed tool calls with the
+/// same arguments, which is pointless for a stale ref. As an `Ok` payload the
+/// model gets the fresh snapshot in hand and can re-pick a ref in one turn.
+fn escalation_payload(
+    action: &str,
+    ref_id: &str,
+    reason: &str,
+    snapshot: Option<Value>,
+    url: Option<&str>,
+) -> Value {
+    json!({
+        "status": "stale_ref",
+        "action_performed": false,
+        "action": action,
+        "ref": ref_id,
+        "reason": reason,
+        "url": url,
+        "message": format!(
+            "Could not '{action}' ref {ref_id}: {reason}. The refs from the previous \
+             snapshot are no longer valid. A fresh snapshot is included under \"snapshot\" \
+             — pick a new ref from it and call act again. Do not reuse the old ref."
+        ),
+        "snapshot": snapshot,
+    })
+}
+
 /// Click an element by CSS selector.
 async fn act_click(page: &Page, selector: &str) -> Result<Value> {
-    let elem = page
-        .find_element(selector)
-        .await
-        .map_err(|e| Error::ToolExecution(format!("element not found '{selector}': {e}").into()))?;
+    let elem = page.find_element(selector).await.map_err(|e| {
+        Error::ToolExecution(ToolError::not_found(format!(
+            "element not found '{selector}': {e}"
+        )))
+    })?;
     elem.click()
         .await
         .map_err(|e| Error::ToolExecution(format!("click failed on '{selector}': {e}").into()))?;
@@ -98,10 +279,11 @@ async fn act_click(page: &Page, selector: &str) -> Result<Value> {
 
 /// Type text into an element, optionally clearing first.
 async fn act_type(page: &Page, selector: &str, text: &str, clear: bool) -> Result<Value> {
-    let elem = page
-        .find_element(selector)
-        .await
-        .map_err(|e| Error::ToolExecution(format!("element not found '{selector}': {e}").into()))?;
+    let elem = page.find_element(selector).await.map_err(|e| {
+        Error::ToolExecution(ToolError::not_found(format!(
+            "element not found '{selector}': {e}"
+        )))
+    })?;
 
     // Focus the element
     elem.click()
@@ -163,9 +345,9 @@ async fn act_press(page: &Page, selector: &str, key: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "pressed", "key": key, "selector": selector }))
@@ -202,9 +384,9 @@ async fn act_hover(page: &Page, selector: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "hovered", "selector": selector }))
@@ -232,9 +414,9 @@ async fn act_select(page: &Page, selector: &str, value: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "selected", "selector": selector, "value": value }))
@@ -277,9 +459,9 @@ async fn act_drag(page: &Page, source_selector: &str, target_selector: &str) -> 
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     match status.as_str() {
-        "source_not_found" => Err(Error::ToolExecution(
-            format!("source element not found: '{source_selector}'").into(),
-        )),
+        "source_not_found" => Err(Error::ToolExecution(ToolError::not_found(format!(
+            "source element not found: '{source_selector}'"
+        )))),
         "target_not_found" => Err(Error::ToolExecution(
             format!("target element not found: '{target_selector}'").into(),
         )),

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -129,6 +129,8 @@ impl Tool for BrowserTool {
          act — interact by ref (click/type/press/hover/select/drag); \
          screenshot/content/evaluate/scroll/console/cookies/pdf. \
          Cookies persist across calls. Use snapshot + act for reliable element interaction. \
+         If act returns status \"stale_ref\", the page changed: read the fresh snapshot in \
+         that response, pick a new ref, and call act again — never reuse the old ref. \
          Use fetch when JS isn't required, stealth_fetch when it is."
     }
 

--- a/crates/rustykrab-tools/src/browser/snapshot.rs
+++ b/crates/rustykrab-tools/src/browser/snapshot.rs
@@ -122,6 +122,25 @@ impl SnapshotStore {
         hit
     }
 
+    /// Find all refs under `key` whose role and name match the given identity.
+    ///
+    /// Used by `act`'s self-heal: after a stale-ref failure we re-snapshot and
+    /// look for the *same logical element* by role+name (ref ids are positional
+    /// and change between snapshots, so they can't be reused). The caller heals
+    /// only on a unique match and escalates on none or several.
+    pub async fn find_by_identity(&self, key: &str, role: &str, name: &str) -> Vec<ElementRef> {
+        let g = self.inner.lock().await;
+        g.refs
+            .get(key)
+            .map(|m| {
+                m.values()
+                    .filter(|r| r.role == role && r.name == name)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Clear refs for a key.
     #[allow(dead_code)]
     pub async fn clear(&self, key: &str) {
@@ -675,6 +694,46 @@ mod tests {
         assert!(inner.refs.contains_key("k-0"));
         assert!(!inner.refs.contains_key("k-1"));
         assert!(inner.refs.contains_key("overflow"));
+    }
+
+    #[tokio::test]
+    async fn find_by_identity_distinguishes_unique_none_and_ambiguous() {
+        let store = SnapshotStore::new();
+        let mut refs = HashMap::new();
+        for (id, sel, role, name) in [
+            ("1", "#a", "button", "Submit"),
+            ("2", "#b", "button", "Submit"),
+            ("3", "#c", "link", "Home"),
+        ] {
+            refs.insert(
+                id.to_string(),
+                ElementRef {
+                    ref_id: id.into(),
+                    selector: sel.into(),
+                    role: role.into(),
+                    name: name.into(),
+                    value: None,
+                    interactive: true,
+                    bounds: None,
+                },
+            );
+        }
+        store.store("k", refs).await;
+
+        // Unique match heals; ambiguous and absent both escalate.
+        assert_eq!(store.find_by_identity("k", "link", "Home").await.len(), 1);
+        assert_eq!(
+            store.find_by_identity("k", "button", "Submit").await.len(),
+            2
+        );
+        assert!(store
+            .find_by_identity("k", "button", "Cancel")
+            .await
+            .is_empty());
+        assert!(store
+            .find_by_identity("missing", "link", "Home")
+            .await
+            .is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The browser `act` tool fails when an element ref goes stale (page re-rendered or navigated since the snapshot). Recovery — re-snapshot, re-resolve, retry — was left entirely to the model's discretion, so weaker models (gemma4) inconsistently retried or gave up. The "functional paralysis" the agent reports is the model rationalizing its own failure to retry, not a tool limitation: the tool was always capable of re-snapshotting.

This makes recovery deterministic in the tool, so the model's willingness to retry is no longer what stands between failure and success.

## How it works (`actions.rs`)

On a **pre-action** "element not found" failure (only this — nothing has happened to the page yet, so a retry can't double-fire a click/submit):

- **Heal** — re-snapshot, then re-resolve the *same logical element* by `role`+`name` (ref ids are positional and change between snapshots, so they can't be reused). Retry the action **once**, but only when:
  - the URL has **not** changed (Guard 1: navigation = semantic change, hand back to the model), **and**
  - exactly **one** element matches the role+name (Guard 2: zero or several = ambiguous).
- **Escalate** — on navigation, no match, or an ambiguous match, return a `stale_ref` payload carrying a **fresh snapshot** so the model re-picks a ref in a single turn.

Genuine mid-action failures (e.g. "click failed" after the element resolved) are left untouched and propagate as before.

## Key design decisions

- **Escalation is returned as `Ok`, not `Err`.** The runner's `execute_with_retries` blindly retries failed tool calls with identical args, which is pointless for a stale ref. As an `Ok` payload (`{status: "stale_ref", action_performed: false, snapshot: {...}, message: ...}`) the model gets the fresh snapshot in hand and avoids a wasted retry storm.
- **Element-not-found is now typed `ToolErrorKind::NotFound`** so stale refs are cleanly distinguishable from genuine mid-action failures — no error-message string matching.
- **Tool description carries the contract** (one line): if `act` returns `stale_ref`, read the included snapshot, pick a new ref, never reuse the old one. Detection/heal/escalate live in tool code; the description only states the contract.

## Known limitations (deliberately conservative — all fail safe to escalation)

- SPA route changes that don't alter the URL slip past Guard 1.
- The heal re-snapshot uses default `ai` mode regardless of the original snapshot's mode.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rustykrab-tools --all-targets` (clean)
- [x] `cargo test -p rustykrab-tools browser::` (26 passed, incl. new `find_by_identity_distinguishes_unique_none_and_ambiguous`)
- [ ] Manual: drive a re-rendering page (stale ref → silent heal) and a navigating page (stale ref → `stale_ref` escalation with fresh snapshot)

> Note: the heal/escalate orchestration itself needs a live `Page`, so it's covered by the conservative guards + the store-level identity test rather than a browser-driven unit test.

https://claude.ai/code/session_014pmt5PpAbjPU9pFz4vgE5S

---
_Generated by [Claude Code](https://claude.ai/code/session_014pmt5PpAbjPU9pFz4vgE5S)_