### PR TITLE
Add intra-loop todo list that survives compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/lib.rs
+++ b/crates/rustykrab-agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod router;
 mod runner;
 pub mod sandbox;
 pub mod subagent;
+pub mod todo_tools;
 pub mod trace;
 pub mod voting;
 
@@ -21,5 +22,6 @@ pub use sandbox::{
     DEFAULT_NET_TOOL_TIMEOUT_SECS,
 };
 pub use subagent::SubagentRunner;
+pub use todo_tools::todo_tools;
 pub use trace::{ExecutionTracer, ToolStats, ToolTrace};
 pub use voting::ConsistencyVoter;

--- a/crates/rustykrab-agent/src/recall_tools.rs
+++ b/crates/rustykrab-agent/src/recall_tools.rs
@@ -452,6 +452,7 @@ mod tests {
             all_tools: Arc::new(Vec::new()),
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall,
+            todos: Arc::new(rustykrab_core::TodoStore::new()),
         };
         (ctx, conv)
     }
@@ -463,6 +464,7 @@ mod tests {
             all_tools: Arc::new(Vec::new()),
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall: Arc::new(RecallStore::new()),
+            todos: Arc::new(rustykrab_core::TodoStore::new()),
         }
     }
 
@@ -568,6 +570,7 @@ mod tests {
             all_tools: Arc::new(Vec::new()),
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall: recall.clone(),
+            todos: Arc::new(rustykrab_core::TodoStore::new()),
         };
         (ctx, conv, recall)
     }

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -9,6 +9,7 @@ use rustykrab_core::capability::Capability;
 use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, ToolChoice};
 use rustykrab_core::recall::RecallStore;
 use rustykrab_core::session::Session;
+use rustykrab_core::todo::TodoStore;
 use rustykrab_core::types::{
     ContentPart, Conversation, Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema,
 };
@@ -61,7 +62,12 @@ fn is_meta_tool(name: &str) -> bool {
 /// collision is blocked at creation time in `rustykrab-tools`'
 /// `SkillsTool::action_create` and at registration time by
 /// `skill_md_as_tools`' dedup against the live tool set.
-const DEFAULT_ACTIVE_TOOLS: &[&str] = &["skills"];
+///
+/// `todo_write` / `todo_read` are seeded here so the planning scratchpad is
+/// reachable from the first turn and — because this set is re-seeded on
+/// every `compute_schemas` call — remains reachable after compaction, when
+/// the model most needs to re-establish or consult its plan.
+const DEFAULT_ACTIVE_TOOLS: &[&str] = &["skills", "todo_write", "todo_read"];
 
 use crate::sandbox::{tool_timeout_secs, Sandbox, SandboxPolicy, DEFAULT_NET_TOOL_TIMEOUT_SECS};
 use crate::trace::{ExecutionTracer, ToolTrace};
@@ -699,6 +705,7 @@ pub struct AgentRunner {
     on_message: Option<OnMessageCallback>,
     active_tools: Arc<ActiveToolsRegistry>,
     recall: Arc<RecallStore>,
+    todos: Arc<TodoStore>,
 }
 
 impl AgentRunner {
@@ -716,6 +723,7 @@ impl AgentRunner {
             on_message: None,
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall: Arc::new(RecallStore::new()),
+            todos: Arc::new(TodoStore::new()),
         }
     }
 
@@ -731,6 +739,14 @@ impl AgentRunner {
     /// any prior request on the same conversation.
     pub fn with_recall_store(mut self, store: Arc<RecallStore>) -> Self {
         self.recall = store;
+        self
+    }
+
+    /// Share a per-gateway todo store with the runner so the agent's plan,
+    /// maintained via the `todo_*` tools, persists across the separate
+    /// requests of a single conversation rather than resetting each turn.
+    pub fn with_todo_store(mut self, store: Arc<TodoStore>) -> Self {
+        self.todos = store;
         self
     }
 
@@ -766,6 +782,7 @@ impl AgentRunner {
             all_tools: Arc::new(self.tools.clone()),
             active_tools: self.active_tools.clone(),
             recall: self.recall.clone(),
+            todos: self.todos.clone(),
         }
     }
 
@@ -886,6 +903,7 @@ impl AgentRunner {
         let on_message = self.on_message.clone();
         let active_tools = self.active_tools.clone();
         let recall = self.recall.clone();
+        let todos = self.todos.clone();
 
         // Carry the trace id from the calling task into the spawned agent
         // task so prompt-log rows and agent-loop logs share the same id.
@@ -901,6 +919,7 @@ impl AgentRunner {
                 on_message,
                 active_tools,
                 recall,
+                todos,
             };
             let body = async move {
                 runner
@@ -2558,6 +2577,22 @@ impl AgentRunner {
                  Use recall_info / recall_search / recall_peek / recall_sub_query to \
                  fetch specifics this summary may have dropped.]"
             )
+        };
+
+        // Re-emit the current todo list verbatim at the top of the summary so
+        // the agent's plan survives compaction intact. The checklist is the
+        // single artifact most worth protecting from lossy summarisation —
+        // it's the run's anchor — and a few lines of markdown cost far less
+        // than re-deriving the plan. Placed first so the per-summary size cap
+        // (which truncates from the end) can never clip it. The model keeps
+        // it current with `todo_write`; the store, not this text, is the
+        // source of truth, so a later edit supersedes what's frozen here.
+        let summary_with_hint = match self.todos.render(conv.id) {
+            Some(todos) => format!(
+                "Current task list (maintained via todo_write — update statuses as you \
+                 work):\n{todos}\n\n{summary_with_hint}"
+            ),
+            None => summary_with_hint,
         };
 
         // Synthesize the two new messages compaction produces. They need

--- a/crates/rustykrab-agent/src/todo_tools.rs
+++ b/crates/rustykrab-agent/src/todo_tools.rs
@@ -1,0 +1,432 @@
+//! `todo_*` tools — the agent's intra-loop planning scratchpad.
+//!
+//! A structured todo list is the standard remedy for goal drift over long
+//! task horizons: the agent writes the plan down, then re-reads and rewrites
+//! it as it works, so the objective stays in view even after the surrounding
+//! context has churned. Unlike the `recall_*` tools (which recover *facts*
+//! displaced by compaction), these maintain the agent's *intentions*.
+//!
+//! State lives in the per-conversation [`TodoStore`](rustykrab_core::TodoStore)
+//! on the runner's [`SessionToolContext`]; these tools resolve it at
+//! `execute()` time via [`with_session_context`], so the same instances are
+//! registered globally and shared across conversations. The runner re-emits
+//! the rendered list verbatim across a compaction
+//! ([`compact_history`](crate::AgentRunner)) so the plan survives the one
+//! event most likely to lose it.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rustykrab_core::active_tools::with_session_context;
+use rustykrab_core::tool::Tool;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Error, TodoItem, TodoStatus};
+use serde_json::{json, Value};
+
+/// Maximum number of items a single todo list may hold. Keeps the rendered
+/// checklist — which is re-emitted on every compaction — bounded.
+const MAX_TODO_ITEMS: usize = 100;
+
+/// Build the todo tools. Both are stateless structs that resolve the active
+/// conversation's list at `execute()` time, so they can be registered once
+/// and shared across conversations.
+pub fn todo_tools() -> Vec<Arc<dyn Tool>> {
+    vec![Arc::new(TodoWriteTool), Arc::new(TodoReadTool)]
+}
+
+/// Render the JSON payload returned to the model after a read or write:
+/// the markdown checklist plus per-status counts so progress is legible.
+fn list_payload(items: &[TodoItem]) -> Value {
+    let pending = items
+        .iter()
+        .filter(|i| i.status == TodoStatus::Pending)
+        .count();
+    let in_progress = items
+        .iter()
+        .filter(|i| i.status == TodoStatus::InProgress)
+        .count();
+    let completed = items
+        .iter()
+        .filter(|i| i.status == TodoStatus::Completed)
+        .count();
+    json!({
+        "todos": items
+            .iter()
+            .map(|i| json!({ "content": i.content, "status": i.status.as_str() }))
+            .collect::<Vec<_>>(),
+        "rendered": rustykrab_core::render_todos(items),
+        "counts": {
+            "total": items.len(),
+            "pending": pending,
+            "in_progress": in_progress,
+            "completed": completed,
+        },
+    })
+}
+
+// ── todo_write ──────────────────────────────────────────────────────────
+
+struct TodoWriteTool;
+
+#[async_trait]
+impl Tool for TodoWriteTool {
+    fn name(&self) -> &str {
+        "todo_write"
+    }
+
+    fn description(&self) -> &str {
+        "Record or update your task list for this conversation. Pass the \
+         WHOLE list every time — it replaces the previous one, so include \
+         already-completed items (marked completed) alongside what's left. \
+         Each item is {content, status} where status is one of \"pending\", \
+         \"in_progress\", or \"completed\". Keep exactly one item \
+         \"in_progress\" to mark your current focus. Use this for any task \
+         with more than a couple of steps: write the plan up front, then \
+         flip statuses as you go. The list is preserved across context \
+         compaction, so it's your durable anchor on long tasks. Send an \
+         empty list to clear it."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "todos": {
+                        "type": "array",
+                        "description": "The full task list, in order. Replaces any previous list.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": {
+                                    "type": "string",
+                                    "description": "The step, as a short imperative phrase."
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": ["pending", "in_progress", "completed"],
+                                    "description": "Lifecycle state of this step."
+                                }
+                            },
+                            "required": ["content", "status"]
+                        }
+                    }
+                },
+                "required": ["todos"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> rustykrab_core::Result<Value> {
+        let raw = args
+            .get("todos")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| Error::ToolExecution("missing `todos` array".into()))?;
+
+        if raw.len() > MAX_TODO_ITEMS {
+            return Err(Error::ToolExecution(
+                format!(
+                    "too many items: {} exceeds the {MAX_TODO_ITEMS}-item limit; keep the plan focused",
+                    raw.len()
+                )
+                .into(),
+            ));
+        }
+
+        let mut items = Vec::with_capacity(raw.len());
+        for (idx, entry) in raw.iter().enumerate() {
+            let content = entry
+                .get("content")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    Error::ToolExecution(
+                        format!("todo[{idx}] is missing a non-empty `content`").into(),
+                    )
+                })?;
+            let status_str = entry
+                .get("status")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    Error::ToolExecution(format!("todo[{idx}] is missing `status`").into())
+                })?;
+            let status = TodoStatus::parse(status_str).ok_or_else(|| {
+                Error::ToolExecution(
+                    format!(
+                        "todo[{idx}] has unknown status {status_str:?}; use pending, in_progress, or completed"
+                    )
+                    .into(),
+                )
+            })?;
+            items.push(TodoItem::new(content, status));
+        }
+
+        // More than one in-progress item defeats the "current focus" signal.
+        // Warn rather than reject — the list is still usable, and rejecting
+        // would force a model that mislabels into a retry loop.
+        let in_progress = items
+            .iter()
+            .filter(|i| i.status == TodoStatus::InProgress)
+            .count();
+        let note = (in_progress > 1).then_some(
+            "more than one item is in_progress; mark just one to signal your current focus",
+        );
+
+        let payload = with_session_context(|ctx| {
+            ctx.todos.set(ctx.conversation_id, items.clone());
+            list_payload(&items)
+        })
+        .ok_or_else(|| {
+            Error::ToolExecution("todo_write called outside a session context".into())
+        })?;
+
+        let mut payload = payload;
+        if let Some(note) = note {
+            payload["note"] = json!(note);
+        }
+        Ok(payload)
+    }
+}
+
+// ── todo_read ───────────────────────────────────────────────────────────
+
+struct TodoReadTool;
+
+#[async_trait]
+impl Tool for TodoReadTool {
+    fn name(&self) -> &str {
+        "todo_read"
+    }
+
+    fn description(&self) -> &str {
+        "Return your current task list for this conversation (the one you \
+         maintain with todo_write). Use it to re-check what's done and what's \
+         next — especially after a long stretch of tool calls or once the \
+         conversation has been compacted."
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: self.name().to_string(),
+            description: self.description().to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, _args: Value) -> rustykrab_core::Result<Value> {
+        let result = with_session_context(|ctx| ctx.todos.get(ctx.conversation_id));
+        match result {
+            Some(Some(items)) => Ok(list_payload(&items)),
+            Some(None) => Ok(json!({
+                "empty": true,
+                "note": "no task list has been set for this conversation yet; create one with todo_write",
+            })),
+            None => Err(Error::ToolExecution(
+                "todo_read called outside a session context".into(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext};
+    use rustykrab_core::capability::CapabilitySet;
+    use rustykrab_core::recall::RecallStore;
+    use rustykrab_core::{TodoStore, SESSION_TOOL_CONTEXT};
+    use uuid::Uuid;
+
+    fn ctx_with_store() -> (SessionToolContext, Uuid, Arc<TodoStore>) {
+        let conv = Uuid::new_v4();
+        let todos = Arc::new(TodoStore::new());
+        let ctx = SessionToolContext {
+            conversation_id: conv,
+            capabilities: Arc::new(CapabilitySet::none()),
+            all_tools: Arc::new(Vec::new()),
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+            recall: Arc::new(RecallStore::new()),
+            todos: todos.clone(),
+        };
+        (ctx, conv, todos)
+    }
+
+    #[tokio::test]
+    async fn write_sets_and_renders_list() {
+        let (ctx, conv, store) = ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({
+                        "todos": [
+                            {"content": "design", "status": "completed"},
+                            {"content": "build", "status": "in_progress"},
+                            {"content": "test", "status": "pending"},
+                        ]
+                    }))
+                    .await
+            })
+            .await
+            .unwrap();
+        assert_eq!(result["counts"]["total"], 3);
+        assert_eq!(result["counts"]["completed"], 1);
+        assert_eq!(result["rendered"], "[x] design\n[~] build\n[ ] test");
+        // State landed in the store.
+        assert_eq!(store.get(conv).unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn write_replaces_previous_list() {
+        let (ctx, conv, store) = ctx_with_store();
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "old", "status": "pending"}]}))
+                    .await
+                    .unwrap();
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "new", "status": "in_progress"}]}))
+                    .await
+                    .unwrap();
+            })
+            .await;
+        let items = store.get(conv).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].content, "new");
+    }
+
+    #[tokio::test]
+    async fn write_accepts_status_aliases() {
+        let (ctx, _conv, store) = ctx_with_store();
+        let conv = _conv;
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "x", "status": "done"}]}))
+                    .await
+                    .unwrap();
+            })
+            .await;
+        assert_eq!(store.get(conv).unwrap()[0].status, TodoStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn write_rejects_unknown_status() {
+        let (ctx, _, _) = ctx_with_store();
+        let err = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "x", "status": "frobnicate"}]}))
+                    .await
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown status"));
+    }
+
+    #[tokio::test]
+    async fn write_rejects_empty_content() {
+        let (ctx, _, _) = ctx_with_store();
+        let err = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "   ", "status": "pending"}]}))
+                    .await
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("non-empty `content`"));
+    }
+
+    #[tokio::test]
+    async fn write_warns_on_multiple_in_progress() {
+        let (ctx, _, _) = ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({
+                        "todos": [
+                            {"content": "a", "status": "in_progress"},
+                            {"content": "b", "status": "in_progress"},
+                        ]
+                    }))
+                    .await
+            })
+            .await
+            .unwrap();
+        assert!(result["note"].as_str().unwrap().contains("in_progress"));
+    }
+
+    #[tokio::test]
+    async fn empty_write_clears_list() {
+        let (ctx, conv, store) = ctx_with_store();
+        SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "x", "status": "pending"}]}))
+                    .await
+                    .unwrap();
+                TodoWriteTool.execute(json!({"todos": []})).await.unwrap();
+            })
+            .await;
+        assert!(store.get(conv).is_none());
+    }
+
+    #[tokio::test]
+    async fn read_returns_current_list() {
+        let (ctx, _, _) = ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool
+                    .execute(json!({"todos": [{"content": "step", "status": "pending"}]}))
+                    .await?;
+                TodoReadTool.execute(json!({})).await
+            })
+            .await
+            .unwrap();
+        assert_eq!(result["counts"]["total"], 1);
+        assert_eq!(result["rendered"], "[ ] step");
+    }
+
+    #[tokio::test]
+    async fn read_reports_empty_when_unset() {
+        let (ctx, _, _) = ctx_with_store();
+        let result = SESSION_TOOL_CONTEXT
+            .scope(ctx, async { TodoReadTool.execute(json!({})).await })
+            .await
+            .unwrap();
+        assert_eq!(result["empty"], true);
+    }
+
+    #[tokio::test]
+    async fn write_errors_outside_session_scope() {
+        let err = TodoWriteTool
+            .execute(json!({"todos": [{"content": "x", "status": "pending"}]}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("outside a session context"));
+    }
+
+    #[tokio::test]
+    async fn write_rejects_too_many_items() {
+        let (ctx, _, _) = ctx_with_store();
+        let many: Vec<Value> = (0..MAX_TODO_ITEMS + 1)
+            .map(|i| json!({"content": format!("item {i}"), "status": "pending"}))
+            .collect();
+        let err = SESSION_TOOL_CONTEXT
+            .scope(ctx, async {
+                TodoWriteTool.execute(json!({ "todos": many })).await
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("too many items"));
+    }
+}

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -760,6 +760,12 @@ async fn main() -> anyhow::Result<()> {
     ));
     tracing::info!("recall tools registered");
 
+    // --- Todo tools (intra-loop planning scratchpad) ---
+    // State is threaded through the runner's SessionToolContext (the shared
+    // TodoStore on AppState), so the tools resolve it at execute() time.
+    tools.extend(rustykrab_agent::todo_tools());
+    tracing::info!("todo tools registered");
+
     // --- SKILL.md skills as first-class tools ---
     // Each registered SKILL.md is also exposed as a tool whose name is the
     // skill name and whose `execute()` returns the skill body verbatim.

--- a/crates/rustykrab-core/src/active_tools.rs
+++ b/crates/rustykrab-core/src/active_tools.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use crate::capability::CapabilitySet;
 use crate::recall::RecallStore;
+use crate::todo::TodoStore;
 use crate::tool::Tool;
 
 /// Tracks which tools are "active" for each conversation.
@@ -85,6 +86,10 @@ pub struct SessionToolContext {
     /// `recall_*` tools read from this so the model can recover detail
     /// the compaction summary dropped.
     pub recall: Arc<RecallStore>,
+    /// Per-conversation todo list.  The `todo_write` / `todo_read` tools
+    /// maintain it, and the runner re-emits it verbatim across compaction
+    /// so the agent's plan survives the churn.
+    pub todos: Arc<TodoStore>,
 }
 
 tokio::task_local! {

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod prompt_trace;
 pub mod recall;
 pub mod schema_validate;
 pub mod session;
+pub mod todo;
 pub mod tool;
 pub mod types;
 
@@ -23,4 +24,5 @@ pub use orchestration::{OrchestrationConfig, RecursiveCall, TaskComplexity, Vote
 pub use recall::RecallStore;
 pub use schema_validate::validate_tool_args;
 pub use session::Session;
+pub use todo::{render_todos, TodoItem, TodoStatus, TodoStore};
 pub use tool::{SandboxRequirements, Tool};

--- a/crates/rustykrab-core/src/todo.rs
+++ b/crates/rustykrab-core/src/todo.rs
@@ -1,0 +1,256 @@
+//! Per-conversation todo list — an intra-loop planning scratchpad.
+//!
+//! Long-horizon agent runs drift: as the prompt fills with tool output and
+//! intermediate reasoning, the original plan gets buried, and compaction
+//! (see `rustykrab-agent`'s `compact_history`) can summarise it away. A
+//! structured todo list is the standard remedy — a cheap, high-signal
+//! artifact the agent writes once and rewrites as it works, so the goal
+//! stays in view even after the surrounding context has churned. It is a
+//! scratchpad for *intentions* rather than a record of facts (which is what
+//! [`crate::recall::RecallStore`] holds).
+//!
+//! [`TodoStore`] holds the current list per conversation. The `todo_write`
+//! / `todo_read` tools in `rustykrab-agent` mutate and inspect it, and the
+//! runner re-emits the rendered list verbatim across a compaction so the
+//! checklist survives the one event most likely to lose it.
+//!
+//! Unlike [`crate::recall::RecallStore`], this is in-memory only: a todo
+//! list is short-horizon working state for the active run, re-derivable by
+//! the model at any time, not durable history worth a SQLite round-trip.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Lifecycle state of a single todo item. Mirrors the de-facto standard
+/// three-state model (pending → in_progress → completed) used by agent
+/// todo-list tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl TodoStatus {
+    /// Parse a status from its wire string, tolerating the common aliases
+    /// models emit (`done`, `doing`, `todo`, hyphenated `in-progress`).
+    /// Returns `None` for anything unrecognised so the tool layer can
+    /// surface a precise error rather than silently defaulting.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "pending" | "todo" | "open" | "not_started" | "not-started" => Some(Self::Pending),
+            "in_progress" | "in-progress" | "inprogress" | "active" | "doing" => {
+                Some(Self::InProgress)
+            }
+            "completed" | "complete" | "done" | "finished" => Some(Self::Completed),
+            _ => None,
+        }
+    }
+
+    /// Markdown checkbox marker used when rendering the list. `[~]` marks the
+    /// single in-progress item so the current focus is visible at a glance.
+    pub fn marker(self) -> &'static str {
+        match self {
+            Self::Pending => "[ ]",
+            Self::InProgress => "[~]",
+            Self::Completed => "[x]",
+        }
+    }
+
+    /// Canonical wire string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+/// A single checklist entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoItem {
+    /// What the step is — imperative and short ("Add the migration").
+    pub content: String,
+    /// Where the step is in its lifecycle.
+    pub status: TodoStatus,
+}
+
+impl TodoItem {
+    pub fn new(content: impl Into<String>, status: TodoStatus) -> Self {
+        Self {
+            content: content.into(),
+            status,
+        }
+    }
+}
+
+/// Render a list of items as a markdown checklist, or `None` when the list
+/// is empty so callers can skip emitting an empty block.
+pub fn render_todos(items: &[TodoItem]) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut out = String::new();
+    for item in items {
+        out.push_str(item.status.marker());
+        out.push(' ');
+        out.push_str(item.content.trim());
+        out.push('\n');
+    }
+    Some(out.trim_end().to_string())
+}
+
+/// Thread-safe map from conversation id to its current todo list.
+///
+/// Replace semantics: [`set`](Self::set) overwrites the whole list for a
+/// conversation (the canonical "rewrite the full checklist on each update"
+/// model), so the store never holds a stale partial list, and an empty
+/// write clears it.
+#[derive(Debug, Default)]
+pub struct TodoStore {
+    inner: RwLock<HashMap<Uuid, Arc<Vec<TodoItem>>>>,
+}
+
+impl TodoStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the todo list for a conversation. An empty `items` clears it.
+    pub fn set(&self, conversation_id: Uuid, items: Vec<TodoItem>) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        if items.is_empty() {
+            guard.remove(&conversation_id);
+        } else {
+            guard.insert(conversation_id, Arc::new(items));
+        }
+    }
+
+    /// Return a cheap clone of the current list, or `None` if unset/empty.
+    pub fn get(&self, conversation_id: Uuid) -> Option<Arc<Vec<TodoItem>>> {
+        let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+        guard.get(&conversation_id).cloned()
+    }
+
+    /// Render the current list as a markdown checklist, or `None` if unset.
+    pub fn render(&self, conversation_id: Uuid) -> Option<String> {
+        self.get(conversation_id)
+            .and_then(|items| render_todos(&items))
+    }
+
+    /// Forget the list for a conversation (session teardown / deletion).
+    pub fn clear(&self, conversation_id: Uuid) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        guard.remove(&conversation_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accepts_aliases() {
+        assert_eq!(TodoStatus::parse("pending"), Some(TodoStatus::Pending));
+        assert_eq!(TodoStatus::parse(" TODO "), Some(TodoStatus::Pending));
+        assert_eq!(
+            TodoStatus::parse("in-progress"),
+            Some(TodoStatus::InProgress)
+        );
+        assert_eq!(TodoStatus::parse("doing"), Some(TodoStatus::InProgress));
+        assert_eq!(TodoStatus::parse("done"), Some(TodoStatus::Completed));
+        assert_eq!(TodoStatus::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn render_produces_markdown_checklist() {
+        let items = vec![
+            TodoItem::new("design the store", TodoStatus::Completed),
+            TodoItem::new("wire the tool", TodoStatus::InProgress),
+            TodoItem::new("add tests", TodoStatus::Pending),
+        ];
+        let rendered = render_todos(&items).unwrap();
+        assert_eq!(
+            rendered,
+            "[x] design the store\n[~] wire the tool\n[ ] add tests"
+        );
+    }
+
+    #[test]
+    fn render_empty_is_none() {
+        assert!(render_todos(&[]).is_none());
+    }
+
+    #[test]
+    fn set_and_get_roundtrips() {
+        let store = TodoStore::new();
+        let conv = Uuid::new_v4();
+        assert!(store.get(conv).is_none());
+        store.set(conv, vec![TodoItem::new("step one", TodoStatus::Pending)]);
+        let got = store.get(conv).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].content, "step one");
+    }
+
+    #[test]
+    fn set_replaces_rather_than_appends() {
+        let store = TodoStore::new();
+        let conv = Uuid::new_v4();
+        store.set(conv, vec![TodoItem::new("old", TodoStatus::Pending)]);
+        store.set(
+            conv,
+            vec![
+                TodoItem::new("new a", TodoStatus::InProgress),
+                TodoItem::new("new b", TodoStatus::Pending),
+            ],
+        );
+        let got = store.get(conv).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].content, "new a");
+    }
+
+    #[test]
+    fn empty_set_clears() {
+        let store = TodoStore::new();
+        let conv = Uuid::new_v4();
+        store.set(conv, vec![TodoItem::new("x", TodoStatus::Pending)]);
+        store.set(conv, vec![]);
+        assert!(store.get(conv).is_none());
+    }
+
+    #[test]
+    fn render_via_store() {
+        let store = TodoStore::new();
+        let conv = Uuid::new_v4();
+        store.set(
+            conv,
+            vec![TodoItem::new("only step", TodoStatus::InProgress)],
+        );
+        assert_eq!(store.render(conv).as_deref(), Some("[~] only step"));
+    }
+
+    #[test]
+    fn conversations_are_isolated() {
+        let store = TodoStore::new();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        store.set(a, vec![TodoItem::new("a-step", TodoStatus::Pending)]);
+        store.set(b, vec![TodoItem::new("b-step", TodoStatus::Pending)]);
+        assert_eq!(store.get(a).unwrap()[0].content, "a-step");
+        assert_eq!(store.get(b).unwrap()[0].content, "b-step");
+    }
+
+    #[test]
+    fn clear_drops_entry() {
+        let store = TodoStore::new();
+        let conv = Uuid::new_v4();
+        store.set(conv, vec![TodoItem::new("x", TodoStatus::Pending)]);
+        store.clear(conv);
+        assert!(store.get(conv).is_none());
+    }
+}

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -286,7 +286,8 @@ async fn prepare_agent(
     )
     .with_config(agent_config)
     .with_active_tools(state.active_tools.clone())
-    .with_recall_store(state.recall.clone());
+    .with_recall_store(state.recall.clone())
+    .with_todo_store(state.todos.clone());
 
     if let Some(cb) = build_memory_callback(state, conv) {
         // The inbound user message was pushed onto conv.messages by
@@ -392,7 +393,8 @@ pub async fn run_agent_interactive(
             state.tools.clone(),
             state.sandbox.clone(),
         )
-        .with_config(profile.to_agent_config());
+        .with_config(profile.to_agent_config())
+        .with_todo_store(state.todos.clone());
 
         // The agent loop runs in a tokio::spawn'd task inside `start`, so
         // the task-local trace id won't follow it. Re-scope the spawned

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -275,6 +275,8 @@ async fn delete_conversation(
     // Drop the recall archive too (cache + durable row) so a deleted
     // conversation leaves nothing behind.
     state.recall.purge(id);
+    // Drop the conversation's todo list as well.
+    state.todos.clear(id);
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -4,6 +4,7 @@ use rustykrab_core::active_tools::ActiveToolsRegistry;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::recall::RecallStore;
+use rustykrab_core::todo::TodoStore;
 use rustykrab_memory::MemorySystem;
 use rustykrab_skills::SkillRegistry;
 use rustykrab_store::Store;
@@ -52,6 +53,11 @@ pub struct AppState {
     /// the `recall_*` tools so the agent can recover detail dropped by
     /// summarisation.
     pub recall: Arc<RecallStore>,
+    /// Per-conversation todo list backing the `todo_*` tools. Shared across
+    /// a conversation's requests so the agent's plan persists between turns.
+    /// In-memory only: a todo list is short-horizon working state, not
+    /// durable history like `recall`.
+    pub todos: Arc<TodoStore>,
     /// Whether sub-agent / session-management tools should be granted to
     /// sessions created by this gateway. Default `false`. Driven by the
     /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var at startup; threaded through
@@ -92,6 +98,7 @@ impl AppState {
             agent_id: None,
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall,
+            todos: Arc::new(TodoStore::new()),
             subagents_enabled: false,
         }
     }

--- a/crates/rustykrab-tools/src/skills.rs
+++ b/crates/rustykrab-tools/src/skills.rs
@@ -720,12 +720,14 @@ mod tests {
         use rustykrab_core::active_tools::{ActiveToolsRegistry, SessionToolContext};
         use rustykrab_core::capability::CapabilitySet;
         use rustykrab_core::recall::RecallStore;
+        use rustykrab_core::TodoStore;
         SessionToolContext {
             conversation_id: uuid::Uuid::new_v4(),
             capabilities: Arc::new(CapabilitySet::none()),
             all_tools: Arc::new(tools),
             active_tools: Arc::new(ActiveToolsRegistry::new()),
             recall: Arc::new(RecallStore::new()),
+            todos: Arc::new(TodoStore::new()),
         }
     }
 


### PR DESCRIPTION
Long-horizon agent runs drift: as the prompt fills with tool output and
intermediate reasoning, the original plan gets buried, and compaction can
summarise it away. This adds a structured todo list — the standard agent
remedy — as a cheap, high-signal anchor the model maintains and that the
runner protects across the one event most likely to lose it.

- rustykrab-core: new in-memory `TodoStore` (per-conversation, replace
  semantics) plus `TodoItem` / `TodoStatus`, mirroring `RecallStore`'s
  shape. Threaded onto `SessionToolContext` so tools resolve it at
  execute() time. In-memory only — a todo list is short-horizon working
  state, not durable history like the recall archive.
- rustykrab-agent: `todo_write` / `todo_read` tools (full-list replace,
  status aliases tolerated, one-in_progress soft warning). Seeded into
  DEFAULT_ACTIVE_TOOLS so they're reachable from turn 0 and after
  compaction. `compact_history` now re-emits the rendered checklist
  verbatim at the top of the summary, so the plan survives intact rather
  than being lost to lossy summarisation. `AgentRunner` gains a `todos`
  field + `with_todo_store` builder.
- rustykrab-gateway: shared `TodoStore` on `AppState`, threaded into both
  runner build paths so the plan persists across a conversation's
  requests; purged on conversation delete.
- rustykrab-cli: register `todo_tools()` alongside recall tools.

Tests: core + agent suites green (incl. new TodoStore and todo_tools
coverage); fmt and clippy clean.

https://claude.ai/code/session_01VWXxY5xwbp4kAPG2XZw4JQ