### PR TITLE
perf(tools): reuse IMAP sessions and HTTP clients, hoist regexes, stream file reads

### DIFF
--- a/crates/rustykrab-tools/src/caldav.rs
+++ b/crates/rustykrab-tools/src/caldav.rs
@@ -10,6 +10,9 @@
 //! Because the host is fixed to Google, there is no arbitrary-URL / SSRF
 //! surface: every request targets `apidata.googleusercontent.com`.
 
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, SecondsFormat, Utc};
 use regex::Regex;
@@ -262,16 +265,13 @@ impl CalDavTool {
             )
             .await?;
 
-        // Heuristic: a calendar resourcetype contains a <...:calendar/> tag.
-        let calendar_re = Regex::new(r"<[^>]*:?calendar\s*/?>").expect("static regex");
-
         let mut calendars = Vec::new();
         for block in split_responses(&list_xml) {
             // Only collections advertising the CalDAV "calendar" resourcetype.
             if !block.contains("calendar") || !block.to_lowercase().contains("resourcetype") {
                 continue;
             }
-            if !calendar_re.is_match(&block) {
+            if !CALENDAR_TYPE_RE.is_match(&block) {
                 continue;
             }
             let href = extract_hrefs(&block).into_iter().next().unwrap_or_default();
@@ -547,6 +547,26 @@ impl CalDavTool {
 // Pure helpers (unit-tested, no network)
 // ---------------------------------------------------------------------------
 
+// WebDAV/CalDAV parsing patterns, compiled once. These run per response
+// fragment, so recompiling them per call would dominate parse time.
+
+/// Heuristic: a calendar resourcetype contains a `<...:calendar/>` tag.
+static CALENDAR_TYPE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<[^>]*:?calendar\s*/?>").expect("static regex"));
+static CALENDAR_ID_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"/caldav/v2/([^/]+)/").expect("static regex"));
+static RESPONSE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?si)<[a-z0-9]*:?response[\s>].*?</[a-z0-9]*:?response>").expect("static regex")
+});
+static HREF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?si)<[a-z0-9]*:?href\s*>(.*?)</[a-z0-9]*:?href>").expect("static regex")
+});
+/// Cache for the per-tag patterns built by [`extract_tag_text`]. The set of
+/// tag names is small and fixed (`displayname`, `getetag`, `calendar-data`),
+/// so this stays tiny while avoiding a recompile per fragment.
+static TAG_TEXT_RES: LazyLock<Mutex<HashMap<String, Regex>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Remove all whitespace from a Google app password. Google shows app
 /// passwords as four space-separated groups; the spaces are not part of the
 /// secret and break CalDAV `Basic` auth, so strip them.
@@ -569,9 +589,9 @@ fn absolutize(href: &str) -> String {
 /// Extract the calendar id (the segment between `/caldav/v2/` and `/events`)
 /// from an href, percent-decoding `%40` back to `@`.
 fn calendar_id_from_href(href: &str) -> String {
-    let id = Regex::new(r"/caldav/v2/([^/]+)/")
-        .ok()
-        .and_then(|re| re.captures(href).map(|c| c[1].to_string()))
+    let id = CALENDAR_ID_RE
+        .captures(href)
+        .map(|c| c[1].to_string())
         .unwrap_or_default();
     id.replace("%40", "@")
 }
@@ -588,23 +608,35 @@ fn uid_from_url(url: &str) -> String {
 /// Split a WebDAV multistatus document into individual `<response>` blocks,
 /// tolerant of any namespace prefix.
 fn split_responses(xml: &str) -> Vec<String> {
-    let re = Regex::new(r"(?si)<[a-z0-9]*:?response[\s>].*?</[a-z0-9]*:?response>")
-        .expect("static regex");
-    re.find_iter(xml).map(|m| m.as_str().to_string()).collect()
+    RESPONSE_RE
+        .find_iter(xml)
+        .map(|m| m.as_str().to_string())
+        .collect()
 }
 
 /// Extract all `<href>` text values from an XML fragment (any prefix).
 fn extract_hrefs(xml: &str) -> Vec<String> {
-    let re = Regex::new(r"(?si)<[a-z0-9]*:?href\s*>(.*?)</[a-z0-9]*:?href>").expect("static regex");
-    re.captures_iter(xml)
+    HREF_RE
+        .captures_iter(xml)
         .map(|c| unescape_xml(c[1].trim()))
         .collect()
 }
 
 /// Extract the text content of the first element with the given local name.
 fn extract_tag_text(xml: &str, local_name: &str) -> Option<String> {
-    let pattern = format!(r"(?si)<[a-z0-9]*:?{local_name}\s*>(.*?)</[a-z0-9]*:?{local_name}>");
-    let re = Regex::new(&pattern).ok()?;
+    let re = {
+        let mut cache = TAG_TEXT_RES.lock().expect("tag regex cache poisoned");
+        match cache.get(local_name) {
+            Some(re) => re.clone(),
+            None => {
+                let pattern =
+                    format!(r"(?si)<[a-z0-9]*:?{local_name}\s*>(.*?)</[a-z0-9]*:?{local_name}>");
+                let re = Regex::new(&pattern).ok()?;
+                cache.insert(local_name.to_string(), re.clone());
+                re
+            }
+        }
+    };
     re.captures(xml).map(|c| unescape_xml(c[1].trim()))
 }
 
@@ -1075,6 +1107,17 @@ mod tests {
             uid_from_url("https://x/caldav/v2/me/events/the-uid.ics"),
             "the-uid"
         );
+    }
+
+    #[test]
+    fn extract_tag_text_caches_per_tag_patterns() {
+        let xml = "<d:displayname>Work</d:displayname><d:getetag>\"abc\"</d:getetag>";
+        // Distinct tags each get their own compiled pattern...
+        assert_eq!(extract_tag_text(xml, "displayname").unwrap(), "Work");
+        assert_eq!(extract_tag_text(xml, "getetag").unwrap(), "\"abc\"");
+        // ...and repeat lookups (the cached path) behave identically.
+        assert_eq!(extract_tag_text(xml, "displayname").unwrap(), "Work");
+        assert_eq!(extract_tag_text(xml, "absent"), None);
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -23,16 +23,99 @@ const MAX_SEARCH_RESULTS: usize = 50;
 type ImapSession = async_imap::Session<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>;
 
 // ---------------------------------------------------------------------------
+// Cached IMAP session
+// ---------------------------------------------------------------------------
+
+/// An authenticated IMAP session cached across tool calls, plus the state
+/// needed to reuse it safely. Establishing a Gmail IMAP session costs a full
+/// TCP + TLS + LOGIN round trip (300ms–1s) and Gmail throttles rapid
+/// re-authentication, so the session is kept open between operations.
+struct CachedSession {
+    session: ImapSession,
+    /// Account the session is authenticated as; a credential change
+    /// invalidates the cache.
+    email: String,
+    /// Mailbox currently SELECTed, so repeat operations on the same mailbox
+    /// skip the redundant SELECT round trip.
+    selected_mailbox: Option<String>,
+}
+
+impl std::ops::Deref for CachedSession {
+    type Target = ImapSession;
+    fn deref(&self) -> &ImapSession {
+        &self.session
+    }
+}
+
+impl std::ops::DerefMut for CachedSession {
+    fn deref_mut(&mut self) -> &mut ImapSession {
+        &mut self.session
+    }
+}
+
+/// Return a live, authenticated session for `email`, reusing the cached one
+/// when it belongs to the same account and still answers a NOOP; otherwise
+/// (re)connect lazily.
+async fn ensure_session<'a>(
+    cache: &'a mut Option<CachedSession>,
+    email: &str,
+    password: &str,
+) -> Result<&'a mut CachedSession> {
+    let reusable = match cache.as_mut() {
+        // NOOP doubles as a liveness probe and lets the server deliver
+        // pending mailbox updates (RFC 3501 §6.1.2).
+        Some(cached) if cached.email == email => cached.session.noop().await.is_ok(),
+        _ => false,
+    };
+    if !reusable {
+        // Drop rather than LOGOUT: the old connection is dead or belongs to
+        // another account, and a LOGOUT on a broken socket can stall.
+        *cache = None;
+        let session = connect_imap(email, password).await?;
+        *cache = Some(CachedSession {
+            session,
+            email: email.to_string(),
+            selected_mailbox: None,
+        });
+    }
+    Ok(cache.as_mut().expect("session was just ensured"))
+}
+
+/// SELECT `mailbox` unless it is already the selected mailbox of this session.
+async fn select_mailbox(cached: &mut CachedSession, mailbox: &str) -> Result<()> {
+    if cached.selected_mailbox.as_deref() == Some(mailbox) {
+        return Ok(());
+    }
+    // Clear first so a failed SELECT never leaves a stale mailbox recorded
+    // (RFC 3501: a failed SELECT leaves no mailbox selected).
+    cached.selected_mailbox = None;
+    cached
+        .session
+        .select(mailbox)
+        .await
+        .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+    cached.selected_mailbox = Some(mailbox.to_string());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Tool struct
 // ---------------------------------------------------------------------------
 
 pub struct GmailTool {
     secrets: SecretStore,
+    /// Cached IMAP session, reused across calls. The lock is held for the
+    /// duration of an operation — IMAP is stateful, so operations on one
+    /// connection must not interleave.
+    imap: tokio::sync::Mutex<Option<CachedSession>>,
 }
 
 impl GmailTool {
     pub fn new(secrets: SecretStore) -> Self {
-        Self { secrets }
+        Self {
+            secrets,
+            imap: tokio::sync::Mutex::new(None),
+        }
     }
 
     /// Get email and app password from the credential store.
@@ -86,9 +169,17 @@ impl GmailTool {
                 Error::ToolExecution(format!("failed to store app password: {e}").into())
             })?;
 
-        // Verify credentials by connecting to IMAP.
-        let mut session = connect_imap(email, app_password).await?;
-        let _ = session.logout().await;
+        // Verify the new credentials by connecting to IMAP, dropping any
+        // session cached for the previous account and seeding the cache with
+        // the freshly verified one.
+        let mut guard = self.imap.lock().await;
+        *guard = None;
+        let session = connect_imap(email, app_password).await?;
+        *guard = Some(CachedSession {
+            session,
+            email: email.to_string(),
+            selected_mailbox: None,
+        });
 
         Ok(json!({
             "status": "authenticated",
@@ -110,12 +201,9 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, mailbox).await?;
 
         // Use Gmail's X-GM-RAW extension for full search syntax,
         // falling back to standard IMAP SEARCH.
@@ -141,7 +229,6 @@ impl GmailTool {
         uid_list.truncate(max_results);
 
         if uid_list.is_empty() {
-            let _ = session.logout().await;
             return Ok(json!({ "messages": [], "count": 0 }));
         }
 
@@ -194,8 +281,6 @@ impl GmailTool {
             }));
         }
 
-        let _ = session.logout().await;
-
         Ok(json!({
             "messages": messages,
             "count": messages.len(),
@@ -214,12 +299,9 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, mailbox).await?;
 
         let fetches: Vec<async_imap::types::Fetch> = session
             .uid_fetch(uid.to_string(), "(UID RFC822 FLAGS ENVELOPE)")
@@ -334,8 +416,6 @@ impl GmailTool {
 
         let flags: Vec<String> = fetch.flags().map(|f| format!("{f:?}")).collect();
 
-        let _ = session.logout().await;
-
         let mut result = json!({
             "uid": uid,
             "subject": subject,
@@ -429,7 +509,8 @@ impl GmailTool {
 
     async fn action_labels(&self) -> Result<Value> {
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
 
         let names: Vec<async_imap::types::Name> = session
             .list(Some(""), Some("*"))
@@ -448,8 +529,6 @@ impl GmailTool {
                 })
             })
             .collect();
-
-        let _ = session.logout().await;
 
         Ok(json!({ "labels": labels }))
     }
@@ -470,18 +549,14 @@ impl GmailTool {
             .to_string();
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session.select(&from_mailbox).await.map_err(|e| {
-            Error::ToolExecution(format!("select {from_mailbox} failed: {e}").into())
-        })?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, &from_mailbox).await?;
 
         session
             .uid_mv(uid.to_string(), &to_mailbox)
             .await
             .map_err(|e| Error::ToolExecution(format!("move failed: {e}").into()))?;
-
-        let _ = session.logout().await;
 
         Ok(json!({
             "status": "moved",
@@ -503,19 +578,14 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, mailbox).await?;
 
         session
             .uid_mv(uid.to_string(), "[Gmail]/Trash")
             .await
             .map_err(|e| Error::ToolExecution(format!("trash failed: {e}").into()))?;
-
-        let _ = session.logout().await;
 
         Ok(json!({ "status": "trashed", "uid": uid }))
     }
@@ -532,12 +602,9 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, mailbox).await?;
 
         // uid_store returns a stream of FETCH responses; drain it so the server
         // response is consumed before the next command.
@@ -557,8 +624,6 @@ impl GmailTool {
             .await
             .map_err(|e| Error::ToolExecution(format!("store stream failed: {e}").into()))?;
 
-        let _ = session.logout().await;
-
         let status = if read { "marked_read" } else { "marked_unread" };
         Ok(json!({ "status": status, "uid": uid }))
     }
@@ -575,13 +640,11 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
 
         // First, fetch the target message to get its References/In-Reply-To/Message-ID.
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        select_mailbox(session, mailbox).await?;
 
         let fetches: Vec<async_imap::types::Fetch> = session
             .uid_fetch(uid.to_string(), "(UID RFC822)")
@@ -621,7 +684,6 @@ impl GmailTool {
         }
 
         if msg_ids.is_empty() {
-            let _ = session.logout().await;
             return Ok(json!({
                 "thread": [],
                 "count": 0,
@@ -630,10 +692,7 @@ impl GmailTool {
         }
 
         // Search [Gmail]/All Mail for all messages matching any of these IDs.
-        session
-            .select("[Gmail]/All Mail")
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select All Mail failed: {e}").into()))?;
+        select_mailbox(session, "[Gmail]/All Mail").await?;
 
         let mut all_uids = std::collections::HashSet::new();
         for mid in &msg_ids {
@@ -653,7 +712,6 @@ impl GmailTool {
         }
 
         if all_uids.is_empty() {
-            let _ = session.logout().await;
             return Ok(json!({
                 "thread": [],
                 "count": 0,
@@ -743,8 +801,6 @@ impl GmailTool {
             }));
         }
 
-        let _ = session.logout().await;
-
         Ok(json!({
             "thread": messages,
             "count": messages.len(),
@@ -768,12 +824,9 @@ impl GmailTool {
         let mailbox = args["mailbox"].as_str().unwrap_or("INBOX");
 
         let (email, password) = self.get_credentials().await?;
-        let mut session = connect_imap(&email, &password).await?;
-
-        session
-            .select(mailbox)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("select {mailbox} failed: {e}").into()))?;
+        let mut guard = self.imap.lock().await;
+        let session = ensure_session(&mut guard, &email, &password).await?;
+        select_mailbox(session, mailbox).await?;
 
         let fetches: Vec<async_imap::types::Fetch> = session
             .uid_fetch(uid.to_string(), "(UID RFC822)")
@@ -855,8 +908,6 @@ impl GmailTool {
         }
         std::fs::write(&dest, contents)
             .map_err(|e| Error::ToolExecution(format!("write failed: {e}").into()))?;
-
-        let _ = session.logout().await;
 
         Ok(json!({
             "status": "downloaded",

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -198,9 +198,19 @@ pub async fn mcp_connector_tools(secrets: &SecretStore) -> Vec<Arc<dyn Tool>> {
         .filter(|s| !s.is_empty())
         .collect();
 
+    // Connect to all servers concurrently — startup latency is the slowest
+    // server, not the sum. `join_all` preserves input order, so tool
+    // registration order stays deterministic.
+    let results = futures::future::join_all(
+        names
+            .iter()
+            .map(|name| async move { connect_server(name, secrets).await }),
+    )
+    .await;
+
     let mut out: Vec<Arc<dyn Tool>> = Vec::new();
-    for name in names {
-        match connect_server(&name, secrets).await {
+    for (name, result) in names.iter().zip(results) {
+        match result {
             Ok(server_tools) => out.extend(server_tools),
             Err(e) => tracing::warn!(
                 server = %name,

--- a/crates/rustykrab-tools/src/notion.rs
+++ b/crates/rustykrab-tools/src/notion.rs
@@ -31,7 +31,10 @@ impl NotionTool {
     pub fn new(secrets: SecretStore) -> Self {
         Self {
             secrets,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         }
     }
 

--- a/crates/rustykrab-tools/src/obsidian.rs
+++ b/crates/rustykrab-tools/src/obsidian.rs
@@ -13,6 +13,17 @@ const KEY_API_KEY: &str = "obsidian_api_key";
 const KEY_SYNC_FOLDER: &str = "obsidian_sync_folder";
 const DEFAULT_API_URL: &str = "https://127.0.0.1:27124";
 
+/// Shared client for the free-function sync helpers, built once instead of
+/// per call. The Obsidian Local REST API uses a self-signed certificate by
+/// default, so invalid certs are accepted — this is a localhost-only
+/// connection.
+static SYNC_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap_or_default()
+});
+
 // ---------------------------------------------------------------------------
 // Tool struct
 // ---------------------------------------------------------------------------
@@ -591,12 +602,7 @@ pub async fn try_sync_to_obsidian(
 
     let note_content = format_synced_note(title, content, notion_id, notion_url);
 
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .map_err(|e| format!("failed to create HTTP client: {e}"))?;
-
-    let resp = client
+    let resp = SYNC_CLIENT
         .put(format!("{api_url}/vault/{vault_path}"))
         .header("Authorization", format!("Bearer {api_key}"))
         .header("Content-Type", "text/markdown")
@@ -646,12 +652,7 @@ pub async fn try_sync_append_to_obsidian(
         None => format!("{filename}.md"),
     };
 
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .map_err(|e| format!("failed to create HTTP client: {e}"))?;
-
-    let resp = client
+    let resp = SYNC_CLIENT
         .patch(format!("{api_url}/vault/{vault_path}"))
         .header("Authorization", format!("Bearer {api_key}"))
         .header("Content-Type", "text/markdown")

--- a/crates/rustykrab-tools/src/read.rs
+++ b/crates/rustykrab-tools/src/read.rs
@@ -90,6 +90,52 @@ impl Tool for ReadTool {
             }
         })?;
 
+        let offset = args["offset"].as_u64().unwrap_or(0) as usize;
+        let limit = args["limit"].as_u64().map(|v| v as usize);
+
+        if offset > 0 || limit.is_some() {
+            // Stream line by line: skip `offset` lines, take up to `limit`,
+            // and stop reading as soon as the window is filled instead of
+            // loading the whole file. This also lets a windowed read work on
+            // files larger than MAX_FILE_SIZE.
+            use tokio::io::AsyncBufReadExt;
+
+            let file = tokio::fs::File::open(&safe_path).await.map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    rustykrab_core::Error::ToolExecution(ToolError::not_found(format!(
+                        "file not found: {path}"
+                    )))
+                } else {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to read {path}: {e}").into(),
+                    )
+                }
+            })?;
+            let mut lines = tokio::io::BufReader::new(file).lines();
+
+            let mut selected: Vec<String> = Vec::new();
+            let mut line_no: usize = 0;
+            while limit.is_none_or(|l| selected.len() < l) {
+                let Some(line) = lines.next_line().await.map_err(|e| {
+                    rustykrab_core::Error::ToolExecution(
+                        format!("failed to read {path}: {e}").into(),
+                    )
+                })?
+                else {
+                    break;
+                };
+                if line_no >= offset {
+                    selected.push(line);
+                }
+                line_no += 1;
+            }
+
+            return Ok(json!({
+                "content": selected.join("\n"),
+                "lines": selected.len(),
+            }));
+        }
+
         if metadata.len() > MAX_FILE_SIZE {
             return Err(rustykrab_core::Error::ToolExecution(
                 format!(
@@ -112,28 +158,109 @@ impl Tool for ReadTool {
         })?;
 
         let lines: Vec<&str> = content.lines().collect();
-        let total_lines = lines.len();
-
-        let offset = args["offset"].as_u64().unwrap_or(0) as usize;
-        let limit = args["limit"].as_u64().map(|v| v as usize);
-
-        let sliced: Vec<&str> = if offset > 0 || limit.is_some() {
-            let start = offset.min(total_lines);
-            let end = match limit {
-                Some(l) => (start + l).min(total_lines),
-                None => total_lines,
-            };
-            lines[start..end].to_vec()
-        } else {
-            lines
-        };
-
-        let result_lines = sliced.len();
-        let result_content = sliced.join("\n");
+        let result_lines = lines.len();
+        let result_content = lines.join("\n");
 
         Ok(json!({
             "content": result_content,
             "lines": result_lines,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a fixture file inside the current directory (the workspace
+    /// boundary enforced by `security::validate_path`).
+    fn write_fixture(name: &str, content: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix("read-tool-test-")
+            .tempdir_in(std::env::current_dir().unwrap())
+            .unwrap();
+        let path = dir.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        (dir, path.to_string_lossy().into_owned())
+    }
+
+    fn numbered_lines(count: usize) -> String {
+        (0..count).map(|i| format!("line {i}\n")).collect()
+    }
+
+    #[tokio::test]
+    async fn reads_whole_file_without_offset() {
+        let (_dir, path) = write_fixture("whole.txt", &numbered_lines(5));
+        let result = ReadTool::new()
+            .execute(json!({ "path": path }))
+            .await
+            .unwrap();
+        assert_eq!(result["lines"], 5);
+        assert_eq!(result["content"], "line 0\nline 1\nline 2\nline 3\nline 4");
+    }
+
+    #[tokio::test]
+    async fn offset_and_limit_stream_a_window() {
+        let (_dir, path) = write_fixture("window.txt", &numbered_lines(10));
+        let result = ReadTool::new()
+            .execute(json!({ "path": path, "offset": 3, "limit": 2 }))
+            .await
+            .unwrap();
+        assert_eq!(result["lines"], 2);
+        assert_eq!(result["content"], "line 3\nline 4");
+    }
+
+    #[tokio::test]
+    async fn limit_alone_takes_from_start() {
+        let (_dir, path) = write_fixture("limit.txt", &numbered_lines(10));
+        let result = ReadTool::new()
+            .execute(json!({ "path": path, "limit": 3 }))
+            .await
+            .unwrap();
+        assert_eq!(result["lines"], 3);
+        assert_eq!(result["content"], "line 0\nline 1\nline 2");
+    }
+
+    #[tokio::test]
+    async fn offset_alone_reads_to_end() {
+        let (_dir, path) = write_fixture("offset.txt", &numbered_lines(5));
+        let result = ReadTool::new()
+            .execute(json!({ "path": path, "offset": 3 }))
+            .await
+            .unwrap();
+        assert_eq!(result["lines"], 2);
+        assert_eq!(result["content"], "line 3\nline 4");
+    }
+
+    #[tokio::test]
+    async fn offset_past_end_returns_empty() {
+        let (_dir, path) = write_fixture("past-end.txt", &numbered_lines(3));
+        let result = ReadTool::new()
+            .execute(json!({ "path": path, "offset": 100 }))
+            .await
+            .unwrap();
+        assert_eq!(result["lines"], 0);
+        assert_eq!(result["content"], "");
+    }
+
+    #[tokio::test]
+    async fn large_file_readable_with_window_but_capped_without() {
+        // A file above MAX_FILE_SIZE must reject a whole-file read but still
+        // serve a windowed read via streaming.
+        let line = format!("{}\n", "x".repeat(1023));
+        let count = (MAX_FILE_SIZE as usize / 1024) + 16;
+        let content: String = std::iter::repeat_n(line.as_str(), count).collect();
+        let (_dir, path) = write_fixture("large.txt", &content);
+
+        let whole = ReadTool::new().execute(json!({ "path": path })).await;
+        let err = whole.expect_err("whole-file read of oversized file must fail");
+        assert!(err.to_string().contains("too large"), "got: {err}");
+
+        let window = ReadTool::new()
+            .execute(json!({ "path": path, "offset": 1, "limit": 2 }))
+            .await
+            .unwrap();
+        assert_eq!(window["lines"], 2);
+        assert_eq!(window["content"], format!("{0}\n{0}", "x".repeat(1023)));
     }
 }

--- a/crates/rustykrab-tools/src/wiki.rs
+++ b/crates/rustykrab-tools/src/wiki.rs
@@ -31,7 +31,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
 use regex::Regex;
@@ -55,6 +55,29 @@ const SUMMARY_LIMIT: usize = 200;
 /// the agent-authored body.
 const BACKLINKS_START: &str = "<!--wiki:backlinks-->";
 const BACKLINKS_END: &str = "<!--wiki:backlinks:end-->";
+
+// Compiled once and reused — these run on every page read/write/search hit.
+static SCRIPT_STYLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)<(script|style)\b[^>]*>.*?</(script|style)>").expect("static regex")
+});
+static TAG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<[^>]+>").expect("static regex"));
+static WHITESPACE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").expect("static regex"));
+static ANCHOR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?is)<a\b[^>]*href\s*=\s*["']([^"']*)["'][^>]*>(.*?)</a>"#).expect("static regex")
+});
+static TITLE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<title>(.*?)</title>").expect("static regex"));
+static WIKI_MARKER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[\[wiki:([^\]]+)\]\]").expect("static regex"));
+static BACKLINKS_REGION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        "(?s){}.*?{}",
+        regex::escape(BACKLINKS_START),
+        regex::escape(BACKLINKS_END)
+    ))
+    .expect("static regex")
+});
 
 // ---------------------------------------------------------------------------
 // Sidecar index
@@ -444,13 +467,7 @@ impl WikiTool {
         };
         let backlinks = backlinks_for(index, target);
         let region = render_backlinks_region(&backlinks, &rel_root_for(target));
-        let re = Regex::new(&format!(
-            "(?s){}.*?{}",
-            regex::escape(BACKLINKS_START),
-            regex::escape(BACKLINKS_END)
-        ))
-        .expect("static regex");
-        let updated = re.replace(&document, region.as_str());
+        let updated = BACKLINKS_REGION_RE.replace(&document, region.as_str());
         if updated != document {
             let _ = std::fs::write(&path, updated.as_ref());
         }
@@ -882,14 +899,8 @@ fn render_page(
 /// Strip HTML to readable plaintext: drop script/style, remove tags, decode a
 /// handful of common entities, and collapse whitespace.
 fn html_to_text(html: &str) -> String {
-    let without_blocks = Regex::new(r"(?is)<(script|style)\b[^>]*>.*?</(script|style)>")
-        .expect("static regex")
-        .replace_all(html, " ")
-        .into_owned();
-    let without_tags = Regex::new(r"(?s)<[^>]+>")
-        .expect("static regex")
-        .replace_all(&without_blocks, " ")
-        .into_owned();
+    let without_blocks = SCRIPT_STYLE_RE.replace_all(html, " ").into_owned();
+    let without_tags = TAG_RE.replace_all(&without_blocks, " ").into_owned();
     let decoded = without_tags
         .replace("&lt;", "<")
         .replace("&gt;", ">")
@@ -898,18 +909,13 @@ fn html_to_text(html: &str) -> String {
         .replace("&apos;", "'")
         .replace("&nbsp;", " ")
         .replace("&amp;", "&");
-    Regex::new(r"\s+")
-        .expect("static regex")
-        .replace_all(&decoded, " ")
-        .trim()
-        .to_string()
+    WHITESPACE_RE.replace_all(&decoded, " ").trim().to_string()
 }
 
 /// Extract `(href, text)` pairs from anchor tags.
 fn extract_links(html: &str) -> Vec<(String, String)> {
-    let re = Regex::new(r#"(?is)<a\b[^>]*href\s*=\s*["']([^"']*)["'][^>]*>(.*?)</a>"#)
-        .expect("static regex");
-    re.captures_iter(html)
+    ANCHOR_RE
+        .captures_iter(html)
         .map(|c| {
             let href = c.get(1).map(|m| m.as_str().to_string()).unwrap_or_default();
             let text = html_to_text(c.get(2).map(|m| m.as_str()).unwrap_or(""));
@@ -919,8 +925,7 @@ fn extract_links(html: &str) -> Vec<(String, String)> {
 }
 
 fn extract_title(html: &str) -> Option<String> {
-    Regex::new(r"(?is)<title>(.*?)</title>")
-        .expect("static regex")
+    TITLE_RE
         .captures(html)
         .and_then(|c| c.get(1))
         .map(|m| html_to_text(m.as_str()))
@@ -928,8 +933,7 @@ fn extract_title(html: &str) -> Option<String> {
 
 /// Pull the `[[wiki:<slug>]]` back-reference out of an indexed memory fact.
 fn extract_wiki_marker(content: &str) -> Option<String> {
-    Regex::new(r"\[\[wiki:([^\]]+)\]\]")
-        .expect("static regex")
+    WIKI_MARKER_RE
         .captures(content)
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().to_string())


### PR DESCRIPTION
Performance sweep over `crates/rustykrab-tools`. Six independent fixes, all behavior-preserving:

## Fixes

1. **Gmail: cached IMAP session** (`gmail.rs`)
   Every action (`search`, `read`, `move`, `trash`, `mark_*`, `thread`, `labels`, `download_attachment`) opened a fresh TCP+TLS+IMAP LOGIN and logged out at the end — 300ms–1s of handshake per tool call, and Gmail throttles rapid re-authentication. The authenticated session is now cached in the tool struct behind a `tokio::sync::Mutex<Option<CachedSession>>`:
   - a `NOOP` probes liveness before reuse (and lets the server deliver pending mailbox updates per RFC 3501 §6.1.2), with lazy reconnect on failure;
   - the cache is keyed by account and invalidated on credential change; `setup` verifies the new credentials and seeds the cache;
   - SELECT state is tracked so repeat operations on the same mailbox skip the extra round trip, and a different target mailbox triggers a re-SELECT (a failed SELECT never records stale state);
   - per-call `LOGOUT`s are dropped — dead/stale connections are simply dropped rather than logged out, since LOGOUT on a broken socket can stall.

2. **Regexes recompiled per call** (`wiki.rs`, `caldav.rs`)
   `html_to_text()` compiled 3 regexes per invocation and `extract_links()` called it once per anchor (≈1+3N compilations per page); `refresh_page_backlinks` compiled per page; caldav's `split_responses`/`extract_hrefs`/`extract_tag_text`/`calendar_id_from_href` recompiled per WebDAV fragment. Static patterns are hoisted into `std::sync::LazyLock<Regex>`; `extract_tag_text`'s dynamic per-tag pattern is memoized in a small `LazyLock<Mutex<HashMap<String, Regex>>>` (the tag set is three fixed names). Behavior identical.

3. **`read` tool loads the whole file even with offset/limit** (`read.rs`)
   With `offset`/`limit` set, the tool now streams via `tokio::io::BufReader::lines()`, skips `offset`, takes `limit`, and stops reading once the window fills. The no-offset path keeps the existing 10MB cap and formatting; windowed reads now also work on files above the cap — which is exactly what the cap's error message tells the caller to do.

4. **Obsidian sync built a fresh reqwest client per call** (`obsidian.rs`)
   The free-function sync helpers (`try_sync_to_obsidian`, `try_sync_append_to_obsidian`) now share one `LazyLock<reqwest::Client>`. TLS behavior (`danger_accept_invalid_certs` for the self-signed localhost REST API) is deliberately unchanged.

5. **Notion client had no timeout** (`notion.rs`)
   Added a 30s `Client::builder().timeout(...)`, matching caldav/canvas/http_request/web_fetch.

6. **MCP servers connected sequentially at startup** (`mcp_connector.rs`)
   Connections now run concurrently via `futures::future::join_all`, so startup latency is the slowest server rather than the sum. `join_all` preserves input order, keeping tool registration deterministic, and per-server WARN logging is unchanged.

## Tests

- New unit tests for the `read` tool: whole-file, offset+limit window, limit-only, offset-only, offset-past-EOF, and a >10MB file that rejects a whole read but serves a windowed read.
- New caldav test exercising the per-tag regex cache (distinct tags, repeat lookups, absent tag).
- Existing wiki/caldav helper tests cover the hoisted regexes.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` (zero warnings), and `cargo test --workspace` (all green, 432 tests) pass locally. Gmail/IMAP session reuse is compile-verified and structured for testability, but not covered by a fake IMAP server.

Note: branched from `main`; touches only `crates/rustykrab-tools`. Overlaps textually with the pending store-async PR in gmail/caldav/notion/obsidian/mcp_connector — hunks here are kept tight around the connection/regex/read sites so merge conflicts stay trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2)_