### PR TITLE
memory: honor search tags, surface extracted facts, prompt recall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.1.4"
+version = "4.3.1"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -56,12 +56,21 @@ fn is_meta_tool(name: &str) -> bool {
 /// because skill *authoring* (create/load/delete) is otherwise unreachable
 /// — nothing tells the model the tool exists, so it never loads it.
 ///
+/// `memory_search` and `memory_save` live here for the same reason: memory
+/// is a cross-cutting, reflexive capability (recall what the user told you
+/// before acting; persist facts worth keeping) that the model should reach
+/// for without a `tools_list`/`tools_load` round-trip first. Left lazy, the
+/// model rarely discovers them, so long-term memory effectively goes
+/// unused. `memory_get`/`memory_delete` stay lazy on purpose — they're
+/// occasional and (for delete) destructive, so reflexive availability isn't
+/// wanted.
+///
 /// Seeding by bare name means these names must be reserved: a SKILL.md
 /// skill that took the name `skills` would collide with this tool. That
 /// collision is blocked at creation time in `rustykrab-tools`'
 /// `SkillsTool::action_create` and at registration time by
 /// `skill_md_as_tools`' dedup against the live tool set.
-const DEFAULT_ACTIVE_TOOLS: &[&str] = &["skills"];
+const DEFAULT_ACTIVE_TOOLS: &[&str] = &["skills", "memory_search", "memory_save"];
 
 use crate::sandbox::{tool_timeout_secs, Sandbox, SandboxPolicy, DEFAULT_NET_TOOL_TIMEOUT_SECS};
 use crate::trace::{ExecutionTracer, ToolTrace};
@@ -4180,14 +4189,21 @@ mod task_complete_tests {
     }
 
     #[tokio::test]
-    async fn skills_is_seeded_into_active_set() {
-        // `skills` must surface from turn 0 without a `tools_load`
-        // round-trip, while a non-seeded, non-meta tool stays hidden until
-        // it's explicitly activated.
+    async fn default_tools_are_seeded_into_active_set() {
+        // The default-active tools (`skills`, `memory_search`, `memory_save`)
+        // must surface from turn 0 without a `tools_load` round-trip, while a
+        // non-seeded, non-meta tool stays hidden until it's explicitly
+        // activated.
         let active = Arc::new(ActiveToolsRegistry::new());
         let tools: Vec<Arc<dyn Tool>> = vec![
             Arc::new(NoopTool {
                 name: "skills".into(),
+            }),
+            Arc::new(NoopTool {
+                name: "memory_search".into(),
+            }),
+            Arc::new(NoopTool {
+                name: "memory_save".into(),
             }),
             Arc::new(NoopTool {
                 name: "hidden".into(),
@@ -4200,20 +4216,27 @@ mod task_complete_tests {
         )
         .with_active_tools(active.clone());
         let conv_id = Uuid::new_v4();
-        let caps = CapabilitySet::for_tools_permissive(&["skills", "hidden"]);
+        let caps = CapabilitySet::for_tools_permissive(&[
+            "skills",
+            "memory_search",
+            "memory_save",
+            "hidden",
+        ]);
         let session = Session::with_capabilities(conv_id, caps);
 
-        // Nothing activated yet — the default seed should still expose
-        // `skills` and only `skills`.
+        // Nothing activated yet — the default seed should expose every
+        // default-active tool but not the non-seeded one.
         let names: Vec<String> = runner
             .compute_schemas(&session, conv_id)
             .into_iter()
             .map(|s| s.name)
             .collect();
-        assert!(
-            names.contains(&"skills".to_string()),
-            "skills should be seeded into the active set, got {names:?}"
-        );
+        for expected in ["skills", "memory_search", "memory_save"] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "{expected} should be seeded into the active set, got {names:?}"
+            );
+        }
         assert!(
             !names.contains(&"hidden".to_string()),
             "a non-seeded, non-meta tool must stay hidden until activated"
@@ -4221,7 +4244,10 @@ mod task_complete_tests {
 
         // The seed is recorded in the registry itself, so `tools_load`'s
         // active listing reflects it too — not just the schema view.
-        assert!(active.active_for(conv_id).contains("skills"));
+        let seeded = active.active_for(conv_id);
+        assert!(seeded.contains("skills"));
+        assert!(seeded.contains("memory_search"));
+        assert!(seeded.contains("memory_save"));
     }
 
     #[tokio::test]

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -3,7 +3,23 @@ use std::sync::Arc;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use crate::types::ExtractedFact;
 use crate::MemorySystem;
+
+/// Render an [`ExtractedFact`] as a compact JSON object for tool output.
+///
+/// Surfaces the structured triple plus type and confidence so the agent can
+/// reason over stated preferences/decisions directly rather than re-parsing
+/// the verbatim source text.
+fn fact_to_json(fact: &ExtractedFact) -> Value {
+    json!({
+        "type": fact.fact_type,
+        "subject": fact.subject,
+        "predicate": fact.predicate,
+        "object": fact.object,
+        "confidence": fact.confidence,
+    })
+}
 
 /// Adapter that bridges [MemorySystem] to the `MemoryBackend` trait
 /// used by the existing tool system in `rustykrab-tools`.
@@ -55,31 +71,68 @@ impl HybridMemoryBackend {
     }
 
     /// Search memories using hybrid retrieval (vector + FTS5 + graph + temporal).
+    ///
+    /// When `tags` is non-empty, results are filtered to memories carrying at
+    /// least one of the requested tags. Because the tag filter runs after
+    /// retrieval, we over-fetch candidates so a tag-scoped search can still
+    /// return up to `limit` rows.
+    ///
+    /// Each result also carries any extracted facts (e.g. stated preferences,
+    /// decisions) attached to the source memory, so a caller searching for
+    /// "what does the user prefer" surfaces the structured fact, not just the
+    /// raw conversational text it was lifted from.
     pub async fn search(
         &self,
         query: &str,
-        _tags: &[String],
+        tags: &[String],
         limit: usize,
     ) -> rustykrab_core::Result<Value> {
-        let results = self.system.recall(query, self.agent_id, limit).await?;
+        // Over-fetch when tag-filtering so the post-filter can still fill `limit`.
+        let fetch = if tags.is_empty() {
+            limit
+        } else {
+            (limit * 4).min(100)
+        };
+        let results = self.system.recall(query, self.agent_id, fetch).await?;
 
-        let items: Vec<Value> = results
-            .iter()
-            .map(|r| {
-                json!({
-                    "id": r.memory_id.to_string(),
-                    "content": r.content,
-                    "score": r.effective_score,
-                    "rrf_score": r.rrf_score,
-                    "sources": r.sources.iter().map(|s| format!("{:?}", s)).collect::<Vec<_>>(),
-                    "lifecycle_stage": format!("{:?}", r.memory.lifecycle_stage),
-                    "scope": format!("{:?}", r.memory.scope),
-                    "importance": r.memory.importance,
-                    "access_count": r.memory.access_count,
-                    "created_at": r.memory.created_at.to_rfc3339(),
-                })
-            })
-            .collect();
+        let mut items: Vec<Value> = Vec::with_capacity(limit);
+        for r in &results {
+            // Tag filter: keep only memories carrying at least one requested tag.
+            if !tags.is_empty() && !r.memory.tags.iter().any(|t| tags.contains(t)) {
+                continue;
+            }
+
+            let mut item = json!({
+                "id": r.memory_id.to_string(),
+                "content": r.content,
+                "score": r.effective_score,
+                "rrf_score": r.rrf_score,
+                "sources": r.sources.iter().map(|s| format!("{:?}", s)).collect::<Vec<_>>(),
+                "lifecycle_stage": format!("{:?}", r.memory.lifecycle_stage),
+                "scope": format!("{:?}", r.memory.scope),
+                "importance": r.memory.importance,
+                "access_count": r.memory.access_count,
+                "tags": r.memory.tags,
+                "created_at": r.memory.created_at.to_rfc3339(),
+            });
+
+            // Attach extracted facts when present. Best-effort: a facts lookup
+            // failure must not sink an otherwise-good search result.
+            let facts = self
+                .system
+                .storage()
+                .get_facts_for_memory(r.memory_id)
+                .await
+                .unwrap_or_default();
+            if !facts.is_empty() {
+                item["facts"] = json!(facts.iter().map(fact_to_json).collect::<Vec<_>>());
+            }
+
+            items.push(item);
+            if items.len() >= limit {
+                break;
+            }
+        }
 
         Ok(json!({
             "results": items,
@@ -93,17 +146,26 @@ impl HybridMemoryBackend {
             .map_err(|e| rustykrab_core::Error::Internal(format!("invalid memory ID: {e}")))?;
 
         match self.system.get_memory(id).await? {
-            Some(mem) => Ok(json!({
-                "id": mem.id.to_string(),
-                "content": mem.content,
-                "importance": mem.importance,
-                "lifecycle_stage": format!("{:?}", mem.lifecycle_stage),
-                "scope": format!("{:?}", mem.scope),
-                "access_count": mem.access_count,
-                "tags": mem.tags,
-                "created_at": mem.created_at.to_rfc3339(),
-                "last_accessed_at": mem.last_accessed_at.map(|t| t.to_rfc3339()),
-            })),
+            Some(mem) => {
+                let facts = self
+                    .system
+                    .storage()
+                    .get_facts_for_memory(mem.id)
+                    .await
+                    .unwrap_or_default();
+                Ok(json!({
+                    "id": mem.id.to_string(),
+                    "content": mem.content,
+                    "importance": mem.importance,
+                    "lifecycle_stage": format!("{:?}", mem.lifecycle_stage),
+                    "scope": format!("{:?}", mem.scope),
+                    "access_count": mem.access_count,
+                    "tags": mem.tags,
+                    "created_at": mem.created_at.to_rfc3339(),
+                    "last_accessed_at": mem.last_accessed_at.map(|t| t.to_rfc3339()),
+                    "facts": facts.iter().map(fact_to_json).collect::<Vec<_>>(),
+                }))
+            }
             None => Err(rustykrab_core::Error::NotFound(format!(
                 "memory {memory_id}"
             ))),
@@ -179,5 +241,57 @@ impl HybridMemoryBackend {
             "memories": items,
             "count": items.len(),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::config::MemoryConfig;
+    use crate::embedding::HashEmbedder;
+    use crate::storage::SqliteMemoryStorage;
+
+    fn backend() -> HybridMemoryBackend {
+        let storage = Arc::new(SqliteMemoryStorage::open_in_memory().unwrap());
+        let embedder = Arc::new(HashEmbedder::new(768));
+        let system = Arc::new(MemorySystem::new(
+            MemoryConfig::default(),
+            storage,
+            embedder,
+        ));
+        HybridMemoryBackend::new(system, Uuid::new_v4(), Uuid::new_v4())
+    }
+
+    /// The `tags` argument is honored: a tag-scoped search must exclude
+    /// memories that don't carry the requested tag, while an untagged search
+    /// returns everything. This guards against the regression where `tags`
+    /// was silently ignored.
+    #[tokio::test]
+    async fn search_filters_by_tag() {
+        let backend = backend();
+        backend
+            .save("I prefer dark mode", &["ui".to_string()])
+            .await
+            .unwrap();
+        backend
+            .save("Deploy on Fridays", &["ops".to_string()])
+            .await
+            .unwrap();
+
+        // Untagged search returns both memories.
+        let all = backend.search("preferences", &[], 10).await.unwrap();
+        assert_eq!(all["count"], 2, "untagged search should return both");
+
+        // Tag-scoped search returns only the matching memory.
+        let ui = backend
+            .search("preferences", &["ui".to_string()], 10)
+            .await
+            .unwrap();
+        assert_eq!(ui["count"], 1, "tag filter should drop the ops memory");
+        let results = ui["results"].as_array().unwrap();
+        assert_eq!(results[0]["content"], "I prefer dark mode");
+        let tags = results[0]["tags"].as_array().unwrap();
+        assert!(tags.iter().any(|t| t == "ui"));
     }
 }

--- a/crates/rustykrab-skills/src/prompt.rs
+++ b/crates/rustykrab-skills/src/prompt.rs
@@ -25,7 +25,10 @@ Read that message and execute it. Never reply with 'I'm ready', 'please provide 
 claims you have nothing to do — the task is in the conversation. If the task names a skill, \
 call the tool with that skill's name and follow the instructions it returns; do not narrate \
 that you would call it.\n\n\
-Use memory_save to persist important facts; context is limited.";
+Use memory_save to persist important facts; context is limited. Before acting on \
+anything that depends on the user's standing preferences or earlier decisions, call \
+memory_search first to check what you already know — don't re-ask for things you've \
+been told before.";
 
 /// Return the baked-in default soul template (with the literal `{name}`
 /// placeholder still in it). Exposed so `rustykrab-cli` can seed the


### PR DESCRIPTION
The memory tool path was write-mostly: the agent was told to persist
facts but never to consult them, and two existing affordances were
inert.

- HybridMemoryBackend::search ignored its `tags` argument (it was
  bound as `_tags`). Tag-scoped recall now filters results to memories
  carrying at least one requested tag, over-fetching candidates so a
  filtered search can still fill `limit`.
- search/get now attach any extracted facts (preferences, decisions)
  associated with a memory, so a query for stated preferences surfaces
  the structured triple rather than only the verbatim source text.
  These were extracted into `extracted_facts` but never read back.
- The default soul now tells the model to memory_search for the user's
  standing preferences and earlier decisions before acting, turning the
  guidance from write-only into read+write.

Adds a backend test covering tag filtering.