### PR TITLE
Raise snapshot max_depth default to 50 for deep SPAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.1.0"
+version = "4.1.2"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -246,7 +246,7 @@ impl Tool for BrowserTool {
                     },
                     "depth": {
                         "type": "integer",
-                        "description": "Snapshot: max tree depth (default: 10)"
+                        "description": "Snapshot: max tree depth (default: 50). Modern SPAs nest interactive elements 25-40 levels deep; raise this if a snapshot returns no/too few elements."
                     },
                     "highlight": {
                         "type": "boolean",
@@ -544,7 +544,7 @@ impl Tool for BrowserTool {
                     mode,
                     interactive_only: args["interactive"].as_bool().unwrap_or(false),
                     compact: args["compact"].as_bool().unwrap_or(false),
-                    max_depth: args["depth"].as_u64().unwrap_or(10) as usize,
+                    max_depth: args["depth"].as_u64().unwrap_or(50) as usize,
                     selector: args["selector"].as_str().map(|s| s.to_string()),
                     highlight: args["highlight"].as_bool().unwrap_or(false),
                 };

--- a/crates/rustykrab-tools/src/browser/snapshot.rs
+++ b/crates/rustykrab-tools/src/browser/snapshot.rs
@@ -25,7 +25,14 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 /// Maximum depth for accessibility tree traversal.
-const DEFAULT_MAX_DEPTH: usize = 10;
+///
+/// Modern React/Angular/Vue SPAs nest interactive elements deeply — Instagram's
+/// login inputs sit ~32 levels down, and Google/Amazon are similar. A shallow
+/// limit makes the walker stop before reaching them, so a snapshot reports 0
+/// interactive elements even though they're visible and functional. 50 covers
+/// all practical cases; the walker is O(n) in DOM nodes, so the extra headroom
+/// is cheap. Callers can still override via the `depth` snapshot parameter.
+const DEFAULT_MAX_DEPTH: usize = 50;
 
 /// Marker between segments of a shadow-DOM piercing selector.
 #[allow(dead_code)]
@@ -213,7 +220,7 @@ const SNAPSHOT_JS: &str = r#"
     var SHADOW_SEP = ' >>> ';
     var IFRAME_SEP = ' ||| ';
 
-    var MAX_DEPTH = arguments[0] || 10;
+    var MAX_DEPTH = arguments[0] || 50;
     var INTERACTIVE_ONLY = arguments[1] || false;
     var SCOPE_SELECTOR = arguments[2] || null;
     var HIGHLIGHT = arguments[3] || false;
@@ -664,6 +671,20 @@ mod tests {
         let mut m = HashMap::new();
         m.insert(id.to_string(), mk_ref(id));
         m
+    }
+
+    #[test]
+    fn default_max_depth_reaches_deep_spa_elements() {
+        // Modern React/Angular/Vue SPAs nest interactive elements deeply.
+        // Instagram's login inputs sit ~32 levels down; the default must walk
+        // past that or snapshots report 0 interactive elements on such pages.
+        const DEEPEST_OBSERVED_SPA_NESTING: usize = 32;
+        assert!(
+            SnapshotOptions::default().max_depth > DEEPEST_OBSERVED_SPA_NESTING,
+            "default max_depth ({}) must exceed real-world SPA nesting ({})",
+            SnapshotOptions::default().max_depth,
+            DEEPEST_OBSERVED_SPA_NESTING,
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
The browser snapshot walker's default max tree depth was 10, far too
shallow for modern React/Angular/Vue SPAs. Instagram's login inputs sit
~32 levels deep, so the walker stopped before reaching them and the
snapshot reported 0 interactive elements even though the inputs were
visible and functional — easily misread as anti-bot detection.

Bump DEFAULT_MAX_DEPTH (and the JS/tool-input fallbacks) from 10 to 50.
The walker is O(n) in DOM nodes, so the extra headroom is cheap, and 50
covers all practical SPA nesting. The `depth` tool parameter still lets
callers override per snapshot.

Add a regression test asserting the default exceeds real-world SPA
nesting, and update the tool schema docs.