### PR TITLE
perf(providers): linear stream buffering, fix UTF-8 chunk-boundary corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,6 +4209,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "rand 0.9.4",
  "reqwest 0.13.3",
  "rustykrab-core",
  "secrecy",

--- a/crates/rustykrab-providers/Cargo.toml
+++ b/crates/rustykrab-providers/Cargo.toml
@@ -17,3 +17,4 @@ tokio.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 secrecy.workspace = true
+rand.workspace = true

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -1,3 +1,5 @@
+use crate::backoff::retry_delay;
+use crate::line_buffer::LineBuffer;
 use async_trait::async_trait;
 use chrono::Utc;
 use rustykrab_core::error::Result;
@@ -374,7 +376,7 @@ impl AnthropicProvider {
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
-                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
                 tracing::warn!(attempt, "retrying Anthropic API after {delay:?}");
                 tokio::time::sleep(delay).await;
             }
@@ -576,7 +578,7 @@ impl AnthropicProvider {
         let mut resp = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
-                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
                 tracing::warn!(attempt, "retrying Anthropic streaming API after {delay:?}");
                 tokio::time::sleep(delay).await;
             }
@@ -616,8 +618,10 @@ impl AnthropicProvider {
             last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into()))
         })?;
 
-        // Parse SSE events from the response body.
-        let mut buffer = String::new();
+        // Parse SSE events from the response body. Raw bytes are buffered
+        // and split on `\n` before UTF-8 decoding, so multi-byte codepoints
+        // that span network chunks are reassembled instead of corrupted.
+        let mut buffer = LineBuffer::new();
         let mut current_event_type = String::new();
         let mut full_text = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -662,11 +666,10 @@ impl AnthropicProvider {
             };
             chunks_received += 1;
             bytes_received += chunk.len() as u64;
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.push_chunk(&chunk);
 
-            while let Some(newline_pos) = buffer.find('\n') {
-                let line = buffer[..newline_pos].trim_end().to_string();
-                buffer = buffer[newline_pos + 1..].to_string();
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim_end();
 
                 if let Some(event_type) = line.strip_prefix("event: ") {
                     current_event_type = event_type.to_string();
@@ -1033,6 +1036,66 @@ mod tests {
     fn tool_choice_any_emits_any_type() {
         let v = AnthropicProvider::tool_choice_json(ToolChoice::Any).expect("Any → Some");
         assert_eq!(v, serde_json::json!({ "type": "any" }));
+    }
+
+    #[test]
+    fn sse_text_delta_survives_chunk_split_inside_multibyte_char() {
+        // A text_delta whose JSON contains multi-byte characters, delivered
+        // in two network chunks with the boundary inside a codepoint. The
+        // byte-level line buffer must reassemble it without U+FFFD.
+        let payload = "event: content_block_delta\n\
+                       data: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"日本語\"}}\n";
+        let bytes = payload.as_bytes();
+        // Split one byte into the first multi-byte character.
+        let split = payload.find('日').unwrap() + 1;
+
+        let mut buffer = LineBuffer::new();
+        let mut current_event_type = String::new();
+        let mut text = String::new();
+        for chunk in [&bytes[..split], &bytes[split..]] {
+            buffer.push_chunk(chunk);
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim_end();
+                if let Some(event_type) = line.strip_prefix("event: ") {
+                    current_event_type = event_type.to_string();
+                } else if let Some(data) = line.strip_prefix("data: ") {
+                    assert_eq!(current_event_type, "content_block_delta");
+                    let evt: SseContentBlockDelta = serde_json::from_str(data).expect("parse");
+                    if let SseDelta::TextDelta { text: t } = evt.delta {
+                        text.push_str(&t);
+                    }
+                }
+            }
+        }
+        assert_eq!(text, "日本語");
+    }
+
+    #[test]
+    fn sse_multiple_lines_in_one_chunk_parse_in_order() {
+        let payload = "event: content_block_delta\n\
+                       data: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"a\"}}\n\
+                       \n\
+                       event: content_block_delta\n\
+                       data: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"b\"}}\n";
+        let mut buffer = LineBuffer::new();
+        buffer.push_chunk(payload.as_bytes());
+
+        let mut current_event_type = String::new();
+        let mut text = String::new();
+        while let Some(line) = buffer.next_line() {
+            let line = line.trim_end();
+            if let Some(event_type) = line.strip_prefix("event: ") {
+                current_event_type = event_type.to_string();
+            } else if let Some(data) = line.strip_prefix("data: ") {
+                assert_eq!(current_event_type, "content_block_delta");
+                let evt: SseContentBlockDelta = serde_json::from_str(data).expect("parse");
+                if let SseDelta::TextDelta { text: t } = evt.delta {
+                    text.push_str(&t);
+                }
+            }
+        }
+        assert_eq!(text, "ab");
+        assert_eq!(buffer.len(), 0);
     }
 
     #[test]

--- a/crates/rustykrab-providers/src/backoff.rs
+++ b/crates/rustykrab-providers/src/backoff.rs
@@ -1,0 +1,35 @@
+use rand::Rng;
+use std::time::Duration;
+
+/// Exponential backoff delay for retry `attempt` (1-based), with ±25%
+/// jitter so concurrent clients retrying a struggling server don't all
+/// hit it again at the same instant (thundering herd).
+pub(crate) fn retry_delay(base: Duration, attempt: u32) -> Duration {
+    let exp = base.saturating_mul(2u32.saturating_pow(attempt.saturating_sub(1)));
+    let jitter = rand::rng().random_range(0.75..=1.25);
+    exp.mul_f64(jitter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_delay_is_exponential_with_bounded_jitter() {
+        let base = Duration::from_secs(1);
+        for attempt in 1..=4 {
+            let expected = base * 2u32.pow(attempt - 1);
+            for _ in 0..100 {
+                let d = retry_delay(base, attempt);
+                assert!(
+                    d >= expected.mul_f64(0.75),
+                    "attempt {attempt}: {d:?} below jitter floor"
+                );
+                assert!(
+                    d <= expected.mul_f64(1.25),
+                    "attempt {attempt}: {d:?} above jitter ceiling"
+                );
+            }
+        }
+    }
+}

--- a/crates/rustykrab-providers/src/lib.rs
+++ b/crates/rustykrab-providers/src/lib.rs
@@ -1,4 +1,6 @@
 mod anthropic;
+mod backoff;
+mod line_buffer;
 mod ollama;
 
 pub use anthropic::AnthropicProvider;

--- a/crates/rustykrab-providers/src/line_buffer.rs
+++ b/crates/rustykrab-providers/src/line_buffer.rs
@@ -1,0 +1,130 @@
+use std::borrow::Cow;
+
+/// Incremental byte-level line splitter for streaming HTTP bodies.
+///
+/// Network chunks are appended as raw bytes and complete `\n`-terminated
+/// lines are handed back one at a time. Decoding to UTF-8 happens per
+/// complete line, so a multi-byte codepoint split across two chunks is
+/// reassembled correctly instead of being mangled into U+FFFD (the failure
+/// mode of decoding each chunk independently with `from_utf8_lossy`).
+///
+/// Draining is linear: consumed bytes are tracked with a start offset and
+/// compacted once per appended chunk, rather than reallocating the entire
+/// remaining buffer for every line (which made parsing O(L²) in the
+/// response length).
+pub(crate) struct LineBuffer {
+    buf: Vec<u8>,
+    /// Byte offset of the first unconsumed byte in `buf`.
+    start: usize,
+}
+
+impl LineBuffer {
+    pub(crate) fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            start: 0,
+        }
+    }
+
+    /// Number of unconsumed bytes currently buffered.
+    pub(crate) fn len(&self) -> usize {
+        self.buf.len() - self.start
+    }
+
+    /// Append a chunk of raw bytes from the network.
+    pub(crate) fn push_chunk(&mut self, chunk: &[u8]) {
+        // Compact once per chunk so consumed bytes don't accumulate.
+        if self.start > 0 {
+            self.buf.drain(..self.start);
+            self.start = 0;
+        }
+        self.buf.extend_from_slice(chunk);
+    }
+
+    /// Pop the next complete line (excluding the trailing `\n`), if any.
+    ///
+    /// Trailing partial bytes (no newline yet) stay buffered for the next
+    /// chunk. A line containing invalid UTF-8 is decoded lossily — that can
+    /// only happen when the server sent genuinely invalid bytes, never from
+    /// a codepoint spanning a chunk boundary.
+    pub(crate) fn next_line(&mut self) -> Option<Cow<'_, str>> {
+        let rest = &self.buf[self.start..];
+        let pos = rest.iter().position(|&b| b == b'\n')?;
+        let line_start = self.start;
+        self.start += pos + 1;
+        Some(String::from_utf8_lossy(
+            &self.buf[line_start..line_start + pos],
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drain all currently complete lines into owned strings.
+    fn lines(buf: &mut LineBuffer) -> Vec<String> {
+        let mut out = Vec::new();
+        while let Some(l) = buf.next_line() {
+            out.push(l.into_owned());
+        }
+        out
+    }
+
+    #[test]
+    fn multibyte_codepoint_split_across_chunks_is_not_corrupted() {
+        // "é" is 0xC3 0xA9; the chunk boundary falls between the two bytes.
+        let mut buf = LineBuffer::new();
+        buf.push_chunk(b"caf\xC3");
+        assert!(buf.next_line().is_none(), "no complete line yet");
+        buf.push_chunk(b"\xA9\n");
+        assert_eq!(lines(&mut buf), vec!["café"]);
+    }
+
+    #[test]
+    fn four_byte_emoji_split_across_three_chunks() {
+        let emoji = "🦀".as_bytes(); // 4 bytes
+        let mut buf = LineBuffer::new();
+        buf.push_chunk(&emoji[..1]);
+        buf.push_chunk(&emoji[1..3]);
+        assert!(buf.next_line().is_none());
+        buf.push_chunk(&emoji[3..]);
+        buf.push_chunk(b"\n");
+        assert_eq!(lines(&mut buf), vec!["🦀"]);
+    }
+
+    #[test]
+    fn multiple_lines_in_one_chunk() {
+        let mut buf = LineBuffer::new();
+        buf.push_chunk(b"event: ping\ndata: {}\n\npartial");
+        assert_eq!(lines(&mut buf), vec!["event: ping", "data: {}", ""]);
+        // The trailing partial line stays buffered for the next chunk.
+        assert_eq!(buf.len(), "partial".len());
+        buf.push_chunk(b" line\n");
+        assert_eq!(lines(&mut buf), vec!["partial line"]);
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn crlf_line_endings_leave_cr_for_caller_to_trim() {
+        let mut buf = LineBuffer::new();
+        buf.push_chunk(b"hello\r\n");
+        assert_eq!(lines(&mut buf), vec!["hello\r"]);
+    }
+
+    #[test]
+    fn invalid_utf8_within_a_line_is_decoded_lossily() {
+        let mut buf = LineBuffer::new();
+        buf.push_chunk(b"ok\n\xFF\xFE\nafter\n");
+        assert_eq!(lines(&mut buf), vec!["ok", "\u{FFFD}\u{FFFD}", "after"]);
+    }
+
+    #[test]
+    fn empty_buffer_yields_no_lines() {
+        let mut buf = LineBuffer::new();
+        assert!(buf.next_line().is_none());
+        buf.push_chunk(b"");
+        assert!(buf.next_line().is_none());
+        assert_eq!(buf.len(), 0);
+    }
+}

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -1,3 +1,5 @@
+use crate::backoff::retry_delay;
+use crate::line_buffer::LineBuffer;
 use async_trait::async_trait;
 use chrono::Utc;
 use rustykrab_core::error::Result;
@@ -10,7 +12,7 @@ use uuid::Uuid;
 
 /// Maximum number of retries for transient errors (429, 5xx).
 const MAX_RETRIES: u32 = 3;
-/// Base delay for exponential backoff (doubles each retry).
+/// Base delay for exponential backoff (doubles each retry, with jitter).
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
 /// Configuration for Ollama model inference.
@@ -526,21 +528,25 @@ impl OllamaProvider {
         let system_count = messages.iter().take_while(|m| m.role == "system").count();
         let mut trimmed = messages;
         let mut current = total;
-        let mut dropped = 0usize;
 
-        while current > budget && trimmed.len() > system_count {
-            let removed = trimmed.remove(system_count);
-            current = current.saturating_sub(estimate_message_tokens(&removed));
-            dropped += 1;
+        // Walk forward from the first non-system message counting how many
+        // to drop, then remove them with a single `drain` — per-message
+        // `Vec::remove` would shift the entire tail once per drop (O(n·k)).
+        let mut drop_end = system_count;
+        while current > budget && drop_end < trimmed.len() {
+            current = current.saturating_sub(estimate_message_tokens(&trimmed[drop_end]));
+            drop_end += 1;
         }
 
         // If trimming left a leading orphan tool-result (no preceding
         // assistant tool_call), drop it so Ollama doesn't reject the request.
-        while trimmed.len() > system_count && trimmed[system_count].role == "tool" {
-            let removed = trimmed.remove(system_count);
-            current = current.saturating_sub(estimate_message_tokens(&removed));
-            dropped += 1;
+        while drop_end < trimmed.len() && trimmed[drop_end].role == "tool" {
+            current = current.saturating_sub(estimate_message_tokens(&trimmed[drop_end]));
+            drop_end += 1;
         }
+
+        let dropped = drop_end - system_count;
+        trimmed.drain(system_count..drop_end);
 
         tracing::warn!(
             num_ctx = total_ctx,
@@ -643,7 +649,7 @@ impl ModelProvider for OllamaProvider {
         let mut last_err = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
-                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
                 tracing::warn!(attempt, "retrying Ollama API after {delay:?}");
                 tokio::time::sleep(delay).await;
             }
@@ -802,7 +808,7 @@ impl ModelProvider for OllamaProvider {
         let mut resp = None;
         for attempt in 0..=MAX_RETRIES {
             if attempt > 0 {
-                let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
                 tracing::warn!(attempt, "retrying Ollama streaming API after {delay:?}");
                 tokio::time::sleep(delay).await;
             }
@@ -856,8 +862,10 @@ impl ModelProvider for OllamaProvider {
             last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into()))
         })?;
 
-        // Parse newline-delimited JSON chunks.
-        let mut buffer = String::new();
+        // Parse newline-delimited JSON chunks. Raw bytes are buffered and
+        // split on `\n` before UTF-8 decoding, so multi-byte codepoints
+        // that span network chunks are reassembled instead of corrupted.
+        let mut buffer = LineBuffer::new();
         let mut full_text = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut prompt_eval_count: u32 = 0;
@@ -891,17 +899,16 @@ impl ModelProvider for OllamaProvider {
             };
             chunks_received += 1;
             bytes_received += chunk.len() as u64;
-            buffer.push_str(&String::from_utf8_lossy(&chunk));
+            buffer.push_chunk(&chunk);
 
-            while let Some(newline_pos) = buffer.find('\n') {
-                let line = buffer[..newline_pos].trim().to_string();
-                buffer = buffer[newline_pos + 1..].to_string();
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim();
 
                 if line.is_empty() {
                     continue;
                 }
 
-                let stream_chunk: OllamaStreamChunk = serde_json::from_str(&line).map_err(|e| {
+                let stream_chunk: OllamaStreamChunk = serde_json::from_str(line).map_err(|e| {
                     Error::ModelProvider(format!("failed to parse Ollama stream chunk: {e}"))
                 })?;
 
@@ -1093,11 +1100,35 @@ fn estimate_message_tokens(msg: &OllamaMessage) -> u32 {
         for tc in tcs {
             tokens = tokens.saturating_add(8);
             tokens = tokens.saturating_add(estimate_text_tokens(&tc.function.name));
-            tokens =
-                tokens.saturating_add(estimate_text_tokens(&tc.function.arguments.to_string()));
+            tokens = tokens.saturating_add(estimate_json_tokens(&tc.function.arguments));
         }
     }
     tokens
+}
+
+/// `io::Write` sink that counts bytes without storing them, so a JSON
+/// value's serialized size can be measured without allocating the string.
+struct CountingWriter(usize);
+
+impl std::io::Write for CountingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Estimate tokens for a JSON value from its serialized byte length.
+/// Bytes ≥ chars, so multibyte content is over-counted slightly — this
+/// errs on the high side, consistent with the trimming policy above.
+fn estimate_json_tokens(v: &serde_json::Value) -> u32 {
+    let mut w = CountingWriter(0);
+    // Serializing a `Value` into an infallible sink cannot fail.
+    let _ = serde_json::to_writer(&mut w, v);
+    w.0.div_ceil(CHARS_PER_TOKEN) as u32
 }
 
 fn estimate_text_tokens(s: &str) -> u32 {
@@ -1451,5 +1482,75 @@ mod tests {
         // 4 multibyte chars should count as ceil(4/4) = 1 token, not 12 (their byte length).
         let tokens = estimate_text_tokens("日本語x");
         assert_eq!(tokens, 1);
+    }
+
+    #[test]
+    fn estimate_json_tokens_matches_serialized_length_without_allocating() {
+        let v = serde_json::json!({ "path": "/tmp/file.txt", "recursive": true });
+        let serialized_len = v.to_string().len();
+        assert_eq!(
+            estimate_json_tokens(&v),
+            serialized_len.div_ceil(CHARS_PER_TOKEN) as u32
+        );
+    }
+
+    #[test]
+    fn ndjson_stream_survives_chunk_split_inside_multibyte_char() {
+        // Two NDJSON chunks whose content contains multi-byte characters,
+        // delivered with a network-chunk boundary inside a codepoint. The
+        // byte-level line buffer must reassemble it without U+FFFD.
+        let payload = "{\"message\":{\"content\":\"héllo\"},\"done\":false}\n\
+                       {\"message\":{\"content\":\" wörld\"},\"done\":true,\"done_reason\":\"stop\"}\n";
+        let bytes = payload.as_bytes();
+        // Split one byte into the "é" (0xC3 0xA9).
+        let split = payload.find('é').unwrap() + 1;
+
+        let mut buffer = LineBuffer::new();
+        let mut full_text = String::new();
+        let mut done_reason: Option<String> = None;
+        for chunk in [&bytes[..split], &bytes[split..]] {
+            buffer.push_chunk(chunk);
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let stream_chunk: OllamaStreamChunk = serde_json::from_str(line).expect("parse");
+                if let Some(content) = stream_chunk.message.content {
+                    full_text.push_str(&content);
+                }
+                if stream_chunk.done {
+                    done_reason = stream_chunk.done_reason;
+                }
+            }
+        }
+        assert_eq!(full_text, "héllo wörld");
+        assert_eq!(done_reason.as_deref(), Some("stop"));
+    }
+
+    #[test]
+    fn ndjson_multiple_lines_in_one_chunk_parse_in_order() {
+        let payload = "{\"message\":{\"content\":\"a\"},\"done\":false}\n\
+                       {\"message\":{\"content\":\"b\"},\"done\":false}\n\
+                       {\"message\":{\"content\":\"c\"},\"done\":true}\n";
+        let mut buffer = LineBuffer::new();
+        buffer.push_chunk(payload.as_bytes());
+
+        let mut full_text = String::new();
+        let mut saw_done = false;
+        while let Some(line) = buffer.next_line() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let stream_chunk: OllamaStreamChunk = serde_json::from_str(line).expect("parse");
+            if let Some(content) = stream_chunk.message.content {
+                full_text.push_str(&content);
+            }
+            saw_done |= stream_chunk.done;
+        }
+        assert_eq!(full_text, "abc");
+        assert!(saw_done);
+        assert_eq!(buffer.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes two problems in the Anthropic (SSE) and Ollama (NDJSON) streaming parsers, plus two smaller issues in `rustykrab-providers`. No behavior changes to event semantics — SSE `event:`/`data:` handling, NDJSON parsing, and the existing `trim_end`/`trim` behavior are preserved exactly.

### 1. Quadratic buffer draining → linear

Both stream loops drained their line buffer like this, for every line of every streamed response:

```rust
// before
buffer.push_str(&String::from_utf8_lossy(&chunk));
while let Some(newline_pos) = buffer.find('\n') {
    let line = buffer[..newline_pos].trim_end().to_string();
    buffer = buffer[newline_pos + 1..].to_string(); // reallocates the entire remaining buffer per line
    ...
}
```

Each consumed line reallocated and copied the whole remaining buffer — O(L²) copying in the response length, running on the hot path for every token.

Both parsers now share a byte-level `LineBuffer` (`crates/rustykrab-providers/src/line_buffer.rs`):

```rust
// after
buffer.push_chunk(&chunk);
while let Some(line) = buffer.next_line() {
    let line = line.trim_end();
    ...
}
```

Consumed bytes are tracked with a start offset and compacted once per network chunk, so draining is linear overall with no per-line reallocation.

### 2. UTF-8 corruption at chunk boundaries

`buffer.push_str(&String::from_utf8_lossy(&chunk))` decoded each network chunk independently. A multi-byte codepoint split across a TCP chunk boundary (e.g. `é` = `0xC3 0xA9` arriving as `…0xC3 | 0xA9…`) decoded to U+FFFD replacement characters — real corruption for any non-ASCII model output.

`LineBuffer` accumulates raw bytes, splits on `\n` at the byte level, and only converts *complete lines* to UTF-8, so split codepoints are reassembled correctly. A line that genuinely contains invalid bytes (server bug) is still decoded lossily per line.

### 3. `trim_to_budget` O(n·k) removal + allocation-free size estimate

- The trimming loop called `Vec::remove(system_count)` once per dropped message, shifting the entire tail each time. It now counts how many messages to drop (including the orphan-tool-result sweep) and removes them with a single `drain(system_count..drop_end)`.
- `estimate_message_tokens` called `arguments.to_string()` just to measure serialized size. It now serializes into a counting `io::Write` sink (`serde_json::to_writer`), measuring the size without allocating the string.

### 4. Retry backoff jitter

The comment in `anthropic.rs` claimed "doubles each retry, with jitter" but the code was pure `RETRY_BASE_DELAY * 2^attempt` — a thundering-herd risk when many clients retry a struggling server in lockstep. Both providers now use a shared `retry_delay()` helper applying ±25% jitter (`rand` was already a workspace dependency). The code now matches its comment.

## Tests

New unit tests cover:
- multi-byte codepoint split across two chunks (2-byte `é`) and a 4-byte emoji split across three chunks — asserting no U+FFFD corruption
- multiple lines per chunk, trailing-partial-line carry-over, CRLF handling, lossy decoding of genuinely invalid bytes
- end-to-end SSE (`event:`/`data:` + `SseContentBlockDelta`) and NDJSON (`OllamaStreamChunk`) parsing across a mid-codepoint chunk split
- the counting-writer token estimator matches the previous `to_string().len()`-based result
- jitter stays within the ±25% envelope of the exponential delay

Results: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets` no warnings, `cargo test --workspace` all green (436 passed, 0 failed; providers crate: 31 passed). Note: building `rustykrab-cli` locally required supplying a local onnxruntime lib because the sandbox proxy blocks `cdn.pyke.io` (pre-existing `ort-sys` download, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2)_