### PR TITLE
perf(store): run SQLite work on blocking threads, tune pragmas

### DIFF
--- a/crates/rustykrab-cli/src/chat.rs
+++ b/crates/rustykrab-cli/src/chat.rs
@@ -32,7 +32,7 @@ pub async fn run(data_dir: &Path, _args: &[String]) -> anyhow::Result<()> {
     let gateway_url =
         std::env::var("RUSTYKRAB_GATEWAY_URL").unwrap_or_else(|_| DEFAULT_GATEWAY_URL.to_string());
 
-    let token = resolve_auth_token(data_dir)?;
+    let token = resolve_auth_token(data_dir).await?;
 
     let mut auth_headers = HeaderMap::new();
     auth_headers.insert(
@@ -352,7 +352,7 @@ async fn delete_secret(client: &reqwest::Client, base: &str, name: &str) -> anyh
 // If the store is locked (daemon holds it), we fall back to env/keychain
 // only; the user can also set RUSTYKRAB_AUTH_TOKEN explicitly.
 
-fn resolve_auth_token(data_dir: &Path) -> anyhow::Result<String> {
+async fn resolve_auth_token(data_dir: &Path) -> anyhow::Result<String> {
     if let Ok(v) = std::env::var("RUSTYKRAB_AUTH_TOKEN") {
         let v = v.trim();
         if !v.is_empty() {
@@ -379,7 +379,7 @@ fn resolve_auth_token(data_dir: &Path) -> anyhow::Result<String> {
     if db_path.exists() {
         if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
             if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
-                if let Ok(v) = store.secrets().get(spec.store_name) {
+                if let Ok(v) = store.secrets().get(spec.store_name).await {
                     return Ok(v);
                 }
             }

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -114,24 +114,30 @@ impl CronBackend for CronAdapter {
         chat_id: Option<&str>,
         thread_id: Option<&str>,
     ) -> rustykrab_core::Result<serde_json::Value> {
-        let inherited = rustykrab_core::active_tools::with_session_context(|ctx| {
-            self.store.conversations().get(ctx.conversation_id).ok()
-        })
-        .flatten();
+        let session_conv_id =
+            rustykrab_core::active_tools::with_session_context(|ctx| ctx.conversation_id);
+        let inherited = match session_conv_id {
+            Some(conv_id) => self.store.conversations().get(conv_id).await.ok(),
+            None => None,
+        };
         let (ch, cid, tid) =
             inherit_channel_for_create(channel, chat_id, thread_id, inherited.as_ref());
-        let job = self.store.jobs().create_job(
-            schedule,
-            task,
-            ch.as_deref(),
-            cid.as_deref(),
-            tid.as_deref(),
-        )?;
+        let job = self
+            .store
+            .jobs()
+            .create_job(
+                schedule,
+                task,
+                ch.as_deref(),
+                cid.as_deref(),
+                tid.as_deref(),
+            )
+            .await?;
         Ok(serde_json::to_value(&job).expect("ScheduledJob is always serializable"))
     }
 
     async fn list_jobs(&self) -> rustykrab_core::Result<serde_json::Value> {
-        let jobs = self.store.jobs().list_jobs()?;
+        let jobs = self.store.jobs().list_jobs().await?;
         Ok(serde_json::to_value(&jobs).expect("Vec<ScheduledJob> is always serializable"))
     }
 
@@ -139,19 +145,19 @@ impl CronBackend for CronAdapter {
         // Grab the conversation id (if any) before the row goes away so we
         // can reap the associated persistent conversation below. Missing
         // jobs are fine; delete_job returns `false` without error.
-        let conversation_id = match self.store.jobs().get_job(job_id) {
+        let conversation_id = match self.store.jobs().get_job(job_id).await {
             Ok(job) => job.conversation_id,
             Err(rustykrab_core::Error::NotFound(_)) => None,
             Err(e) => return Err(e),
         };
 
-        let deleted = self.store.jobs().delete_job(job_id)?;
+        let deleted = self.store.jobs().delete_job(job_id).await?;
 
         if deleted {
             if let Some(cid) = conversation_id {
                 if let Ok(uuid) = uuid::Uuid::parse_str(&cid) {
                     // NotFound is fine — the conversation may already be gone.
-                    match self.store.conversations().delete(uuid) {
+                    match self.store.conversations().delete(uuid).await {
                         Ok(()) | Err(rustykrab_core::Error::NotFound(_)) => {}
                         Err(e) => {
                             tracing::warn!(
@@ -173,7 +179,7 @@ impl CronBackend for CronAdapter {
         job_id: &str,
         limit: u32,
     ) -> rustykrab_core::Result<serde_json::Value> {
-        let runs = self.store.jobs().list_runs(job_id, limit)?;
+        let runs = self.store.jobs().list_runs(job_id, limit).await?;
         Ok(serde_json::to_value(&runs).expect("Vec<JobRun> is always serializable"))
     }
 }
@@ -343,7 +349,7 @@ async fn main() -> anyhow::Result<()> {
         return handle_skill_subcommand(&data_dir, &args[2..]);
     }
     if args.len() >= 2 && args[1] == "keychain" {
-        return handle_keychain_subcommand(&data_dir, &args[2..]);
+        return handle_keychain_subcommand(&data_dir, &args[2..]).await;
     }
     if args.len() >= 2 && args[1] == "chat" {
         return chat::run(&data_dir, &args[2..]).await;
@@ -378,7 +384,7 @@ async fn main() -> anyhow::Result<()> {
     // Required secrets that cannot be resolved from any source (env var,
     // OS keychain, or encrypted store) cause a hard startup failure.
     {
-        let missing = rustykrab_store::registry::validate(&store.secrets());
+        let missing = rustykrab_store::registry::validate(&store.secrets()).await;
         let required_missing: Vec<_> = missing.iter().filter(|m| m.spec.required).collect();
 
         if !required_missing.is_empty() {
@@ -421,7 +427,7 @@ async fn main() -> anyhow::Result<()> {
     // 2. OS credential store (persists across restarts without env var)
     // 3. Encrypted local SecretStore
     // 4. Generate a new token and persist it in Keychain + SecretStore
-    let auth_token = resolve_auth_token(&store);
+    let auth_token = resolve_auth_token(&store).await;
 
     // --- Model provider ---
     let provider_name =
@@ -452,7 +458,7 @@ async fn main() -> anyhow::Result<()> {
             Arc::new(p)
         }
         _ => {
-            let api_key = resolve_api_key(&store);
+            let api_key = resolve_api_key(&store).await;
             let model = std::env::var("ANTHROPIC_MODEL")
                 .unwrap_or_else(|_| "claude-sonnet-4-20250514".to_string());
             tracing::info!(%model, "using Anthropic provider");
@@ -1114,6 +1120,7 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("flushing database...");
     store_handle
         .flush()
+        .await
         .map_err(|e| anyhow::anyhow!("flush failed: {e}"))?;
     tracing::info!("shutdown complete");
 
@@ -1182,7 +1189,7 @@ async fn telegram_agent_loop(
                     }
                     states.remove(&key);
                 }
-                if let Err(e) = state.store.chat_map().remove(chat_id, thread_id) {
+                if let Err(e) = state.store.chat_map().remove(chat_id, thread_id).await {
                     tracing::warn!(chat_id, thread_id, "failed to remove chat map entry: {e}");
                 }
                 return;
@@ -1235,6 +1242,7 @@ async fn telegram_agent_loop(
                             .store
                             .chat_map()
                             .lookup(chat_id, thread_id)
+                            .await
                             .ok()
                             .flatten();
 
@@ -1253,14 +1261,14 @@ async fn telegram_agent_loop(
                                 );
                                 id
                             }
-                            None => match state.store.conversations().create() {
+                            None => match state.store.conversations().create().await {
                                 Ok(mut conv) => {
                                     conv.channel_source = Some("telegram".to_string());
                                     conv.channel_id = Some(chat_id.to_string());
                                     if thread_id != 0 {
                                         conv.channel_thread_id = Some(thread_id.to_string());
                                     }
-                                    if let Err(e) = state.store.conversations().save(&conv) {
+                                    if let Err(e) = state.store.conversations().save(&conv).await {
                                         tracing::warn!(
                                             chat_id,
                                             "failed to persist channel metadata: {e}"
@@ -1275,7 +1283,7 @@ async fn telegram_agent_loop(
                                         },
                                     );
                                     if let Err(e) =
-                                        state.store.chat_map().upsert(chat_id, thread_id, id)
+                                        state.store.chat_map().upsert(chat_id, thread_id, id).await
                                     {
                                         tracing::warn!(
                                             chat_id,
@@ -1357,7 +1365,7 @@ async fn process_telegram_message(
     key: (i64, i64),
 ) -> String {
     // Load the conversation.
-    let mut conv = match state.store.conversations().get(conv_id) {
+    let mut conv = match state.store.conversations().get(conv_id).await {
         Ok(c) => c,
         Err(e) => {
             tracing::error!(chat_id, thread_id, %conv_id, "failed to load conversation: {e}");
@@ -1469,7 +1477,7 @@ async fn process_telegram_message(
         match join_handle.await {
             Ok(Ok(final_conv)) => {
                 // Persist the final conversation.
-                if let Err(e) = state.store.conversations().save(&final_conv) {
+                if let Err(e) = state.store.conversations().save(&final_conv).await {
                     tracing::error!(chat_id, %conv_id, "failed to persist conversation: {e}");
                 }
                 // Extract last assistant text.
@@ -1574,11 +1582,12 @@ async fn slack_agent_loop(
                     let mut states = chat_states.lock().await;
                     states.remove(&key);
                 }
-                if let Err(e) = state.store.slack_chat_map().remove(
-                    &inbound.team_id,
-                    &inbound.channel_id,
-                    &effective_thread_ts,
-                ) {
+                if let Err(e) = state
+                    .store
+                    .slack_chat_map()
+                    .remove(&inbound.team_id, &inbound.channel_id, &effective_thread_ts)
+                    .await
+                {
                     tracing::warn!(
                         team_id = %inbound.team_id,
                         channel_id = %inbound.channel_id,
@@ -1604,6 +1613,7 @@ async fn slack_agent_loop(
                             .store
                             .slack_chat_map()
                             .lookup(&inbound.team_id, &inbound.channel_id, &effective_thread_ts)
+                            .await
                             .ok()
                             .flatten();
 
@@ -1625,12 +1635,12 @@ async fn slack_agent_loop(
                                 );
                                 id
                             }
-                            None => match state.store.conversations().create() {
+                            None => match state.store.conversations().create().await {
                                 Ok(mut conv) => {
                                     conv.channel_source = Some("slack".to_string());
                                     conv.channel_id = Some(inbound.channel_id.clone());
                                     conv.channel_thread_id = Some(effective_thread_ts.clone());
-                                    if let Err(e) = state.store.conversations().save(&conv) {
+                                    if let Err(e) = state.store.conversations().save(&conv).await {
                                         tracing::warn!(
                                             channel_id = %inbound.channel_id,
                                             "failed to persist Slack channel metadata: {e}"
@@ -1644,12 +1654,17 @@ async fn slack_agent_loop(
                                             busy: false,
                                         },
                                     );
-                                    if let Err(e) = state.store.slack_chat_map().upsert(
-                                        &inbound.team_id,
-                                        &inbound.channel_id,
-                                        &effective_thread_ts,
-                                        id,
-                                    ) {
+                                    if let Err(e) = state
+                                        .store
+                                        .slack_chat_map()
+                                        .upsert(
+                                            &inbound.team_id,
+                                            &inbound.channel_id,
+                                            &effective_thread_ts,
+                                            id,
+                                        )
+                                        .await
+                                    {
                                         tracing::warn!(
                                             team_id = %inbound.team_id,
                                             channel_id = %inbound.channel_id,
@@ -1737,7 +1752,7 @@ async fn process_slack_message(
     message: rustykrab_core::types::Message,
     user_text: &str,
 ) -> String {
-    let mut conv = match state.store.conversations().get(conv_id) {
+    let mut conv = match state.store.conversations().get(conv_id).await {
         Ok(c) => c,
         Err(e) => {
             tracing::error!(channel_id, thread_ts, %conv_id, "failed to load Slack conversation: {e}");
@@ -1802,7 +1817,7 @@ async fn process_slack_message(
         }
     };
 
-    if let Err(e) = state.store.conversations().save(&conv) {
+    if let Err(e) = state.store.conversations().save(&conv).await {
         tracing::error!(channel_id, %conv_id, "failed to persist Slack conversation: {e}");
     }
 
@@ -1830,7 +1845,7 @@ async fn job_executor_loop(store: rustykrab_store::Store, queue: task_queue::Tas
         interval.tick().await;
 
         let now = Utc::now();
-        let due_jobs = match store.jobs().get_due_jobs(now) {
+        let due_jobs = match store.jobs().get_due_jobs(now).await {
             Ok(jobs) => jobs,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to query due jobs");
@@ -2017,11 +2032,11 @@ fn handle_skill_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyho
 ///
 /// Uses the registry to check env / keychain / store, then generates
 /// a new token if none exists.
-fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
+async fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
     let spec = rustykrab_store::registry::lookup("rustykrab_auth_token")
         .expect("rustykrab_auth_token must be in the registry");
 
-    if let Some(token) = rustykrab_store::registry::resolve(spec, &store.secrets()) {
+    if let Some(token) = rustykrab_store::registry::resolve(spec, &store.secrets()).await {
         tracing::info!("auth token resolved via registry");
         return token;
     }
@@ -2035,18 +2050,18 @@ fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
     if rustykrab_store::keychain::keychain_available() {
         let _ = rustykrab_store::keychain::set_credential(svc, spec.keychain_account, &token);
     }
-    let _ = store.secrets().set(spec.store_name, &token);
+    let _ = store.secrets().set(spec.store_name, &token).await;
     token
 }
 
 /// Resolve the Anthropic API key.
 ///
 /// Uses the registry to check env / keychain / store.
-fn resolve_api_key(store: &rustykrab_store::Store) -> String {
+async fn resolve_api_key(store: &rustykrab_store::Store) -> String {
     let spec = rustykrab_store::registry::lookup("anthropic_api_key")
         .expect("anthropic_api_key must be in the registry");
 
-    if let Some(key) = rustykrab_store::registry::resolve(spec, &store.secrets()) {
+    if let Some(key) = rustykrab_store::registry::resolve(spec, &store.secrets()).await {
         tracing::info!("API key resolved via registry");
         return key;
     }
@@ -2070,7 +2085,10 @@ fn resolve_api_key(store: &rustykrab_store::Store) -> String {
 ///
 /// These let the user verify Keychain connectivity, migrate legacy keychain
 /// items to the Data Protection Keychain, and manually seed credentials.
-fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyhow::Result<()> {
+async fn handle_keychain_subcommand(
+    data_dir: &std::path::Path,
+    args: &[String],
+) -> anyhow::Result<()> {
     let sub = args.first().map(|s| s.as_str()).unwrap_or("status");
 
     match sub {
@@ -2185,7 +2203,7 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
                 if db_path.exists() {
                     if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
                         if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
-                            let _ = store.secrets().set(sn, value);
+                            let _ = store.secrets().set(sn, value).await;
                             println!("Also stored in encrypted store as '{sn}'");
                         }
                     }
@@ -2217,7 +2235,7 @@ fn handle_keychain_subcommand(data_dir: &std::path::Path, args: &[String]) -> an
                     if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
                         let svc = rustykrab_store::registry::keychain_service();
                         for spec in rustykrab_store::registry::REGISTRY {
-                            if let Ok(val) = store.secrets().get(spec.store_name) {
+                            if let Ok(val) = store.secrets().get(spec.store_name).await {
                                 match rustykrab_store::keychain::set_credential(
                                     svc,
                                     spec.keychain_account,

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -157,18 +157,21 @@ async fn execute_cron_task(
 
     // Load the job so we can resume its persistent conversation and use
     // last_run_at in the prompt.
-    let job = match store.jobs().get_job(job_id) {
+    let job = match store.jobs().get_job(job_id).await {
         Ok(j) => j,
         Err(e) => {
             tracing::error!(job_id = %job_id, "failed to load scheduled job: {e}");
             let finished_at = Utc::now();
-            let _ = store.jobs().record_run(
-                job_id,
-                "error",
-                Some(&format!("failed to load job: {e}")),
-                started_at,
-                finished_at,
-            );
+            let _ = store
+                .jobs()
+                .record_run(
+                    job_id,
+                    "error",
+                    Some(&format!("failed to load job: {e}")),
+                    started_at,
+                    finished_at,
+                )
+                .await;
             return;
         }
     };
@@ -183,31 +186,39 @@ async fn execute_cron_task(
             job_id = %job_id,
             "scheduled job has an empty task body — disabling so it stops firing"
         );
-        let _ = store.jobs().record_run(
-            job_id,
-            "error",
-            Some("scheduled job has an empty task body; disabled. Recreate with a non-empty task."),
-            started_at,
-            finished_at,
-        );
-        if let Err(e) = store.jobs().set_enabled(job_id, false) {
+        let _ = store
+            .jobs()
+            .record_run(
+                job_id,
+                "error",
+                Some(
+                    "scheduled job has an empty task body; disabled. Recreate with a non-empty task.",
+                ),
+                started_at,
+                finished_at,
+            )
+            .await;
+        if let Err(e) = store.jobs().set_enabled(job_id, false).await {
             tracing::warn!(job_id = %job_id, "failed to disable empty-task job: {e}");
         }
         return;
     }
 
-    let mut conv = match resume_or_create_conversation(&job, state, store) {
+    let mut conv = match resume_or_create_conversation(&job, state, store).await {
         Ok(c) => c,
         Err(e) => {
             tracing::error!(job_id = %job_id, "failed to resume conversation for scheduled job: {e}");
             let finished_at = Utc::now();
-            let _ = store.jobs().record_run(
-                job_id,
-                "error",
-                Some(&format!("failed to resume conversation: {e}")),
-                started_at,
-                finished_at,
-            );
+            let _ = store
+                .jobs()
+                .record_run(
+                    job_id,
+                    "error",
+                    Some(&format!("failed to resume conversation: {e}")),
+                    started_at,
+                    finished_at,
+                )
+                .await;
             return;
         }
     };
@@ -232,7 +243,7 @@ async fn execute_cron_task(
         effective_chat_id.as_deref(),
         effective_thread_id.as_deref(),
     ) {
-        if let Err(e) = state.store.conversations().save(&conv) {
+        if let Err(e) = state.store.conversations().save(&conv).await {
             tracing::warn!(
                 job_id = %job_id,
                 "failed to persist channel context onto job conversation: {e}"
@@ -379,18 +390,22 @@ async fn execute_cron_task(
     // Record the run before marking executed so the result is persisted
     // even if mark_executed fails.
     let finished_at = Utc::now();
-    if let Err(e) = store.jobs().record_run(
-        job_id,
-        status,
-        Some(&response_text),
-        started_at,
-        finished_at,
-    ) {
+    if let Err(e) = store
+        .jobs()
+        .record_run(
+            job_id,
+            status,
+            Some(&response_text),
+            started_at,
+            finished_at,
+        )
+        .await
+    {
         tracing::warn!(job_id = %job_id, "failed to record job run: {e}");
     }
 
     // Mark the job as executed (advances next_run_at or disables one-shot).
-    if let Err(e) = store.jobs().mark_executed(job_id) {
+    if let Err(e) = store.jobs().mark_executed(job_id).await {
         tracing::error!(job_id = %job_id, "failed to mark scheduled job as executed: {e}");
     }
 
@@ -402,14 +417,14 @@ async fn execute_cron_task(
 /// Resume this job's persistent conversation, or create one on the first
 /// run. If the stored id points at a conversation that has been deleted
 /// out from under us, silently create a fresh one and re-link.
-fn resume_or_create_conversation(
+async fn resume_or_create_conversation(
     job: &rustykrab_store::ScheduledJob,
     state: &AppState,
     store: &rustykrab_store::Store,
 ) -> Result<Conversation, rustykrab_core::Error> {
     if let Some(cid) = &job.conversation_id {
         if let Ok(uuid) = Uuid::parse_str(cid) {
-            match state.store.conversations().get(uuid) {
+            match state.store.conversations().get(uuid).await {
                 Ok(c) => return Ok(c),
                 Err(rustykrab_core::Error::NotFound(_)) => {
                     tracing::warn!(
@@ -429,10 +444,11 @@ fn resume_or_create_conversation(
         }
     }
 
-    let conv = state.store.conversations().create()?;
+    let conv = state.store.conversations().create().await?;
     store
         .jobs()
-        .set_conversation_id(&job.id, &conv.id.to_string())?;
+        .set_conversation_id(&job.id, &conv.id.to_string())
+        .await?;
     Ok(conv)
 }
 

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -223,6 +223,7 @@ async fn create_conversation(
         .store
         .conversations()
         .create_with_title(title)
+        .await
         .map(|c| Json(ApolloConversation::from(&c)))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
@@ -234,6 +235,7 @@ async fn list_conversations(
         .store
         .conversations()
         .list_summaries()
+        .await
         .map(|summaries| {
             Json(
                 summaries
@@ -253,6 +255,7 @@ async fn get_conversation(
         .store
         .conversations()
         .get(id)
+        .await
         .map(|c| Json(ApolloConversation::from(&c)))
         .map_err(|e| match e {
             rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
@@ -268,6 +271,7 @@ async fn delete_conversation(
         .store
         .conversations()
         .delete(id)
+        .await
         .map_err(|e| match e {
             rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -291,10 +295,15 @@ async fn list_messages(
     State(state): State<AppState>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<ApolloMessage>>, StatusCode> {
-    let conv = state.store.conversations().get(id).map_err(|e| match e {
-        rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
-    })?;
+    let conv = state
+        .store
+        .conversations()
+        .get(id)
+        .await
+        .map_err(|e| match e {
+            rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        })?;
     let msgs: Vec<ApolloMessage> = conv
         .messages
         .iter()
@@ -336,6 +345,7 @@ async fn send_message(
         .store
         .conversations()
         .get(id)
+        .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
     // Clone content before moving into the message (needed for profile classification).
@@ -361,6 +371,7 @@ async fn send_message(
         .store
         .conversations()
         .save(&conv)
+        .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let apollo_msg = ApolloMessage::from_message(conv.id, &assistant_msg);
@@ -407,6 +418,7 @@ async fn send_message_stream(
         .store
         .conversations()
         .get(id)
+        .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     let conv_id = conv.id;
 
@@ -501,7 +513,7 @@ async fn send_message_stream(
 
         // Persist conversation regardless of outcome to preserve the user message.
         conv.updated_at = Utc::now();
-        if let Err(e) = agent_state.store.conversations().save(&conv) {
+        if let Err(e) = agent_state.store.conversations().save(&conv).await {
             tracing::error!("failed to save conversation: {e}");
         }
 
@@ -671,7 +683,7 @@ struct ListSecretsResponse {
 async fn list_secrets(
     State(state): State<AppState>,
 ) -> Result<Json<ListSecretsResponse>, StatusCode> {
-    let names = state.store.secrets().list_names().map_err(|e| {
+    let names = state.store.secrets().list_names().await.map_err(|e| {
         tracing::error!(error = %e, "list_secrets failed");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -698,6 +710,7 @@ async fn set_secret(
                 .store
                 .secrets()
                 .set(&body.name, &body.value)
+                .await
                 .map_err(|e| {
                     tracing::warn!(error = %e, name = %body.name, "set_secret: store write failed");
                     StatusCode::BAD_REQUEST
@@ -731,7 +744,7 @@ async fn delete_secret(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
-    state.store.secrets().delete(&name).map_err(|e| {
+    state.store.secrets().delete(&name).await.map_err(|e| {
         tracing::error!(error = %e, "delete_secret failed");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;

--- a/crates/rustykrab-store/src/chat_map.rs
+++ b/crates/rustykrab-store/src/chat_map.rs
@@ -5,6 +5,8 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+use crate::with_conn;
+
 /// Maps Telegram `(chat_id, thread_id)` pairs to conversation UUIDs.
 ///
 /// The `thread_id` column uses `0` for non-forum chats (or the implicit
@@ -22,50 +24,56 @@ impl ChatMapStore {
 
     /// Look up the conversation UUID for a `(chat_id, thread_id)` pair.
     /// Returns `None` if no mapping exists yet.
-    pub fn lookup(&self, chat_id: i64, thread_id: i64) -> Result<Option<Uuid>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare(
-                "SELECT conv_id FROM telegram_chat_map
-                 WHERE chat_id = ?1 AND thread_id = ?2",
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+    pub async fn lookup(&self, chat_id: i64, thread_id: i64) -> Result<Option<Uuid>, Error> {
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT conv_id FROM telegram_chat_map
+                     WHERE chat_id = ?1 AND thread_id = ?2",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        match stmt.query_row(params![chat_id, thread_id], |row| {
-            let id_str: String = row.get(0)?;
-            Ok(id_str)
-        }) {
-            Ok(id_str) => {
-                let id = Uuid::parse_str(&id_str)
-                    .map_err(|e| Error::Storage(format!("invalid conv_id UUID: {e}")))?;
-                Ok(Some(id))
+            match stmt.query_row(params![chat_id, thread_id], |row| {
+                let id_str: String = row.get(0)?;
+                Ok(id_str)
+            }) {
+                Ok(id_str) => {
+                    let id = Uuid::parse_str(&id_str)
+                        .map_err(|e| Error::Storage(format!("invalid conv_id UUID: {e}")))?;
+                    Ok(Some(id))
+                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(Error::Storage(e.to_string())),
             }
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(Error::Storage(e.to_string())),
-        }
+        })
+        .await
     }
 
     /// Insert or update the mapping for a `(chat_id, thread_id)` pair.
-    pub fn upsert(&self, chat_id: i64, thread_id: i64, conv_id: Uuid) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO telegram_chat_map (chat_id, thread_id, conv_id)
-             VALUES (?1, ?2, ?3)
-             ON CONFLICT(chat_id, thread_id) DO UPDATE SET conv_id = excluded.conv_id",
-            params![chat_id, thread_id, conv_id.to_string()],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn upsert(&self, chat_id: i64, thread_id: i64, conv_id: Uuid) -> Result<(), Error> {
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO telegram_chat_map (chat_id, thread_id, conv_id)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(chat_id, thread_id) DO UPDATE SET conv_id = excluded.conv_id",
+                params![chat_id, thread_id, conv_id.to_string()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Remove the mapping for a `(chat_id, thread_id)` pair (e.g. on `/reset`).
-    pub fn remove(&self, chat_id: i64, thread_id: i64) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "DELETE FROM telegram_chat_map WHERE chat_id = ?1 AND thread_id = ?2",
-            params![chat_id, thread_id],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn remove(&self, chat_id: i64, thread_id: i64) -> Result<(), Error> {
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "DELETE FROM telegram_chat_map WHERE chat_id = ?1 AND thread_id = ?2",
+                params![chat_id, thread_id],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 }

--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -7,6 +7,8 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+use crate::with_conn;
+
 /// Lightweight summary of a conversation used by listing endpoints.
 #[derive(Debug, Clone)]
 pub struct ConversationSummary {
@@ -17,6 +19,9 @@ pub struct ConversationSummary {
 }
 
 /// CRUD operations on conversations backed by SQLite.
+///
+/// All methods run their rusqlite work on tokio's blocking pool via
+/// `spawn_blocking` so async workers never park on disk I/O.
 #[derive(Clone)]
 pub struct ConversationStore {
     conn: Arc<Mutex<rusqlite::Connection>>,
@@ -28,12 +33,12 @@ impl ConversationStore {
     }
 
     /// Create a new empty conversation and return it.
-    pub fn create(&self) -> Result<Conversation, Error> {
-        self.create_with_title(None)
+    pub async fn create(&self) -> Result<Conversation, Error> {
+        self.create_with_title(None).await
     }
 
     /// Create a new empty conversation with an optional title and return it.
-    pub fn create_with_title(&self, title: Option<String>) -> Result<Conversation, Error> {
+    pub async fn create_with_title(&self, title: Option<String>) -> Result<Conversation, Error> {
         let conv = Conversation {
             id: Uuid::new_v4(),
             messages: Vec::new(),
@@ -46,103 +51,114 @@ impl ConversationStore {
             channel_id: None,
             channel_thread_id: None,
         };
-        self.save(&conv)?;
+        self.save(&conv).await?;
         Ok(conv)
     }
 
     /// Persist a conversation (insert or update).
-    pub fn save(&self, conv: &Conversation) -> Result<(), Error> {
+    pub async fn save(&self, conv: &Conversation) -> Result<(), Error> {
+        let id = conv.id.to_string();
         let data = serde_json::to_string(conv)?;
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO conversations (id, data) VALUES (?1, ?2)
-             ON CONFLICT(id) DO UPDATE SET data = excluded.data",
-            params![conv.id.to_string(), data],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO conversations (id, data) VALUES (?1, ?2)
+                 ON CONFLICT(id) DO UPDATE SET data = excluded.data",
+                params![id, data],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Retrieve a conversation by ID.
-    pub fn get(&self, id: Uuid) -> Result<Conversation, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare("SELECT data FROM conversations WHERE id = ?1")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let data: String = stmt
-            .query_row(params![id.to_string()], |row| row.get(0))
-            .map_err(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => {
-                    Error::NotFound(format!("conversation {id}"))
-                }
-                other => Error::Storage(other.to_string()),
-            })?;
-        let conv: Conversation = serde_json::from_str(&data)?;
-        Ok(conv)
+    pub async fn get(&self, id: Uuid) -> Result<Conversation, Error> {
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT data FROM conversations WHERE id = ?1")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let data: String = stmt
+                .query_row(params![id.to_string()], |row| row.get(0))
+                .map_err(|e| match e {
+                    rusqlite::Error::QueryReturnedNoRows => {
+                        Error::NotFound(format!("conversation {id}"))
+                    }
+                    other => Error::Storage(other.to_string()),
+                })?;
+            let conv: Conversation = serde_json::from_str(&data)?;
+            Ok(conv)
+        })
+        .await
     }
 
     /// List all conversation IDs (lightweight, doesn't deserialize messages).
-    pub fn list_ids(&self) -> Result<Vec<Uuid>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare("SELECT id FROM conversations")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let rows = stmt
-            .query_map([], |row| {
-                let id_str: String = row.get(0)?;
-                Ok(id_str)
-            })
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let mut ids = Vec::new();
-        for row in rows {
-            let id_str = row.map_err(|e| Error::Storage(e.to_string()))?;
-            let id = Uuid::parse_str(&id_str).map_err(|e| Error::Storage(e.to_string()))?;
-            ids.push(id);
-        }
-        Ok(ids)
+    pub async fn list_ids(&self) -> Result<Vec<Uuid>, Error> {
+        with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare("SELECT id FROM conversations")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let id_str: String = row.get(0)?;
+                    Ok(id_str)
+                })
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut ids = Vec::new();
+            for row in rows {
+                let id_str = row.map_err(|e| Error::Storage(e.to_string()))?;
+                let id = Uuid::parse_str(&id_str).map_err(|e| Error::Storage(e.to_string()))?;
+                ids.push(id);
+            }
+            Ok(ids)
+        })
+        .await
     }
 
     /// List all conversation summaries (id, title, timestamps) ordered by
     /// `updated_at` descending. Skips entries whose stored JSON cannot be
     /// parsed instead of failing the whole list.
-    pub fn list_summaries(&self) -> Result<Vec<ConversationSummary>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare("SELECT data FROM conversations")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, String>(0))
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let mut out = Vec::new();
-        for row in rows {
-            let data = row.map_err(|e| Error::Storage(e.to_string()))?;
-            if let Ok(conv) = serde_json::from_str::<Conversation>(&data) {
-                out.push(ConversationSummary {
-                    id: conv.id,
-                    title: conv.title,
-                    created_at: conv.created_at,
-                    updated_at: conv.updated_at,
-                });
+    pub async fn list_summaries(&self) -> Result<Vec<ConversationSummary>, Error> {
+        with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare("SELECT data FROM conversations")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                let data = row.map_err(|e| Error::Storage(e.to_string()))?;
+                if let Ok(conv) = serde_json::from_str::<Conversation>(&data) {
+                    out.push(ConversationSummary {
+                        id: conv.id,
+                        title: conv.title,
+                        created_at: conv.created_at,
+                        updated_at: conv.updated_at,
+                    });
+                }
             }
-        }
-        out.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
-        Ok(out)
+            out.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
+            Ok(out)
+        })
+        .await
     }
 
     /// Delete a conversation by ID. Returns `NotFound` if the conversation
     /// does not exist, so callers can distinguish 404 from 500.
-    pub fn delete(&self, id: Uuid) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        let affected = conn
-            .execute(
-                "DELETE FROM conversations WHERE id = ?1",
-                params![id.to_string()],
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        if affected == 0 {
-            return Err(Error::NotFound(format!("conversation {id}")));
-        }
-        Ok(())
+    pub async fn delete(&self, id: Uuid) -> Result<(), Error> {
+        with_conn(&self.conn, move |conn| {
+            let affected = conn
+                .execute(
+                    "DELETE FROM conversations WHERE id = ?1",
+                    params![id.to_string()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if affected == 0 {
+                return Err(Error::NotFound(format!("conversation {id}")));
+            }
+            Ok(())
+        })
+        .await
     }
 }
 
@@ -161,36 +177,37 @@ mod tests {
         ConversationStore::new(Arc::new(Mutex::new(conn)))
     }
 
-    #[test]
-    fn create_with_title_persists_title_and_round_trips() {
+    #[tokio::test]
+    async fn create_with_title_persists_title_and_round_trips() {
         let store = in_memory_store();
         let conv = store
             .create_with_title(Some("hello".into()))
+            .await
             .expect("create");
         assert_eq!(conv.title.as_deref(), Some("hello"));
-        let reloaded = store.get(conv.id).expect("get");
+        let reloaded = store.get(conv.id).await.expect("get");
         assert_eq!(reloaded.title.as_deref(), Some("hello"));
     }
 
-    #[test]
-    fn create_defaults_title_to_none() {
+    #[tokio::test]
+    async fn create_defaults_title_to_none() {
         let store = in_memory_store();
-        let conv = store.create().expect("create");
+        let conv = store.create().await.expect("create");
         assert!(conv.title.is_none());
     }
 
-    #[test]
-    fn list_summaries_returns_entries_sorted_desc_by_updated_at() {
+    #[tokio::test]
+    async fn list_summaries_returns_entries_sorted_desc_by_updated_at() {
         let store = in_memory_store();
-        let mut a = store.create_with_title(Some("a".into())).unwrap();
-        let mut b = store.create_with_title(Some("b".into())).unwrap();
+        let mut a = store.create_with_title(Some("a".into())).await.unwrap();
+        let mut b = store.create_with_title(Some("b".into())).await.unwrap();
         // Force `b` to be older than `a`.
         b.updated_at = a.updated_at - chrono::Duration::seconds(60);
-        store.save(&b).unwrap();
+        store.save(&b).await.unwrap();
         a.updated_at = Utc::now();
-        store.save(&a).unwrap();
+        store.save(&a).await.unwrap();
 
-        let summaries = store.list_summaries().unwrap();
+        let summaries = store.list_summaries().await.unwrap();
         assert_eq!(summaries.len(), 2);
         assert_eq!(
             summaries[0].id, a.id,
@@ -200,10 +217,10 @@ mod tests {
         assert_eq!(summaries[1].id, b.id);
     }
 
-    #[test]
-    fn get_returns_not_found_for_unknown_id() {
+    #[tokio::test]
+    async fn get_returns_not_found_for_unknown_id() {
         let store = in_memory_store();
-        let err = store.get(Uuid::new_v4()).unwrap_err();
+        let err = store.get(Uuid::new_v4()).await.unwrap_err();
         assert!(matches!(err, Error::NotFound(_)));
     }
 }

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -9,6 +9,12 @@ use uuid::Uuid;
 
 use rustykrab_core::Error;
 
+use crate::with_conn;
+
+/// Maximum retained `job_runs` rows per job. Older runs are pruned on
+/// insert so the history table can't grow without bound.
+const MAX_RUNS_PER_JOB: u32 = 100;
+
 /// A persisted scheduled job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScheduledJob {
@@ -46,6 +52,9 @@ pub struct JobRun {
 }
 
 /// Handle for scheduled-job CRUD operations, backed by SQLite.
+///
+/// All methods run their rusqlite work on tokio's blocking pool via
+/// `spawn_blocking` so async workers never park on disk I/O.
 #[derive(Clone)]
 pub struct JobStore {
     conn: Arc<Mutex<rusqlite::Connection>>,
@@ -61,7 +70,7 @@ impl JobStore {
     /// `schedule` is either a cron expression (e.g. `"0 9 * * *"`) for
     /// recurring jobs, or an ISO 8601 timestamp (e.g. `"2025-03-15T14:30:00Z"`)
     /// for one-shot jobs.
-    pub fn create_job(
+    pub async fn create_job(
         &self,
         schedule: &str,
         task: &str,
@@ -88,152 +97,181 @@ impl JobStore {
             conversation_id: None,
         };
 
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, thread_id, one_shot, enabled, next_run_at, last_run_at, created_at, conversation_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
-            params![
-                job.id,
-                job.schedule,
-                job.task,
-                job.channel,
-                job.chat_id,
-                job.thread_id,
-                job.one_shot as i32,
-                job.enabled as i32,
-                job.next_run_at.to_rfc3339(),
-                job.last_run_at.map(|t| t.to_rfc3339()),
-                job.created_at.to_rfc3339(),
-                job.conversation_id,
-            ],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
+        let row = job.clone();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, thread_id, one_shot, enabled, next_run_at, last_run_at, created_at, conversation_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                params![
+                    row.id,
+                    row.schedule,
+                    row.task,
+                    row.channel,
+                    row.chat_id,
+                    row.thread_id,
+                    row.one_shot as i32,
+                    row.enabled as i32,
+                    row.next_run_at.to_rfc3339(),
+                    row.last_run_at.map(|t| t.to_rfc3339()),
+                    row.created_at.to_rfc3339(),
+                    row.conversation_id,
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await?;
 
         Ok(job)
     }
 
     /// List all scheduled jobs.
-    pub fn list_jobs(&self) -> Result<Vec<ScheduledJob>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare(&format!(
-                "SELECT {JOB_COLUMNS} FROM scheduled_jobs ORDER BY next_run_at",
-            ))
-            .map_err(|e| Error::Storage(e.to_string()))?;
+    pub async fn list_jobs(&self) -> Result<Vec<ScheduledJob>, Error> {
+        with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {JOB_COLUMNS} FROM scheduled_jobs ORDER BY next_run_at",
+                ))
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        let jobs = stmt
-            .query_map([], row_to_job)
-            .map_err(|e| Error::Storage(e.to_string()))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::Storage(e.to_string()))?;
+            let jobs = stmt
+                .query_map([], row_to_job)
+                .map_err(|e| Error::Storage(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        Ok(jobs)
+            Ok(jobs)
+        })
+        .await
     }
 
     /// Fetch a single scheduled job by ID. Returns `NotFound` if absent.
-    pub fn get_job(&self, job_id: &str) -> Result<ScheduledJob, Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.query_row(
-            &format!("SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE id = ?1"),
-            params![job_id],
-            row_to_job,
-        )
-        .map_err(|e| match e {
-            rusqlite::Error::QueryReturnedNoRows => Error::NotFound(format!("job {job_id}")),
-            other => Error::Storage(other.to_string()),
+    pub async fn get_job(&self, job_id: &str) -> Result<ScheduledJob, Error> {
+        let job_id = job_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.query_row(
+                &format!("SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE id = ?1"),
+                params![job_id],
+                row_to_job,
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Error::NotFound(format!("job {job_id}")),
+                other => Error::Storage(other.to_string()),
+            })
         })
+        .await
     }
 
     /// Delete a scheduled job by ID.
-    pub fn delete_job(&self, job_id: &str) -> Result<bool, Error> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn
-            .execute("DELETE FROM scheduled_jobs WHERE id = ?1", params![job_id])
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(rows > 0)
+    pub async fn delete_job(&self, job_id: &str) -> Result<bool, Error> {
+        let job_id = job_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let rows = conn
+                .execute("DELETE FROM scheduled_jobs WHERE id = ?1", params![job_id])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(rows > 0)
+        })
+        .await
     }
 
     /// Toggle a job's `enabled` flag. The cron poller skips disabled jobs.
     /// Used by the executor to retire jobs that turn out to be unrunnable
     /// (e.g. an empty task body persisted by an older build) so they stop
     /// firing every cycle.
-    pub fn set_enabled(&self, job_id: &str, enabled: bool) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "UPDATE scheduled_jobs SET enabled = ?1 WHERE id = ?2",
-            params![enabled as i32, job_id],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn set_enabled(&self, job_id: &str, enabled: bool) -> Result<(), Error> {
+        let job_id = job_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE scheduled_jobs SET enabled = ?1 WHERE id = ?2",
+                params![enabled as i32, job_id],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Attach a conversation id to a job. Called on the first run once the
     /// executor has created (or resumed) the conversation the agent uses.
-    pub fn set_conversation_id(&self, job_id: &str, conversation_id: &str) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "UPDATE scheduled_jobs SET conversation_id = ?1 WHERE id = ?2",
-            params![conversation_id, job_id],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn set_conversation_id(
+        &self,
+        job_id: &str,
+        conversation_id: &str,
+    ) -> Result<(), Error> {
+        let job_id = job_id.to_string();
+        let conversation_id = conversation_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE scheduled_jobs SET conversation_id = ?1 WHERE id = ?2",
+                params![conversation_id, job_id],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Return all enabled jobs whose `next_run_at` is at or before `now`.
-    pub fn get_due_jobs(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledJob>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare(&format!(
-                "SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE enabled = 1 AND next_run_at <= ?1",
-            ))
-            .map_err(|e| Error::Storage(e.to_string()))?;
+    pub async fn get_due_jobs(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledJob>, Error> {
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {JOB_COLUMNS} FROM scheduled_jobs WHERE enabled = 1 AND next_run_at <= ?1",
+                ))
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        let jobs = stmt
-            .query_map(params![now.to_rfc3339()], row_to_job)
-            .map_err(|e| Error::Storage(e.to_string()))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::Storage(e.to_string()))?;
+            let jobs = stmt
+                .query_map(params![now.to_rfc3339()], row_to_job)
+                .map_err(|e| Error::Storage(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        Ok(jobs)
+            Ok(jobs)
+        })
+        .await
     }
 
     /// Mark a job as executed: update `last_run_at`, advance `next_run_at`
     /// for recurring jobs, or disable one-shot jobs.
-    pub fn mark_executed(&self, job_id: &str) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        let now = Utc::now();
+    pub async fn mark_executed(&self, job_id: &str) -> Result<(), Error> {
+        let job_id = job_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let now = Utc::now();
 
-        // Read the job to determine schedule type.
-        let (schedule, one_shot): (String, bool) = conn
-            .query_row(
-                "SELECT schedule, one_shot FROM scheduled_jobs WHERE id = ?1",
-                params![job_id],
-                |row| Ok((row.get(0)?, row.get::<_, i32>(1)? != 0)),
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+            // Read the job to determine schedule type.
+            let (schedule, one_shot): (String, bool) = conn
+                .query_row(
+                    "SELECT schedule, one_shot FROM scheduled_jobs WHERE id = ?1",
+                    params![job_id],
+                    |row| Ok((row.get(0)?, row.get::<_, i32>(1)? != 0)),
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        if one_shot {
-            // Disable one-shot jobs after execution.
-            conn.execute(
-                "UPDATE scheduled_jobs SET enabled = 0, last_run_at = ?1 WHERE id = ?2",
-                params![now.to_rfc3339(), job_id],
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        } else {
-            // Advance next_run_at for recurring jobs.
-            let next = compute_next_cron_run(&schedule, now)
-                .unwrap_or_else(|_| now + chrono::Duration::hours(1));
-            conn.execute(
-                "UPDATE scheduled_jobs SET last_run_at = ?1, next_run_at = ?2 WHERE id = ?3",
-                params![now.to_rfc3339(), next.to_rfc3339(), job_id],
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        }
+            if one_shot {
+                // Disable one-shot jobs after execution.
+                conn.execute(
+                    "UPDATE scheduled_jobs SET enabled = 0, last_run_at = ?1 WHERE id = ?2",
+                    params![now.to_rfc3339(), job_id],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            } else {
+                // Advance next_run_at for recurring jobs.
+                let next = compute_next_cron_run(&schedule, now)
+                    .unwrap_or_else(|_| now + chrono::Duration::hours(1));
+                conn.execute(
+                    "UPDATE scheduled_jobs SET last_run_at = ?1, next_run_at = ?2 WHERE id = ?3",
+                    params![now.to_rfc3339(), next.to_rfc3339(), job_id],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            }
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
-    /// Record a completed run for a job.
-    pub fn record_run(
+    /// Record a completed run for a job, pruning history beyond the most
+    /// recent [`MAX_RUNS_PER_JOB`] entries for that job.
+    pub async fn record_run(
         &self,
         job_id: &str,
         status: &str,
@@ -241,63 +279,85 @@ impl JobStore {
         started_at: DateTime<Utc>,
         finished_at: DateTime<Utc>,
     ) -> Result<JobRun, Error> {
-        let id = Uuid::new_v4().to_string();
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO job_runs (id, job_id, status, output, started_at, finished_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                id,
-                job_id,
-                status,
-                output,
-                started_at.to_rfc3339(),
-                finished_at.to_rfc3339(),
-            ],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-
-        Ok(JobRun {
-            id,
+        let run = JobRun {
+            id: Uuid::new_v4().to_string(),
             job_id: job_id.to_string(),
             status: status.to_string(),
             output: output.map(|s| s.to_string()),
             started_at,
             finished_at,
+        };
+        let row = run.clone();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO job_runs (id, job_id, status, output, started_at, finished_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    row.id,
+                    row.job_id,
+                    row.status,
+                    row.output,
+                    row.started_at.to_rfc3339(),
+                    row.finished_at.to_rfc3339(),
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+            // Retention cap: drop rows older than the newest N for this job.
+            conn.execute(
+                "DELETE FROM job_runs
+                 WHERE job_id = ?1
+                   AND id NOT IN (
+                       SELECT id FROM job_runs
+                       WHERE job_id = ?1
+                       ORDER BY finished_at DESC
+                       LIMIT ?2
+                   )",
+                params![row.job_id, MAX_RUNS_PER_JOB],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+            Ok(())
         })
+        .await?;
+
+        Ok(run)
     }
 
     /// List recent runs for a job, newest first.
     ///
     /// Returns at most `limit` entries.
-    pub fn list_runs(&self, job_id: &str, limit: u32) -> Result<Vec<JobRun>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare(
-                "SELECT id, job_id, status, output, started_at, finished_at
-                 FROM job_runs
-                 WHERE job_id = ?1
-                 ORDER BY finished_at DESC
-                 LIMIT ?2",
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+    pub async fn list_runs(&self, job_id: &str, limit: u32) -> Result<Vec<JobRun>, Error> {
+        let job_id = job_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, job_id, status, output, started_at, finished_at
+                     FROM job_runs
+                     WHERE job_id = ?1
+                     ORDER BY finished_at DESC
+                     LIMIT ?2",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        let runs = stmt
-            .query_map(params![job_id, limit], |row| {
-                Ok(JobRun {
-                    id: row.get(0)?,
-                    job_id: row.get(1)?,
-                    status: row.get(2)?,
-                    output: row.get(3)?,
-                    started_at: parse_stored_timestamp(row.get::<_, String>(4)?),
-                    finished_at: parse_stored_timestamp(row.get::<_, String>(5)?),
+            let runs = stmt
+                .query_map(params![job_id, limit], |row| {
+                    Ok(JobRun {
+                        id: row.get(0)?,
+                        job_id: row.get(1)?,
+                        status: row.get(2)?,
+                        output: row.get(3)?,
+                        started_at: parse_stored_timestamp(row.get::<_, String>(4)?),
+                        finished_at: parse_stored_timestamp(row.get::<_, String>(5)?),
+                    })
                 })
-            })
-            .map_err(|e| Error::Storage(e.to_string()))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::Storage(e.to_string()))?;
+                .map_err(|e| Error::Storage(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        Ok(runs)
+            Ok(runs)
+        })
+        .await
     }
 }
 
@@ -512,28 +572,29 @@ mod tests {
         JobStore::new(Arc::new(Mutex::new(conn)))
     }
 
-    #[test]
-    fn conversation_id_round_trip() {
+    #[tokio::test]
+    async fn conversation_id_round_trip() {
         let jobs = in_memory_jobs();
         let job = jobs
             .create_job("*/5 * * * *", "ping", None, None, None)
+            .await
             .unwrap();
         assert!(
             job.conversation_id.is_none(),
             "newly created jobs have no conversation yet"
         );
 
-        jobs.set_conversation_id(&job.id, "conv-123").unwrap();
-        let reloaded = jobs.get_job(&job.id).unwrap();
+        jobs.set_conversation_id(&job.id, "conv-123").await.unwrap();
+        let reloaded = jobs.get_job(&job.id).await.unwrap();
         assert_eq!(reloaded.conversation_id.as_deref(), Some("conv-123"));
 
         // list_jobs and get_due_jobs also propagate the column.
-        let listed = jobs.list_jobs().unwrap();
+        let listed = jobs.list_jobs().await.unwrap();
         assert_eq!(listed[0].conversation_id.as_deref(), Some("conv-123"));
     }
 
-    #[test]
-    fn thread_id_round_trip() {
+    #[tokio::test]
+    async fn thread_id_round_trip() {
         let jobs = in_memory_jobs();
         let job = jobs
             .create_job(
@@ -543,25 +604,55 @@ mod tests {
                 Some("C012345"),
                 Some("1700000000.000100"),
             )
+            .await
             .unwrap();
         assert_eq!(job.thread_id.as_deref(), Some("1700000000.000100"));
 
-        let reloaded = jobs.get_job(&job.id).unwrap();
+        let reloaded = jobs.get_job(&job.id).await.unwrap();
         assert_eq!(reloaded.thread_id.as_deref(), Some("1700000000.000100"));
         assert_eq!(reloaded.channel.as_deref(), Some("slack"));
         assert_eq!(reloaded.chat_id.as_deref(), Some("C012345"));
 
-        let listed = jobs.list_jobs().unwrap();
+        let listed = jobs.list_jobs().await.unwrap();
         assert_eq!(listed[0].thread_id.as_deref(), Some("1700000000.000100"));
     }
 
-    #[test]
-    fn get_job_missing_returns_not_found() {
+    #[tokio::test]
+    async fn get_job_missing_returns_not_found() {
         let jobs = in_memory_jobs();
-        let err = jobs.get_job("nope").unwrap_err();
+        let err = jobs.get_job("nope").await.unwrap_err();
         assert!(
             matches!(err, Error::NotFound(_)),
             "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_run_caps_history_per_job() {
+        let jobs = in_memory_jobs();
+        let job = jobs
+            .create_job("*/5 * * * *", "ping", None, None, None)
+            .await
+            .unwrap();
+
+        let base = Utc::now();
+        for i in 0..(MAX_RUNS_PER_JOB + 10) {
+            let ts = base + chrono::Duration::seconds(i as i64);
+            jobs.record_run(&job.id, "ok", Some("out"), ts, ts)
+                .await
+                .unwrap();
+        }
+
+        let runs = jobs.list_runs(&job.id, MAX_RUNS_PER_JOB * 2).await.unwrap();
+        assert_eq!(
+            runs.len(),
+            MAX_RUNS_PER_JOB as usize,
+            "history should be capped at MAX_RUNS_PER_JOB"
+        );
+        // The newest run survives the prune; the oldest ten are gone.
+        assert_eq!(
+            runs[0].finished_at.timestamp(),
+            (base + chrono::Duration::seconds((MAX_RUNS_PER_JOB + 9) as i64)).timestamp()
         );
     }
 }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -46,7 +46,10 @@ impl Store {
             "PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;
              PRAGMA foreign_keys = ON;
-             PRAGMA busy_timeout = 5000;",
+             PRAGMA busy_timeout = 5000;
+             PRAGMA cache_size = -65536;
+             PRAGMA mmap_size = 268435456;
+             PRAGMA temp_store = MEMORY;",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
 
@@ -188,11 +191,45 @@ impl Store {
     }
 
     /// Flush all pending writes to disk.
-    pub fn flush(&self) -> Result<(), Error> {
+    pub async fn flush(&self) -> Result<(), Error> {
         // WAL mode checkpoints automatically; explicit checkpoint for shutdown.
-        let conn = self.conn.lock().unwrap();
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+        with_conn(&self.conn, |conn| {
+            conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+                .map_err(|e| Error::Storage(e.to_string()))
+        })
+        .await
     }
+}
+
+/// Run a blocking closure on tokio's blocking pool, flattening the join
+/// error into a storage error. Keeps rusqlite work (and other CPU-heavy
+/// tasks such as Argon2 key derivation) off the async worker threads.
+pub(crate) async fn run_blocking<T, F>(f: F) -> Result<T, Error>
+where
+    F: FnOnce() -> Result<T, Error> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| Error::Storage(format!("join error: {e}")))?
+}
+
+/// Helper: run a blocking closure on the shared connection inside
+/// `spawn_blocking`, mirroring `SqliteMemoryStorage::with_conn` in
+/// rustykrab-memory. The mutex is locked on the blocking thread so async
+/// workers never park on disk I/O or the connection lock.
+pub(crate) async fn with_conn<T, F>(
+    conn: &Arc<Mutex<rusqlite::Connection>>,
+    f: F,
+) -> Result<T, Error>
+where
+    F: FnOnce(&rusqlite::Connection) -> Result<T, Error> + Send + 'static,
+    T: Send + 'static,
+{
+    let conn = Arc::clone(conn);
+    run_blocking(move || {
+        let conn = conn.lock().unwrap();
+        f(&conn)
+    })
+    .await
 }

--- a/crates/rustykrab-store/src/recall_archive.rs
+++ b/crates/rustykrab-store/src/recall_archive.rs
@@ -7,6 +7,8 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+use crate::with_conn;
+
 /// SQLite-backed durable store for compaction-displaced recall archives,
 /// keyed by conversation id.
 ///
@@ -25,52 +27,75 @@ impl RecallArchiveStore {
 
     /// Insert or replace the archive text for a conversation. `created_at`
     /// is preserved on update; only `updated_at` advances.
-    pub fn upsert(&self, conversation_id: Uuid, archive: &str) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO recall_archive (conversation_id, archive, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?3)
-             ON CONFLICT(conversation_id) DO UPDATE SET
-                 archive = excluded.archive,
-                 updated_at = excluded.updated_at",
-            params![conversation_id.to_string(), archive, now],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn upsert(&self, conversation_id: Uuid, archive: &str) -> Result<(), Error> {
+        let archive = archive.to_string();
+        with_conn(&self.conn, move |conn| {
+            upsert_row(conn, conversation_id, &archive)
+        })
+        .await
     }
 
     /// Fetch the archive text for a conversation, or `None` if absent.
-    pub fn get(&self, conversation_id: Uuid) -> Result<Option<String>, Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.query_row(
-            "SELECT archive FROM recall_archive WHERE conversation_id = ?1",
-            params![conversation_id.to_string()],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()
-        .map_err(|e| Error::Storage(e.to_string()))
+    pub async fn get(&self, conversation_id: Uuid) -> Result<Option<String>, Error> {
+        with_conn(&self.conn, move |conn| get_row(conn, conversation_id)).await
     }
 
     /// Delete the archive for a conversation. Idempotent — deleting a
     /// missing row is not an error.
-    pub fn delete(&self, conversation_id: Uuid) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "DELETE FROM recall_archive WHERE conversation_id = ?1",
-            params![conversation_id.to_string()],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn delete(&self, conversation_id: Uuid) -> Result<(), Error> {
+        with_conn(&self.conn, move |conn| delete_row(conn, conversation_id)).await
     }
+}
+
+fn upsert_row(
+    conn: &rusqlite::Connection,
+    conversation_id: Uuid,
+    archive: &str,
+) -> Result<(), Error> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO recall_archive (conversation_id, archive, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?3)
+         ON CONFLICT(conversation_id) DO UPDATE SET
+             archive = excluded.archive,
+             updated_at = excluded.updated_at",
+        params![conversation_id.to_string(), archive, now],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
+}
+
+fn get_row(conn: &rusqlite::Connection, conversation_id: Uuid) -> Result<Option<String>, Error> {
+    conn.query_row(
+        "SELECT archive FROM recall_archive WHERE conversation_id = ?1",
+        params![conversation_id.to_string()],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|e| Error::Storage(e.to_string()))
+}
+
+fn delete_row(conn: &rusqlite::Connection, conversation_id: Uuid) -> Result<(), Error> {
+    conn.execute(
+        "DELETE FROM recall_archive WHERE conversation_id = ?1",
+        params![conversation_id.to_string()],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
 }
 
 /// Best-effort adapter: persistence failures are logged and swallowed so
 /// they never break the agent loop. The in-memory `RecallStore` cache
 /// remains authoritative for the live session even if a write is dropped.
+///
+/// `RecallPersistence` is a synchronous trait by contract, so these
+/// methods run the rusqlite work directly on the calling thread (the same
+/// behaviour the store had before its public API moved to
+/// `spawn_blocking`).
 impl RecallPersistence for RecallArchiveStore {
     fn load(&self, conversation_id: Uuid) -> Option<String> {
-        match self.get(conversation_id) {
+        let conn = self.conn.lock().unwrap();
+        match get_row(&conn, conversation_id) {
             Ok(archive) => archive,
             Err(e) => {
                 tracing::warn!(error = %e, %conversation_id, "failed to load recall archive");
@@ -80,13 +105,15 @@ impl RecallPersistence for RecallArchiveStore {
     }
 
     fn upsert(&self, conversation_id: Uuid, archive: &str) {
-        if let Err(e) = RecallArchiveStore::upsert(self, conversation_id, archive) {
+        let conn = self.conn.lock().unwrap();
+        if let Err(e) = upsert_row(&conn, conversation_id, archive) {
             tracing::warn!(error = %e, %conversation_id, "failed to persist recall archive");
         }
     }
 
     fn delete(&self, conversation_id: Uuid) {
-        if let Err(e) = RecallArchiveStore::delete(self, conversation_id) {
+        let conn = self.conn.lock().unwrap();
+        if let Err(e) = delete_row(&conn, conversation_id) {
             tracing::warn!(error = %e, %conversation_id, "failed to delete recall archive");
         }
     }
@@ -110,44 +137,44 @@ mod tests {
         RecallArchiveStore::new(Arc::new(Mutex::new(conn)))
     }
 
-    #[test]
-    fn upsert_then_get_round_trips() {
+    #[tokio::test]
+    async fn upsert_then_get_round_trips() {
         let store = in_memory_store();
         let conv = Uuid::new_v4();
-        store.upsert(conv, "hello").unwrap();
-        assert_eq!(store.get(conv).unwrap().as_deref(), Some("hello"));
+        store.upsert(conv, "hello").await.unwrap();
+        assert_eq!(store.get(conv).await.unwrap().as_deref(), Some("hello"));
     }
 
-    #[test]
-    fn upsert_replaces_existing() {
+    #[tokio::test]
+    async fn upsert_replaces_existing() {
         let store = in_memory_store();
         let conv = Uuid::new_v4();
-        store.upsert(conv, "first").unwrap();
-        store.upsert(conv, "second").unwrap();
-        assert_eq!(store.get(conv).unwrap().as_deref(), Some("second"));
+        store.upsert(conv, "first").await.unwrap();
+        store.upsert(conv, "second").await.unwrap();
+        assert_eq!(store.get(conv).await.unwrap().as_deref(), Some("second"));
     }
 
-    #[test]
-    fn get_missing_returns_none() {
+    #[tokio::test]
+    async fn get_missing_returns_none() {
         let store = in_memory_store();
-        assert_eq!(store.get(Uuid::new_v4()).unwrap(), None);
+        assert_eq!(store.get(Uuid::new_v4()).await.unwrap(), None);
     }
 
-    #[test]
-    fn delete_is_idempotent() {
-        let store = in_memory_store();
-        let conv = Uuid::new_v4();
-        store.upsert(conv, "x").unwrap();
-        store.delete(conv).unwrap();
-        store.delete(conv).unwrap();
-        assert_eq!(store.get(conv).unwrap(), None);
-    }
-
-    #[test]
-    fn upsert_preserves_created_at_on_update() {
+    #[tokio::test]
+    async fn delete_is_idempotent() {
         let store = in_memory_store();
         let conv = Uuid::new_v4();
-        store.upsert(conv, "first").unwrap();
+        store.upsert(conv, "x").await.unwrap();
+        store.delete(conv).await.unwrap();
+        store.delete(conv).await.unwrap();
+        assert_eq!(store.get(conv).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn upsert_preserves_created_at_on_update() {
+        let store = in_memory_store();
+        let conv = Uuid::new_v4();
+        store.upsert(conv, "first").await.unwrap();
         let created: String = {
             let conn = store.conn.lock().unwrap();
             conn.query_row(
@@ -157,7 +184,7 @@ mod tests {
             )
             .unwrap()
         };
-        store.upsert(conv, "second").unwrap();
+        store.upsert(conv, "second").await.unwrap();
         let created_after: String = {
             let conn = store.conn.lock().unwrap();
             conn.query_row(

--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -90,12 +90,14 @@ pub struct MissingSecret {
 ///
 /// This does **not** mutate any store — it is a read-only check suitable for
 /// startup validation.
-pub fn validate(secrets: &SecretStore) -> Vec<MissingSecret> {
-    REGISTRY
-        .iter()
-        .filter(|spec| !is_present(spec, secrets))
-        .map(|spec| MissingSecret { spec })
-        .collect()
+pub async fn validate(secrets: &SecretStore) -> Vec<MissingSecret> {
+    let mut missing = Vec::new();
+    for spec in REGISTRY {
+        if !is_present(spec, secrets).await {
+            missing.push(MissingSecret { spec });
+        }
+    }
+    missing
 }
 
 /// Resolve a secret from all sources in priority order.
@@ -104,7 +106,7 @@ pub fn validate(secrets: &SecretStore) -> Vec<MissingSecret> {
 /// so future runs can find it without the env var.
 ///
 /// Returns `None` only when the secret is absent from every source.
-pub fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String> {
+pub async fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String> {
     // 1. Environment variable (highest priority).
     if let Ok(val) = std::env::var(spec.env_var) {
         let val = val.trim().to_string();
@@ -113,7 +115,7 @@ pub fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String> {
             if keychain::keychain_available() {
                 let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
             }
-            let _ = secrets.set(spec.store_name, &val);
+            let _ = secrets.set(spec.store_name, &val).await;
             return Some(val);
         }
     }
@@ -121,13 +123,13 @@ pub fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String> {
     // 2. OS credential store.
     if keychain::keychain_available() {
         if let Ok(Some(cred)) = keychain::get_credential(KEYCHAIN_SERVICE, spec.keychain_account) {
-            let _ = secrets.set(spec.store_name, &cred.value);
+            let _ = secrets.set(spec.store_name, &cred.value).await;
             return Some(cred.value);
         }
     }
 
     // 3. Encrypted local store.
-    if let Ok(val) = secrets.get(spec.store_name) {
+    if let Ok(val) = secrets.get(spec.store_name).await {
         // Back-fill into keychain if available.
         if keychain::keychain_available() {
             let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
@@ -157,7 +159,7 @@ pub fn keychain_service() -> &'static str {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-fn is_present(spec: &SecretSpec, secrets: &SecretStore) -> bool {
+async fn is_present(spec: &SecretSpec, secrets: &SecretStore) -> bool {
     // env var
     if let Ok(val) = std::env::var(spec.env_var) {
         if !val.trim().is_empty() {
@@ -171,5 +173,5 @@ fn is_present(spec: &SecretSpec, secrets: &SecretStore) -> bool {
         }
     }
     // store
-    secrets.get(spec.store_name).is_ok()
+    secrets.get(spec.store_name).await.is_ok()
 }

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -9,6 +9,8 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use zeroize::Zeroizing;
 
+use crate::run_blocking;
+
 /// The salt length used for Argon2 key derivation.
 const SALT_LEN: usize = 16;
 /// The nonce length for AES-256-GCM (96 bits).
@@ -47,60 +49,84 @@ impl SecretStore {
     }
 
     /// Store a secret value under the given name.
-    pub fn set(&self, name: &str, value: &str) -> Result<(), Error> {
+    ///
+    /// The Argon2id key derivation and SQLite write both run on tokio's
+    /// blocking pool — neither may occupy an async worker thread.
+    pub async fn set(&self, name: &str, value: &str) -> Result<(), Error> {
         // Validate secret name to prevent injection and normalization attacks
         Self::validate_name(name)?;
 
-        let encrypted = self.encrypt(name, value.as_bytes())?;
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO secrets (name, data) VALUES (?1, ?2)
-             ON CONFLICT(name) DO UPDATE SET data = excluded.data",
-            params![name, encrypted],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+        let store = self.clone();
+        let name = name.to_string();
+        let value = Zeroizing::new(value.to_string());
+        run_blocking(move || {
+            let encrypted = store.encrypt(&name, value.as_bytes())?;
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO secrets (name, data) VALUES (?1, ?2)
+                 ON CONFLICT(name) DO UPDATE SET data = excluded.data",
+                params![name, encrypted],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Retrieve and decrypt a secret by name.
-    pub fn get(&self, name: &str) -> Result<String, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare("SELECT data FROM secrets WHERE name = ?1")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let encrypted: Vec<u8> = stmt
-            .query_row(params![name], |row| row.get(0))
-            .map_err(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => Error::NotFound(format!("secret '{name}'")),
-                other => Error::Storage(other.to_string()),
-            })?;
-        let plaintext = self.decrypt(name, &encrypted)?;
-        String::from_utf8(plaintext)
-            .map_err(|e| Error::Storage(format!("invalid utf-8 in secret: {e}")))
+    ///
+    /// Runs on tokio's blocking pool — see [`SecretStore::set`].
+    pub async fn get(&self, name: &str) -> Result<String, Error> {
+        let store = self.clone();
+        let name = name.to_string();
+        run_blocking(move || {
+            let encrypted: Vec<u8> = {
+                let conn = store.conn.lock().unwrap();
+                let mut stmt = conn
+                    .prepare("SELECT data FROM secrets WHERE name = ?1")
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                stmt.query_row(params![name], |row| row.get(0))
+                    .map_err(|e| match e {
+                        rusqlite::Error::QueryReturnedNoRows => {
+                            Error::NotFound(format!("secret '{name}'"))
+                        }
+                        other => Error::Storage(other.to_string()),
+                    })?
+            };
+            let plaintext = store.decrypt(&name, &encrypted)?;
+            String::from_utf8(plaintext)
+                .map_err(|e| Error::Storage(format!("invalid utf-8 in secret: {e}")))
+        })
+        .await
     }
 
     /// Delete a secret.
-    pub fn delete(&self, name: &str) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM secrets WHERE name = ?1", params![name])
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn delete(&self, name: &str) -> Result<(), Error> {
+        let name = name.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            conn.execute("DELETE FROM secrets WHERE name = ?1", params![name])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// List all secret names (does not decrypt values).
-    pub fn list_names(&self) -> Result<Vec<String>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare("SELECT name FROM secrets")
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let rows = stmt
-            .query_map([], |row| row.get(0))
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        let mut names = Vec::new();
-        for row in rows {
-            names.push(row.map_err(|e| Error::Storage(e.to_string()))?);
-        }
-        Ok(names)
+    pub async fn list_names(&self) -> Result<Vec<String>, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare("SELECT name FROM secrets")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| row.get(0))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut names = Vec::new();
+            for row in rows {
+                names.push(row.map_err(|e| Error::Storage(e.to_string()))?);
+            }
+            Ok(names)
+        })
+        .await
     }
 
     /// Validate that a secret name is well-formed.

--- a/crates/rustykrab-store/src/slack_chat_map.rs
+++ b/crates/rustykrab-store/src/slack_chat_map.rs
@@ -5,6 +5,8 @@ use rustykrab_core::Error;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+use crate::with_conn;
+
 /// Maps Slack `(team_id, channel_id, thread_ts)` triples to conversation UUIDs.
 ///
 /// The `thread_ts` column stores an empty string `""` to mean "no thread"
@@ -25,64 +27,84 @@ impl SlackChatMapStore {
     /// Look up the conversation UUID for a `(team_id, channel_id, thread_ts)`
     /// triple. `thread_ts` is the Slack thread timestamp, or `""` for a
     /// top-level / DM conversation. Returns `None` if no mapping exists.
-    pub fn lookup(
+    pub async fn lookup(
         &self,
         team_id: &str,
         channel_id: &str,
         thread_ts: &str,
     ) -> Result<Option<Uuid>, Error> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn
-            .prepare(
-                "SELECT conv_id FROM slack_chat_map
-                 WHERE team_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+        let team_id = team_id.to_string();
+        let channel_id = channel_id.to_string();
+        let thread_ts = thread_ts.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT conv_id FROM slack_chat_map
+                     WHERE team_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
 
-        match stmt.query_row(params![team_id, channel_id, thread_ts], |row| {
-            let id_str: String = row.get(0)?;
-            Ok(id_str)
-        }) {
-            Ok(id_str) => {
-                let id = Uuid::parse_str(&id_str)
-                    .map_err(|e| Error::Storage(format!("invalid conv_id UUID: {e}")))?;
-                Ok(Some(id))
+            match stmt.query_row(params![team_id, channel_id, thread_ts], |row| {
+                let id_str: String = row.get(0)?;
+                Ok(id_str)
+            }) {
+                Ok(id_str) => {
+                    let id = Uuid::parse_str(&id_str)
+                        .map_err(|e| Error::Storage(format!("invalid conv_id UUID: {e}")))?;
+                    Ok(Some(id))
+                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(Error::Storage(e.to_string())),
             }
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(Error::Storage(e.to_string())),
-        }
+        })
+        .await
     }
 
     /// Insert or update the mapping for a `(team_id, channel_id, thread_ts)` triple.
-    pub fn upsert(
+    pub async fn upsert(
         &self,
         team_id: &str,
         channel_id: &str,
         thread_ts: &str,
         conv_id: Uuid,
     ) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO slack_chat_map (team_id, channel_id, thread_ts, conv_id)
-             VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(team_id, channel_id, thread_ts) DO UPDATE SET conv_id = excluded.conv_id",
-            params![team_id, channel_id, thread_ts, conv_id.to_string()],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+        let team_id = team_id.to_string();
+        let channel_id = channel_id.to_string();
+        let thread_ts = thread_ts.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO slack_chat_map (team_id, channel_id, thread_ts, conv_id)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(team_id, channel_id, thread_ts) DO UPDATE SET conv_id = excluded.conv_id",
+                params![team_id, channel_id, thread_ts, conv_id.to_string()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 
     /// Remove the mapping for a `(team_id, channel_id, thread_ts)` triple
     /// (e.g. on `/reset`).
-    pub fn remove(&self, team_id: &str, channel_id: &str, thread_ts: &str) -> Result<(), Error> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "DELETE FROM slack_chat_map
-             WHERE team_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
-            params![team_id, channel_id, thread_ts],
-        )
-        .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(())
+    pub async fn remove(
+        &self,
+        team_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+    ) -> Result<(), Error> {
+        let team_id = team_id.to_string();
+        let channel_id = channel_id.to_string();
+        let thread_ts = thread_ts.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "DELETE FROM slack_chat_map
+                 WHERE team_id = ?1 AND channel_id = ?2 AND thread_ts = ?3",
+                params![team_id, channel_id, thread_ts],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
     }
 }
 
@@ -106,51 +128,55 @@ mod tests {
         SlackChatMapStore::new(Arc::new(Mutex::new(conn)))
     }
 
-    #[test]
-    fn upsert_and_lookup_thread() {
+    #[tokio::test]
+    async fn upsert_and_lookup_thread() {
         let store = in_memory_store();
         let id = Uuid::new_v4();
-        store.upsert("T1", "C1", "1700000000.000100", id).unwrap();
+        store
+            .upsert("T1", "C1", "1700000000.000100", id)
+            .await
+            .unwrap();
         assert_eq!(
-            store.lookup("T1", "C1", "1700000000.000100").unwrap(),
+            store.lookup("T1", "C1", "1700000000.000100").await.unwrap(),
             Some(id)
         );
         // A different thread in the same channel is a different conversation.
-        assert_eq!(store.lookup("T1", "C1", "other.0001").unwrap(), None);
+        assert_eq!(store.lookup("T1", "C1", "other.0001").await.unwrap(), None);
     }
 
-    #[test]
-    fn empty_thread_ts_is_distinct_from_threads() {
+    #[tokio::test]
+    async fn empty_thread_ts_is_distinct_from_threads() {
         let store = in_memory_store();
         let dm = Uuid::new_v4();
         let thread = Uuid::new_v4();
-        store.upsert("T1", "D1", "", dm).unwrap();
+        store.upsert("T1", "D1", "", dm).await.unwrap();
         store
             .upsert("T1", "D1", "1700000000.000100", thread)
+            .await
             .unwrap();
-        assert_eq!(store.lookup("T1", "D1", "").unwrap(), Some(dm));
+        assert_eq!(store.lookup("T1", "D1", "").await.unwrap(), Some(dm));
         assert_eq!(
-            store.lookup("T1", "D1", "1700000000.000100").unwrap(),
+            store.lookup("T1", "D1", "1700000000.000100").await.unwrap(),
             Some(thread)
         );
     }
 
-    #[test]
-    fn upsert_overwrites_existing_mapping() {
+    #[tokio::test]
+    async fn upsert_overwrites_existing_mapping() {
         let store = in_memory_store();
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
-        store.upsert("T1", "C1", "ts1", first).unwrap();
-        store.upsert("T1", "C1", "ts1", second).unwrap();
-        assert_eq!(store.lookup("T1", "C1", "ts1").unwrap(), Some(second));
+        store.upsert("T1", "C1", "ts1", first).await.unwrap();
+        store.upsert("T1", "C1", "ts1", second).await.unwrap();
+        assert_eq!(store.lookup("T1", "C1", "ts1").await.unwrap(), Some(second));
     }
 
-    #[test]
-    fn remove_clears_mapping() {
+    #[tokio::test]
+    async fn remove_clears_mapping() {
         let store = in_memory_store();
         let id = Uuid::new_v4();
-        store.upsert("T1", "C1", "ts1", id).unwrap();
-        store.remove("T1", "C1", "ts1").unwrap();
-        assert_eq!(store.lookup("T1", "C1", "ts1").unwrap(), None);
+        store.upsert("T1", "C1", "ts1", id).await.unwrap();
+        store.remove("T1", "C1", "ts1").await.unwrap();
+        assert_eq!(store.lookup("T1", "C1", "ts1").await.unwrap(), None);
     }
 }

--- a/crates/rustykrab-tools/src/caldav.rs
+++ b/crates/rustykrab-tools/src/caldav.rs
@@ -69,8 +69,8 @@ impl CalDavTool {
     }
 
     /// Fetch the Google email + app password from the shared credential store.
-    fn get_credentials(&self) -> Result<(String, String)> {
-        let email = self.secrets.get(KEY_EMAIL).map_err(|e| {
+    async fn get_credentials(&self) -> Result<(String, String)> {
+        let email = self.secrets.get(KEY_EMAIL).await.map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "gmail_email not available: {e}. The CalDAV tool reuses your Gmail \
@@ -81,7 +81,7 @@ impl CalDavTool {
                 .into(),
             )
         })?;
-        let password = self.secrets.get(KEY_APP_PASSWORD).map_err(|e| {
+        let password = self.secrets.get(KEY_APP_PASSWORD).await.map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "gmail_app_password not available: {e}. The CalDAV tool reuses your \
@@ -173,15 +173,16 @@ impl CalDavTool {
         if let Some(email) = args["email"].as_str() {
             self.secrets
                 .set(KEY_EMAIL, email)
+                .await
                 .map_err(|e| Error::ToolExecution(format!("failed to store email: {e}").into()))?;
         }
         if let Some(pw) = args["app_password"].as_str() {
-            self.secrets.set(KEY_APP_PASSWORD, pw).map_err(|e| {
+            self.secrets.set(KEY_APP_PASSWORD, pw).await.map_err(|e| {
                 Error::ToolExecution(format!("failed to store app password: {e}").into())
             })?;
         }
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
 
         // Verify by enumerating calendars.
         let calendars = self.discover_calendars(&email, &password).await?;
@@ -200,7 +201,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_list_calendars(&self) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let calendars = self.discover_calendars(&email, &password).await?;
         Ok(json!({ "calendars": calendars }))
     }
@@ -291,7 +292,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_list_events(&self, args: &Value) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let calendar_id = args["calendar_id"].as_str();
         let collection = self.events_collection(&email, calendar_id);
 
@@ -370,7 +371,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_get_event(&self, args: &Value) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let url = self.resolve_event_url(args, &email)?;
         let (_, ics) = self
             .dav_request("GET", &url, &email, &password, DavReq::default())
@@ -388,7 +389,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_create_event(&self, args: &Value) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let calendar_id = args["calendar_id"].as_str();
         let collection = self.events_collection(&email, calendar_id);
 
@@ -432,7 +433,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_update_event(&self, args: &Value) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let url = self.resolve_event_url(args, &email)?;
 
         // Fetch the existing event so we can preserve its UID and any fields
@@ -503,7 +504,7 @@ impl CalDavTool {
     // -----------------------------------------------------------------------
 
     async fn action_delete_event(&self, args: &Value) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let url = self.resolve_event_url(args, &email)?;
         let etag = args["etag"].as_str();
         self.dav_request(

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -107,7 +107,7 @@ impl CredentialReadTool {
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing name for 'get' action".into()))?;
 
-                match self.secrets.get(name) {
+                match self.secrets.get(name).await {
                     Ok(value) => Ok(json!({
                         "source": "store",
                         "name": name,
@@ -123,7 +123,7 @@ impl CredentialReadTool {
                 }
             }
             "list" => {
-                let names = self.secrets.list_names().map_err(|e| {
+                let names = self.secrets.list_names().await.map_err(|e| {
                     Error::ToolExecution(format!("failed to list secrets: {e}").into())
                 })?;
 

--- a/crates/rustykrab-tools/src/credential_write.rs
+++ b/crates/rustykrab-tools/src/credential_write.rs
@@ -128,7 +128,7 @@ impl CredentialWriteTool {
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
 
-                self.secrets.set(name, value).map_err(|e| {
+                self.secrets.set(name, value).await.map_err(|e| {
                     Error::ToolExecution(format!("failed to store secret: {e}").into())
                 })?;
 
@@ -139,7 +139,7 @@ impl CredentialWriteTool {
                 }))
             }
             "delete" => {
-                self.secrets.delete(name).map_err(|e| {
+                self.secrets.delete(name).await.map_err(|e| {
                     Error::ToolExecution(format!("failed to delete secret: {e}").into())
                 })?;
 
@@ -271,7 +271,7 @@ impl CredentialWriteTool {
             })?;
 
         // Write to local encrypted store.
-        self.secrets.set(name, &cred.value).map_err(|e| {
+        self.secrets.set(name, &cred.value).await.map_err(|e| {
             Error::ToolExecution(format!("failed to store imported secret: {e}").into())
         })?;
 

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -36,8 +36,8 @@ impl GmailTool {
     }
 
     /// Get email and app password from the credential store.
-    fn get_credentials(&self) -> Result<(String, String)> {
-        let email = self.secrets.get(KEY_EMAIL).map_err(|e| {
+    async fn get_credentials(&self) -> Result<(String, String)> {
+        let email = self.secrets.get(KEY_EMAIL).await.map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "gmail_email not available: {e}. Store it with: \
@@ -48,7 +48,7 @@ impl GmailTool {
                 .into(),
             )
         })?;
-        let password = self.secrets.get(KEY_APP_PASSWORD).map_err(|e| {
+        let password = self.secrets.get(KEY_APP_PASSWORD).await.map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "gmail_app_password not available: {e}. Store it with: \
@@ -77,9 +77,11 @@ impl GmailTool {
 
         self.secrets
             .set(KEY_EMAIL, email)
+            .await
             .map_err(|e| Error::ToolExecution(format!("failed to store email: {e}").into()))?;
         self.secrets
             .set(KEY_APP_PASSWORD, app_password)
+            .await
             .map_err(|e| {
                 Error::ToolExecution(format!("failed to store app password: {e}").into())
             })?;
@@ -107,7 +109,7 @@ impl GmailTool {
             .min(MAX_SEARCH_RESULTS as u64) as usize;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session
@@ -211,7 +213,7 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session
@@ -373,7 +375,7 @@ impl GmailTool {
         let cc = args["cc"].as_str();
         let in_reply_to = args["in_reply_to"].as_str();
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
 
         let mut message_builder =
             lettre::message::Message::builder()
@@ -426,7 +428,7 @@ impl GmailTool {
     // -----------------------------------------------------------------------
 
     async fn action_labels(&self) -> Result<Value> {
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         let names: Vec<async_imap::types::Name> = session
@@ -467,7 +469,7 @@ impl GmailTool {
             .ok_or_else(|| Error::ToolExecution("missing 'to_mailbox'".into()))?
             .to_string();
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session.select(&from_mailbox).await.map_err(|e| {
@@ -500,7 +502,7 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session
@@ -529,7 +531,7 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session
@@ -572,7 +574,7 @@ impl GmailTool {
             as u32;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         // First, fetch the target message to get its References/In-Reply-To/Message-ID.
@@ -765,7 +767,7 @@ impl GmailTool {
         })? as usize;
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
-        let (email, password) = self.get_credentials()?;
+        let (email, password) = self.get_credentials().await?;
         let mut session = connect_imap(&email, &password).await?;
 
         session

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -252,7 +252,7 @@ async fn connect_http(
     let url_key = format!("RUSTYKRAB_MCP_{upper}_URL");
     let url = std::env::var(&url_key).map_err(|_| format!("missing env var {url_key}"))?;
 
-    let headers = build_http_headers(server, upper, secrets)?;
+    let headers = build_http_headers(server, upper, secrets).await?;
     let client = McpHttpClient::connect(&url, headers)
         .await
         .map_err(|e| format!("connect: {e}"))?;
@@ -285,6 +285,7 @@ async fn connect_stdio(
     let mut resolved_env: Vec<(String, String)> = Vec::new();
     for (key, raw_value) in collect_prefixed(upper, "ENV_") {
         let value = resolve_value_ref(server, &raw_value, secrets)
+            .await
             .map_err(|e| format!("ENV_{key}: {e}"))?;
         resolved_env.push((key, value));
     }
@@ -306,7 +307,7 @@ async fn connect_stdio(
 /// Assemble HTTP headers from `RUSTYKRAB_MCP_<NAME>_TOKEN` (bearer shorthand)
 /// plus every `RUSTYKRAB_MCP_<NAME>_HEADER_<KEY>` entry. Values may be
 /// `ref:` references resolved via `secrets`.
-fn build_http_headers(
+async fn build_http_headers(
     server: &str,
     upper: &str,
     secrets: &SecretStore,
@@ -314,7 +315,9 @@ fn build_http_headers(
     let mut headers = HeaderMap::new();
 
     if let Ok(raw) = std::env::var(format!("RUSTYKRAB_MCP_{upper}_TOKEN")) {
-        let token = resolve_value_ref(server, &raw, secrets).map_err(|e| format!("TOKEN: {e}"))?;
+        let token = resolve_value_ref(server, &raw, secrets)
+            .await
+            .map_err(|e| format!("TOKEN: {e}"))?;
         let value = HeaderValue::from_str(&format!("Bearer {token}"))
             .map_err(|e| format!("invalid bearer token: {e}"))?;
         headers.insert(AUTHORIZATION, value);
@@ -325,6 +328,7 @@ fn build_http_headers(
         let name = HeaderName::from_bytes(header_name.as_bytes())
             .map_err(|e| format!("invalid header name `{header_name}`: {e}"))?;
         let resolved = resolve_value_ref(server, &raw_value, secrets)
+            .await
             .map_err(|e| format!("HEADER_{key}: {e}"))?;
         let value = HeaderValue::from_str(&resolved)
             .map_err(|e| format!("invalid header value for `{header_name}`: {e}"))?;
@@ -363,7 +367,7 @@ fn collect_prefixed(upper: &str, prefix: &str) -> Vec<(String, String)> {
 ///
 /// Errors carry the ref kind but never the looked-up value. Audit logs
 /// emitted by this function never log the resolved value either.
-fn resolve_value_ref(
+async fn resolve_value_ref(
     server: &str,
     raw: &str,
     secrets: &SecretStore,
@@ -387,7 +391,7 @@ fn resolve_value_ref(
                      (must begin with `{expected_prefix}`)"
                 ));
             }
-            let value = secrets.get(name).map_err(|e| match e {
+            let value = secrets.get(name).await.map_err(|e| match e {
                 rustykrab_core::Error::NotFound(_) => {
                     format!("store ref `{name}` not found in SecretStore")
                 }
@@ -478,98 +482,119 @@ mod tests {
         store.secrets()
     }
 
-    #[test]
-    fn resolve_value_ref_passes_through_literals() {
+    #[tokio::test]
+    async fn resolve_value_ref_passes_through_literals() {
         let secrets = make_test_secrets();
-        let v = resolve_value_ref("github", "ghp_literaltoken", &secrets).unwrap();
+        let v = resolve_value_ref("github", "ghp_literaltoken", &secrets)
+            .await
+            .unwrap();
         assert_eq!(v, "ghp_literaltoken");
     }
 
-    #[test]
-    fn resolve_value_ref_store_lookup_succeeds_in_namespace() {
+    #[tokio::test]
+    async fn resolve_value_ref_store_lookup_succeeds_in_namespace() {
         let secrets = make_test_secrets();
         secrets
             .set("mcp.github.token", "stored-token-value")
+            .await
             .unwrap();
-        let v = resolve_value_ref("github", "ref:store:mcp.github.token", &secrets).unwrap();
+        let v = resolve_value_ref("github", "ref:store:mcp.github.token", &secrets)
+            .await
+            .unwrap();
         assert_eq!(v, "stored-token-value");
     }
 
-    #[test]
-    fn resolve_value_ref_store_lookup_is_case_insensitive_on_server() {
+    #[tokio::test]
+    async fn resolve_value_ref_store_lookup_is_case_insensitive_on_server() {
         let secrets = make_test_secrets();
         secrets
             .set("mcp.github.token", "stored-token-value")
+            .await
             .unwrap();
-        let v = resolve_value_ref("GitHub", "ref:store:mcp.github.token", &secrets).unwrap();
+        let v = resolve_value_ref("GitHub", "ref:store:mcp.github.token", &secrets)
+            .await
+            .unwrap();
         assert_eq!(v, "stored-token-value");
     }
 
-    #[test]
-    fn resolve_value_ref_store_rejects_cross_server_lookup() {
+    #[tokio::test]
+    async fn resolve_value_ref_store_rejects_cross_server_lookup() {
         let secrets = make_test_secrets();
         secrets
             .set("mcp.notion.token", "other-server-token")
+            .await
             .unwrap();
-        let err = resolve_value_ref("github", "ref:store:mcp.notion.token", &secrets).unwrap_err();
+        let err = resolve_value_ref("github", "ref:store:mcp.notion.token", &secrets)
+            .await
+            .unwrap_err();
         assert!(
             err.contains("outside server"),
             "expected namespace error, got: {err}"
         );
     }
 
-    #[test]
-    fn resolve_value_ref_store_rejects_unnamespaced_keys() {
+    #[tokio::test]
+    async fn resolve_value_ref_store_rejects_unnamespaced_keys() {
         let secrets = make_test_secrets();
-        secrets.set("global_secret", "x").unwrap();
-        let err = resolve_value_ref("github", "ref:store:global_secret", &secrets).unwrap_err();
+        secrets.set("global_secret", "x").await.unwrap();
+        let err = resolve_value_ref("github", "ref:store:global_secret", &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("outside server"));
     }
 
-    #[test]
-    fn resolve_value_ref_store_missing_key_errors() {
+    #[tokio::test]
+    async fn resolve_value_ref_store_missing_key_errors() {
         let secrets = make_test_secrets();
-        let err =
-            resolve_value_ref("github", "ref:store:mcp.github.missing", &secrets).unwrap_err();
+        let err = resolve_value_ref("github", "ref:store:mcp.github.missing", &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("not found"), "got: {err}");
     }
 
-    #[test]
-    fn resolve_value_ref_rejects_unknown_kind() {
+    #[tokio::test]
+    async fn resolve_value_ref_rejects_unknown_kind() {
         let secrets = make_test_secrets();
-        let err = resolve_value_ref("github", "ref:vault:foo", &secrets).unwrap_err();
+        let err = resolve_value_ref("github", "ref:vault:foo", &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("unknown credential ref kind"));
     }
 
-    #[test]
-    fn resolve_value_ref_rejects_malformed_ref() {
+    #[tokio::test]
+    async fn resolve_value_ref_rejects_malformed_ref() {
         let secrets = make_test_secrets();
-        let err = resolve_value_ref("github", "ref:store", &secrets).unwrap_err();
+        let err = resolve_value_ref("github", "ref:store", &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("malformed"));
     }
 
     #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn resolve_value_ref_keychain_unavailable_on_non_mac() {
+    #[tokio::test]
+    async fn resolve_value_ref_keychain_unavailable_on_non_mac() {
         let secrets = make_test_secrets();
-        let err =
-            resolve_value_ref("github", "ref:keychain:Service/account", &secrets).unwrap_err();
+        let err = resolve_value_ref("github", "ref:keychain:Service/account", &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("unavailable"), "got: {err}");
     }
 
-    #[test]
-    fn build_http_headers_token_becomes_bearer() {
+    #[tokio::test]
+    async fn build_http_headers_token_becomes_bearer() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTTOKEN";
         let secrets = make_test_secrets();
         std::env::set_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"), "abc123");
-        let headers = build_http_headers("testtoken", upper, &secrets).unwrap();
+        let headers = build_http_headers("testtoken", upper, &secrets)
+            .await
+            .unwrap();
         assert_eq!(headers.get("authorization").unwrap(), "Bearer abc123");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
     }
 
-    #[test]
-    fn build_http_headers_supports_arbitrary_headers() {
+    #[tokio::test]
+    async fn build_http_headers_supports_arbitrary_headers() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTDD";
         let secrets = make_test_secrets();
@@ -581,24 +606,29 @@ mod tests {
             format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"),
             "key-bbb",
         );
-        let headers = build_http_headers("testdd", upper, &secrets).unwrap();
+        let headers = build_http_headers("testdd", upper, &secrets).await.unwrap();
         assert_eq!(headers.get("dd-api-key").unwrap(), "key-aaa");
         assert_eq!(headers.get("dd-application-key").unwrap(), "key-bbb");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_API_KEY"));
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_DD_APPLICATION_KEY"));
     }
 
-    #[test]
-    fn build_http_headers_resolves_token_ref() {
+    #[tokio::test]
+    async fn build_http_headers_resolves_token_ref() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTREF";
         let secrets = make_test_secrets();
-        secrets.set("mcp.testref.token", "resolved-bearer").unwrap();
+        secrets
+            .set("mcp.testref.token", "resolved-bearer")
+            .await
+            .unwrap();
         std::env::set_var(
             format!("RUSTYKRAB_MCP_{upper}_TOKEN"),
             "ref:store:mcp.testref.token",
         );
-        let headers = build_http_headers("testref", upper, &secrets).unwrap();
+        let headers = build_http_headers("testref", upper, &secrets)
+            .await
+            .unwrap();
         assert_eq!(
             headers.get("authorization").unwrap(),
             "Bearer resolved-bearer"
@@ -606,32 +636,42 @@ mod tests {
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
     }
 
-    #[test]
-    fn build_http_headers_resolves_header_ref() {
+    #[tokio::test]
+    async fn build_http_headers_resolves_header_ref() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTHDRREF";
         let secrets = make_test_secrets();
-        secrets.set("mcp.testhdrref.api_key", "secret-key").unwrap();
+        secrets
+            .set("mcp.testhdrref.api_key", "secret-key")
+            .await
+            .unwrap();
         std::env::set_var(
             format!("RUSTYKRAB_MCP_{upper}_HEADER_X_API_KEY"),
             "ref:store:mcp.testhdrref.api_key",
         );
-        let headers = build_http_headers("testhdrref", upper, &secrets).unwrap();
+        let headers = build_http_headers("testhdrref", upper, &secrets)
+            .await
+            .unwrap();
         assert_eq!(headers.get("x-api-key").unwrap(), "secret-key");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_HEADER_X_API_KEY"));
     }
 
-    #[test]
-    fn build_http_headers_rejects_cross_server_ref() {
+    #[tokio::test]
+    async fn build_http_headers_rejects_cross_server_ref() {
         // Safety: unique prefix; no other test reads these.
         let upper = "TESTXSERVER";
         let secrets = make_test_secrets();
-        secrets.set("mcp.notion.token", "wrong-server").unwrap();
+        secrets
+            .set("mcp.notion.token", "wrong-server")
+            .await
+            .unwrap();
         std::env::set_var(
             format!("RUSTYKRAB_MCP_{upper}_TOKEN"),
             "ref:store:mcp.notion.token",
         );
-        let err = build_http_headers("testxserver", upper, &secrets).unwrap_err();
+        let err = build_http_headers("testxserver", upper, &secrets)
+            .await
+            .unwrap_err();
         assert!(err.contains("outside server"), "got: {err}");
         std::env::remove_var(format!("RUSTYKRAB_MCP_{upper}_TOKEN"));
     }

--- a/crates/rustykrab-tools/src/notion.rs
+++ b/crates/rustykrab-tools/src/notion.rs
@@ -36,8 +36,8 @@ impl NotionTool {
     }
 
     /// Get the stored Notion API token.
-    fn get_token(&self) -> Result<String> {
-        self.secrets.get(KEY_API_TOKEN).map_err(|_| {
+    async fn get_token(&self) -> Result<String> {
+        self.secrets.get(KEY_API_TOKEN).await.map_err(|_| {
             Error::ToolExecution(
                 "notion_api_token not found. Store it with: \
                  notion(action='setup', api_token='ntn_...') or \
@@ -48,17 +48,17 @@ impl NotionTool {
     }
 
     /// Get the optional default parent page ID.
-    fn get_default_parent(&self) -> Option<String> {
-        self.secrets.get(KEY_DEFAULT_PARENT).ok()
+    async fn get_default_parent(&self) -> Option<String> {
+        self.secrets.get(KEY_DEFAULT_PARENT).await.ok()
     }
 
     /// Build an authorized request to the Notion API.
-    fn notion_request(
+    async fn notion_request(
         &self,
         method: reqwest::Method,
         path: &str,
     ) -> Result<reqwest::RequestBuilder> {
-        let token = self.get_token()?;
+        let token = self.get_token().await?;
         let url = format!("{NOTION_API_BASE}{path}");
         Ok(self
             .client
@@ -102,12 +102,14 @@ impl NotionTool {
 
         self.secrets
             .set(KEY_API_TOKEN, api_token)
+            .await
             .map_err(|e| Error::ToolExecution(format!("failed to store API token: {e}").into()))?;
 
         // Optionally store a default parent page ID.
         if let Some(parent_id) = args["default_parent_page_id"].as_str() {
             self.secrets
                 .set(KEY_DEFAULT_PARENT, parent_id)
+                .await
                 .map_err(|e| {
                     Error::ToolExecution(format!("failed to store default parent: {e}").into())
                 })?;
@@ -169,7 +171,8 @@ impl NotionTool {
         }
 
         let req = self
-            .notion_request(reqwest::Method::POST, "/search")?
+            .notion_request(reqwest::Method::POST, "/search")
+            .await?
             .json(&body);
 
         let data = self.send_and_parse(req).await?;
@@ -219,7 +222,9 @@ impl NotionTool {
         let include_content = args["include_content"].as_bool().unwrap_or(true);
 
         // Fetch page properties.
-        let req = self.notion_request(reqwest::Method::GET, &format!("/pages/{page_id}"))?;
+        let req = self
+            .notion_request(reqwest::Method::GET, &format!("/pages/{page_id}"))
+            .await?;
         let page = self.send_and_parse(req).await?;
 
         let title = extract_title(&page);
@@ -252,15 +257,16 @@ impl NotionTool {
             .ok_or_else(|| Error::ToolExecution("missing 'title' parameter".into()))?;
 
         // Determine parent: explicit > default stored > error.
-        let parent_id = args["parent_page_id"]
-            .as_str()
-            .map(|s| s.to_string())
-            .or_else(|| self.get_default_parent())
-            .ok_or_else(|| {
-                Error::ToolExecution(
-                    "missing 'parent_page_id'. Provide one or set a default via setup.".into(),
-                )
-            })?;
+        let explicit_parent = args["parent_page_id"].as_str().map(|s| s.to_string());
+        let parent_id = match explicit_parent {
+            Some(id) => Some(id),
+            None => self.get_default_parent().await,
+        }
+        .ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'parent_page_id'. Provide one or set a default via setup.".into(),
+            )
+        })?;
 
         let icon = args["icon"].as_str();
         let cover_url = args["cover_url"].as_str();
@@ -297,7 +303,8 @@ impl NotionTool {
         }
 
         let req = self
-            .notion_request(reqwest::Method::POST, "/pages")?
+            .notion_request(reqwest::Method::POST, "/pages")
+            .await?
             .json(&body);
 
         let page = self.send_and_parse(req).await?;
@@ -376,16 +383,18 @@ impl NotionTool {
 
         // Sync append to Obsidian if content was provided as markdown.
         if let Some(markdown) = args["content"].as_str() {
-            if self.secrets.get("obsidian_api_key").is_ok() {
+            if self.secrets.get("obsidian_api_key").await.is_ok() {
                 // Look up the page title to derive the Obsidian vault path.
-                let title =
-                    match self.notion_request(reqwest::Method::GET, &format!("/pages/{page_id}")) {
-                        Ok(req) => match self.send_and_parse(req).await {
-                            Ok(page) => extract_title(&page),
-                            Err(_) => String::new(),
-                        },
+                let title = match self
+                    .notion_request(reqwest::Method::GET, &format!("/pages/{page_id}"))
+                    .await
+                {
+                    Ok(req) => match self.send_and_parse(req).await {
+                        Ok(page) => extract_title(&page),
                         Err(_) => String::new(),
-                    };
+                    },
+                    Err(_) => String::new(),
+                };
 
                 if !title.is_empty() {
                     match crate::obsidian::try_sync_append_to_obsidian(
@@ -420,15 +429,16 @@ impl NotionTool {
             .as_str()
             .ok_or_else(|| Error::ToolExecution("missing 'title' parameter".into()))?;
 
-        let parent_id = args["parent_page_id"]
-            .as_str()
-            .map(|s| s.to_string())
-            .or_else(|| self.get_default_parent())
-            .ok_or_else(|| {
-                Error::ToolExecution(
-                    "missing 'parent_page_id'. Provide one or set a default via setup.".into(),
-                )
-            })?;
+        let explicit_parent = args["parent_page_id"].as_str().map(|s| s.to_string());
+        let parent_id = match explicit_parent {
+            Some(id) => Some(id),
+            None => self.get_default_parent().await,
+        }
+        .ok_or_else(|| {
+            Error::ToolExecution(
+                "missing 'parent_page_id'. Provide one or set a default via setup.".into(),
+            )
+        })?;
 
         let properties = args.get("properties").cloned().unwrap_or_else(|| {
             // Sensible default for a trip-planning database.
@@ -461,7 +471,8 @@ impl NotionTool {
         }
 
         let req = self
-            .notion_request(reqwest::Method::POST, "/databases")?
+            .notion_request(reqwest::Method::POST, "/databases")
+            .await?
             .json(&body);
 
         let db = self.send_and_parse(req).await?;
@@ -501,7 +512,8 @@ impl NotionTool {
         }
 
         let req = self
-            .notion_request(reqwest::Method::POST, "/pages")?
+            .notion_request(reqwest::Method::POST, "/pages")
+            .await?
             .json(&body);
 
         let page = self.send_and_parse(req).await?;
@@ -541,7 +553,8 @@ impl NotionTool {
         }
 
         let req = self
-            .notion_request(reqwest::Method::PATCH, &format!("/pages/{page_id}"))?
+            .notion_request(reqwest::Method::PATCH, &format!("/pages/{page_id}"))
+            .await?
             .json(&body);
 
         let page = self.send_and_parse(req).await?;
@@ -562,7 +575,9 @@ impl NotionTool {
             .as_str()
             .ok_or_else(|| Error::ToolExecution("missing 'block_id' parameter".into()))?;
 
-        let req = self.notion_request(reqwest::Method::DELETE, &format!("/blocks/{block_id}"))?;
+        let req = self
+            .notion_request(reqwest::Method::DELETE, &format!("/blocks/{block_id}"))
+            .await?;
         self.send_and_parse(req).await?;
 
         Ok(json!({
@@ -592,7 +607,7 @@ impl NotionTool {
                     path.push_str(&format!("&start_cursor={c}"));
                 }
 
-                let req = self.notion_request(reqwest::Method::GET, &path)?;
+                let req = self.notion_request(reqwest::Method::GET, &path).await?;
                 let data = self.send_and_parse(req).await?;
 
                 if let Some(results) = data["results"].as_array() {
@@ -630,7 +645,8 @@ impl NotionTool {
                 .notion_request(
                     reqwest::Method::PATCH,
                     &format!("/blocks/{page_id}/children"),
-                )?
+                )
+                .await?
                 .json(&body);
             self.send_and_parse(req).await?;
         }

--- a/crates/rustykrab-tools/src/obsidian.rs
+++ b/crates/rustykrab-tools/src/obsidian.rs
@@ -33,14 +33,15 @@ impl ObsidianTool {
         Self { secrets, client }
     }
 
-    fn get_api_url(&self) -> String {
+    async fn get_api_url(&self) -> String {
         self.secrets
             .get(KEY_API_URL)
+            .await
             .unwrap_or_else(|_| DEFAULT_API_URL.to_string())
     }
 
-    fn get_api_key(&self) -> Result<String> {
-        self.secrets.get(KEY_API_KEY).map_err(|_| {
+    async fn get_api_key(&self) -> Result<String> {
+        self.secrets.get(KEY_API_KEY).await.map_err(|_| {
             Error::ToolExecution(
                 "obsidian_api_key not found. Store it with: \
                  obsidian(action='setup', api_key='...') or \
@@ -51,13 +52,13 @@ impl ObsidianTool {
     }
 
     /// Build an authorized request to the Obsidian Local REST API.
-    fn obsidian_request(
+    async fn obsidian_request(
         &self,
         method: reqwest::Method,
         path: &str,
     ) -> Result<reqwest::RequestBuilder> {
-        let api_key = self.get_api_key()?;
-        let base_url = self.get_api_url();
+        let api_key = self.get_api_key().await?;
+        let base_url = self.get_api_url().await;
         let url = format!("{base_url}{path}");
         Ok(self
             .client
@@ -101,25 +102,29 @@ impl ObsidianTool {
 
         self.secrets
             .set(KEY_API_KEY, api_key)
+            .await
             .map_err(|e| Error::ToolExecution(format!("failed to store API key: {e}").into()))?;
 
         if let Some(url) = args["api_url"].as_str() {
-            self.secrets.set(KEY_API_URL, url).map_err(|e| {
+            self.secrets.set(KEY_API_URL, url).await.map_err(|e| {
                 Error::ToolExecution(format!("failed to store API URL: {e}").into())
             })?;
         }
 
         if let Some(folder) = args["sync_folder"].as_str() {
-            self.secrets.set(KEY_SYNC_FOLDER, folder).map_err(|e| {
-                Error::ToolExecution(format!("failed to store sync folder: {e}").into())
-            })?;
+            self.secrets
+                .set(KEY_SYNC_FOLDER, folder)
+                .await
+                .map_err(|e| {
+                    Error::ToolExecution(format!("failed to store sync folder: {e}").into())
+                })?;
         }
 
         // Verify connectivity.
         let base_url = if let Some(url) = args["api_url"].as_str() {
             url.to_string()
         } else {
-            self.get_api_url()
+            self.get_api_url().await
         };
 
         let resp = self
@@ -169,7 +174,8 @@ impl ObsidianTool {
         let path = ensure_md_extension(path);
 
         let req = self
-            .obsidian_request(reqwest::Method::PUT, &format!("/vault/{path}"))?
+            .obsidian_request(reqwest::Method::PUT, &format!("/vault/{path}"))
+            .await?
             .header("Content-Type", "text/markdown")
             .body(content.to_string());
 
@@ -199,7 +205,8 @@ impl ObsidianTool {
         let path = ensure_md_extension(path);
 
         let req = self
-            .obsidian_request(reqwest::Method::GET, &format!("/vault/{path}"))?
+            .obsidian_request(reqwest::Method::GET, &format!("/vault/{path}"))
+            .await?
             .header("Accept", "text/markdown");
 
         let (status, body) = self.send_text(req).await?;
@@ -237,7 +244,8 @@ impl ObsidianTool {
         let path = ensure_md_extension(path);
 
         let req = self
-            .obsidian_request(reqwest::Method::PATCH, &format!("/vault/{path}"))?
+            .obsidian_request(reqwest::Method::PATCH, &format!("/vault/{path}"))
+            .await?
             .header("Content-Type", "text/markdown")
             .header("Content-Insertion-Position", "end")
             .body(content.to_string());
@@ -267,8 +275,8 @@ impl ObsidianTool {
 
         let context_length = args["context_length"].as_u64().unwrap_or(100);
 
-        let api_key = self.get_api_key()?;
-        let base_url = self.get_api_url();
+        let api_key = self.get_api_key().await?;
+        let base_url = self.get_api_url().await;
 
         let resp = self
             .client
@@ -317,7 +325,9 @@ impl ObsidianTool {
 
         let path = ensure_md_extension(path);
 
-        let req = self.obsidian_request(reqwest::Method::DELETE, &format!("/vault/{path}"))?;
+        let req = self
+            .obsidian_request(reqwest::Method::DELETE, &format!("/vault/{path}"))
+            .await?;
 
         let (status, body) = self.send_text(req).await?;
 
@@ -346,7 +356,8 @@ impl ObsidianTool {
         let directory = args["directory"].as_str().unwrap_or("");
 
         let req = self
-            .obsidian_request(reqwest::Method::GET, "/vault/")?
+            .obsidian_request(reqwest::Method::GET, "/vault/")
+            .await?
             .header("Accept", "application/json");
 
         let data = self.send_and_parse(req).await?;
@@ -556,16 +567,17 @@ pub async fn try_sync_to_obsidian(
     notion_url: Option<&str>,
 ) -> std::result::Result<Option<Value>, String> {
     // Check if Obsidian is configured.
-    let api_key = match secrets.get(KEY_API_KEY) {
+    let api_key = match secrets.get(KEY_API_KEY).await {
         Ok(key) => key,
         Err(_) => return Ok(None), // Not configured — skip silently.
     };
 
     let api_url = secrets
         .get(KEY_API_URL)
+        .await
         .unwrap_or_else(|_| DEFAULT_API_URL.to_string());
 
-    let sync_folder = secrets.get(KEY_SYNC_FOLDER).ok();
+    let sync_folder = secrets.get(KEY_SYNC_FOLDER).await.ok();
 
     // Build the vault path from the title.
     let filename = sanitize_filename(title);
@@ -613,16 +625,17 @@ pub async fn try_sync_append_to_obsidian(
     title: &str,
     content: &str,
 ) -> std::result::Result<Option<Value>, String> {
-    let api_key = match secrets.get(KEY_API_KEY) {
+    let api_key = match secrets.get(KEY_API_KEY).await {
         Ok(key) => key,
         Err(_) => return Ok(None),
     };
 
     let api_url = secrets
         .get(KEY_API_URL)
+        .await
         .unwrap_or_else(|_| DEFAULT_API_URL.to_string());
 
-    let sync_folder = secrets.get(KEY_SYNC_FOLDER).ok();
+    let sync_folder = secrets.get(KEY_SYNC_FOLDER).await.ok();
 
     let filename = sanitize_filename(title);
     let vault_path = match &sync_folder {


### PR DESCRIPTION
## Problem

The entire `rustykrab-store` crate exposed **synchronous** methods backed by a single `Arc<std::sync::Mutex<rusqlite::Connection>>`, and they were called directly from async code everywhere (gateway routes, CLI channel loops, task queue, tools). Every call parked a tokio worker thread on disk I/O plus the connection mutex (with a 5000ms busy timeout). Worst of all, `SecretStore` ran **Argon2id key derivation synchronously on the async thread** on every secret get/set/resolve — a deliberately expensive KDF executing on the runtime's worker pool.

## Fix

- All public store methods (`ConversationStore`, `JobStore`, `SecretStore`, `ChatMapStore`, `SlackChatMapStore`, `RecallArchiveStore`, and `Store::flush`) are now `async fn`s whose rusqlite work runs inside `tokio::task::spawn_blocking`, via a shared `with_conn` helper that mirrors the existing `SqliteMemoryStorage::with_conn` pattern in `rustykrab-memory`. The mutex is locked on the blocking thread, so async workers never park on it. External semantics are unchanged.
- `SecretStore`'s Argon2id derivation and AES-GCM encrypt/decrypt now run on the blocking pool together with the SQLite access (single `spawn_blocking` per operation).
- `RecallPersistence` remains a sync trait by contract (best-effort, called from the compaction path); its impl keeps direct calls — same behaviour as before — while the store's public API is async.
- All call sites across the workspace updated to `.await`: gateway (`routes.rs`), CLI (`main.rs` including the Telegram/Slack loops, job executor, keychain subcommand and credential resolution, `task_queue.rs`, `chat.rs`), and tools (`credential_read`/`credential_write`, `gmail`, `caldav`, `notion`, `obsidian`, `mcp_connector`). `registry::validate`/`resolve` are now async since they hit the secret store.
- `Store::open` stays sync (one-time startup / one-off CLI paths).

## Pragma tuning

`Store::open` now additionally sets:

```sql
PRAGMA cache_size = -65536;   -- 64 MiB page cache
PRAGMA mmap_size = 268435456; -- 256 MiB mmap
PRAGMA temp_store = MEMORY;
```

## job_runs retention

`JobStore::record_run` now prunes history beyond the most recent 100 rows per job (single `DELETE` with a subquery), so the run-history table can no longer grow without bound.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo test --workspace` — all green (425 tests passed, 0 failed), including new coverage: `record_run_caps_history_per_job`, plus the store/tools test suites converted to `#[tokio::test]` to exercise the async API.

No schema changes to conversation storage (blob normalization is handled in a separate stacked PR) and `rustykrab-memory` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2)_