### PR TITLE
fix: resolve cargo-audit vulnerabilities in CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,4 +12,21 @@ ignore = [
     # actionable upstream fix available; revisit when tokenizers releases a
     # version that drops the dependency.
     "RUSTSEC-2024-0436",
+
+    # quick-xml < 0.41.0 has two DoS advisories (quadratic attribute-name
+    # checking and unbounded namespace-declaration allocation). It is pulled
+    # in transitively, at two different versions, only via the `xcap`
+    # (screenshot capture) dependency used by the optional computer-use
+    # backend:
+    #   - `xcb` 1.7.0 depends on quick-xml ^0.30.0, used solely in its build
+    #     script to parse the crate's own bundled XCB protocol XML files
+    #     (crates.io xcb-1.7.0/build/*.rs) — not attacker-controlled input.
+    #   - `wayland-scanner` 0.31.10 depends on quick-xml ^0.39, used solely
+    #     at compile time to codegen bindings from bundled Wayland protocol
+    #     XML — likewise not attacker-controlled input.
+    # Neither xcb (latest: 1.7.0) nor wayland-scanner (latest: 0.31.10) has
+    # released a version depending on quick-xml >=0.41.0 yet. Revisit when
+    # either does.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -99,9 +99,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -111,7 +111,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -584,6 +584,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chromiumoxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1737,11 +1757,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1751,10 +1769,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2551,9 +2572,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3381,7 +3402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3521,15 +3542,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3604,6 +3626,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,6 +3672,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4026,7 +4074,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4043,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4064,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4097,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4111,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "axum",
  "chrono",
@@ -4135,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4156,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4173,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4212,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.5"
+version = "4.5.6"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -4480,7 +4528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4491,7 +4539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 


### PR DESCRIPTION
Bump quinn-proto 0.11.14 -> 0.11.16 to fix RUSTSEC-2026-0185 (unbounded
out-of-order stream reassembly memory exhaustion), and anyhow/memmap2
patch versions to clear their unsound advisories. Also picks up a stale
Cargo.lock <-> Cargo.toml workspace version drift (4.5.5 -> 4.5.6) that
cargo update naturally corrected.

quick-xml's two DoS advisories (RUSTSEC-2026-0194/0195) can't be fixed
yet: both xcb 1.7.0 and wayland-scanner 0.31.10 (transitive deps of the
xcap screenshot backend) are the latest available releases and still
pin quick-xml ^0.30/^0.39. Verified quick-xml is only used in their
build scripts to parse each crate's own bundled protocol XML, not
attacker-controlled input, so ignore both with justification in
.cargo/audit.toml pending an upstream release.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AKTdyn48KnMFqAgkc8evjC