### PR TITLE
chore: sync Cargo.lock workspace versions to 4.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,7 +4026,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "axum",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.3"
+version = "4.5.5"
 dependencies = [
  "async-imap",
  "async-trait",


### PR DESCRIPTION
The lockfile carried stale internal crate version stamps (4.5.3) that
no longer matched version.workspace (4.5.5); cargo refreshed them on the
next build. No dependency changes.

https://claude.ai/code/session_017NMeZ9hzzqdDfakP4t5yda