### PR TITLE
Group caldav under the integration tool category

### DIFF
--- a/crates/rustykrab-tools/src/tools_list.rs
+++ b/crates/rustykrab-tools/src/tools_list.rs
@@ -16,7 +16,7 @@ pub(crate) fn categorize(name: &str) -> &'static str {
         }
         "image" | "video" | "canvas" => "media",
         "cron" | "gateway" => "automation",
-        "gmail" | "notion" | "obsidian" => "integration",
+        "gmail" | "caldav" | "notion" | "obsidian" => "integration",
         "skills" => "skills",
         "message" => "messaging",
         "nodes" => "devices",


### PR DESCRIPTION
## Summary

The CalDAV Google Calendar tool merged in #456, but the `caldav` tool name was never added to the `categorize()` match in `tools_list.rs`. As a result it falls through to the default `"general"` bucket instead of being grouped with the other account integrations (`gmail`, `notion`, `obsidian`).

This is a one-line follow-up that places `caldav` in the `"integration"` category alongside its peers, so the `tools_list` meta-tool reports it correctly when the agent filters tools by category.

## Details

- Purely cosmetic/organizational — it only affects the category label returned by `tools_list`. The tool was already discoverable and callable at runtime regardless (no `available()` override, present in `builtin_tools()`).
- No behavior, schema, or dependency changes.

```diff
-        "gmail" | "notion" | "obsidian" => "integration",
+        "gmail" | "caldav" | "notion" | "obsidian" => "integration",
```

## Testing

- `cargo build -p rustykrab-tools` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p rustykrab-tools --all-targets` ✅ (no warnings)

https://claude.ai/code/session_01JK5mSLK9ugP3FrxTZoNMgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JK5mSLK9ugP3FrxTZoNMgE)_