### PR TITLE
Computer-use Phase 4: labeled coordinate-grid overlay for screenshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,7 +4026,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "axum",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.0"
+version = "4.5.2"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -4220,6 +4220,7 @@ dependencies = [
  "chromiumoxide",
  "chrono",
  "futures",
+ "image",
  "imap-proto",
  "lettre",
  "libc",

--- a/crates/rustykrab-tools/Cargo.toml
+++ b/crates/rustykrab-tools/Cargo.toml
@@ -33,6 +33,9 @@ rustls-native-certs.workspace = true
 lettre.workspace = true
 mail-parser.workspace = true
 libc.workspace = true
+# Screenshot post-processing (coordinate-grid overlay). PNG codec only —
+# default features pulled in to keep the dependency footprint small.
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/rustykrab-tools/src/computer.rs
+++ b/crates/rustykrab-tools/src/computer.rs
@@ -129,6 +129,14 @@ impl Tool for ComputerTool {
                     "scroll_amount": {
                         "type": "integer",
                         "description": "Number of wheel steps to scroll (action 'scroll'). Defaults to 3."
+                    },
+                    "grid": {
+                        "type": "boolean",
+                        "description": "For 'screenshot': overlay a labeled coordinate grid to read off precise [x, y] targets. Useful when clicks miss."
+                    },
+                    "grid_spacing": {
+                        "type": "integer",
+                        "description": "Grid line spacing in pixels when 'grid' is true. Defaults to 100."
                     }
                 },
                 "required": ["action"]
@@ -144,13 +152,29 @@ impl Tool for ComputerTool {
         match action {
             "screenshot" => {
                 let img = self.backend.screenshot().await?;
+                let grid = args["grid"].as_bool().unwrap_or(false);
+                // Optionally overlay a labeled coordinate grid to help the
+                // model read off pixel coordinates. A failed overlay (e.g. an
+                // unexpected image format) must not fail the screenshot, so we
+                // fall back to the raw capture.
+                let mut png = img.png;
+                if grid {
+                    let spacing = args["grid_spacing"].as_u64().unwrap_or(100) as u32;
+                    match crate::grid::annotate_with_grid(&png, spacing) {
+                        Ok(annotated) => png = annotated,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "grid overlay failed; returning raw screenshot")
+                        }
+                    }
+                }
                 Ok(json!({
                     "action": "screenshot",
                     "width": img.width,
                     "height": img.height,
+                    "grid": grid,
                     "_images": [{
                         "media_type": "image/png",
-                        "data": STANDARD.encode(&img.png),
+                        "data": STANDARD.encode(&png),
                     }],
                 }))
             }
@@ -242,10 +266,14 @@ mod tests {
     impl ComputerBackend for MockBackend {
         async fn screenshot(&self) -> Result<CapturedImage> {
             self.calls.lock().unwrap().push("screenshot".into());
+            // A real (small) PNG so the grid-overlay path can decode it.
+            let img = image::RgbaImage::from_pixel(200, 120, image::Rgba([30, 30, 30, 255]));
+            let mut buf = std::io::Cursor::new(Vec::new());
+            img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
             Ok(CapturedImage {
-                png: vec![0x89, 0x50, 0x4e, 0x47],
-                width: 1920,
-                height: 1080,
+                png: buf.into_inner(),
+                width: 200,
+                height: 120,
             })
         }
         async fn mouse_move(&self, x: i32, y: i32) -> Result<()> {
@@ -314,16 +342,44 @@ mod tests {
         b.calls.lock().unwrap().clone()
     }
 
+    fn decode_image_data(out: &Value) -> Vec<u8> {
+        let imgs = out["_images"].as_array().expect("_images array");
+        assert_eq!(imgs.len(), 1);
+        assert_eq!(imgs[0]["media_type"], "image/png");
+        STANDARD
+            .decode(imgs[0]["data"].as_str().expect("base64 data"))
+            .expect("valid base64")
+    }
+
     #[tokio::test]
     async fn screenshot_returns_image_via_images_key() {
         let (t, _b) = tool();
         let out = t.execute(json!({ "action": "screenshot" })).await.unwrap();
-        assert_eq!(out["width"], 1920);
-        assert_eq!(out["height"], 1080);
-        let imgs = out["_images"].as_array().expect("_images array");
-        assert_eq!(imgs.len(), 1);
-        assert_eq!(imgs[0]["media_type"], "image/png");
-        assert_eq!(imgs[0]["data"], STANDARD.encode([0x89u8, 0x50, 0x4e, 0x47]));
+        assert_eq!(out["width"], 200);
+        assert_eq!(out["height"], 120);
+        assert_eq!(out["grid"], false);
+        let png = decode_image_data(&out);
+        let dims = image::load_from_memory(&png)
+            .unwrap()
+            .to_rgba8()
+            .dimensions();
+        assert_eq!(dims, (200, 120));
+    }
+
+    #[tokio::test]
+    async fn screenshot_with_grid_overlays_and_differs() {
+        let (t, _b) = tool();
+        let plain = decode_image_data(&t.execute(json!({ "action": "screenshot" })).await.unwrap());
+        let out = t
+            .execute(json!({ "action": "screenshot", "grid": true, "grid_spacing": 50 }))
+            .await
+            .unwrap();
+        assert_eq!(out["grid"], true);
+        let gridded = decode_image_data(&out);
+        // Same dimensions, but pixels changed by the overlay.
+        let g = image::load_from_memory(&gridded).unwrap().to_rgba8();
+        assert_eq!(g.dimensions(), (200, 120));
+        assert_ne!(plain, gridded, "grid overlay should change the image");
     }
 
     #[tokio::test]

--- a/crates/rustykrab-tools/src/grid.rs
+++ b/crates/rustykrab-tools/src/grid.rs
@@ -1,0 +1,190 @@
+//! Screenshot annotation: overlay a labeled coordinate grid onto a PNG.
+//!
+//! A coordinate grid is a lightweight grounding aid for vision models that
+//! struggle to estimate absolute pixel coordinates from a bare screenshot
+//! (notably smaller/open models). Gridlines plus axis labels let the model
+//! read off a target's `(x, y)` instead of guessing. This is pure image
+//! processing — no element detection, no extra system dependencies.
+
+use std::io::Cursor;
+
+use image::{Rgba, RgbaImage};
+use rustykrab_core::Result;
+
+fn err(msg: impl Into<String>) -> rustykrab_core::Error {
+    rustykrab_core::Error::ToolExecution(msg.into().into())
+}
+
+/// 3x5 bitmap glyphs for digits 0-9. Each row uses the low 3 bits, MSB = left.
+const DIGITS: [[u8; 5]; 10] = [
+    [0b111, 0b101, 0b101, 0b101, 0b111], // 0
+    [0b010, 0b110, 0b010, 0b010, 0b111], // 1
+    [0b111, 0b001, 0b111, 0b100, 0b111], // 2
+    [0b111, 0b001, 0b111, 0b001, 0b111], // 3
+    [0b101, 0b101, 0b111, 0b001, 0b001], // 4
+    [0b111, 0b100, 0b111, 0b001, 0b111], // 5
+    [0b111, 0b100, 0b111, 0b101, 0b111], // 6
+    [0b111, 0b001, 0b001, 0b001, 0b001], // 7
+    [0b111, 0b101, 0b111, 0b101, 0b111], // 8
+    [0b111, 0b101, 0b111, 0b001, 0b111], // 9
+];
+
+const SCALE: u32 = 2; // glyph pixel scale
+const GLYPH_W: u32 = 3 * SCALE;
+const GLYPH_H: u32 = 5 * SCALE;
+const GLYPH_GAP: u32 = SCALE;
+
+const LINE: Rgba<u8> = Rgba([0, 255, 0, 255]); // grid line color (lime)
+const LABEL_BG: Rgba<u8> = Rgba([0, 0, 0, 255]); // label background
+const LABEL_FG: Rgba<u8> = Rgba([255, 255, 255, 255]); // label text
+
+/// Alpha-blend `over` at 50% onto `base` (ignoring `over`'s alpha).
+fn blend_half(base: Rgba<u8>, over: Rgba<u8>) -> Rgba<u8> {
+    Rgba([
+        ((base[0] as u16 + over[0] as u16) / 2) as u8,
+        ((base[1] as u16 + over[1] as u16) / 2) as u8,
+        ((base[2] as u16 + over[2] as u16) / 2) as u8,
+        255,
+    ])
+}
+
+fn fill_rect(img: &mut RgbaImage, x: u32, y: u32, w: u32, h: u32, color: Rgba<u8>) {
+    let (iw, ih) = img.dimensions();
+    for py in y..(y + h).min(ih) {
+        for px in x..(x + w).min(iw) {
+            img.put_pixel(px, py, color);
+        }
+    }
+}
+
+fn draw_digit(img: &mut RgbaImage, ox: u32, oy: u32, d: usize) {
+    let (iw, ih) = img.dimensions();
+    let glyph = DIGITS[d];
+    for (ry, row) in glyph.iter().enumerate() {
+        for cx in 0..3u32 {
+            if row & (1 << (2 - cx)) != 0 {
+                for dy in 0..SCALE {
+                    for dx in 0..SCALE {
+                        let px = ox + cx * SCALE + dx;
+                        let py = oy + ry as u32 * SCALE + dy;
+                        if px < iw && py < ih {
+                            img.put_pixel(px, py, LABEL_FG);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Draw `value` as a labeled box anchored near `(x, y)`, clamped to stay on
+/// screen so edge labels remain readable.
+fn draw_label(img: &mut RgbaImage, x: u32, y: u32, value: u32) {
+    let (iw, ih) = img.dimensions();
+    let s = value.to_string();
+    let text_w = s.len() as u32 * (GLYPH_W + GLYPH_GAP);
+    let box_w = text_w + 2;
+    let box_h = GLYPH_H + 2;
+
+    let bx = x.min(iw.saturating_sub(box_w));
+    let by = y.min(ih.saturating_sub(box_h));
+
+    fill_rect(img, bx, by, box_w, box_h, LABEL_BG);
+    let mut cx = bx + 1;
+    for ch in s.bytes() {
+        draw_digit(img, cx, by + 1, (ch - b'0') as usize);
+        cx += GLYPH_W + GLYPH_GAP;
+    }
+}
+
+/// Overlay a labeled coordinate grid onto a PNG and return the new PNG bytes.
+///
+/// Vertical lines (and top-edge labels) mark `x` columns; horizontal lines
+/// (and left-edge labels) mark `y` rows, every `spacing` pixels. The output
+/// has the same dimensions as the input. `spacing` is clamped to a sane floor.
+pub fn annotate_with_grid(png: &[u8], spacing: u32) -> Result<Vec<u8>> {
+    let mut img = image::load_from_memory(png)
+        .map_err(|e| err(format!("decoding screenshot PNG: {e}")))?
+        .to_rgba8();
+    let (w, h) = img.dimensions();
+    let spacing = spacing.max(25);
+
+    // Vertical lines + top labels.
+    let mut x = spacing;
+    while x < w {
+        for y in 0..h {
+            let p = *img.get_pixel(x, y);
+            img.put_pixel(x, y, blend_half(p, LINE));
+        }
+        draw_label(&mut img, x + 1, 1, x);
+        x += spacing;
+    }
+    // Horizontal lines + left labels.
+    let mut y = spacing;
+    while y < h {
+        for x in 0..w {
+            let p = *img.get_pixel(x, y);
+            img.put_pixel(x, y, blend_half(p, LINE));
+        }
+        draw_label(&mut img, 1, y + 1, y);
+        y += spacing;
+    }
+
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Png)
+        .map_err(|e| err(format!("encoding annotated PNG: {e}")))?;
+    Ok(buf.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_png(w: u32, h: u32) -> Vec<u8> {
+        let img = RgbaImage::from_pixel(w, h, Rgba([40, 40, 40, 255]));
+        let mut buf = Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    #[test]
+    fn grid_preserves_dimensions_and_is_valid_png() {
+        let src = sample_png(300, 200);
+        let out = annotate_with_grid(&src, 100).expect("annotate");
+        let decoded = image::load_from_memory(&out).expect("valid png").to_rgba8();
+        assert_eq!(decoded.dimensions(), (300, 200));
+        assert_ne!(out, src, "grid should modify the image");
+    }
+
+    #[test]
+    fn grid_draws_lines_at_spacing() {
+        let src = sample_png(300, 200);
+        let out = annotate_with_grid(&src, 100).unwrap();
+        let img = image::load_from_memory(&out).unwrap().to_rgba8();
+        // A pixel on the x=100 vertical line (below the label area) should be
+        // tinted toward the line color, not the original gray.
+        let p = img.get_pixel(100, 150);
+        assert!(
+            p[1] > p[0] && p[1] > p[2],
+            "expected green-tinted line pixel, got {p:?}"
+        );
+    }
+
+    #[test]
+    fn tiny_spacing_is_clamped_and_does_not_panic() {
+        let src = sample_png(80, 60);
+        let out = annotate_with_grid(&src, 1).expect("clamped");
+        assert_eq!(
+            image::load_from_memory(&out)
+                .unwrap()
+                .to_rgba8()
+                .dimensions(),
+            (80, 60)
+        );
+    }
+
+    #[test]
+    fn rejects_non_png_input() {
+        assert!(annotate_with_grid(b"not a png", 100).is_err());
+    }
+}

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -65,6 +65,7 @@ mod nodes;
 // Computer use (screen capture + input synthesis)
 mod computer;
 pub mod computer_backend;
+mod grid;
 
 // HTTP
 mod http_request;


### PR DESCRIPTION
## Summary

Phase 4 of the computer-use suite: a **labeled coordinate-grid overlay** for screenshots, to help vision models ground pixel coordinates.

Smaller/open vision models (e.g. the Ollama-served defaults this gateway targets) frequently misjudge absolute pixel coordinates from a bare screenshot, so computer-use clicks land in the wrong place. Overlaying a labeled grid lets the model *read off* a target's `(x, y)` rather than guess — the grounding technique Anthropic's own computer-use guidance recommends.

- **`grid.rs`** — `annotate_with_grid(png, spacing)`: decodes a PNG, draws green gridlines every `spacing` px with numeric axis labels rendered via a tiny **embedded 3×5 bitmap digit font** (no font crate dependency), re-encodes. Same dimensions in/out; `spacing` clamped to a sane floor.
- **`computer.rs`** — the `screenshot` action gains optional `grid` (bool) and `grid_spacing` (px) params. Overlay failures **fall back to the raw capture**, so a screenshot never fails just because annotation did.
- **`Cargo.toml`** — adds `image` (PNG feature only) to `rustykrab-tools`; already in the lockfile via the cli's `xcap` dependency, so no new crates.

## Scope note

This is the **dependency-light** grounding aid. *True* element-level Set-of-Marks (numbered boxes on detected widgets) needs an accessibility tree or a vision detection model — genuinely heavyweight and platform-specific — and is left as future work. A coordinate grid delivers most of the grounding benefit with none of that infrastructure.

## Testing

Fully verified in-sandbox (`rustykrab-tools` is `ort`-free, unlike the cli):

| Check | Result |
|---|---|
| `cargo test -p rustykrab-tools` | ✅ 121 (5 new grid, +1 new computer grid test) |
| `cargo clippy -p rustykrab-tools --all-targets` | ✅ clean |
| `cargo fmt --all -- --check` | ✅ clean |

Tests cover the grid module (dimension preservation, line drawing at spacing, spacing clamp, non-PNG rejection) and the tool's grid plumbing decoded against a real PNG from the mock backend.

## Usage

```json
{ "action": "screenshot", "grid": true, "grid_spacing": 100 }
```

## Follow-up (Phase 5)
Security hardening: capability gating, optional human confirmation for actions, screenshot size caps / region redaction.

https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL)_