### PR TITLE
feat(recall): persist compaction-displaced history across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-core/src/recall.rs
+++ b/crates/rustykrab-core/src/recall.rs
@@ -18,19 +18,80 @@ use std::sync::{Arc, RwLock};
 
 use uuid::Uuid;
 
+/// Durable backing layer for the recall archive, keyed by conversation id.
+///
+/// Implemented in `rustykrab-store` (SQLite) and injected into
+/// [`RecallStore`] so this crate stays storage-agnostic. All methods are
+/// **best-effort**: implementations must log and swallow their own errors
+/// so a persistence hiccup never breaks the agent loop (which is why
+/// `upsert`/`delete` return `()` and `load` returns `Option` rather than
+/// `Result`).
+pub trait RecallPersistence: Send + Sync + std::fmt::Debug {
+    /// Load the full archive text for a conversation, or `None` if there
+    /// is no persisted archive (or the load failed).
+    fn load(&self, conversation_id: Uuid) -> Option<String>;
+    /// Insert or replace the persisted archive text for a conversation.
+    fn upsert(&self, conversation_id: Uuid, archive: &str);
+    /// Permanently delete the persisted archive for a conversation.
+    fn delete(&self, conversation_id: Uuid);
+}
+
 /// Thread-safe map from conversation id to the rendered text of all
 /// messages that have been displaced by compaction.
 ///
 /// Append-only within a conversation: each compaction appends the
 /// rendered batch, joined to the previous archive with a blank line.
+///
+/// When constructed via [`RecallStore::with_persistence`], the in-memory
+/// map acts as a write-through cache over a durable backing store: writes
+/// are mirrored to the backend, and on a cache miss the entry is lazily
+/// hydrated from it. This lets the archive survive process restarts — a
+/// resumed conversation re-hydrates its history on first `recall_*` access.
 #[derive(Debug, Default)]
 pub struct RecallStore {
     inner: RwLock<HashMap<Uuid, Arc<String>>>,
+    persistence: Option<Arc<dyn RecallPersistence>>,
 }
 
 impl RecallStore {
+    /// Construct a purely in-memory store with no durable backing. The
+    /// archive is lost when the process exits.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Construct a store backed by a durable persistence layer. The
+    /// in-memory map becomes a write-through cache that is lazily hydrated
+    /// from `persistence` on first access per conversation.
+    pub fn with_persistence(persistence: Arc<dyn RecallPersistence>) -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            persistence: Some(persistence),
+        }
+    }
+
+    /// Ensure the in-memory cache holds the persisted archive for
+    /// `conversation_id` (if any). No-op when there is no persistence
+    /// layer or the entry is already cached. The durable load happens
+    /// outside the cache lock so SQLite I/O never serialises behind it.
+    fn hydrate(&self, conversation_id: Uuid) {
+        let Some(persistence) = &self.persistence else {
+            return;
+        };
+        {
+            let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+            if guard.contains_key(&conversation_id) {
+                return;
+            }
+        }
+        if let Some(text) = persistence.load(conversation_id) {
+            let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+            // `or_insert_with` guards against a concurrent writer that
+            // populated the entry while we were loading.
+            guard
+                .entry(conversation_id)
+                .or_insert_with(|| Arc::new(text));
+        }
     }
 
     /// Append `text` to the archive for `conversation_id`. If an entry
@@ -40,33 +101,85 @@ impl RecallStore {
         if text.is_empty() {
             return;
         }
-        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        let entry = guard.entry(conversation_id).or_default();
-        let combined = if entry.is_empty() {
-            text.to_string()
-        } else {
-            format!("{}\n\n{}", entry.as_str(), text)
+        // Hydrate first so we concatenate onto any prior (possibly
+        // persisted-then-restarted) archive rather than silently restarting.
+        self.hydrate(conversation_id);
+        let combined = {
+            let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+            let entry = guard.entry(conversation_id).or_default();
+            let combined = if entry.is_empty() {
+                Arc::new(text.to_string())
+            } else {
+                Arc::new(format!("{}\n\n{}", entry.as_str(), text))
+            };
+            *entry = Arc::clone(&combined);
+            combined
         };
-        *entry = Arc::new(combined);
+        // Mirror to durable storage after releasing the cache lock.
+        if let Some(persistence) = &self.persistence {
+            persistence.upsert(conversation_id, &combined);
+        }
     }
 
     /// Return a cheap clone of the archive for `conversation_id`, or
     /// `None` if nothing has been archived yet.
     pub fn get(&self, conversation_id: Uuid) -> Option<Arc<String>> {
+        self.hydrate(conversation_id);
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         guard.get(&conversation_id).cloned()
     }
 
-    /// Forget the archive for a conversation (used on session teardown).
+    /// Drop the in-memory cache entry for a conversation. The durable
+    /// archive (if any) is left intact so it can be lazily re-hydrated on
+    /// next access; use [`purge`](Self::purge) to delete it permanently.
+    /// Intended for session teardown, where we want to free memory without
+    /// forgetting history.
     pub fn clear(&self, conversation_id: Uuid) {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
         guard.remove(&conversation_id);
+    }
+
+    /// Permanently delete the archive for a conversation from both the
+    /// in-memory cache and the durable store. Use when a conversation is
+    /// deleted outright.
+    pub fn purge(&self, conversation_id: Uuid) {
+        {
+            let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+            guard.remove(&conversation_id);
+        }
+        if let Some(persistence) = &self.persistence {
+            persistence.delete(conversation_id);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// In-memory stand-in for a SQLite-backed [`RecallPersistence`].
+    #[derive(Debug, Default)]
+    struct MockPersistence {
+        rows: Mutex<HashMap<Uuid, String>>,
+        loads: Mutex<u32>,
+    }
+
+    impl RecallPersistence for MockPersistence {
+        fn load(&self, conversation_id: Uuid) -> Option<String> {
+            *self.loads.lock().unwrap() += 1;
+            self.rows.lock().unwrap().get(&conversation_id).cloned()
+        }
+        fn upsert(&self, conversation_id: Uuid, archive: &str) {
+            self.rows
+                .lock()
+                .unwrap()
+                .insert(conversation_id, archive.to_string());
+        }
+        fn delete(&self, conversation_id: Uuid) {
+            self.rows.lock().unwrap().remove(&conversation_id);
+        }
+    }
 
     #[test]
     fn append_creates_entry() {
@@ -112,6 +225,78 @@ mod tests {
         let conv = Uuid::new_v4();
         store.append(conv, "x");
         store.clear(conv);
+        assert!(store.get(conv).is_none());
+    }
+
+    #[test]
+    fn append_mirrors_to_persistence() {
+        let backend = Arc::new(MockPersistence::default());
+        let store = RecallStore::with_persistence(backend.clone());
+        let conv = Uuid::new_v4();
+        store.append(conv, "first");
+        store.append(conv, "second");
+        assert_eq!(
+            backend.rows.lock().unwrap().get(&conv).unwrap(),
+            "first\n\nsecond"
+        );
+    }
+
+    #[test]
+    fn hydrates_from_persistence_after_restart() {
+        let backend = Arc::new(MockPersistence::default());
+        let conv = Uuid::new_v4();
+        backend.upsert(conv, "archived earlier");
+
+        // Fresh store (simulating a process restart) over the same backend.
+        let store = RecallStore::with_persistence(backend.clone());
+        let got = store
+            .get(conv)
+            .expect("archive should hydrate from backend");
+        assert_eq!(got.as_str(), "archived earlier");
+    }
+
+    #[test]
+    fn append_concatenates_onto_hydrated_archive() {
+        let backend = Arc::new(MockPersistence::default());
+        let conv = Uuid::new_v4();
+        backend.upsert(conv, "old");
+
+        let store = RecallStore::with_persistence(backend.clone());
+        store.append(conv, "new");
+        assert_eq!(store.get(conv).unwrap().as_str(), "old\n\nnew");
+        assert_eq!(
+            backend.rows.lock().unwrap().get(&conv).unwrap(),
+            "old\n\nnew"
+        );
+    }
+
+    #[test]
+    fn hydrate_caches_so_repeat_reads_dont_reload() {
+        let backend = Arc::new(MockPersistence::default());
+        let conv = Uuid::new_v4();
+        backend.upsert(conv, "x");
+        let store = RecallStore::with_persistence(backend.clone());
+        store.get(conv);
+        store.get(conv);
+        // Only the first miss should touch the backend.
+        assert_eq!(*backend.loads.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn clear_keeps_durable_archive_purge_removes_it() {
+        let backend = Arc::new(MockPersistence::default());
+        let store = RecallStore::with_persistence(backend.clone());
+        let conv = Uuid::new_v4();
+        store.append(conv, "data");
+
+        // clear() is cache-only: durable row survives and re-hydrates.
+        store.clear(conv);
+        assert!(backend.rows.lock().unwrap().contains_key(&conv));
+        assert_eq!(store.get(conv).unwrap().as_str(), "data");
+
+        // purge() removes both.
+        store.purge(conv);
+        assert!(!backend.rows.lock().unwrap().contains_key(&conv));
         assert!(store.get(conv).is_none());
     }
 }

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -268,11 +268,14 @@ async fn delete_conversation(
         .store
         .conversations()
         .delete(id)
-        .map(|_| StatusCode::NO_CONTENT)
         .map_err(|e| match e {
             rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
-        })
+        })?;
+    // Drop the recall archive too (cache + durable row) so a deleted
+    // conversation leaves nothing behind.
+    state.recall.purge(id);
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// `GET /api/conversations/{id}/messages`.

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -66,6 +66,12 @@ impl AppState {
         provider: Arc<dyn ModelProvider>,
         auth_token: String,
     ) -> Self {
+        // Back the recall archive with SQLite so compaction-displaced
+        // history survives process restarts. The in-memory `RecallStore`
+        // acts as a write-through cache, lazily hydrated per conversation.
+        let recall = Arc::new(RecallStore::with_persistence(Arc::new(
+            store.recall_archive(),
+        )));
         Self {
             store,
             tools,
@@ -85,7 +91,7 @@ impl AppState {
             memory: None,
             agent_id: None,
             active_tools: Arc::new(ActiveToolsRegistry::new()),
-            recall: Arc::new(RecallStore::new()),
+            recall,
             subagents_enabled: false,
         }
     }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -2,6 +2,7 @@ mod chat_map;
 mod conversation;
 mod jobs;
 pub mod keychain;
+mod recall_archive;
 pub mod registry;
 mod secret;
 mod slack_chat_map;
@@ -16,6 +17,7 @@ use zeroize::Zeroizing;
 pub use chat_map::ChatMapStore;
 pub use conversation::{ConversationStore, ConversationSummary};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
+pub use recall_archive::RecallArchiveStore;
 pub use secret::SecretStore;
 pub use slack_chat_map::SlackChatMapStore;
 
@@ -116,6 +118,13 @@ impl Store {
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(team_id, channel_id, thread_ts)
             );
+
+            CREATE TABLE IF NOT EXISTS recall_archive (
+                conversation_id TEXT PRIMARY KEY,
+                archive         TEXT NOT NULL,
+                created_at      TEXT NOT NULL,
+                updated_at      TEXT NOT NULL
+            );
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -169,6 +178,13 @@ impl Store {
     /// Return a handle for Slack (team, channel, thread) → conversation mapping.
     pub fn slack_chat_map(&self) -> SlackChatMapStore {
         SlackChatMapStore::new(Arc::clone(&self.conn))
+    }
+
+    /// Return a handle for the durable recall archive (compaction-displaced
+    /// history). Implements `RecallPersistence` so it can back a
+    /// `RecallStore`.
+    pub fn recall_archive(&self) -> RecallArchiveStore {
+        RecallArchiveStore::new(Arc::clone(&self.conn))
     }
 
     /// Flush all pending writes to disk.

--- a/crates/rustykrab-store/src/recall_archive.rs
+++ b/crates/rustykrab-store/src/recall_archive.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use rusqlite::{params, OptionalExtension};
+use rustykrab_core::recall::RecallPersistence;
+use rustykrab_core::Error;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// SQLite-backed durable store for compaction-displaced recall archives,
+/// keyed by conversation id.
+///
+/// Implements [`RecallPersistence`] so it can be injected into a
+/// `RecallStore` as its write-through backing layer, letting the recall
+/// archive survive process restarts.
+#[derive(Clone, Debug)]
+pub struct RecallArchiveStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl RecallArchiveStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Insert or replace the archive text for a conversation. `created_at`
+    /// is preserved on update; only `updated_at` advances.
+    pub fn upsert(&self, conversation_id: Uuid, archive: &str) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO recall_archive (conversation_id, archive, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?3)
+             ON CONFLICT(conversation_id) DO UPDATE SET
+                 archive = excluded.archive,
+                 updated_at = excluded.updated_at",
+            params![conversation_id.to_string(), archive, now],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Fetch the archive text for a conversation, or `None` if absent.
+    pub fn get(&self, conversation_id: Uuid) -> Result<Option<String>, Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT archive FROM recall_archive WHERE conversation_id = ?1",
+            params![conversation_id.to_string()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| Error::Storage(e.to_string()))
+    }
+
+    /// Delete the archive for a conversation. Idempotent — deleting a
+    /// missing row is not an error.
+    pub fn delete(&self, conversation_id: Uuid) -> Result<(), Error> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM recall_archive WHERE conversation_id = ?1",
+            params![conversation_id.to_string()],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+}
+
+/// Best-effort adapter: persistence failures are logged and swallowed so
+/// they never break the agent loop. The in-memory `RecallStore` cache
+/// remains authoritative for the live session even if a write is dropped.
+impl RecallPersistence for RecallArchiveStore {
+    fn load(&self, conversation_id: Uuid) -> Option<String> {
+        match self.get(conversation_id) {
+            Ok(archive) => archive,
+            Err(e) => {
+                tracing::warn!(error = %e, %conversation_id, "failed to load recall archive");
+                None
+            }
+        }
+    }
+
+    fn upsert(&self, conversation_id: Uuid, archive: &str) {
+        if let Err(e) = RecallArchiveStore::upsert(self, conversation_id, archive) {
+            tracing::warn!(error = %e, %conversation_id, "failed to persist recall archive");
+        }
+    }
+
+    fn delete(&self, conversation_id: Uuid) {
+        if let Err(e) = RecallArchiveStore::delete(self, conversation_id) {
+            tracing::warn!(error = %e, %conversation_id, "failed to delete recall archive");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_memory_store() -> RecallArchiveStore {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE recall_archive (
+                conversation_id TEXT PRIMARY KEY,
+                archive         TEXT NOT NULL,
+                created_at      TEXT NOT NULL,
+                updated_at      TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        RecallArchiveStore::new(Arc::new(Mutex::new(conn)))
+    }
+
+    #[test]
+    fn upsert_then_get_round_trips() {
+        let store = in_memory_store();
+        let conv = Uuid::new_v4();
+        store.upsert(conv, "hello").unwrap();
+        assert_eq!(store.get(conv).unwrap().as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn upsert_replaces_existing() {
+        let store = in_memory_store();
+        let conv = Uuid::new_v4();
+        store.upsert(conv, "first").unwrap();
+        store.upsert(conv, "second").unwrap();
+        assert_eq!(store.get(conv).unwrap().as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn get_missing_returns_none() {
+        let store = in_memory_store();
+        assert_eq!(store.get(Uuid::new_v4()).unwrap(), None);
+    }
+
+    #[test]
+    fn delete_is_idempotent() {
+        let store = in_memory_store();
+        let conv = Uuid::new_v4();
+        store.upsert(conv, "x").unwrap();
+        store.delete(conv).unwrap();
+        store.delete(conv).unwrap();
+        assert_eq!(store.get(conv).unwrap(), None);
+    }
+
+    #[test]
+    fn upsert_preserves_created_at_on_update() {
+        let store = in_memory_store();
+        let conv = Uuid::new_v4();
+        store.upsert(conv, "first").unwrap();
+        let created: String = {
+            let conn = store.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT created_at FROM recall_archive WHERE conversation_id = ?1",
+                params![conv.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        store.upsert(conv, "second").unwrap();
+        let created_after: String = {
+            let conn = store.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT created_at FROM recall_archive WHERE conversation_id = ?1",
+                params![conv.to_string()],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(created, created_after);
+    }
+}


### PR DESCRIPTION
The recall archive (compaction-displaced conversation history, backing
the recall_* tools) lived only in an in-memory RecallStore that was
cleared on session teardown and lost entirely on process restart. After
a restart, a resumed conversation kept only its compaction summary — the
verbatim displaced detail the agent could previously recover via
recall_search/recall_peek was gone.

Add a durable, write-through backing layer so the archive survives
restarts:

- rustykrab-core: define `RecallPersistence` trait (best-effort: load
  returns Option, upsert/delete return ()) and give `RecallStore` an
  optional backend via `with_persistence`. Writes mirror to the backend
  after releasing the cache lock; reads lazily hydrate on cache miss so a
  resumed conversation re-loads its history on first recall_* access.
- Split teardown semantics: `clear` is now cache-only (durable row
  survives for re-hydration); new `purge` deletes both cache and durable
  row for genuine conversation deletion.
- rustykrab-store: add `RecallArchiveStore` (recall_archive table,
  upsert/get/delete) implementing `RecallPersistence`, logging and
  swallowing errors so persistence never breaks the agent loop.
- rustykrab-gateway: back the shared RecallStore with SQLite in
  AppState::new; purge the archive when a conversation is deleted.

The agent crate is untouched — recall_* tools resolve the store through
session context and inherit persistence transparently.

https://claude.ai/code/session_01QYK7sXyB4d6USnQTrkKJnV