### PR TITLE
feat(agent): seed `skills` into the active set so authoring is reachable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.1.3"
+version = "4.1.4"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -45,6 +45,24 @@ fn is_meta_tool(name: &str) -> bool {
     META_TOOL_NAMES.contains(&name)
 }
 
+/// Tool names seeded into every conversation's active set on the first
+/// schema computation, so they're visible from turn 0 without the model
+/// having to discover them via `tools_list` and turn them on with
+/// `tools_load`.
+///
+/// Unlike [`META_TOOL_NAMES`], these go through the normal per-conversation
+/// active set: they're reported by `tools_load`, capability-gated, and
+/// dropped when no tool of that name is registered. `skills` lives here
+/// because skill *authoring* (create/load/delete) is otherwise unreachable
+/// — nothing tells the model the tool exists, so it never loads it.
+///
+/// Seeding by bare name means these names must be reserved: a SKILL.md
+/// skill that took the name `skills` would collide with this tool. That
+/// collision is blocked at creation time in `rustykrab-tools`'
+/// `SkillsTool::action_create` and at registration time by
+/// `skill_md_as_tools`' dedup against the live tool set.
+const DEFAULT_ACTIVE_TOOLS: &[&str] = &["skills"];
+
 use crate::sandbox::{tool_timeout_secs, Sandbox, SandboxPolicy, DEFAULT_NET_TOOL_TIMEOUT_SECS};
 use crate::trace::{ExecutionTracer, ToolTrace};
 
@@ -721,6 +739,14 @@ impl AgentRunner {
     /// Meta-tools (`tools_list`, `tools_load`) are always included so the
     /// agent can always discover and load more tools.
     fn compute_schemas(&self, session: &Session, conv_id: Uuid) -> Vec<ToolSchema> {
+        // Seed the always-on defaults (e.g. `skills`) into this
+        // conversation's active set so they surface from the first turn
+        // without a `tools_load` round-trip. Idempotent — re-seeding an
+        // already-active name is a no-op — so this is safe to run every
+        // iteration. Names with no matching registered tool fall out in the
+        // filter below.
+        self.active_tools
+            .activate(conv_id, DEFAULT_ACTIVE_TOOLS.iter().copied());
         let active = self.active_tools.active_for(conv_id);
         self.tools
             .iter()
@@ -4151,6 +4177,51 @@ mod task_complete_tests {
         let caps = CapabilitySet::for_tools_permissive(&["noop", "task_complete"]);
         let session = Session::with_capabilities(conv_id, caps);
         (runner, session, conv_id)
+    }
+
+    #[tokio::test]
+    async fn skills_is_seeded_into_active_set() {
+        // `skills` must surface from turn 0 without a `tools_load`
+        // round-trip, while a non-seeded, non-meta tool stays hidden until
+        // it's explicitly activated.
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(NoopTool {
+                name: "skills".into(),
+            }),
+            Arc::new(NoopTool {
+                name: "hidden".into(),
+            }),
+        ];
+        let runner = AgentRunner::new(
+            Arc::new(ScriptedProvider::new(vec![])),
+            tools,
+            Arc::new(NoSandbox),
+        )
+        .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        let caps = CapabilitySet::for_tools_permissive(&["skills", "hidden"]);
+        let session = Session::with_capabilities(conv_id, caps);
+
+        // Nothing activated yet — the default seed should still expose
+        // `skills` and only `skills`.
+        let names: Vec<String> = runner
+            .compute_schemas(&session, conv_id)
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        assert!(
+            names.contains(&"skills".to_string()),
+            "skills should be seeded into the active set, got {names:?}"
+        );
+        assert!(
+            !names.contains(&"hidden".to_string()),
+            "a non-seeded, non-meta tool must stay hidden until activated"
+        );
+
+        // The seed is recorded in the registry itself, so `tools_load`'s
+        // active listing reflects it too — not just the schema view.
+        assert!(active.active_for(conv_id).contains("skills"));
     }
 
     #[tokio::test]

--- a/crates/rustykrab-tools/src/skills.rs
+++ b/crates/rustykrab-tools/src/skills.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rustykrab_core::active_tools::with_session_context;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_skills::SkillRegistry;
@@ -50,6 +51,27 @@ impl SkillsTool {
         if !is_valid_name(name) {
             return Err(Error::ToolExecution(
                 "invalid skill name: must be 1-64 chars, lowercase a-z, 0-9, hyphens, underscores only".into(),
+            ));
+        }
+
+        // Reject names that collide with a live tool. Each skill is exposed
+        // as a first-class tool by its name (`skill_md_as_tools`), and
+        // built-ins like `skills` are seeded into the conversation's active
+        // set — so a skill that took one of those names could never surface
+        // as a tool (it'd be dropped at registration) and, worse, would
+        // shadow the meta-tool in the `<available_skills>` catalog. Catch it
+        // here at authoring time instead of letting it fail silently later.
+        //
+        // Best-effort: the live tool set is only visible inside a runner
+        // session context. Outside one (tests, ad-hoc CLI invocations) we
+        // skip this and rely on the on-disk existence check below.
+        let collides_with_tool =
+            with_session_context(|ctx| ctx.all_tools.iter().any(|t| t.name() == name))
+                .unwrap_or(false);
+        if collides_with_tool {
+            return Err(Error::ToolExecution(
+                format!("skill name '{name}' collides with an existing tool; choose another name")
+                    .into(),
             ));
         }
 
@@ -690,6 +712,74 @@ mod tests {
             .await;
         assert!(r.is_err());
         assert!(r.unwrap_err().to_string().contains("unknown action"));
+    }
+
+    fn ctx_with_tools(
+        tools: Vec<Arc<dyn Tool>>,
+    ) -> rustykrab_core::active_tools::SessionToolContext {
+        use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext};
+        use rustykrab_core::capability::CapabilitySet;
+        use rustykrab_core::recall::RecallStore;
+        SessionToolContext {
+            conversation_id: uuid::Uuid::new_v4(),
+            capabilities: Arc::new(CapabilitySet::none()),
+            all_tools: Arc::new(tools),
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+            recall: Arc::new(RecallStore::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_name_colliding_with_live_tool() {
+        use rustykrab_core::SESSION_TOOL_CONTEXT;
+        let tmp = TempDir::new().unwrap();
+        let tool = SkillsTool::new(tmp.path().to_path_buf());
+        // A live tool already owns the name `skills` (the meta-tool itself,
+        // now seeded into the active set). A skill must not shadow it.
+        let existing: Vec<Arc<dyn Tool>> =
+            vec![Arc::new(SkillsTool::new(tmp.path().to_path_buf()))];
+
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx_with_tools(existing), async {
+                tool.execute(json!({
+                    "action": "create",
+                    "name": "skills",
+                    "description": "shadow",
+                    "instructions": "nope"
+                }))
+                .await
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("collides"));
+        // Rejected before any disk write.
+        assert!(!tmp.path().join("skills").exists());
+    }
+
+    #[tokio::test]
+    async fn create_allows_non_colliding_name_in_context() {
+        use rustykrab_core::SESSION_TOOL_CONTEXT;
+        let tmp = TempDir::new().unwrap();
+        let tool = SkillsTool::new(tmp.path().to_path_buf());
+        let existing: Vec<Arc<dyn Tool>> =
+            vec![Arc::new(SkillsTool::new(tmp.path().to_path_buf()))];
+
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx_with_tools(existing), async {
+                tool.execute(json!({
+                    "action": "create",
+                    "name": "fresh-skill",
+                    "description": "ok",
+                    "instructions": "do it"
+                }))
+                .await
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result["created"], true);
+        assert!(tmp.path().join("fresh-skill/SKILL.md").exists());
     }
 
     fn make_skill_md(name: &str, description: &str, body: &str) -> Arc<rustykrab_skills::SkillMd> {


### PR DESCRIPTION
The `skills` tool (create/load/delete SKILL.md skills) was registered but
invisible: `compute_schemas` only surfaces meta-tools and the
per-conversation active set, which starts empty. `skills` is neither, so
the model never saw it and could not author skills without first
discovering and `tools_load`-ing it — which nothing in the prompt tells
it to do.

Seed a `DEFAULT_ACTIVE_TOOLS` set (currently just `skills`) into each
conversation's active set on the first schema computation. The seed goes
through the normal active set, so it's capability-gated and reported by
`tools_load`, and falls out cleanly when no tool of that name is
registered.

Seeding by bare name reserves that name, so guard against collisions:
`SkillsTool::action_create` now rejects a skill whose name matches any
live tool (via the session's tool set), complementing the existing
`skill_md_as_tools` dedup at registration time. This stops a skill from
shadowing the seeded `skills` meta-tool in the `<available_skills>`
catalog.

Tests: seeding exposes `skills` from turn 0 while non-seeded tools stay
hidden; create rejects colliding names and allows non-colliding ones.

https://claude.ai/code/session_011AWtgGxWBnTz9Rqpb9TgDJ