### PR TITLE
Computer-use Phase 5: capability gate + read-only mode (security hardening)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,7 +4026,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "axum",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.2"
+version = "4.5.3"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -705,10 +705,15 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // --- Computer-use tool (opt-in, requires the `computer-use` feature) ---
-    // Driving the desktop is a powerful capability, so it is double-gated:
-    // the binary must be built with `--features computer-use` AND
-    // RUSTYKRAB_COMPUTER_USE must be truthy at runtime. Backend init failures
-    // (e.g. no display) are logged and never block startup.
+    // Driving the desktop is the most powerful capability the agent has, so
+    // it is gated at four layers: (1) the binary must be built with
+    // `--features computer-use`; (2) RUSTYKRAB_COMPUTER_USE must be truthy at
+    // runtime; (3) the session must hold `Capability::ComputerUse` (granted
+    // below via `with_computer_use_enabled`); and (4) RUSTYKRAB_COMPUTER_USE_READONLY
+    // can restrict it to observe-only (screenshot / cursor position). Backend
+    // init failures (e.g. no display) are logged and never block startup.
+    #[cfg_attr(not(feature = "computer-use"), allow(unused_mut))]
+    let mut computer_use_enabled = false;
     #[cfg(feature = "computer-use")]
     if std::env::var("RUSTYKRAB_COMPUTER_USE")
         .map(|v| v == "true" || v == "1")
@@ -716,10 +721,19 @@ async fn main() -> anyhow::Result<()> {
     {
         match computer_backend::EnigoXcapBackend::new() {
             Ok(backend) => {
+                let readonly = std::env::var("RUSTYKRAB_COMPUTER_USE_READONLY")
+                    .map(|v| v == "true" || v == "1")
+                    .unwrap_or(false);
                 let backend: Arc<dyn rustykrab_tools::ComputerBackend> = Arc::new(backend);
                 let (w, h) = backend.display_size();
-                tools.extend(rustykrab_tools::computer_tools(backend));
-                tracing::info!(width = w, height = h, "computer-use tool registered");
+                tools.extend(rustykrab_tools::computer_tools(backend, readonly));
+                computer_use_enabled = true;
+                tracing::info!(
+                    width = w,
+                    height = h,
+                    readonly,
+                    "computer-use tool registered"
+                );
             }
             Err(e) => {
                 tracing::warn!(error = %e, "computer-use enabled but backend init failed; skipping");
@@ -832,7 +846,8 @@ async fn main() -> anyhow::Result<()> {
         .with_orchestration_config(orchestration_config)
         .with_skill_registry(skill_registry)
         .with_memory(Arc::clone(&memory_system), agent_id)
-        .with_subagents_enabled(subagents_enabled);
+        .with_subagents_enabled(subagents_enabled)
+        .with_computer_use_enabled(computer_use_enabled);
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-core/src/capability.rs
+++ b/crates/rustykrab-core/src/capability.rs
@@ -27,6 +27,19 @@ pub fn is_subagent_tool(tool_name: &str) -> bool {
     SUBAGENT_TOOL_NAMES.contains(&tool_name)
 }
 
+/// Name of the computer-use tool which, in addition to a matching
+/// [`Capability::Tool`] grant, requires [`Capability::ComputerUse`] to use.
+/// Driving the desktop (mouse/keyboard/screen) is the most powerful
+/// capability the agent has, so it gets an extra gate beyond mere
+/// registration — granted only when the runtime explicitly opts in.
+pub const COMPUTER_USE_TOOL_NAME: &str = "computer";
+
+/// Returns whether `tool_name` is the computer-use tool, which requires
+/// [`Capability::ComputerUse`].
+pub fn is_computer_use_tool(tool_name: &str) -> bool {
+    tool_name == COMPUTER_USE_TOOL_NAME
+}
+
 /// A capability that can be granted to a conversation session.
 ///
 /// Capabilities follow the principle of least privilege — each
@@ -60,6 +73,10 @@ pub enum Capability {
     /// to [`Capability::Tool`] for those tools so spawning nested agent
     /// loops is opt-in even when the tools are registered.
     Subagent,
+    /// Can use the computer-use tool (screen capture + mouse/keyboard
+    /// synthesis). Required in addition to [`Capability::Tool("computer")`]
+    /// so driving the desktop stays opt-in even when the tool is registered.
+    ComputerUse,
     /// Administrative — can manage other sessions.
     Admin,
 }
@@ -118,6 +135,12 @@ impl CapabilitySet {
         // Two-layer gate for the sub-agent family: even if `Tool(name)`
         // is granted, the session also needs `Subagent`.
         if is_subagent_tool(base) && !self.capabilities.contains(&Capability::Subagent) {
+            return false;
+        }
+
+        // Two-layer gate for computer-use: even if `Tool("computer")` is
+        // granted, the session also needs `ComputerUse`.
+        if is_computer_use_tool(base) && !self.capabilities.contains(&Capability::ComputerUse) {
             return false;
         }
 
@@ -267,5 +290,37 @@ mod tests {
     fn for_tools_permissive_does_not_grant_subagent() {
         let caps = CapabilitySet::for_tools_permissive(&["subagents"]);
         assert!(!caps.has(&Capability::Subagent));
+    }
+
+    #[test]
+    fn computer_tool_blocked_without_computer_use_capability() {
+        // Even with `Tool("computer")` granted, the session still needs
+        // `ComputerUse` to actually drive the desktop.
+        let caps = CapabilitySet::for_tools_permissive(&["computer", "read"]);
+        assert!(!caps.can_use_tool("computer"));
+        assert!(caps.can_use_tool("read"));
+    }
+
+    #[test]
+    fn computer_tool_allowed_when_computer_use_granted() {
+        let mut caps = CapabilitySet::for_tools_permissive(&["computer"]);
+        caps.grant(Capability::ComputerUse);
+        assert!(caps.can_use_tool("computer"));
+        // Colon-suffixed variants some models emit still resolve.
+        assert!(caps.can_use_tool("computer:left_click"));
+    }
+
+    #[test]
+    fn computer_use_capability_alone_does_not_grant_the_tool() {
+        let mut caps = CapabilitySet::none();
+        caps.grant(Capability::ComputerUse);
+        // No `Tool("computer")` grant, so still denied.
+        assert!(!caps.can_use_tool("computer"));
+    }
+
+    #[test]
+    fn for_tools_permissive_does_not_grant_computer_use() {
+        let caps = CapabilitySet::for_tools_permissive(&["computer"]);
+        assert!(!caps.has(&Capability::ComputerUse));
     }
 }

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -246,6 +246,9 @@ fn build_session_capabilities(state: &AppState, tool_names: &[&str]) -> Capabili
     if state.subagents_enabled {
         caps.grant(Capability::Subagent);
     }
+    if state.computer_use_enabled {
+        caps.grant(Capability::ComputerUse);
+    }
     caps
 }
 

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -63,6 +63,11 @@ pub struct AppState {
     /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var at startup; threaded through
     /// here so `prepare_agent` knows whether to grant `Capability::Subagent`.
     pub subagents_enabled: bool,
+    /// Whether the computer-use tool should be granted to sessions created by
+    /// this gateway. Default `false`. Driven by `RUSTYKRAB_COMPUTER_USE` at
+    /// startup; threaded through so `prepare_agent` knows whether to grant
+    /// `Capability::ComputerUse`.
+    pub computer_use_enabled: bool,
 }
 
 impl AppState {
@@ -100,6 +105,7 @@ impl AppState {
             recall,
             todos: Arc::new(TodoStore::new()),
             subagents_enabled: false,
+            computer_use_enabled: false,
         }
     }
 
@@ -108,6 +114,15 @@ impl AppState {
     /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var in the CLI; off by default.
     pub fn with_subagents_enabled(mut self, enabled: bool) -> Self {
         self.subagents_enabled = enabled;
+        self
+    }
+
+    /// Grant the computer-use tool to every session created by this gateway.
+    /// Driven by `RUSTYKRAB_COMPUTER_USE` in the CLI; off by default. Only
+    /// meaningful when the tool is actually registered (built with the
+    /// `computer-use` feature).
+    pub fn with_computer_use_enabled(mut self, enabled: bool) -> Self {
+        self.computer_use_enabled = enabled;
         self
     }
 

--- a/crates/rustykrab-tools/src/computer.rs
+++ b/crates/rustykrab-tools/src/computer.rs
@@ -17,14 +17,22 @@ use std::sync::Arc;
 
 use crate::computer_backend::{ComputerBackend, MouseButton, ScrollDirection};
 
+/// Actions that only observe the screen and never synthesize input. These
+/// remain available in read-only mode.
+const READONLY_ACTIONS: &[&str] = &["screenshot", "cursor_position"];
+
 /// Tool exposing screen capture and input synthesis to the agent.
 pub struct ComputerTool {
     backend: Arc<dyn ComputerBackend>,
+    /// When true, only the observe-only actions in [`READONLY_ACTIONS`] are
+    /// permitted; mouse/keyboard synthesis is refused. A safety control for
+    /// running computer-use in a watch-only posture.
+    readonly: bool,
 }
 
 impl ComputerTool {
-    pub fn new(backend: Arc<dyn ComputerBackend>) -> Self {
-        Self { backend }
+    pub fn new(backend: Arc<dyn ComputerBackend>, readonly: bool) -> Self {
+        Self { backend, readonly }
     }
 
     /// Construct a `ToolExecution` error with a message.
@@ -148,6 +156,14 @@ impl Tool for ComputerTool {
         let action = args["action"]
             .as_str()
             .ok_or_else(|| Self::err("missing action"))?;
+
+        // Read-only posture: refuse any input-synthesizing action.
+        if self.readonly && !READONLY_ACTIONS.contains(&action) {
+            return Err(Self::err(format!(
+                "action '{action}' is disabled: computer-use is in read-only mode \
+                 (only {READONLY_ACTIONS:?} are allowed)"
+            )));
+        }
 
         match action {
             "screenshot" => {
@@ -335,7 +351,12 @@ mod tests {
 
     fn tool() -> (ComputerTool, Arc<MockBackend>) {
         let backend = Arc::new(MockBackend::default());
-        (ComputerTool::new(backend.clone()), backend)
+        (ComputerTool::new(backend.clone(), false), backend)
+    }
+
+    fn readonly_tool() -> (ComputerTool, Arc<MockBackend>) {
+        let backend = Arc::new(MockBackend::default());
+        (ComputerTool::new(backend.clone(), true), backend)
     }
 
     fn calls(b: &MockBackend) -> Vec<String> {
@@ -455,6 +476,37 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("unknown action"));
+    }
+
+    #[tokio::test]
+    async fn readonly_allows_observe_actions() {
+        let (t, b) = readonly_tool();
+        t.execute(json!({ "action": "screenshot" })).await.unwrap();
+        t.execute(json!({ "action": "cursor_position" }))
+            .await
+            .unwrap();
+        assert_eq!(calls(&b), vec!["screenshot", "cursor_position"]);
+    }
+
+    #[tokio::test]
+    async fn readonly_refuses_input_actions_without_touching_backend() {
+        let (t, b) = readonly_tool();
+        for action in ["left_click", "type", "key", "mouse_move", "scroll"] {
+            let err = t
+                .execute(json!({ "action": action, "text": "x", "coordinate": [1, 1], "scroll_direction": "up" }))
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("read-only"),
+                "action {action}: {err}"
+            );
+        }
+        // No input action ever reached the backend.
+        assert!(
+            calls(&b).is_empty(),
+            "backend should not be invoked: {:?}",
+            calls(&b)
+        );
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -383,6 +383,7 @@ pub fn video_tools(
 /// enabled), mirroring how `video_tools` is gated.
 pub fn computer_tools(
     backend: std::sync::Arc<dyn ComputerBackend>,
+    readonly: bool,
 ) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
-    vec![std::sync::Arc::new(ComputerTool::new(backend))]
+    vec![std::sync::Arc::new(ComputerTool::new(backend, readonly))]
 }


### PR DESCRIPTION
## Summary

Phase 5 (final) of the computer-use suite: **security hardening**. Driving the desktop is the most powerful capability the agent has, so it now sits behind explicit, least-privilege gates instead of being usable just because it was registered.

### Capability gate (mirrors the existing `Subagent` two-layer pattern)
- **core** — adds `Capability::ComputerUse` and `is_computer_use_tool`. In `CapabilitySet::can_use_tool`, the `computer` tool now requires `ComputerUse` **in addition to** `Tool("computer")`, so it's denied unless the runtime explicitly grants it.
- **gateway** — `AppState.computer_use_enabled` (+ `with_computer_use_enabled`) grants `Capability::ComputerUse` in `build_session_capabilities` only when enabled — exactly how `subagents_enabled` grants `Subagent`.
- **cli** — sets the flag only when the tool is actually registered.

### Read-only mode
- **tools** — `ComputerTool` gains a `readonly` flag (threaded through `computer_tools`). In read-only mode only `screenshot` and `cursor_position` are permitted; every input-synthesizing action is refused **before the backend is touched**.
- **cli** — driven by `RUSTYKRAB_COMPUTER_USE_READONLY`.

### Net result: four independent gates
1. Build with `--features computer-use`
2. `RUSTYKRAB_COMPUTER_USE` truthy at runtime
3. Session holds `Capability::ComputerUse`
4. Optional `RUSTYKRAB_COMPUTER_USE_READONLY` observe-only restriction

## Deliberately deferred (with rationale)
- **Human-in-the-loop confirmation** and **screenshot region redaction** both need infrastructure not yet present (an interactive confirm channel / a redaction config source).
- **Screenshot downscaling** was *intentionally* skipped: shrinking the image desyncs the model's reported coordinates from real display pixels, breaking clicks. The Phase 4 coordinate grid is the right grounding lever instead.

## Testing

Fully verified for the `ort`-free crates (core + tools):

| Check | Result |
|---|---|
| `cargo test -p rustykrab-core` | ✅ 58 (4 new capability tests) |
| `cargo test -p rustykrab-tools` | ✅ 123 (2 new read-only tests) |
| `cargo clippy -p rustykrab-core -p rustykrab-tools --all-targets` | ✅ clean |
| `cargo fmt --all -- --check` | ✅ clean |

> Note: the **gateway** + **cli** changes (the `ComputerUse` grant plumbing) couldn't be compiled in the dev sandbox because the cli pulls `ort-sys` (ONNX Runtime via `fastembed`) whose CDN download intermittently 403s there — unrelated to this change. Those edits are mechanical mirrors of the proven `subagents_enabled` → `Capability::Subagent` plumbing (same field/builder/grant shape), and `AppState` is only ever built via its `new()` builder (no struct literals to break). CI builds the cli fine.

This completes the planned computer-use suite (Phases 0–5).

https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2D8BPK2e17ThGxNPMZygL)_