### PR TITLE
fix(caldav): strip whitespace from the Google app password

### DIFF
--- a/crates/rustykrab-tools/src/caldav.rs
+++ b/crates/rustykrab-tools/src/caldav.rs
@@ -92,7 +92,13 @@ impl CalDavTool {
                 .into(),
             )
         })?;
-        Ok((email, password))
+        // Google displays app passwords as four space-separated groups
+        // (`abcd efgh ijkl mnop`). Gmail's IMAP/SMTP tolerates the spaces
+        // server-side, but a CalDAV `Basic` auth header base64-encodes them
+        // verbatim and Google's DAV endpoint rejects it with 401. Strip all
+        // whitespace so a password stored in the displayed format still works,
+        // without requiring the user to re-enter it.
+        Ok((email.trim().to_string(), normalize_app_password(&password)))
     }
 
     /// The events collection URL for a given calendar id (defaults to the
@@ -539,6 +545,13 @@ impl CalDavTool {
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-tested, no network)
 // ---------------------------------------------------------------------------
+
+/// Remove all whitespace from a Google app password. Google shows app
+/// passwords as four space-separated groups; the spaces are not part of the
+/// secret and break CalDAV `Basic` auth, so strip them.
+fn normalize_app_password(password: &str) -> String {
+    password.replace(char::is_whitespace, "")
+}
 
 /// Turn an href (possibly path-only) into an absolute Google CalDAV URL.
 fn absolutize(href: &str) -> String {
@@ -1006,6 +1019,25 @@ mod tests {
     #[test]
     fn parse_vevent_returns_none_without_event() {
         assert!(parse_vevent("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n").is_none());
+    }
+
+    #[test]
+    fn app_password_whitespace_is_stripped() {
+        // Google's displayed format: four space-separated groups.
+        assert_eq!(
+            normalize_app_password("abcd efgh ijkl mnop"),
+            "abcdefghijklmnop"
+        );
+        // Leading/trailing and tab/newline whitespace too.
+        assert_eq!(
+            normalize_app_password("  abcd\tefgh\nijkl mnop  "),
+            "abcdefghijklmnop"
+        );
+        // Already-clean passwords are unchanged.
+        assert_eq!(
+            normalize_app_password("abcdefghijklmnop"),
+            "abcdefghijklmnop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In production, the `gmail` and `notion` tools work but `caldav` fails — even though all three are registered identically and `caldav` shipped in v4.1.0. Root cause is a credential-format asymmetry, not a wiring gap:

- Google displays app passwords as four space-separated groups: `abcd efgh ijkl mnop`.
- `gmail` passes that secret to IMAP/SMTP, and Google **tolerates the spaces server-side**, so it authenticates.
- `caldav` passes the *same* secret (`gmail_app_password`) to `reqwest`'s `.basic_auth(...)`, which base64-encodes the spaces verbatim into the `Authorization` header. Google's CalDAV endpoint rejects that with **401 Unauthorized**.

Same stored secret, different server tolerance → `gmail` works, `caldav` doesn't.

## Fix

Strip all whitespace from the app password (and trim the email) in `CalDavTool::get_credentials()`. Doing this at **retrieval** rather than asking the user to re-store means an *already-stored* password in the displayed (spaced) format starts working immediately — no re-entry required — and any future paste of Google's format is handled too.

```rust
Ok((email.trim().to_string(), normalize_app_password(&password)))
```

```rust
/// Remove all whitespace from a Google app password. Google shows app
/// passwords as four space-separated groups; the spaces are not part of the
/// secret and break CalDAV `Basic` auth, so strip them.
fn normalize_app_password(password: &str) -> String {
    password.replace(char::is_whitespace, "")
}
```

The `gmail` tool is intentionally left unchanged — it relies on Google's IMAP/SMTP tolerance and already works; this PR is scoped to the actual CalDAV bug.

## Testing

- New unit test `app_password_whitespace_is_stripped` (spaced, tab/newline, and already-clean inputs).
- `cargo test -p rustykrab-tools caldav` ✅ 15 passed
- `cargo fmt` ✅ · `cargo clippy -p rustykrab-tools --lib` ✅ (no warnings)

## Note

This needs to reach production via a release/redeploy before it takes effect there. For an immediate unblock, re-storing the password without spaces also works and is harmless to `gmail`.

https://claude.ai/code/session_01JK5mSLK9ugP3FrxTZoNMgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JK5mSLK9ugP3FrxTZoNMgE)_