### PR TITLE
Forward structured error context to the agent on tool failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1127,14 +1127,14 @@ impl AgentRunner {
                             }
                         }
                         Err(e) => {
-                            let err_str = sanitize_error(&e.to_string());
-                            tracing::warn!(tool = %tool_name, call_id = %call_id, error = %err_str, "tool call failed");
+                            let (output, err_str) = tool_error_output(&e);
+                            tracing::warn!(tool = %tool_name, call_id = %call_id, error = %err_str, kind = e.kind().as_str(), "tool call failed");
                             Message {
                                 id: Uuid::new_v4(),
                                 role: Role::Tool,
                                 content: MessageContent::ToolResult(ToolResult {
                                     call_id,
-                                    output: serde_json::json!({ "error": err_str }),
+                                    output,
                                     is_error: true,
                                 }),
                                 created_at: Utc::now(),
@@ -1544,14 +1544,14 @@ impl AgentRunner {
                             (msg, true, None)
                         }
                         Err(e) => {
-                            let err_str = sanitize_error(&e.to_string());
-                            tracing::warn!(tool = %tool_name, call_id = %call_id, error = %err_str, "tool call failed");
+                            let (output, err_str) = tool_error_output(&e);
+                            tracing::warn!(tool = %tool_name, call_id = %call_id, error = %err_str, kind = e.kind().as_str(), "tool call failed");
                             let msg = Message {
                                 id: Uuid::new_v4(),
                                 role: Role::Tool,
                                 content: MessageContent::ToolResult(ToolResult {
                                     call_id: call_id.clone(),
-                                    output: serde_json::json!({ "error": err_str }),
+                                    output,
                                     is_error: true,
                                 }),
                                 created_at: Utc::now(),
@@ -2620,9 +2620,89 @@ impl AgentRunner {
     }
 }
 
+/// Clamp an error message before feeding it back to the model.
+///
+/// Preserves multi-line detail — the actionable part (a suggested fix, a
+/// validation message, a stale-ref hint) is often below the first line — but
+/// caps total length so a giant stack trace or HTML body can't blow up the
+/// context window.
 fn sanitize_error(e: &str) -> String {
-    let first_line = e.lines().next().unwrap_or(e);
-    first_line.chars().take(200).collect()
+    const MAX_LEN: usize = 2000;
+    let trimmed = e.trim();
+    if trimmed.chars().count() <= MAX_LEN {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(MAX_LEN).collect();
+    out.push_str("… [truncated]");
+    out
+}
+
+/// Build the structured output fed back to the model for a failed tool call.
+///
+/// Returns the JSON payload and the plain message (for logs / events). The
+/// `error_kind` and `retryable` fields let the model distinguish "fix your
+/// arguments" from "transient, retry as-is" from "permission denied, stop".
+fn tool_error_output(e: &Error) -> (serde_json::Value, String) {
+    let kind = e.kind();
+    let message = sanitize_error(&e.to_string());
+    let output = serde_json::json!({
+        "error": message,
+        "error_kind": kind.as_str(),
+        "retryable": kind.retryable(),
+    });
+    (output, message)
+}
+
+#[cfg(test)]
+mod error_output_tests {
+    use super::*;
+    use rustykrab_core::{ToolError, ToolErrorKind};
+
+    #[test]
+    fn forwards_kind_and_retryable_for_tool_errors() {
+        let e = Error::ToolExecution(ToolError::not_found("ref '12' not found"));
+        let (output, msg) = tool_error_output(&e);
+        assert_eq!(output["error_kind"], "not_found");
+        assert_eq!(output["retryable"], false);
+        assert!(output["error"]
+            .as_str()
+            .unwrap()
+            .contains("ref '12' not found"));
+        assert!(msg.contains("ref '12' not found"));
+    }
+
+    #[test]
+    fn transient_errors_are_marked_retryable() {
+        let e = Error::ToolExecution(ToolError::transient("connection reset"));
+        let (output, _) = tool_error_output(&e);
+        assert_eq!(output["error_kind"], "transient");
+        assert_eq!(output["retryable"], true);
+    }
+
+    #[test]
+    fn non_tool_error_variants_are_categorized() {
+        assert_eq!(
+            Error::Auth("x".into()).kind(),
+            ToolErrorKind::PermissionDenied
+        );
+        assert_eq!(Error::NotFound("x".into()).kind(), ToolErrorKind::NotFound);
+        assert_eq!(
+            Error::ModelRateLimit("x".into()).kind(),
+            ToolErrorKind::RateLimited
+        );
+        assert_eq!(Error::Internal("x".into()).kind(), ToolErrorKind::Internal);
+    }
+
+    #[test]
+    fn sanitize_keeps_multiline_detail_but_caps_length() {
+        let multiline = "element not found\ntake a new snapshot first";
+        assert_eq!(sanitize_error(multiline), multiline);
+
+        let huge = "x".repeat(5000);
+        let clamped = sanitize_error(&huge);
+        assert!(clamped.chars().count() < huge.chars().count());
+        assert!(clamped.ends_with("[truncated]"));
+    }
 }
 
 /// Wrap [`execute_with_retries`] in a watchdog that fires `on_heartbeat`

--- a/crates/rustykrab-core/src/error.rs
+++ b/crates/rustykrab-core/src/error.rs
@@ -77,6 +77,32 @@ impl ToolError {
     }
 }
 
+impl ToolErrorKind {
+    /// Stable machine-readable identifier, forwarded to the model so it can
+    /// react to the failure category rather than parsing the message text.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ToolErrorKind::InvalidInput => "invalid_input",
+            ToolErrorKind::NotFound => "not_found",
+            ToolErrorKind::PermissionDenied => "permission_denied",
+            ToolErrorKind::Timeout => "timeout",
+            ToolErrorKind::RateLimited => "rate_limited",
+            ToolErrorKind::Transient => "transient",
+            ToolErrorKind::Internal => "internal",
+        }
+    }
+
+    /// Whether retrying the *same* call unchanged might succeed. Distinct from
+    /// the runner's retry policy: this is a hint to the model. `InvalidInput`
+    /// and `NotFound` are false because the model must change something first.
+    pub fn retryable(&self) -> bool {
+        matches!(
+            self,
+            ToolErrorKind::Timeout | ToolErrorKind::RateLimited | ToolErrorKind::Transient
+        )
+    }
+}
+
 impl fmt::Display for ToolError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.message)
@@ -144,4 +170,26 @@ pub enum Error {
 
     #[error("{0}")]
     Internal(String),
+}
+
+impl Error {
+    /// Best-effort categorization for surfacing the failure to the agent.
+    ///
+    /// Tool errors carry their own kind; other variants are mapped to the
+    /// closest category so the model always receives a structured signal.
+    pub fn kind(&self) -> ToolErrorKind {
+        match self {
+            Error::ToolExecution(te) => te.kind,
+            Error::ModelRateLimit(_) | Error::ModelOverloaded(_) => ToolErrorKind::RateLimited,
+            Error::ModelAuthError(_) | Error::Auth(_) => ToolErrorKind::PermissionDenied,
+            Error::ModelBadRequest(_) => ToolErrorKind::InvalidInput,
+            Error::NotFound(_) => ToolErrorKind::NotFound,
+            Error::ModelProvider(_) | Error::Channel(_) => ToolErrorKind::Transient,
+            Error::Config(_)
+            | Error::Storage(_)
+            | Error::Serialization(_)
+            | Error::ContentPolicy
+            | Error::Internal(_) => ToolErrorKind::Internal,
+        }
+    }
 }

--- a/crates/rustykrab-tools/src/browser/actions.rs
+++ b/crates/rustykrab-tools/src/browser/actions.rs
@@ -5,7 +5,7 @@
 //! wait, evaluate.
 
 use chromiumoxide::Page;
-use rustykrab_core::{Error, Result};
+use rustykrab_core::{Error, Result, ToolError};
 use serde_json::{json, Value};
 
 use super::snapshot::SnapshotStore;
@@ -30,12 +30,9 @@ pub async fn execute_act(
     args: &Value,
 ) -> Result<Value> {
     let element_ref = store.get_ref(store_key, ref_id).await.ok_or_else(|| {
-        Error::ToolExecution(
-            format!(
-                "ref '{ref_id}' not found. Take a new snapshot first to get current element refs."
-            )
-            .into(),
-        )
+        Error::ToolExecution(ToolError::not_found(format!(
+            "ref '{ref_id}' not found. Take a new snapshot first to get current element refs."
+        )))
     })?;
 
     let selector = &element_ref.selector;
@@ -43,31 +40,41 @@ pub async fn execute_act(
     match action {
         "click" => act_click(page, selector).await,
         "type" | "fill" => {
-            let text = args["text"]
-                .as_str()
-                .ok_or_else(|| Error::ToolExecution("'type' action requires 'text' parameter".into()))?;
+            let text = args["text"].as_str().ok_or_else(|| {
+                Error::ToolExecution(ToolError::invalid_input(
+                    "'type' action requires 'text' parameter",
+                ))
+            })?;
             let clear = args["clear"].as_bool().unwrap_or(true); // fill clears by default
             act_type(page, selector, text, clear).await
         }
         "press" => {
-            let key = args["key"]
-                .as_str()
-                .ok_or_else(|| Error::ToolExecution("'press' action requires 'key' parameter".into()))?;
+            let key = args["key"].as_str().ok_or_else(|| {
+                Error::ToolExecution(ToolError::invalid_input(
+                    "'press' action requires 'key' parameter",
+                ))
+            })?;
             act_press(page, selector, key).await
         }
         "hover" => act_hover(page, selector).await,
         "select" => {
-            let value = args["value"]
-                .as_str()
-                .ok_or_else(|| Error::ToolExecution("'select' action requires 'value' parameter".into()))?;
+            let value = args["value"].as_str().ok_or_else(|| {
+                Error::ToolExecution(ToolError::invalid_input(
+                    "'select' action requires 'value' parameter",
+                ))
+            })?;
             act_select(page, selector, value).await
         }
         "drag" => {
-            let target_ref = args["targetRef"]
-                .as_str()
-                .ok_or_else(|| Error::ToolExecution("'drag' requires 'targetRef' parameter".into()))?;
+            let target_ref = args["targetRef"].as_str().ok_or_else(|| {
+                Error::ToolExecution(ToolError::invalid_input(
+                    "'drag' requires 'targetRef' parameter",
+                ))
+            })?;
             let target = store.get_ref(store_key, target_ref).await.ok_or_else(|| {
-                Error::ToolExecution(format!("target ref '{target_ref}' not found").into())
+                Error::ToolExecution(ToolError::not_found(format!(
+                    "target ref '{target_ref}' not found"
+                )))
             })?;
             act_drag(page, selector, &target.selector).await
         }
@@ -75,21 +82,19 @@ pub async fn execute_act(
             let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(10_000);
             act_wait_for_element(page, selector, timeout_ms).await
         }
-        _ => Err(Error::ToolExecution(
-            format!(
-                "unknown act action '{action}'. Available: click, type, fill, press, hover, select, drag, wait"
-            )
-            .into(),
-        )),
+        _ => Err(Error::ToolExecution(ToolError::invalid_input(format!(
+            "unknown act action '{action}'. Available: click, type, fill, press, hover, select, drag, wait"
+        )))),
     }
 }
 
 /// Click an element by CSS selector.
 async fn act_click(page: &Page, selector: &str) -> Result<Value> {
-    let elem = page
-        .find_element(selector)
-        .await
-        .map_err(|e| Error::ToolExecution(format!("element not found '{selector}': {e}").into()))?;
+    let elem = page.find_element(selector).await.map_err(|e| {
+        Error::ToolExecution(ToolError::not_found(format!(
+            "element not found '{selector}': {e}"
+        )))
+    })?;
     elem.click()
         .await
         .map_err(|e| Error::ToolExecution(format!("click failed on '{selector}': {e}").into()))?;
@@ -98,10 +103,11 @@ async fn act_click(page: &Page, selector: &str) -> Result<Value> {
 
 /// Type text into an element, optionally clearing first.
 async fn act_type(page: &Page, selector: &str, text: &str, clear: bool) -> Result<Value> {
-    let elem = page
-        .find_element(selector)
-        .await
-        .map_err(|e| Error::ToolExecution(format!("element not found '{selector}': {e}").into()))?;
+    let elem = page.find_element(selector).await.map_err(|e| {
+        Error::ToolExecution(ToolError::not_found(format!(
+            "element not found '{selector}': {e}"
+        )))
+    })?;
 
     // Focus the element
     elem.click()
@@ -163,9 +169,9 @@ async fn act_press(page: &Page, selector: &str, key: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "pressed", "key": key, "selector": selector }))
@@ -202,9 +208,9 @@ async fn act_hover(page: &Page, selector: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "hovered", "selector": selector }))
@@ -232,9 +238,9 @@ async fn act_select(page: &Page, selector: &str, value: &str) -> Result<Value> {
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     if status == "element_not_found" {
-        return Err(Error::ToolExecution(
-            format!("element not found: '{selector}'").into(),
-        ));
+        return Err(Error::ToolExecution(ToolError::not_found(format!(
+            "element not found: '{selector}'"
+        ))));
     }
 
     Ok(json!({ "status": "selected", "selector": selector, "value": value }))
@@ -277,12 +283,12 @@ async fn act_drag(page: &Page, source_selector: &str, target_selector: &str) -> 
 
     let status: String = result.into_value().unwrap_or_else(|_| "unknown".into());
     match status.as_str() {
-        "source_not_found" => Err(Error::ToolExecution(
-            format!("source element not found: '{source_selector}'").into(),
-        )),
-        "target_not_found" => Err(Error::ToolExecution(
-            format!("target element not found: '{target_selector}'").into(),
-        )),
+        "source_not_found" => Err(Error::ToolExecution(ToolError::not_found(format!(
+            "source element not found: '{source_selector}'"
+        )))),
+        "target_not_found" => Err(Error::ToolExecution(ToolError::not_found(format!(
+            "target element not found: '{target_selector}'"
+        )))),
         _ => Ok(json!({
             "status": "dragged",
             "source": source_selector,


### PR DESCRIPTION
When a tool call fails, the runner now returns the error category
(error_kind) and a retryable hint to the model alongside an untruncated
message, instead of flattening everything to a 200-char first-line
string. This lets the model distinguish "fix your arguments" from
"transient, retry as-is" from "permission denied, stop" rather than
guessing — and stops it from hallucinating an explanation for a failure
it can't actually see.

- core: add ToolErrorKind::as_str/retryable and Error::kind() so every
  Error variant maps to a category, not just ToolExecution.
- runner: tool_error_output() builds the structured payload; both the
  streaming and non-streaming boundaries use it. sanitize_error now
  preserves multi-line detail up to a length cap instead of chopping to
  the first 200 chars.
- browser/actions: recategorize ref-not-found / element-not-found as
  NotFound and argument validation as InvalidInput, as the first
  consumer of the typed-kind path (stale-ref signals now surface
  cleanly instead of looking like generic internal errors).

https://claude.ai/code/session_01TPQ12DMffY1CaiKZwGjU4F