### PR TITLE
Computer-use foundations: image-bearing tool results + computer-use tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,7 +2996,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -348,20 +348,26 @@ async fn execute_repl_tool(
                     "error": format!("unknown tool: {}", call.name)
                 }),
                 is_error: true,
+                images: Vec::new(),
             };
         }
     };
 
     match tool.execute(call.arguments.clone()).await {
-        Ok(output) => ToolResult {
-            call_id: call.id.clone(),
-            output,
-            is_error: false,
-        },
+        Ok(output) => {
+            let (output, images) = rustykrab_core::types::split_tool_result_images(output);
+            ToolResult {
+                call_id: call.id.clone(),
+                output,
+                is_error: false,
+                images,
+            }
+        }
         Err(e) => ToolResult {
             call_id: call.id.clone(),
             output: serde_json::json!({ "error": e.to_string() }),
             is_error: true,
+            images: Vec::new(),
         },
     }
 }

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1181,6 +1181,7 @@ impl AgentRunner {
                                     call_id,
                                     output,
                                     is_error: true,
+                                    images: Vec::new(),
                                 }),
                                 created_at: Utc::now(),
                             }
@@ -1598,6 +1599,7 @@ impl AgentRunner {
                                     call_id: call_id.clone(),
                                     output,
                                     is_error: true,
+                                    images: Vec::new(),
                                 }),
                                 created_at: Utc::now(),
                             };
@@ -2987,6 +2989,10 @@ async fn execute_single_tool(
         )
     })??;
 
+    // Pull any tool-attached images out before fencing — fencing rewrites
+    // string values and would corrupt base64 payloads.
+    let (output, images) = rustykrab_core::types::split_tool_result_images(output);
+
     let output = if EXTERNAL_CONTENT_TOOLS.contains(&call.name.as_str()) {
         fence_external_output(output)
     } else {
@@ -2997,6 +3003,7 @@ async fn execute_single_tool(
         call_id: call.id.clone(),
         output,
         is_error: false,
+        images,
     })
 }
 

--- a/crates/rustykrab-core/src/types.rs
+++ b/crates/rustykrab-core/src/types.rs
@@ -275,6 +275,53 @@ pub struct ToolResult {
     /// so the model knows to interpret the output as an error message.
     #[serde(default)]
     pub is_error: bool,
+    /// Images produced by the tool (e.g. screenshots). Surfaced to
+    /// vision-capable models as image content blocks alongside the textual
+    /// output; ignored by providers/models without vision. Empty for the
+    /// vast majority of tools.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<ContentBlock>,
+}
+
+/// Reserved JSON key a tool may set on its (object) output to attach binary
+/// images — e.g. a screenshot — to its result. The agent runner extracts
+/// these into [`ToolResult::images`] and strips the key, so the raw base64
+/// never reaches the model as text.
+pub const TOOL_RESULT_IMAGES_KEY: &str = "_images";
+
+/// Split any [`TOOL_RESULT_IMAGES_KEY`] array out of a tool's JSON output.
+///
+/// Each entry must be an object with a `media_type` string and a base64
+/// `data` string; malformed entries are skipped. The key is always removed
+/// from the returned output so large base64 blobs never leak into the text
+/// the model reads. Returns the cleaned output and the parsed image blocks.
+pub fn split_tool_result_images(
+    mut output: serde_json::Value,
+) -> (serde_json::Value, Vec<ContentBlock>) {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+
+    let Some(obj) = output.as_object_mut() else {
+        return (output, Vec::new());
+    };
+    let Some(serde_json::Value::Array(entries)) = obj.remove(TOOL_RESULT_IMAGES_KEY) else {
+        return (output, Vec::new());
+    };
+
+    let mut images = Vec::new();
+    for entry in entries {
+        let media_type = entry.get("media_type").and_then(|v| v.as_str());
+        let data = entry.get("data").and_then(|v| v.as_str());
+        if let (Some(media_type), Some(data)) = (media_type, data) {
+            if let Ok(bytes) = STANDARD.decode(data) {
+                images.push(ContentBlock::Image {
+                    media_type: media_type.to_string(),
+                    data: bytes,
+                });
+            }
+        }
+    }
+    (output, images)
 }
 
 /// A conversation is an ordered sequence of messages.
@@ -312,4 +359,60 @@ pub struct ToolSchema {
     pub name: String,
     pub description: String,
     pub parameters: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+
+    #[test]
+    fn split_tool_result_images_extracts_and_strips_key() {
+        let png = vec![0x89u8, 0x50, 0x4e, 0x47];
+        let output = serde_json::json!({
+            "text": "captured",
+            "_images": [
+                { "media_type": "image/png", "data": STANDARD.encode(&png) }
+            ]
+        });
+
+        let (cleaned, images) = split_tool_result_images(output);
+        // The reserved key is removed so base64 never leaks into model text.
+        assert!(cleaned.get(TOOL_RESULT_IMAGES_KEY).is_none());
+        assert_eq!(cleaned["text"], "captured");
+        assert_eq!(images.len(), 1);
+        match &images[0] {
+            ContentBlock::Image { media_type, data } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, &png);
+            }
+            other => panic!("expected image block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_tool_result_images_skips_malformed_entries_but_strips_key() {
+        let output = serde_json::json!({
+            "_images": [
+                { "media_type": "image/png" },                 // missing data
+                { "data": "not-base64-$$$" },                   // missing media_type + bad b64
+                "garbage"                                        // not an object
+            ]
+        });
+        let (cleaned, images) = split_tool_result_images(output);
+        assert!(cleaned.get(TOOL_RESULT_IMAGES_KEY).is_none());
+        assert!(images.is_empty());
+    }
+
+    #[test]
+    fn split_tool_result_images_passes_through_non_object_and_missing_key() {
+        let (cleaned, images) = split_tool_result_images(serde_json::json!("plain string"));
+        assert_eq!(cleaned, serde_json::json!("plain string"));
+        assert!(images.is_empty());
+
+        let (cleaned, images) = split_tool_result_images(serde_json::json!({ "ok": true }));
+        assert_eq!(cleaned, serde_json::json!({ "ok": true }));
+        assert!(images.is_empty());
+    }
 }

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -807,6 +807,7 @@ mod tests {
             call_id: "1".into(),
             output: serde_json::json!("ok"),
             is_error: false,
+            images: Vec::new(),
         });
         assert!(render_message_content(&result).starts_with("[tool_result]"));
 
@@ -814,6 +815,7 @@ mod tests {
             call_id: "1".into(),
             output: serde_json::json!("boom"),
             is_error: true,
+            images: Vec::new(),
         });
         assert!(render_message_content(&err).starts_with("[tool_error]"));
     }

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -174,9 +174,31 @@ impl AnthropicProvider {
                     if let MessageContent::ToolResult(ref result) = msg.content {
                         // Fix #182: avoid double-serialization of string values.
                         // Fix #195: propagate serialization errors instead of swallowing them.
-                        let content = match &result.output {
+                        let text = match &result.output {
                             serde_json::Value::String(s) => s.clone(),
                             other => serde_json::to_string(other).map_err(Error::Serialization)?,
+                        };
+                        // Attach any tool-produced images (e.g. screenshots)
+                        // as image blocks alongside the text. Claude always
+                        // supports vision, so no capability gate is needed.
+                        let content = if result.images.is_empty() {
+                            ToolResultContent::Text(text)
+                        } else {
+                            use base64::engine::general_purpose::STANDARD;
+                            use base64::Engine;
+                            let mut blocks = vec![ContentBlock::Text { text }];
+                            for img in &result.images {
+                                if let CoreContentBlock::Image { media_type, data } = img {
+                                    blocks.push(ContentBlock::Image {
+                                        source: ImageSource {
+                                            source_type: "base64".to_string(),
+                                            media_type: media_type.clone(),
+                                            data: STANDARD.encode(data),
+                                        },
+                                    });
+                                }
+                            }
+                            ToolResultContent::Blocks(blocks)
                         };
                         api_messages.push(ApiMessage {
                             role: "user".to_string(),
@@ -859,10 +881,20 @@ enum ContentBlock {
     #[serde(rename = "tool_result")]
     ToolResult {
         tool_use_id: String,
-        content: String,
+        content: ToolResultContent,
         #[serde(skip_serializing_if = "is_false")]
         is_error: bool,
     },
+}
+
+/// A `tool_result` block's content is either a plain string or, when the
+/// tool returned images, an array of text/image blocks. The Anthropic API
+/// accepts both shapes; `#[serde(untagged)]` picks the right one.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum ToolResultContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
 }
 
 #[derive(Serialize)]
@@ -1001,5 +1033,60 @@ mod tests {
     fn tool_choice_any_emits_any_type() {
         let v = AnthropicProvider::tool_choice_json(ToolChoice::Any).expect("Any → Some");
         assert_eq!(v, serde_json::json!({ "type": "any" }));
+    }
+
+    #[test]
+    fn tool_result_without_images_serializes_as_string() {
+        use rustykrab_core::types::ToolResult;
+        let msg = Message {
+            id: uuid::Uuid::new_v4(),
+            role: Role::Tool,
+            content: MessageContent::ToolResult(ToolResult {
+                call_id: "call-1".to_string(),
+                output: serde_json::json!("done"),
+                is_error: false,
+                images: Vec::new(),
+            }),
+            created_at: chrono::Utc::now(),
+        };
+        let (_sys, api) = AnthropicProvider::build_messages(&[msg]).expect("build");
+        let json = serde_json::to_value(&api).unwrap();
+        let content = &json[0]["content"][0];
+        assert_eq!(content["type"], "tool_result");
+        // Plain string content (untagged enum picks the string arm).
+        assert_eq!(content["content"], "done");
+    }
+
+    #[test]
+    fn tool_result_with_images_serializes_as_block_array() {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        use rustykrab_core::types::{ContentBlock as CoreBlock, ToolResult};
+
+        let png = vec![0x89u8, 0x50, 0x4e, 0x47];
+        let msg = Message {
+            id: uuid::Uuid::new_v4(),
+            role: Role::Tool,
+            content: MessageContent::ToolResult(ToolResult {
+                call_id: "call-1".to_string(),
+                output: serde_json::json!("screenshot taken"),
+                is_error: false,
+                images: vec![CoreBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: png.clone(),
+                }],
+            }),
+            created_at: chrono::Utc::now(),
+        };
+        let (_sys, api) = AnthropicProvider::build_messages(&[msg]).expect("build");
+        let json = serde_json::to_value(&api).unwrap();
+        let blocks = &json[0]["content"][0]["content"];
+        // Array of [text, image] blocks.
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], "screenshot taken");
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert_eq!(blocks[1]["source"]["data"], STANDARD.encode(&png));
     }
 }

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -277,116 +277,136 @@ impl OllamaProvider {
     }
 
     /// Fix #195: returns Result to propagate serialization errors.
-    fn build_messages(messages: &[Message]) -> Result<Vec<OllamaMessage>> {
-        messages
-            .iter()
-            .map(|msg| {
-                let role = match msg.role {
-                    Role::System => "system",
-                    Role::User => "user",
-                    Role::Assistant => "assistant",
-                    Role::Tool => "tool",
-                };
+    fn build_messages(messages: &[Message], supports_vision: bool) -> Result<Vec<OllamaMessage>> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        use rustykrab_core::types::ContentBlock;
 
-                Ok(match &msg.content {
-                    MessageContent::Text(text) => {
-                        // Strip <think> blocks from assistant messages so
-                        // model thinking is not re-submitted in history.
-                        let content = if msg.role == Role::Assistant && text.contains("<think>") {
-                            let stripped = Self::strip_thinking(text);
-                            tracing::debug!(
-                                original_len = text.len(),
-                                stripped_len = stripped.len(),
-                                "stripped thinking blocks from assistant message"
-                            );
-                            stripped
-                        } else {
-                            text.clone()
-                        };
-                        OllamaMessage {
-                            role: role.to_string(),
-                            content: Some(content),
-                            tool_calls: None,
-                            images: None,
-                        }
-                    }
-                    MessageContent::ToolCall(call) => OllamaMessage {
+        let mut out = Vec::with_capacity(messages.len());
+        for msg in messages {
+            let role = match msg.role {
+                Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::Tool => "tool",
+            };
+
+            match &msg.content {
+                MessageContent::Text(text) => {
+                    // Strip <think> blocks from assistant messages so
+                    // model thinking is not re-submitted in history.
+                    let content = if msg.role == Role::Assistant && text.contains("<think>") {
+                        let stripped = Self::strip_thinking(text);
+                        tracing::debug!(
+                            original_len = text.len(),
+                            stripped_len = stripped.len(),
+                            "stripped thinking blocks from assistant message"
+                        );
+                        stripped
+                    } else {
+                        text.clone()
+                    };
+                    out.push(OllamaMessage {
                         role: role.to_string(),
-                        content: None,
-                        tool_calls: Some(vec![OllamaToolCall {
-                            function: OllamaFunction {
-                                name: call.name.clone(),
-                                arguments: call.arguments.clone(),
-                            },
-                        }]),
+                        content: Some(content),
+                        tool_calls: None,
                         images: None,
-                    },
-                    MessageContent::MultiToolCall(calls) => OllamaMessage {
-                        role: role.to_string(),
-                        content: None,
-                        tool_calls: Some(
-                            calls
-                                .iter()
-                                .map(|c| OllamaToolCall {
-                                    function: OllamaFunction {
-                                        name: c.name.clone(),
-                                        arguments: c.arguments.clone(),
-                                    },
-                                })
-                                .collect(),
-                        ),
-                        images: None,
-                    },
-                    MessageContent::ToolResult(result) => {
-                        // Fix #182: avoid double-serialization of string values.
-                        // Fix #195: propagate serialization errors.
-                        let content = match &result.output {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => serde_json::to_string(other).map_err(Error::Serialization)?,
-                        };
-                        OllamaMessage {
-                            role: role.to_string(),
-                            content: Some(content),
-                            tool_calls: None,
-                            images: None,
-                        }
-                    }
-                    MessageContent::MultiPart(blocks) => {
-                        use base64::engine::general_purpose::STANDARD;
-                        use base64::Engine;
-                        let text = blocks
+                    });
+                }
+                MessageContent::ToolCall(call) => out.push(OllamaMessage {
+                    role: role.to_string(),
+                    content: None,
+                    tool_calls: Some(vec![OllamaToolCall {
+                        function: OllamaFunction {
+                            name: call.name.clone(),
+                            arguments: call.arguments.clone(),
+                        },
+                    }]),
+                    images: None,
+                }),
+                MessageContent::MultiToolCall(calls) => out.push(OllamaMessage {
+                    role: role.to_string(),
+                    content: None,
+                    tool_calls: Some(
+                        calls
                             .iter()
-                            .filter_map(|b| match b {
-                                rustykrab_core::types::ContentBlock::Text { text } => {
-                                    Some(text.as_str())
-                                }
-                                _ => None,
+                            .map(|c| OllamaToolCall {
+                                function: OllamaFunction {
+                                    name: c.name.clone(),
+                                    arguments: c.arguments.clone(),
+                                },
                             })
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        // Ollama carries images at the message level as a list
-                        // of base64 strings (no data-URI prefix). Callers only
-                        // place `Image` blocks here for vision-capable models
-                        // (gated upstream by `supports_vision`).
-                        let images: Vec<String> = blocks
+                            .collect(),
+                    ),
+                    images: None,
+                }),
+                MessageContent::ToolResult(result) => {
+                    // Fix #182: avoid double-serialization of string values.
+                    // Fix #195: propagate serialization errors.
+                    let content = match &result.output {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => serde_json::to_string(other).map_err(Error::Serialization)?,
+                    };
+                    out.push(OllamaMessage {
+                        role: role.to_string(),
+                        content: Some(content),
+                        tool_calls: None,
+                        images: None,
+                    });
+                    // Ollama's chat API has no image slot on a `tool` message,
+                    // so surface any tool-produced images (e.g. screenshots)
+                    // as a follow-up user message — but only for vision models.
+                    if supports_vision && !result.images.is_empty() {
+                        let imgs: Vec<String> = result
+                            .images
                             .iter()
                             .filter_map(|b| match b {
-                                rustykrab_core::types::ContentBlock::Image { data, .. } => {
-                                    Some(STANDARD.encode(data))
-                                }
+                                ContentBlock::Image { data, .. } => Some(STANDARD.encode(data)),
                                 _ => None,
                             })
                             .collect();
-                        OllamaMessage {
-                            role: role.to_string(),
-                            content: Some(text),
-                            tool_calls: None,
-                            images: (!images.is_empty()).then_some(images),
+                        if !imgs.is_empty() {
+                            out.push(OllamaMessage {
+                                role: "user".to_string(),
+                                content: Some(
+                                    "Images returned by the previous tool call:".to_string(),
+                                ),
+                                tool_calls: None,
+                                images: Some(imgs),
+                            });
                         }
                     }
-                })
-            })
-            .collect()
+                }
+                MessageContent::MultiPart(blocks) => {
+                    let text = blocks
+                        .iter()
+                        .filter_map(|b| match b {
+                            ContentBlock::Text { text } => Some(text.as_str()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    // Ollama carries images at the message level as a list of
+                    // base64 strings (no data-URI prefix). Callers only place
+                    // `Image` blocks here for vision-capable models (gated
+                    // upstream by `supports_vision`).
+                    let images: Vec<String> = blocks
+                        .iter()
+                        .filter_map(|b| match b {
+                            ContentBlock::Image { data, .. } => Some(STANDARD.encode(data)),
+                            _ => None,
+                        })
+                        .collect();
+                    out.push(OllamaMessage {
+                        role: role.to_string(),
+                        content: Some(text),
+                        tool_calls: None,
+                        images: (!images.is_empty()).then_some(images),
+                    });
+                }
+            }
+        }
+        Ok(out)
     }
 
     fn build_tools(tools: &[ToolSchema]) -> Vec<OllamaTool> {
@@ -560,7 +580,7 @@ impl ModelProvider for OllamaProvider {
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
-        let ollama_messages = Self::build_messages(messages)?;
+        let ollama_messages = Self::build_messages(messages, self.supports_vision())?;
 
         // Fix #200: validate non-empty messages.
         if ollama_messages.is_empty() {
@@ -722,7 +742,7 @@ impl ModelProvider for OllamaProvider {
         tools: &[ToolSchema],
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ModelResponse> {
-        let ollama_messages = Self::build_messages(messages)?;
+        let ollama_messages = Self::build_messages(messages, self.supports_vision())?;
 
         if ollama_messages.is_empty() {
             return Err(Error::ModelBadRequest(
@@ -1228,7 +1248,7 @@ mod tests {
             created_at: Utc::now(),
         };
 
-        let built = OllamaProvider::build_messages(&[msg]).expect("build_messages");
+        let built = OllamaProvider::build_messages(&[msg], true).expect("build_messages");
         assert_eq!(built.len(), 1);
         assert_eq!(built[0].content.as_deref(), Some("what is this?"));
         let images = built[0].images.as_ref().expect("images present");
@@ -1246,11 +1266,56 @@ mod tests {
             content: MessageContent::Text("hello".to_string()),
             created_at: Utc::now(),
         };
-        let built = OllamaProvider::build_messages(&[msg]).expect("build_messages");
+        let built = OllamaProvider::build_messages(&[msg], false).expect("build_messages");
         assert!(built[0].images.is_none());
         // `images` must be skipped entirely in the wire payload when absent.
         let json = serde_json::to_value(&built[0]).unwrap();
         assert!(json.get("images").is_none());
+    }
+
+    fn tool_result_with_image(png: &[u8]) -> Message {
+        use rustykrab_core::types::{ContentBlock, ToolResult};
+        Message {
+            id: Uuid::new_v4(),
+            role: Role::Tool,
+            content: MessageContent::ToolResult(ToolResult {
+                call_id: "call-1".to_string(),
+                output: serde_json::json!({ "ok": true }),
+                is_error: false,
+                images: vec![ContentBlock::Image {
+                    media_type: "image/png".to_string(),
+                    data: png.to_vec(),
+                }],
+            }),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn tool_result_images_become_followup_user_message_for_vision_models() {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+
+        let png = vec![0x89u8, 0x50, 0x4e, 0x47];
+        let built =
+            OllamaProvider::build_messages(&[tool_result_with_image(&png)], true).expect("build");
+        // One `tool` message plus an injected `user` message carrying the image.
+        assert_eq!(built.len(), 2);
+        assert_eq!(built[0].role, "tool");
+        assert!(built[0].images.is_none());
+        assert_eq!(built[1].role, "user");
+        let imgs = built[1].images.as_ref().expect("follow-up images");
+        assert_eq!(imgs, &vec![STANDARD.encode(&png)]);
+    }
+
+    #[test]
+    fn tool_result_images_dropped_for_text_only_models() {
+        let png = vec![0x89u8, 0x50, 0x4e, 0x47];
+        let built =
+            OllamaProvider::build_messages(&[tool_result_with_image(&png)], false).expect("build");
+        // No follow-up user message when the model can't see images.
+        assert_eq!(built.len(), 1);
+        assert_eq!(built[0].role, "tool");
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/computer.rs
+++ b/crates/rustykrab-tools/src/computer.rs
@@ -1,0 +1,409 @@
+//! A tool that lets the agent drive a desktop: take screenshots and
+//! synthesize mouse/keyboard input.
+//!
+//! Actions follow Anthropic's computer-use vocabulary (`screenshot`,
+//! `left_click`, `type`, `key`, `scroll`, …) so the same backend can later be
+//! wired to the native `computer_*` tool type. Screenshots are returned via
+//! the reserved `_images` key, which the agent runner extracts into the
+//! tool result's image blocks for vision-capable models.
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use rustykrab_core::types::ToolSchema;
+use rustykrab_core::{Result, SandboxRequirements, Tool};
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::computer_backend::{ComputerBackend, MouseButton, ScrollDirection};
+
+/// Tool exposing screen capture and input synthesis to the agent.
+pub struct ComputerTool {
+    backend: Arc<dyn ComputerBackend>,
+}
+
+impl ComputerTool {
+    pub fn new(backend: Arc<dyn ComputerBackend>) -> Self {
+        Self { backend }
+    }
+
+    /// Construct a `ToolExecution` error with a message.
+    fn err(msg: impl Into<String>) -> rustykrab_core::Error {
+        rustykrab_core::Error::ToolExecution(msg.into().into())
+    }
+
+    /// Parse coordinates from either a `coordinate: [x, y]` array (Anthropic
+    /// style) or separate `x` / `y` integer fields. Returns `None` when
+    /// neither form is present or well-formed.
+    fn parse_coords(args: &Value, key: &str) -> Option<(i32, i32)> {
+        if let Some(arr) = args.get(key).and_then(|v| v.as_array()) {
+            if arr.len() == 2 {
+                if let (Some(x), Some(y)) = (arr[0].as_i64(), arr[1].as_i64()) {
+                    return Some((x as i32, y as i32));
+                }
+            }
+        }
+        match (
+            args.get("x").and_then(|v| v.as_i64()),
+            args.get("y").and_then(|v| v.as_i64()),
+        ) {
+            (Some(x), Some(y)) => Some((x as i32, y as i32)),
+            _ => None,
+        }
+    }
+
+    fn require_coords(args: &Value, key: &str, action: &str) -> Result<(i32, i32)> {
+        Self::parse_coords(args, key)
+            .ok_or_else(|| Self::err(format!("action '{action}' requires a coordinate [x, y]")))
+    }
+}
+
+#[async_trait]
+impl Tool for ComputerTool {
+    fn name(&self) -> &str {
+        "computer"
+    }
+
+    fn description(&self) -> &str {
+        "Control the desktop: take a screenshot, move/click the mouse, type \
+         text, press keys, or scroll. Coordinates are absolute display pixels \
+         (origin top-left). Start with a `screenshot` to see the screen."
+    }
+
+    fn sandbox_requirements(&self) -> SandboxRequirements {
+        // Driving the display is a system-level side effect.
+        SandboxRequirements {
+            needs_spawn: true,
+            ..SandboxRequirements::default()
+        }
+    }
+
+    fn schema(&self) -> ToolSchema {
+        let (w, h) = self.backend.display_size();
+        ToolSchema {
+            name: self.name().to_string(),
+            description: format!("{} The display is {w}x{h} pixels.", self.description()),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": [
+                            "screenshot",
+                            "cursor_position",
+                            "mouse_move",
+                            "left_click",
+                            "right_click",
+                            "middle_click",
+                            "double_click",
+                            "left_click_drag",
+                            "type",
+                            "key",
+                            "scroll"
+                        ],
+                        "description": "The action to perform."
+                    },
+                    "coordinate": {
+                        "type": "array",
+                        "items": { "type": "integer" },
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "description": "Target [x, y] in display pixels. Required for mouse_move and left_click_drag (destination); optional for clicks and scroll."
+                    },
+                    "start_coordinate": {
+                        "type": "array",
+                        "items": { "type": "integer" },
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "description": "Drag start [x, y] for left_click_drag. Defaults to the current cursor position."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to type (action 'type') or key combination such as 'ctrl+s' (action 'key')."
+                    },
+                    "scroll_direction": {
+                        "type": "string",
+                        "enum": ["up", "down", "left", "right"],
+                        "description": "Scroll direction (action 'scroll')."
+                    },
+                    "scroll_amount": {
+                        "type": "integer",
+                        "description": "Number of wheel steps to scroll (action 'scroll'). Defaults to 3."
+                    }
+                },
+                "required": ["action"]
+            }),
+        }
+    }
+
+    async fn execute(&self, args: Value) -> Result<Value> {
+        let action = args["action"]
+            .as_str()
+            .ok_or_else(|| Self::err("missing action"))?;
+
+        match action {
+            "screenshot" => {
+                let img = self.backend.screenshot().await?;
+                Ok(json!({
+                    "action": "screenshot",
+                    "width": img.width,
+                    "height": img.height,
+                    "_images": [{
+                        "media_type": "image/png",
+                        "data": STANDARD.encode(&img.png),
+                    }],
+                }))
+            }
+            "cursor_position" => {
+                let (x, y) = self.backend.cursor_position().await?;
+                Ok(json!({ "action": "cursor_position", "x": x, "y": y }))
+            }
+            "mouse_move" => {
+                let (x, y) = Self::require_coords(&args, "coordinate", action)?;
+                self.backend.mouse_move(x, y).await?;
+                Ok(json!({ "action": "mouse_move", "x": x, "y": y }))
+            }
+            "left_click" | "right_click" | "middle_click" => {
+                let button = match action {
+                    "left_click" => MouseButton::Left,
+                    "right_click" => MouseButton::Right,
+                    _ => MouseButton::Middle,
+                };
+                let at = Self::parse_coords(&args, "coordinate");
+                self.backend.click(button, at).await?;
+                Ok(json!({ "action": action, "coordinate": at.map(|(x, y)| [x, y]) }))
+            }
+            "double_click" => {
+                let at = Self::parse_coords(&args, "coordinate");
+                self.backend.double_click(at).await?;
+                Ok(json!({ "action": "double_click", "coordinate": at.map(|(x, y)| [x, y]) }))
+            }
+            "left_click_drag" => {
+                let to = Self::require_coords(&args, "coordinate", action)?;
+                let from = match Self::parse_coords(&args, "start_coordinate") {
+                    Some(p) => p,
+                    None => self.backend.cursor_position().await?,
+                };
+                self.backend.drag(from, to).await?;
+                Ok(json!({
+                    "action": "left_click_drag",
+                    "from": [from.0, from.1],
+                    "to": [to.0, to.1],
+                }))
+            }
+            "type" => {
+                let text = args["text"]
+                    .as_str()
+                    .ok_or_else(|| Self::err("action 'type' requires 'text'"))?;
+                self.backend.type_text(text).await?;
+                Ok(json!({ "action": "type", "typed": text.len() }))
+            }
+            "key" => {
+                let combo = args["text"]
+                    .as_str()
+                    .ok_or_else(|| Self::err("action 'key' requires 'text' (the key combo)"))?;
+                self.backend.key(combo).await?;
+                Ok(json!({ "action": "key", "combo": combo }))
+            }
+            "scroll" => {
+                let dir_str = args["scroll_direction"]
+                    .as_str()
+                    .ok_or_else(|| Self::err("action 'scroll' requires 'scroll_direction'"))?;
+                let direction = ScrollDirection::parse(dir_str)
+                    .ok_or_else(|| Self::err(format!("invalid scroll_direction: {dir_str}")))?;
+                let amount = args["scroll_amount"].as_i64().unwrap_or(3) as i32;
+                let at = Self::parse_coords(&args, "coordinate");
+                self.backend.scroll(direction, amount, at).await?;
+                Ok(json!({
+                    "action": "scroll",
+                    "scroll_direction": dir_str,
+                    "scroll_amount": amount,
+                }))
+            }
+            other => Err(Self::err(format!("unknown action: {other}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::computer_backend::CapturedImage;
+    use std::sync::Mutex;
+
+    /// Records every backend call so tests can assert on dispatch + parsing.
+    #[derive(Default)]
+    struct MockBackend {
+        calls: Mutex<Vec<String>>,
+        cursor: (i32, i32),
+    }
+
+    #[async_trait]
+    impl ComputerBackend for MockBackend {
+        async fn screenshot(&self) -> Result<CapturedImage> {
+            self.calls.lock().unwrap().push("screenshot".into());
+            Ok(CapturedImage {
+                png: vec![0x89, 0x50, 0x4e, 0x47],
+                width: 1920,
+                height: 1080,
+            })
+        }
+        async fn mouse_move(&self, x: i32, y: i32) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("mouse_move({x},{y})"));
+            Ok(())
+        }
+        async fn click(&self, button: MouseButton, at: Option<(i32, i32)>) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("click({button:?},{at:?})"));
+            Ok(())
+        }
+        async fn double_click(&self, at: Option<(i32, i32)>) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("double_click({at:?})"));
+            Ok(())
+        }
+        async fn drag(&self, from: (i32, i32), to: (i32, i32)) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("drag({from:?},{to:?})"));
+            Ok(())
+        }
+        async fn type_text(&self, text: &str) -> Result<()> {
+            self.calls.lock().unwrap().push(format!("type({text})"));
+            Ok(())
+        }
+        async fn key(&self, combo: &str) -> Result<()> {
+            self.calls.lock().unwrap().push(format!("key({combo})"));
+            Ok(())
+        }
+        async fn scroll(
+            &self,
+            direction: ScrollDirection,
+            amount: i32,
+            at: Option<(i32, i32)>,
+        ) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("scroll({direction:?},{amount},{at:?})"));
+            Ok(())
+        }
+        async fn cursor_position(&self) -> Result<(i32, i32)> {
+            self.calls.lock().unwrap().push("cursor_position".into());
+            Ok(self.cursor)
+        }
+        fn display_size(&self) -> (u32, u32) {
+            (1920, 1080)
+        }
+    }
+
+    fn tool() -> (ComputerTool, Arc<MockBackend>) {
+        let backend = Arc::new(MockBackend::default());
+        (ComputerTool::new(backend.clone()), backend)
+    }
+
+    fn calls(b: &MockBackend) -> Vec<String> {
+        b.calls.lock().unwrap().clone()
+    }
+
+    #[tokio::test]
+    async fn screenshot_returns_image_via_images_key() {
+        let (t, _b) = tool();
+        let out = t.execute(json!({ "action": "screenshot" })).await.unwrap();
+        assert_eq!(out["width"], 1920);
+        assert_eq!(out["height"], 1080);
+        let imgs = out["_images"].as_array().expect("_images array");
+        assert_eq!(imgs.len(), 1);
+        assert_eq!(imgs[0]["media_type"], "image/png");
+        assert_eq!(imgs[0]["data"], STANDARD.encode([0x89u8, 0x50, 0x4e, 0x47]));
+    }
+
+    #[tokio::test]
+    async fn left_click_with_coordinate_array() {
+        let (t, b) = tool();
+        t.execute(json!({ "action": "left_click", "coordinate": [10, 20] }))
+            .await
+            .unwrap();
+        assert_eq!(calls(&b), vec!["click(Left,Some((10, 20)))"]);
+    }
+
+    #[tokio::test]
+    async fn click_accepts_separate_x_y_fields() {
+        let (t, b) = tool();
+        t.execute(json!({ "action": "right_click", "x": 5, "y": 6 }))
+            .await
+            .unwrap();
+        assert_eq!(calls(&b), vec!["click(Right,Some((5, 6)))"]);
+    }
+
+    #[tokio::test]
+    async fn mouse_move_requires_coordinate() {
+        let (t, _b) = tool();
+        let err = t
+            .execute(json!({ "action": "mouse_move" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("coordinate"));
+    }
+
+    #[tokio::test]
+    async fn drag_defaults_start_to_cursor_position() {
+        let (t, b) = tool();
+        t.execute(json!({ "action": "left_click_drag", "coordinate": [100, 200] }))
+            .await
+            .unwrap();
+        // Falls back to cursor_position() (mock returns (0,0)) for the start.
+        assert_eq!(
+            calls(&b),
+            vec![
+                "cursor_position".to_string(),
+                "drag((0, 0),(100, 200))".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn type_and_key_dispatch() {
+        let (t, b) = tool();
+        t.execute(json!({ "action": "type", "text": "hello" }))
+            .await
+            .unwrap();
+        t.execute(json!({ "action": "key", "text": "ctrl+s" }))
+            .await
+            .unwrap();
+        assert_eq!(calls(&b), vec!["type(hello)", "key(ctrl+s)"]);
+    }
+
+    #[tokio::test]
+    async fn scroll_parses_direction_and_default_amount() {
+        let (t, b) = tool();
+        t.execute(json!({ "action": "scroll", "scroll_direction": "Down" }))
+            .await
+            .unwrap();
+        assert_eq!(calls(&b), vec!["scroll(Down,3,None)"]);
+    }
+
+    #[tokio::test]
+    async fn unknown_action_errors() {
+        let (t, _b) = tool();
+        let err = t
+            .execute(json!({ "action": "teleport" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown action"));
+    }
+
+    #[test]
+    fn schema_includes_display_dimensions() {
+        let (t, _b) = tool();
+        assert!(t.schema().description.contains("1920x1080"));
+    }
+}

--- a/crates/rustykrab-tools/src/computer_backend.rs
+++ b/crates/rustykrab-tools/src/computer_backend.rs
@@ -1,0 +1,95 @@
+//! Backend abstraction for "computer use": capturing the screen and
+//! synthesizing mouse/keyboard input.
+//!
+//! The trait lives here (dependency-light) so the [`crate::ComputerTool`] can
+//! be built and unit-tested anywhere. Concrete implementations that pull in
+//! platform/GUI dependencies (e.g. an `enigo` + `xcap` backend) live in the
+//! crate that owns those dependencies — typically the binary — and are bridged
+//! in via an adapter, mirroring the `CronBackend` / `MessageBackend` pattern.
+
+use async_trait::async_trait;
+use rustykrab_core::Result;
+
+/// A screenshot captured from the display.
+#[derive(Debug, Clone)]
+pub struct CapturedImage {
+    /// PNG-encoded image bytes.
+    pub png: Vec<u8>,
+    /// Image width in pixels.
+    pub width: u32,
+    /// Image height in pixels.
+    pub height: u32,
+}
+
+/// Mouse button for click/drag actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseButton {
+    Left,
+    Right,
+    Middle,
+}
+
+/// Direction for a scroll action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl ScrollDirection {
+    /// Parse a direction from its lowercase string form.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "up" => Some(Self::Up),
+            "down" => Some(Self::Down),
+            "left" => Some(Self::Left),
+            "right" => Some(Self::Right),
+            _ => None,
+        }
+    }
+}
+
+/// Abstract interface for controlling a desktop session: capturing the screen
+/// and synthesizing pointer/keyboard input. All coordinates are absolute
+/// display pixels with the origin at the top-left.
+#[async_trait]
+pub trait ComputerBackend: Send + Sync {
+    /// Capture the current screen as a PNG.
+    async fn screenshot(&self) -> Result<CapturedImage>;
+
+    /// Move the mouse cursor to absolute coordinates.
+    async fn mouse_move(&self, x: i32, y: i32) -> Result<()>;
+
+    /// Click a mouse button. When `at` is provided, move there first.
+    async fn click(&self, button: MouseButton, at: Option<(i32, i32)>) -> Result<()>;
+
+    /// Double-click the left button. When `at` is provided, move there first.
+    async fn double_click(&self, at: Option<(i32, i32)>) -> Result<()>;
+
+    /// Press the left button at `from`, move to `to`, then release.
+    async fn drag(&self, from: (i32, i32), to: (i32, i32)) -> Result<()>;
+
+    /// Type a string of text at the current focus.
+    async fn type_text(&self, text: &str) -> Result<()>;
+
+    /// Press a key combination such as `"ctrl+s"`, `"Return"`, or `"alt+Tab"`.
+    async fn key(&self, combo: &str) -> Result<()>;
+
+    /// Scroll in a direction by `amount` wheel steps. When `at` is provided,
+    /// move the cursor there first.
+    async fn scroll(
+        &self,
+        direction: ScrollDirection,
+        amount: i32,
+        at: Option<(i32, i32)>,
+    ) -> Result<()>;
+
+    /// Return the current cursor position as `(x, y)`.
+    async fn cursor_position(&self) -> Result<(i32, i32)>;
+
+    /// Display dimensions in pixels as `(width, height)`. Reported to the
+    /// model so it can reason about coordinate bounds.
+    fn display_size(&self) -> (u32, u32);
+}

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -62,6 +62,10 @@ mod canvas;
 // Device tools
 mod nodes;
 
+// Computer use (screen capture + input synthesis)
+mod computer;
+pub mod computer_backend;
+
 // HTTP
 mod http_request;
 mod http_session;
@@ -155,6 +159,10 @@ pub use canvas::CanvasTool;
 
 // Devices
 pub use nodes::NodesTool;
+
+// Computer use
+pub use computer::ComputerTool;
+pub use computer_backend::{CapturedImage, ComputerBackend, MouseButton, ScrollDirection};
 
 // HTTP
 pub use http_request::HttpRequestTool;
@@ -367,4 +375,13 @@ pub fn video_tools(
     backend: std::sync::Arc<dyn VideoBackend>,
 ) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
     vec![std::sync::Arc::new(VideoTool::new(backend))]
+}
+
+/// Build the computer-use tool from a [`ComputerBackend`]. Registered only
+/// when a backend is available (e.g. a display is present and the feature is
+/// enabled), mirroring how `video_tools` is gated.
+pub fn computer_tools(
+    backend: std::sync::Arc<dyn ComputerBackend>,
+) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
+    vec![std::sync::Arc::new(ComputerTool::new(backend))]
 }


### PR DESCRIPTION
## Summary

Two of the foundational pieces for a computer-use tool suite. (Ollama vision support — the third piece — already landed separately as #460, so it's omitted here after rebasing onto `main`.)

This branch is provider-agnostic and ships in independently-useful layers:

### 1. Image-bearing tool results
Tool results were text-only — a tool returning a screenshot could only emit it as a base64 string buried in JSON, which the model reads as *text*, not as a viewable image. This adds an image channel for tool results, end-to-end:

- **core** — `ToolResult` gains an `images: Vec<ContentBlock>` field, plus a `split_tool_result_images` helper and the reserved `_images` output key. A tool attaches images by returning `{"_images":[{"media_type","data"}]}`; the runner extracts and strips the key so base64 never leaks into the text the model reads. The field is `#[serde(default)]`, so persisted conversations without it still deserialize.
- **agent** — extract `_images` in the tool-execution path (before fencing, which would corrupt base64) and in the recursive-call path.
- **anthropic** — emit `tool_result` content as a text+image block array when images are present (Claude always supports vision).
- **ollama** — surface tool-result images as a follow-up user message (its chat API has no image slot on tool messages), gated on the model's vision support.

A nice side benefit: the existing browser-screenshot tool can now return a viewable image instead of a base64 blob.

### 2. Computer-use tool + backend trait
The agent-facing half of the computer-use suite, kept dependency-light so it builds and unit-tests anywhere (no X11/GUI deps in this crate):

- `computer_backend.rs` — the `ComputerBackend` trait (screenshot, mouse move/click/drag, type, key, scroll, cursor position, display size) plus `CapturedImage`, `MouseButton`, `ScrollDirection`. Concrete platform backends (e.g. an `enigo` + `xcap` backend) live in the owning crate and bridge in via an adapter, mirroring `CronBackend`/`VideoBackend`.
- `computer.rs` — `ComputerTool`, a single `Tool` with an `action` enum following Anthropic's computer-use vocabulary (`screenshot`, `mouse_move`, `left/right/middle_click`, `double_click`, `left_click_drag`, `type`, `key`, `scroll`). Coordinates accept both `[x, y]` arrays and separate `x`/`y` fields. Screenshots are returned via the `_images` key from layer 1. Declares `needs_spawn` sandbox requirements.
- `lib.rs` — module declarations, re-exports, and a `computer_tools` factory mirroring `video_tools`.

## Testing

All touched crates tested individually:

| Crate | Tests |
|---|---|
| core | 54 ✅ |
| providers (anthropic + ollama) | 19 ✅ |
| agent | 101 ✅ |
| gateway | 6 ✅ |
| tools | 116 ✅ (9 new for `computer`) |

`cargo fmt --all -- --check` clean; `cargo clippy` clean on all touched crates.

> Note: a full-workspace `cargo test`/`clippy` couldn't complete in the dev sandbox because `ort-sys` (ONNX Runtime via `fastembed`) intermittently 403s when downloading its prebuilt binary — an environment/network limitation unrelated to these changes. CI with network access should exercise it.

## Not included (follow-up)
The concrete `enigo`+`xcap` platform backend and its env-gated registration in the CLI land in a follow-up, behind an optional cargo feature (those deps need X11/XCB dev headers to build and a real/virtual display to run).

https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL)_