### PR TITLE
perf(cli): lazy embedder, background index rebuild, concurrent startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ All configuration is via environment variables. No plaintext config files.
 | `SIGNAL_ALLOWED_NUMBERS` | — | Comma-separated E.164 numbers allowed to message |
 | `SIGNAL_WEBHOOK_URL` | — | Webhook URL (omit for polling mode) |
 | `SIGNAL_WEBHOOK_SECRET` | — | Shared secret for webhook validation |
-| `RUST_LOG` | — | Log level (`info`, `debug`, `rustykrab_gateway=debug`) |
+| `RUST_LOG` | `info` | Log level (`info`, `debug`, `rustykrab_gateway=debug`) |
+| `RUSTYKRAB_LOG_STDOUT` | auto | Force stdout logging on (`1`) or off (`0`). Default: enabled only when stdout is a terminal. The rolling log file under the data directory is always written |
 
 ### Persisting credentials
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -31,7 +31,7 @@ use rustykrab_core::types::{ContentPart, MessageContent};
 use rustykrab_core::AgentRegistry;
 use rustykrab_gateway::AppState;
 use rustykrab_memory::backend::HybridMemoryBackend;
-use rustykrab_memory::embedding::FastEmbedder;
+use rustykrab_memory::embedding::LazyFastEmbedder;
 use rustykrab_memory::storage::SqliteMemoryStorage;
 use rustykrab_memory::{MemoryConfig, MemorySystem};
 use rustykrab_skills::SkillRegistry;
@@ -319,11 +319,25 @@ async fn main() -> anyhow::Result<()> {
     let file_appender = tracing_appender::rolling::daily(&log_dir, "rustykrab.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
-    let env_filter = EnvFilter::from_default_env();
+    // Default to `info` when RUST_LOG is unset so verbosity doesn't silently
+    // depend on the environment; RUST_LOG still overrides as before.
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    // The stdout layer is only active on a terminal (interactive runs) or
+    // when forced via RUSTYKRAB_LOG_STDOUT=1 — otherwise every event would
+    // be formatted twice (stdout + rolling file) for no reader. Setting
+    // RUSTYKRAB_LOG_STDOUT=0 disables it even on a TTY. The rolling file
+    // layer is always active.
+    let stdout_log_enabled = match std::env::var("RUSTYKRAB_LOG_STDOUT") {
+        Ok(v) => matches!(v.trim(), "1" | "true" | "TRUE" | "True"),
+        Err(_) => std::io::IsTerminal::is_terminal(&std::io::stdout()),
+    };
 
     tracing_subscriber::registry()
         .with(env_filter)
-        .with(fmt::layer().with_writer(std::io::stdout))
+        .with(stdout_log_enabled.then(|| fmt::layer().with_writer(std::io::stdout)))
         .with(fmt::layer().with_writer(non_blocking).with_ansi(false))
         .init();
 
@@ -423,6 +437,16 @@ async fn main() -> anyhow::Result<()> {
     // 4. Generate a new token and persist it in Keychain + SecretStore
     let auth_token = resolve_auth_token(&store);
 
+    // --- MCP connector (remote MCP servers as native tools) ---
+    // Kicked off now so per-server connection latency overlaps with the
+    // rest of startup (provider detection, memory init, skill loading);
+    // joined below at tool-registration time. Per-server connect failures
+    // are logged inside and never block startup.
+    let mcp_tools_task = {
+        let secrets = store.secrets();
+        tokio::spawn(async move { rustykrab_tools::mcp_connector_tools(&secrets).await })
+    };
+
     // --- Model provider ---
     let provider_name =
         std::env::var("RUSTYKRAB_PROVIDER").unwrap_or_else(|_| "anthropic".to_string());
@@ -521,8 +545,11 @@ async fn main() -> anyhow::Result<()> {
     );
     let model_cache_dir = data_dir.join("models");
     std::fs::create_dir_all(&model_cache_dir)?;
-    let embedder =
-        Arc::new(FastEmbedder::new(model_cache_dir).expect("failed to initialize embedding model"));
+    // Lazy: ONNX Runtime init (and a ~275MB model download on first run)
+    // happens off-thread on the first embed() call instead of blocking
+    // boot. Init failures surface as clear errors from the first
+    // embedding operation.
+    let embedder = Arc::new(LazyFastEmbedder::new(model_cache_dir));
     let memory_system = Arc::new(MemorySystem::new(
         MemoryConfig::default(),
         memory_storage,
@@ -549,11 +576,22 @@ async fn main() -> anyhow::Result<()> {
 
     let session_id = Uuid::new_v4();
 
-    // Rebuild FTS5 index from persisted memories (idempotent).
-    let indexed = memory_system.rebuild_indexes(agent_id).await?;
-    if indexed > 0 {
-        tracing::info!(indexed, "FTS5 index rebuilt from stored memories");
-    }
+    // Rebuild FTS5 index from persisted memories (idempotent). Runs in the
+    // background so a large corpus doesn't delay gateway bind; the handle
+    // is pushed into `infra_handles` below for graceful shutdown.
+    let index_rebuild_handle = {
+        let system = Arc::clone(&memory_system);
+        tokio::spawn(async move {
+            match system.rebuild_indexes(agent_id).await {
+                Ok(indexed) => {
+                    if indexed > 0 {
+                        tracing::info!(indexed, "FTS5 index rebuilt from stored memories");
+                    }
+                }
+                Err(e) => tracing::error!(error = %e, "FTS5 index rebuild failed"),
+            }
+        })
+    };
 
     let memory_backend: Arc<dyn MemoryBackend> = Arc::new(MemoryAdapter {
         inner: HybridMemoryBackend::new(Arc::clone(&memory_system), agent_id, session_id),
@@ -741,11 +779,13 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // --- MCP connector (remote MCP servers as native tools) ---
+    // --- MCP connector tools (join the task started before provider setup) ---
     // Registered before the sub-agent snapshot below so sub-agents also
     // inherit MCP tools. Per-server connect failures are logged inside
     // and never block startup.
-    let mcp_tools = rustykrab_tools::mcp_connector_tools(&store.secrets()).await;
+    let mcp_tools = mcp_tools_task
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP connector task panicked: {e}"))?;
     if !mcp_tools.is_empty() {
         tracing::info!(count = mcp_tools.len(), "MCP connector tools registered");
         tools.extend(mcp_tools);
@@ -857,11 +897,17 @@ async fn main() -> anyhow::Result<()> {
     // Track infrastructure task JoinHandles so panics are surfaced
     // instead of silently swallowed (fixes ASYNC-H4).
     let mut infra_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+    infra_handles.push(index_rebuild_handle);
 
     // --- Telegram channel (optional) ---
     // We need to take the inbound_rx before wrapping in Arc, so build in stages.
     let mut telegram_rx: Option<mpsc::Receiver<ChannelMessage>> = None;
     let mut telegram_arc: Option<Arc<TelegramChannel>> = None;
+    // Webhook registration runs concurrently with the rest of channel
+    // setup and is joined below, before the agent loops start. A
+    // registration failure stays fatal, exactly as it was inline.
+    let mut telegram_webhook_task: Option<tokio::task::JoinHandle<rustykrab_core::Result<()>>> =
+        None;
 
     if let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") {
         let allowed_chats: HashSet<i64> = std::env::var("TELEGRAM_ALLOWED_CHATS")
@@ -886,7 +932,10 @@ async fn main() -> anyhow::Result<()> {
         state = state.with_telegram(tg.clone());
 
         if let Ok(webhook_url) = std::env::var("TELEGRAM_WEBHOOK_URL") {
-            tg.set_webhook(&webhook_url).await?;
+            let tg_hook = tg.clone();
+            telegram_webhook_task = Some(tokio::spawn(async move {
+                tg_hook.set_webhook(&webhook_url).await
+            }));
             tracing::info!("Telegram: webhook mode");
         } else {
             let tg_poll = tg.clone();
@@ -936,19 +985,30 @@ async fn main() -> anyhow::Result<()> {
         channel_hub.set_signal(sig.clone());
         state = state.with_signal(sig.clone());
 
-        // Health check — verify signal-cli-rest-api is running.
-        match sig.health_check().await {
-            Ok(()) => tracing::info!("signal-cli-rest-api connected"),
-            Err(e) => tracing::error!("signal-cli-rest-api not reachable: {e}"),
+        // Health check — verify signal-cli-rest-api is running. Runs
+        // concurrently with the rest of startup; the outcome is logged
+        // (it was never fatal).
+        {
+            let sig_health = sig.clone();
+            infra_handles.push(tokio::spawn(async move {
+                match sig_health.health_check().await {
+                    Ok(()) => tracing::info!("signal-cli-rest-api connected"),
+                    Err(e) => tracing::error!("signal-cli-rest-api not reachable: {e}"),
+                }
+            }));
         }
 
-        // Webhook or polling mode.
+        // Webhook or polling mode. Webhook registration also runs
+        // concurrently; failures are logged (as before, non-fatal).
         if let Ok(webhook_url) = std::env::var("SIGNAL_WEBHOOK_URL") {
-            if let Err(e) = sig.register_webhook(&webhook_url).await {
-                tracing::error!("failed to register Signal webhook: {e}");
-            } else {
-                tracing::info!("Signal: webhook mode");
-            }
+            let sig_hook = sig.clone();
+            infra_handles.push(tokio::spawn(async move {
+                if let Err(e) = sig_hook.register_webhook(&webhook_url).await {
+                    tracing::error!("failed to register Signal webhook: {e}");
+                } else {
+                    tracing::info!("Signal: webhook mode");
+                }
+            }));
         } else {
             let sig_poll = sig.clone();
             // Store handle so panics are not silently swallowed (fixes ASYNC-H4).
@@ -971,6 +1031,14 @@ async fn main() -> anyhow::Result<()> {
                 "Signal allowed numbers configured"
             );
         }
+    }
+
+    // --- Join deferred Telegram webhook registration ---
+    // Ran concurrently with the Signal setup above; a failure is still
+    // fatal, exactly as when the call was inline.
+    if let Some(task) = telegram_webhook_task {
+        task.await
+            .map_err(|e| anyhow::anyhow!("Telegram webhook task panicked: {e}"))??;
     }
 
     // --- Spawn Telegram agent loop (after state is fully built) ---

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -153,7 +153,9 @@ async fn execute_cron_task(
     store: &rustykrab_store::Store,
 ) {
     let started_at = Utc::now();
-    tracing::info!(job_id = %job_id, task = %task_prompt, "executing scheduled job");
+    // Full task body only at debug — the info-level start marker (with
+    // trace_id) is emitted below once the run actually begins.
+    tracing::debug!(job_id = %job_id, task = %task_prompt, "executing scheduled job");
 
     // Load the job so we can resume its persistent conversation and use
     // last_run_at in the prompt.

--- a/crates/rustykrab-core/Cargo.toml
+++ b/crates/rustykrab-core/Cargo.toml
@@ -12,5 +12,9 @@ chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+# Deliberately not the workspace `full` feature set: this crate only uses
+# `tokio::task_local!` (rt) and `#[tokio::test]` (macros). Workspace feature
+# unification leaves the final binary unchanged; this keeps the leaf crate's
+# dependency graph honest and standalone builds fast.
+tokio = { version = "1", features = ["rt", "macros"] }
 uuid.workspace = true

--- a/crates/rustykrab-memory/src/embedding.rs
+++ b/crates/rustykrab-memory/src/embedding.rs
@@ -236,10 +236,74 @@ mod fastembed_impl {
             &self.model_version
         }
     }
+
+    /// Lazily-initialized [`FastEmbedder`].
+    ///
+    /// Construction is instant; the underlying model (ONNX Runtime init plus
+    /// a ~275MB download on first run) is built inside `spawn_blocking` on
+    /// the first `embed()` call, so daemon startup never blocks on it.
+    /// Init failure surfaces as a clear error from `embed()` and is retried
+    /// on the next call (transient download failures are recoverable).
+    ///
+    /// Dimensions and model version match [`FastEmbedder::new`]
+    /// (Nomic-embed-text-v1.5, 768d) and are available without init.
+    pub struct LazyFastEmbedder {
+        cache_dir: PathBuf,
+        inner: tokio::sync::OnceCell<FastEmbedder>,
+        dims: usize,
+        model_version: String,
+    }
+
+    impl LazyFastEmbedder {
+        /// Create a lazy embedder using the default model
+        /// (Nomic-embed-text-v1.5, matching [`FastEmbedder::new`]).
+        pub fn new(cache_dir: PathBuf) -> Self {
+            Self {
+                cache_dir,
+                inner: tokio::sync::OnceCell::new(),
+                dims: 768,
+                model_version: format!("{:?}", EmbeddingModel::NomicEmbedTextV15),
+            }
+        }
+
+        async fn embedder(&self) -> std::result::Result<&FastEmbedder, rustykrab_core::Error> {
+            self.inner
+                .get_or_try_init(|| async {
+                    let cache_dir = self.cache_dir.clone();
+                    tracing::info!(
+                        "initializing embedding model (first use — may download model files)"
+                    );
+                    let embedder =
+                        tokio::task::spawn_blocking(move || FastEmbedder::new(cache_dir))
+                            .await
+                            .map_err(|e| {
+                                rustykrab_core::Error::Internal(format!("spawn_blocking: {e}"))
+                            })??;
+                    tracing::info!("embedding model initialized");
+                    Ok(embedder)
+                })
+                .await
+        }
+    }
+
+    #[async_trait]
+    impl Embedder for LazyFastEmbedder {
+        async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
+            self.embedder().await?.embed(texts).await
+        }
+
+        fn dimensions(&self) -> usize {
+            self.dims
+        }
+
+        fn model_version(&self) -> &str {
+            &self.model_version
+        }
+    }
 }
 
 #[cfg(feature = "fastembed")]
-pub use fastembed_impl::FastEmbedder;
+pub use fastembed_impl::{FastEmbedder, LazyFastEmbedder};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Startup-path performance fixes: the daemon now binds the gateway without waiting on work that can happen lazily, off-thread, or concurrently.

### Fixes

1. **Lazy, off-thread embedder** — `FastEmbedder::new` ran inline on the async main thread at boot: ONNX Runtime init plus a ~275MB model download on first run, during which the daemon served nothing. New `LazyFastEmbedder` (in `rustykrab-memory/src/embedding.rs`, exported alongside `FastEmbedder`) constructs the inner model inside `spawn_blocking` behind a `tokio::sync::OnceCell` on the first `embed()` call. Init failure surfaces as a clear error from that call and is retried on the next one (transient download failures are recoverable, not a silent no-op). Dimensions/model version are available without init and match `FastEmbedder::new` (Nomic-embed-text-v1.5, 768d).
2. **Background FTS5 index rebuild** — `memory_system.rebuild_indexes(agent_id).await` rebuilt the index from all persisted memories inline before the gateway bound, growing with corpus size. It now runs as a background task pushed onto `infra_handles` (the existing graceful-shutdown pattern) with info/error log lines on completion/failure.
3. **Concurrent startup network I/O** — the boot sequence was one long sequential await chain:
   - MCP connector connections (previously one-by-one, inline) now start before provider setup and are joined at tool-registration time, overlapping with Ollama context-window detection, memory init, and skill loading. Per-server failure semantics unchanged (logged, never fatal).
   - Telegram `set_webhook` runs concurrently with the rest of channel setup and is joined before the agent loops start — **a failure is still fatal**, exactly as when it was inline.
   - Signal `health_check` and `register_webhook` run as background tasks; both were already non-fatal/logged, and remain so.
4. **Logging** — the stdout fmt layer is now active only when stdout is a TTY, or when forced via `RUSTYKRAB_LOG_STDOUT=1` (`0` disables it even on a TTY), so every event isn't formatted twice (stdout + rolling file) under a service manager. `EnvFilter` gets `.with_default_directive(LevelFilter::INFO)`, so an unset `RUST_LOG` behaves sensibly instead of silently depending on the environment. Documented in the README env-var table.
5. **Log demotion (cli only)** — `task_queue.rs` logged the full scheduled-job prompt body at info on every job fire; demoted to debug (the per-run info marker with `trace_id` remains).
6. **Tokio feature trim** — `rustykrab-core` inherited the workspace `tokio = { features = ["full"] }` but only uses `task_local!` (`rt`) and `#[tokio::test]` (`macros`); its `Cargo.toml` now declares exactly those. Feature unification leaves the workspace binary unchanged — this is dependency-graph honesty plus faster standalone/incremental builds. `rustykrab-skills` turned out to have no tokio dependency at all, so there was nothing to trim there (verified it still checks standalone).

Also included: `Cargo.lock` workspace-member versions synced 4.5.5 → 4.5.6 — the lock on `main` lagged the workspace version bump and any cargo invocation regenerates it.

### Non-overlap with the gateway/channels PR

This PR deliberately does not touch the channel poller spawn blocks (Telegram/Signal polling, Slack Socket Mode) that `claude/perf-05-gateway-channels` rewrites with supervised restart loops — those hunks are untouched context in this diff. It also skips `rustykrab-gateway/src/orchestrate.rs` logging (owned by that PR). No source changes in rustykrab-store, -gateway, -channels, -providers, -tools, or -agent.

### Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — zero warnings
- `cargo test --workspace` — all green (425 passed, 0 failed)
- `cargo check -p rustykrab-core -p rustykrab-skills` — trimmed features stand alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2)_