### PR TITLE
fix(browser): reframe stale-ref recovery payload as observation, not failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/actions.rs
+++ b/crates/rustykrab-tools/src/browser/actions.rs
@@ -30,8 +30,8 @@ fn js_string_literal(s: &str) -> String {
 ///   and re-resolve the *same logical element* by role+name. When exactly one
 ///   element matches and the page hasn't navigated, retry the action once.
 /// - **Escalate** — if the page navigated, the element is gone, or several now
-///   match (ambiguous), return a `stale_ref` payload carrying a fresh snapshot
-///   so the model can re-pick a ref in the same turn.
+///   match (ambiguous), return a `new_snapshot` payload carrying a fresh
+///   snapshot so the model can re-pick a ref in the same turn.
 ///
 /// Healing is only attempted for pre-action "element not found" failures, where
 /// nothing happened yet — so a retry can't double-fire a click or a submit.
@@ -55,7 +55,7 @@ pub async fn execute_act(
                 store_key,
                 action,
                 ref_id,
-                "ref not found in the latest snapshot for this tab",
+                "that ref isn't present in the current snapshot for this tab",
             )
             .await);
         }
@@ -180,10 +180,10 @@ async fn heal_or_escalate(
     // Guard 1 — navigation. A changed URL means the page is semantically
     // different; never silently re-target, hand control back to the model.
     if url_before != url_after.as_deref() {
-        return Ok(escalation_payload(
+        return Ok(new_snapshot_payload(
             action,
             ref_id,
-            "the tab navigated to a different URL since the snapshot",
+            "the tab navigated to a different URL",
             snapshot,
             url_after.as_deref(),
         ));
@@ -202,25 +202,25 @@ async fn heal_or_escalate(
                 }
                 Ok(v)
             }
-            Err(_) => Ok(escalation_payload(
+            Err(_) => Ok(new_snapshot_payload(
                 action,
                 ref_id,
-                "the re-resolved element could still not be actioned",
+                "the matching element could not be actioned",
                 snapshot,
                 url_after.as_deref(),
             )),
         },
-        [] => Ok(escalation_payload(
+        [] => Ok(new_snapshot_payload(
             action,
             ref_id,
-            "the element is no longer present after the page changed",
+            "the element is no longer present on the page",
             snapshot,
             url_after.as_deref(),
         )),
-        _ => Ok(escalation_payload(
+        _ => Ok(new_snapshot_payload(
             action,
             ref_id,
-            "several elements now match the same role/name — ambiguous, cannot auto-recover",
+            "several elements now match the same role/name (ambiguous)",
             snapshot,
             url_after.as_deref(),
         )),
@@ -241,14 +241,17 @@ async fn escalate(
         .await
         .ok();
     let url = current_url(page).await;
-    escalation_payload(action, ref_id, reason, snapshot, url.as_deref())
+    new_snapshot_payload(action, ref_id, reason, snapshot, url.as_deref())
 }
 
-/// Build the `stale_ref` payload returned to the model. Returned as `Ok` (not
-/// `Err`) on purpose: the runner blindly retries failed tool calls with the
-/// same arguments, which is pointless for a stale ref. As an `Ok` payload the
-/// model gets the fresh snapshot in hand and can re-pick a ref in one turn.
-fn escalation_payload(
+/// Build the `new_snapshot` payload returned to the model. Returned as `Ok`
+/// (not `Err`) on purpose: the runner blindly retries failed tool calls with
+/// the same arguments, which is pointless when the page has moved on. As an
+/// `Ok` payload the model gets the fresh snapshot in hand and can re-pick a
+/// ref in one turn — and the framing is an observation ("here's the current
+/// state"), not a failure report, so weaker models are less likely to read it
+/// as "retry the same call."
+fn new_snapshot_payload(
     action: &str,
     ref_id: &str,
     reason: &str,
@@ -256,18 +259,18 @@ fn escalation_payload(
     url: Option<&str>,
 ) -> Value {
     json!({
-        "status": "stale_ref",
-        "action_performed": false,
-        "action": action,
-        "ref": ref_id,
-        "reason": reason,
-        "url": url,
-        "message": format!(
-            "Could not '{action}' ref {ref_id}: {reason}. The refs from the previous \
-             snapshot are no longer valid. A fresh snapshot is included under \"snapshot\" \
-             — pick a new ref from it and call act again. Do not reuse the old ref."
-        ),
+        "status": "new_snapshot",
         "snapshot": snapshot,
+        "url": url,
+        "action": action,
+        "previous_ref": ref_id,
+        "reason": reason,
+        "message": format!(
+            "Fresh snapshot taken — {reason}. The current page state is in \
+             \"snapshot\". Pick a ref from this new snapshot and call act with \
+             that ref to continue. The previous ref {ref_id} refers to an \
+             element that is not in this snapshot."
+        ),
     })
 }
 

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -129,8 +129,9 @@ impl Tool for BrowserTool {
          act — interact by ref (click/type/press/hover/select/drag); \
          screenshot/content/evaluate/scroll/console/cookies/pdf. \
          Cookies persist across calls. Use snapshot + act for reliable element interaction. \
-         If act returns status \"stale_ref\", the page changed: read the fresh snapshot in \
-         that response, pick a new ref, and call act again — never reuse the old ref. \
+         If act returns status \"new_snapshot\", the page state moved on: the response \
+         contains the current snapshot under \"snapshot\" — pick a ref from it and call \
+         act with that ref. The previous_ref in the response is no longer valid. \
          Use fetch when JS isn't required, stealth_fetch when it is."
     }
 


### PR DESCRIPTION
The act tool already returns Ok(...) on stale refs to avoid the runner's
blind-retry loop, but the payload itself reads as a failure ("status":
"stale_ref", "action_performed": false, "Could not '...': ..."). Weaker
models pattern-match on that error framing and either retry with the same
ref or give up, instead of reading the embedded fresh snapshot and picking
a new ref.

Same control flow, observation-shaped payload:
- status: "stale_ref" -> "new_snapshot"
- drop action_performed: false (negation framing)
- message leads with the new state ("Fresh snapshot taken — ...") and the
  next action, instead of apologizing for the dead ref
- per-reason strings rephrased as facts about current state rather than
  failure descriptions

Tool description in browser/mod.rs updated to match the new status name
and framing.