### PR TITLE
perf(store): normalize conversation storage — append messages instead of rewriting the blob

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1394,7 +1394,9 @@ async fn telegram_agent_loop(
                                     if thread_id != 0 {
                                         conv.channel_thread_id = Some(thread_id.to_string());
                                     }
-                                    if let Err(e) = state.store.conversations().save(&conv).await {
+                                    if let Err(e) =
+                                        state.store.conversations().save_meta(&conv).await
+                                    {
                                         tracing::warn!(
                                             chat_id,
                                             "failed to persist channel metadata: {e}"
@@ -1490,7 +1492,9 @@ async fn process_telegram_message(
     chat_states: &Arc<tokio::sync::Mutex<HashMap<(i64, i64), ChatState>>>,
     key: (i64, i64),
 ) -> String {
-    // Load the conversation.
+    // Load the conversation. `persisted_ids` lets the post-run save
+    // append only this turn's messages (full rewrite if the agent
+    // compacted history mid-run).
     let mut conv = match state.store.conversations().get(conv_id).await {
         Ok(c) => c,
         Err(e) => {
@@ -1498,6 +1502,7 @@ async fn process_telegram_message(
             return "Internal error — please try again.".to_string();
         }
     };
+    let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
 
     // Ensure channel metadata is present (backfills conversations created
     // before this field was populated).
@@ -1602,8 +1607,15 @@ async fn process_telegram_message(
         // Await the join handle to get the final conversation.
         match join_handle.await {
             Ok(Ok(final_conv)) => {
-                // Persist the final conversation.
-                if let Err(e) = state.store.conversations().save(&final_conv).await {
+                // Persist the turn: appends the new messages, or falls
+                // back to a full rewrite if compaction replaced the
+                // persisted prefix.
+                if let Err(e) = state
+                    .store
+                    .conversations()
+                    .save_turn(&final_conv, &persisted_ids)
+                    .await
+                {
                     tracing::error!(chat_id, %conv_id, "failed to persist conversation: {e}");
                 }
                 // Extract last assistant text.
@@ -1885,6 +1897,10 @@ async fn process_slack_message(
             return "Internal error — please try again.".to_string();
         }
     };
+    // Ids of the already-persisted messages: the post-run save appends
+    // only this turn's tail (full rewrite if the agent compacted
+    // history mid-run).
+    let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
 
     if conv.channel_source.is_none() {
         conv.channel_source = Some("slack".to_string());
@@ -1943,7 +1959,12 @@ async fn process_slack_message(
         }
     };
 
-    if let Err(e) = state.store.conversations().save(&conv).await {
+    if let Err(e) = state
+        .store
+        .conversations()
+        .save_turn(&conv, &persisted_ids)
+        .await
+    {
         tracing::error!(channel_id, %conv_id, "failed to persist Slack conversation: {e}");
     }
 

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -245,7 +245,9 @@ async fn execute_cron_task(
         effective_chat_id.as_deref(),
         effective_thread_id.as_deref(),
     ) {
-        if let Err(e) = state.store.conversations().save(&conv).await {
+        // Metadata-only change — the resumed conversation's messages are
+        // untouched here, so skip rewriting them.
+        if let Err(e) = state.store.conversations().save_meta(&conv).await {
             tracing::warn!(
                 job_id = %job_id,
                 "failed to persist channel context onto job conversation: {e}"

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -340,13 +340,17 @@ async fn send_message(
         return Err(StatusCode::PAYLOAD_TOO_LARGE);
     }
 
-    // Load the conversation.
+    // Load the conversation. Capture the ids of the already-persisted
+    // messages so the post-turn save can append just the new tail —
+    // save_turn falls back to a full rewrite if the agent compacted
+    // history (the persisted prefix no longer matches).
     let mut conv = state
         .store
         .conversations()
         .get(id)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
+    let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
 
     // Clone content before moving into the message (needed for profile classification).
     let user_content = body.content.clone();
@@ -365,12 +369,14 @@ async fn send_message(
     let assistant_msg =
         crate::orchestrate::run_agent(&state, &mut conv, &user_content, trace_id).await?;
 
-    // Persist the full conversation (including intermediate tool call messages).
+    // Persist the turn (including intermediate tool call messages):
+    // appends the new messages and bumps updated_at, or rewrites the
+    // whole conversation if compaction replaced the persisted prefix.
     conv.updated_at = Utc::now();
     state
         .store
         .conversations()
-        .save(&conv)
+        .save_turn(&conv, &persisted_ids)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -424,13 +430,16 @@ async fn send_message_stream(
         return Err(StatusCode::PAYLOAD_TOO_LARGE);
     }
 
-    // Load the conversation.
+    // Load the conversation. `persisted_ids` lets the post-turn
+    // save_turn append only the new messages (full rewrite if the agent
+    // compacted history mid-run).
     let mut conv = state
         .store
         .conversations()
         .get(id)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
+    let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
     let conv_id = conv.id;
 
     let user_content = body.content.clone();
@@ -515,9 +524,16 @@ async fn send_message_stream(
         // 5 minutes after the agent completes normally.
         monitor.abort();
 
-        // Persist conversation regardless of outcome to preserve the user message.
+        // Persist the turn regardless of outcome to preserve the user
+        // message. Appends the new tail; full rewrite when compaction
+        // replaced the persisted prefix.
         conv.updated_at = Utc::now();
-        if let Err(e) = agent_state.store.conversations().save(&conv).await {
+        if let Err(e) = agent_state
+            .store
+            .conversations()
+            .save_turn(&conv, &persisted_ids)
+            .await
+        {
             tracing::error!("failed to save conversation: {e}");
         }
 

--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use rusqlite::params;
-use rustykrab_core::types::Conversation;
+use rustykrab_core::types::{Conversation, Message};
 use rustykrab_core::Error;
 use std::sync::Mutex;
 use uuid::Uuid;
@@ -18,10 +18,153 @@ pub struct ConversationSummary {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Fixed-width UTC RFC3339 so `ORDER BY updated_at` on the TEXT column
+/// is chronological (variable-precision timestamps don't sort
+/// lexicographically).
+fn fmt_ts(dt: &DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+fn parse_ts(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|t| t.with_timezone(&Utc))
+}
+
+/// Clone of the conversation with the messages stripped — this is what
+/// the `conversations.data` column stores. Messages live in the
+/// `messages` table, one row each. Struct literal (not `..clone()`) so
+/// adding a field to `Conversation` forces a decision here.
+fn meta_only(conv: &Conversation) -> Conversation {
+    Conversation {
+        id: conv.id,
+        messages: Vec::new(),
+        created_at: conv.created_at,
+        updated_at: conv.updated_at,
+        title: conv.title.clone(),
+        summary: conv.summary.clone(),
+        detected_profile: conv.detected_profile.clone(),
+        channel_source: conv.channel_source.clone(),
+        channel_id: conv.channel_id.clone(),
+        channel_thread_id: conv.channel_thread_id.clone(),
+    }
+}
+
+/// Upsert the metadata row: slimmed JSON blob plus the promoted
+/// `title`/`created_at`/`updated_at` columns that `list_summaries`
+/// reads without any JSON parsing.
+fn upsert_meta_row(conn: &rusqlite::Connection, conv: &Conversation) -> Result<(), Error> {
+    let meta = serde_json::to_string(&meta_only(conv))?;
+    conn.execute(
+        "INSERT INTO conversations (id, data, title, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(id) DO UPDATE SET
+             data = excluded.data,
+             title = excluded.title,
+             created_at = excluded.created_at,
+             updated_at = excluded.updated_at",
+        params![
+            conv.id.to_string(),
+            meta,
+            conv.title,
+            fmt_ts(&conv.created_at),
+            fmt_ts(&conv.updated_at)
+        ],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
+}
+
+fn insert_message_row(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    idx: usize,
+    msg: &Message,
+) -> Result<(), Error> {
+    let data = serde_json::to_string(msg)?;
+    conn.execute(
+        "INSERT OR REPLACE INTO messages (conversation_id, idx, data) VALUES (?1, ?2, ?3)",
+        params![conversation_id, idx as i64, data],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
+}
+
+/// Full rewrite of one conversation: metadata row plus every message
+/// row, atomically. Must run outside any open transaction.
+fn write_full(conn: &rusqlite::Connection, conv: &Conversation) -> Result<(), Error> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| Error::Storage(e.to_string()))?;
+    upsert_meta_row(&tx, conv)?;
+    let id = conv.id.to_string();
+    tx.execute(
+        "DELETE FROM messages WHERE conversation_id = ?1",
+        params![id],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    for (idx, msg) in conv.messages.iter().enumerate() {
+        insert_message_row(&tx, &id, idx, msg)?;
+    }
+    tx.commit().map_err(|e| Error::Storage(e.to_string()))
+}
+
+/// One-time migration of legacy single-blob rows into the normalized
+/// schema (metadata row + one `messages` row per message).
+///
+/// Legacy rows are exactly those with `updated_at IS NULL`: the column
+/// was just added by `run_migrations` for old databases, and every
+/// write path in this module sets it. Runs in ONE transaction for the
+/// whole sweep — an interrupt rolls back atomically, leaving every row
+/// in its legacy blob form (no data loss, no half-migrated
+/// conversations), and the NULL predicate makes a completed sweep a
+/// no-op, so re-running on every startup is safe and cheap.
+///
+/// Rows whose JSON cannot be parsed are left untouched (still legacy),
+/// mirroring the old `list_summaries` skip-on-parse-failure behavior.
+pub(crate) fn migrate_legacy_blobs(conn: &rusqlite::Connection) -> Result<(), Error> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| Error::Storage(e.to_string()))?;
+    let legacy: Vec<(String, String)> = {
+        let mut stmt = tx
+            .prepare("SELECT id, data FROM conversations WHERE updated_at IS NULL")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Storage(e.to_string()))?
+    };
+    for (id, data) in legacy {
+        let conv: Conversation = match serde_json::from_str(&data) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(conversation_id = %id, "skipping unparseable legacy conversation blob: {e}");
+                continue;
+            }
+        };
+        for (idx, msg) in conv.messages.iter().enumerate() {
+            insert_message_row(&tx, &id, idx, msg)?;
+        }
+        upsert_meta_row(&tx, &conv)?;
+    }
+    tx.commit().map_err(|e| Error::Storage(e.to_string()))
+}
+
 /// CRUD operations on conversations backed by SQLite.
 ///
 /// All methods run their rusqlite work on tokio's blocking pool via
 /// `spawn_blocking` so async workers never park on disk I/O.
+///
+/// Storage layout: `conversations` holds one metadata row per
+/// conversation (slimmed JSON without messages, plus promoted
+/// title/timestamp columns); `messages` holds one row per message keyed
+/// by `(conversation_id, idx)`. Per-turn persistence appends message
+/// rows instead of rewriting the whole conversation — see
+/// [`ConversationStore::save_turn`].
 #[derive(Clone)]
 pub struct ConversationStore {
     conn: Arc<Mutex<rusqlite::Connection>>,
@@ -55,37 +198,130 @@ impl ConversationStore {
         Ok(conv)
     }
 
-    /// Persist a conversation (insert or update).
+    /// Persist a conversation, rewriting every message row (insert or
+    /// update). O(total messages) — use [`Self::save_turn`] for the
+    /// per-turn hot path and reserve this for genuine full rewrites
+    /// (creation, compaction).
     pub async fn save(&self, conv: &Conversation) -> Result<(), Error> {
-        let id = conv.id.to_string();
-        let data = serde_json::to_string(conv)?;
+        let conv = conv.clone();
+        with_conn(&self.conn, move |conn| write_full(conn, &conv)).await
+    }
+
+    /// Upsert the conversation's metadata (title, timestamps, summary,
+    /// channel fields) without touching its message rows.
+    pub async fn save_meta(&self, conv: &Conversation) -> Result<(), Error> {
+        let meta = meta_only(conv);
+        with_conn(&self.conn, move |conn| upsert_meta_row(conn, &meta)).await
+    }
+
+    /// Insert (or overwrite) the single message at position `idx` of a
+    /// conversation. Callers appending a turn should follow up with
+    /// [`Self::save_meta`] to bump `updated_at` — or use
+    /// [`Self::save_turn`], which does both atomically.
+    pub async fn append_message(
+        &self,
+        conversation_id: Uuid,
+        idx: usize,
+        msg: &Message,
+    ) -> Result<(), Error> {
+        let msg = msg.clone();
         with_conn(&self.conn, move |conn| {
-            conn.execute(
-                "INSERT INTO conversations (id, data) VALUES (?1, ?2)
-                 ON CONFLICT(id) DO UPDATE SET data = excluded.data",
-                params![id, data],
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
-            Ok(())
+            insert_message_row(conn, &conversation_id.to_string(), idx, &msg)
         })
         .await
     }
 
-    /// Retrieve a conversation by ID.
+    /// Persist the outcome of an agent turn without rewriting history.
+    ///
+    /// `persisted_ids` are the ids of the messages that were already
+    /// stored when the conversation was loaded — capture them right
+    /// after `get()`. If the in-memory conversation still starts with
+    /// exactly that sequence, only the new tail is appended (plus the
+    /// metadata row, and the message at idx 0, which the orchestrator
+    /// rewrites in place with a fresh system prompt on every run). If
+    /// the prefix no longer matches — compaction rewrote history — this
+    /// falls back to a full [`Self::save`].
+    ///
+    /// Known in-place edit this deliberately does not persist: the
+    /// agent's oversized-summary repair mutates a mid-history message
+    /// without changing its id. That repair is deterministic and
+    /// re-applied on every load, so losing it on the append path is
+    /// harmless.
+    pub async fn save_turn(
+        &self,
+        conv: &Conversation,
+        persisted_ids: &[Uuid],
+    ) -> Result<(), Error> {
+        let prefix_intact = conv.messages.len() >= persisted_ids.len()
+            && conv
+                .messages
+                .iter()
+                .zip(persisted_ids.iter())
+                .all(|(m, id)| m.id == *id);
+        if !prefix_intact {
+            return self.save(conv).await;
+        }
+
+        let meta = meta_only(conv);
+        let first = if persisted_ids.is_empty() {
+            None
+        } else {
+            conv.messages.first().cloned()
+        };
+        let base = persisted_ids.len();
+        let tail: Vec<Message> = conv.messages[base..].to_vec();
+        with_conn(&self.conn, move |conn| {
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            upsert_meta_row(&tx, &meta)?;
+            let id = meta.id.to_string();
+            if let Some(first) = &first {
+                insert_message_row(&tx, &id, 0, first)?;
+            }
+            for (offset, msg) in tail.iter().enumerate() {
+                insert_message_row(&tx, &id, base + offset, msg)?;
+            }
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))
+        })
+        .await
+    }
+
+    /// Retrieve a conversation by ID, reassembling it from the metadata
+    /// row plus its ordered message rows.
     pub async fn get(&self, id: Uuid) -> Result<Conversation, Error> {
         with_conn(&self.conn, move |conn| {
-            let mut stmt = conn
-                .prepare("SELECT data FROM conversations WHERE id = ?1")
-                .map_err(|e| Error::Storage(e.to_string()))?;
-            let data: String = stmt
-                .query_row(params![id.to_string()], |row| row.get(0))
+            let data: String = conn
+                .query_row(
+                    "SELECT data FROM conversations WHERE id = ?1",
+                    params![id.to_string()],
+                    |row| row.get(0),
+                )
                 .map_err(|e| match e {
                     rusqlite::Error::QueryReturnedNoRows => {
                         Error::NotFound(format!("conversation {id}"))
                     }
                     other => Error::Storage(other.to_string()),
                 })?;
-            let conv: Conversation = serde_json::from_str(&data)?;
+            let mut conv: Conversation = serde_json::from_str(&data)?;
+
+            let mut stmt = conn
+                .prepare("SELECT data FROM messages WHERE conversation_id = ?1 ORDER BY idx")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map(params![id.to_string()], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut messages: Vec<Message> = Vec::new();
+            for row in rows {
+                let msg_data = row.map_err(|e| Error::Storage(e.to_string()))?;
+                messages.push(serde_json::from_str(&msg_data)?);
+            }
+            // A legacy row not yet migrated keeps its messages in the
+            // blob and has no rows here; migrated/new rows keep them
+            // only here.
+            if !messages.is_empty() {
+                conv.messages = messages;
+            }
             Ok(conv)
         })
         .await
@@ -115,48 +351,76 @@ impl ConversationStore {
     }
 
     /// List all conversation summaries (id, title, timestamps) ordered by
-    /// `updated_at` descending. Skips entries whose stored JSON cannot be
-    /// parsed instead of failing the whole list.
+    /// `updated_at` descending — straight off the promoted columns, no
+    /// JSON parsing. Rows without column values (unmigrated blobs whose
+    /// JSON couldn't be parsed) are skipped instead of failing the whole
+    /// list, matching the old behavior.
     pub async fn list_summaries(&self) -> Result<Vec<ConversationSummary>, Error> {
         with_conn(&self.conn, |conn| {
             let mut stmt = conn
-                .prepare("SELECT data FROM conversations")
+                .prepare(
+                    "SELECT id, title, created_at, updated_at FROM conversations
+                     WHERE updated_at IS NOT NULL
+                     ORDER BY updated_at DESC",
+                )
                 .map_err(|e| Error::Storage(e.to_string()))?;
             let rows = stmt
-                .query_map([], |row| row.get::<_, String>(0))
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, String>(3)?,
+                    ))
+                })
                 .map_err(|e| Error::Storage(e.to_string()))?;
             let mut out = Vec::new();
             for row in rows {
-                let data = row.map_err(|e| Error::Storage(e.to_string()))?;
-                if let Ok(conv) = serde_json::from_str::<Conversation>(&data) {
-                    out.push(ConversationSummary {
-                        id: conv.id,
-                        title: conv.title,
-                        created_at: conv.created_at,
-                        updated_at: conv.updated_at,
-                    });
-                }
+                let (id, title, created_at, updated_at) =
+                    row.map_err(|e| Error::Storage(e.to_string()))?;
+                let (Ok(id), Some(created_at), Some(updated_at)) = (
+                    Uuid::parse_str(&id),
+                    created_at.as_deref().and_then(parse_ts),
+                    parse_ts(&updated_at),
+                ) else {
+                    continue;
+                };
+                out.push(ConversationSummary {
+                    id,
+                    title,
+                    created_at,
+                    updated_at,
+                });
             }
-            out.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
             Ok(out)
         })
         .await
     }
 
-    /// Delete a conversation by ID. Returns `NotFound` if the conversation
-    /// does not exist, so callers can distinguish 404 from 500.
+    /// Delete a conversation (and its message rows) by ID. Returns
+    /// `NotFound` if the conversation does not exist, so callers can
+    /// distinguish 404 from 500.
     pub async fn delete(&self, id: Uuid) -> Result<(), Error> {
         with_conn(&self.conn, move |conn| {
-            let affected = conn
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            tx.execute(
+                "DELETE FROM messages WHERE conversation_id = ?1",
+                params![id.to_string()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            let affected = tx
                 .execute(
                     "DELETE FROM conversations WHERE id = ?1",
                     params![id.to_string()],
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
             if affected == 0 {
+                // Dropping the uncommitted transaction rolls back.
                 return Err(Error::NotFound(format!("conversation {id}")));
             }
-            Ok(())
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))
         })
         .await
     }
@@ -165,16 +429,90 @@ impl ConversationStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustykrab_core::types::{ContentBlock, MessageContent, Role, ToolCall, ToolResult};
 
     /// Open a `ConversationStore` backed by an in-memory SQLite
-    /// connection with just the schema this module needs. Mirrors the
-    /// pattern used in `jobs.rs` so the store tests don't need a
-    /// tempdir crate.
+    /// connection running the real migrations, so tests exercise the
+    /// production schema.
     fn in_memory_store() -> ConversationStore {
+        ConversationStore::new(in_memory_conn())
+    }
+
+    fn in_memory_conn() -> Arc<Mutex<rusqlite::Connection>> {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
-        conn.execute_batch("CREATE TABLE conversations (id TEXT PRIMARY KEY, data TEXT NOT NULL);")
-            .unwrap();
-        ConversationStore::new(Arc::new(Mutex::new(conn)))
+        crate::Store::run_migrations(&conn).unwrap();
+        Arc::new(Mutex::new(conn))
+    }
+
+    fn msg(role: Role, content: MessageContent) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role,
+            content,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// One message of every content shape, so round-trip tests cover the
+    /// full serde surface.
+    fn all_shapes() -> Vec<Message> {
+        vec![
+            msg(Role::System, MessageContent::Text("system prompt".into())),
+            msg(Role::User, MessageContent::Text("hello".into())),
+            msg(
+                Role::Assistant,
+                MessageContent::ToolCall(ToolCall {
+                    id: "call-1".into(),
+                    name: "web_fetch".into(),
+                    arguments: serde_json::json!({"url": "https://example.com"}),
+                }),
+            ),
+            msg(
+                Role::Tool,
+                MessageContent::ToolResult(ToolResult {
+                    call_id: "call-1".into(),
+                    output: serde_json::json!({"status": 200}),
+                    is_error: false,
+                    images: vec![],
+                }),
+            ),
+            msg(
+                Role::Assistant,
+                MessageContent::MultiToolCall(vec![
+                    ToolCall {
+                        id: "call-2".into(),
+                        name: "a".into(),
+                        arguments: serde_json::json!({}),
+                    },
+                    ToolCall {
+                        id: "call-3".into(),
+                        name: "b".into(),
+                        arguments: serde_json::json!({"x": 1}),
+                    },
+                ]),
+            ),
+            msg(
+                Role::User,
+                MessageContent::MultiPart(vec![
+                    ContentBlock::Text {
+                        text: "look at this".into(),
+                    },
+                    ContentBlock::Image {
+                        media_type: "image/png".into(),
+                        data: vec![0x89, 0x50, 0x4e, 0x47],
+                    },
+                ]),
+            ),
+        ]
+    }
+
+    fn assert_conv_eq(a: &Conversation, b: &Conversation) {
+        // Conversation doesn't derive PartialEq; compare via JSON, which
+        // is also the persisted representation.
+        assert_eq!(
+            serde_json::to_value(a).unwrap(),
+            serde_json::to_value(b).unwrap()
+        );
     }
 
     #[tokio::test]
@@ -197,6 +535,172 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn save_get_round_trips_every_message_shape() {
+        let store = in_memory_store();
+        let mut conv = store
+            .create_with_title(Some("shapes".into()))
+            .await
+            .unwrap();
+        conv.messages = all_shapes();
+        conv.summary = Some("a summary".into());
+        conv.detected_profile = Some("default".into());
+        conv.channel_source = Some("telegram".into());
+        conv.channel_id = Some("42".into());
+        conv.channel_thread_id = Some("7".into());
+        conv.updated_at = Utc::now();
+        store.save(&conv).await.unwrap();
+
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+    }
+
+    #[tokio::test]
+    async fn append_then_get_matches_in_memory_conversation() {
+        let store = in_memory_store();
+        let mut conv = store.create().await.unwrap();
+        let persisted: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+
+        conv.messages = all_shapes();
+        conv.updated_at = Utc::now();
+        store.save_turn(&conv, &persisted).await.unwrap();
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+
+        // Second turn: append on top of what's now persisted.
+        let persisted: Vec<Uuid> = reloaded.messages.iter().map(|m| m.id).collect();
+        conv.messages
+            .push(msg(Role::User, MessageContent::Text("second turn".into())));
+        conv.messages.push(msg(
+            Role::Assistant,
+            MessageContent::Text("second reply".into()),
+        ));
+        conv.updated_at = Utc::now();
+        store.save_turn(&conv, &persisted).await.unwrap();
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+        assert_eq!(reloaded.messages.len(), all_shapes().len() + 2);
+    }
+
+    #[tokio::test]
+    async fn save_turn_rewrites_in_place_system_prompt_at_idx_zero() {
+        let store = in_memory_store();
+        let mut conv = store.create().await.unwrap();
+        conv.messages = vec![
+            msg(Role::System, MessageContent::Text("old prompt".into())),
+            msg(Role::User, MessageContent::Text("hi".into())),
+        ];
+        store.save(&conv).await.unwrap();
+
+        let persisted: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+        // The orchestrator rewrites the system message in place (same id).
+        conv.messages[0].content = MessageContent::Text("fresh prompt".into());
+        conv.messages
+            .push(msg(Role::Assistant, MessageContent::Text("hello".into())));
+        store.save_turn(&conv, &persisted).await.unwrap();
+
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+        assert_eq!(reloaded.messages[0].content.as_text(), Some("fresh prompt"));
+    }
+
+    #[tokio::test]
+    async fn save_turn_falls_back_to_full_rewrite_after_compaction() {
+        let store = in_memory_store();
+        let mut conv = store.create().await.unwrap();
+        conv.messages = all_shapes();
+        store.save(&conv).await.unwrap();
+        let persisted: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+
+        // Simulate compaction: history collapses to a fresh summary
+        // message plus the latest turn — the persisted prefix no longer
+        // matches, so save_turn must fall back to a full rewrite.
+        conv.messages = vec![
+            msg(Role::System, MessageContent::Text("system".into())),
+            msg(
+                Role::Assistant,
+                MessageContent::Text("summary of earlier turns".into()),
+            ),
+            msg(Role::User, MessageContent::Text("latest turn".into())),
+        ];
+        conv.summary = Some("summary of earlier turns".into());
+        conv.updated_at = Utc::now();
+        store.save_turn(&conv, &persisted).await.unwrap();
+
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+        // Stale rows past the compacted history must be gone — an
+        // append-only write here would leave the six original rows.
+        assert_eq!(reloaded.messages.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn legacy_blob_rows_migrate_to_normalized_schema() {
+        let conn = in_memory_conn();
+
+        // Insert a legacy-format row raw: the whole conversation
+        // (messages included) as one JSON blob, no column metadata.
+        let legacy = Conversation {
+            id: Uuid::new_v4(),
+            messages: all_shapes(),
+            created_at: Utc::now() - chrono::Duration::days(2),
+            updated_at: Utc::now() - chrono::Duration::days(1),
+            title: Some("legacy".into()),
+            summary: Some("old summary".into()),
+            detected_profile: None,
+            channel_source: Some("signal".into()),
+            channel_id: Some("+15550100".into()),
+            channel_thread_id: None,
+        };
+        {
+            let guard = conn.lock().unwrap();
+            guard
+                .execute(
+                    "INSERT INTO conversations (id, data) VALUES (?1, ?2)",
+                    params![
+                        legacy.id.to_string(),
+                        serde_json::to_string(&legacy).unwrap()
+                    ],
+                )
+                .unwrap();
+            // Re-run migrations against a database that now has a legacy
+            // row — this is what startup does. Run twice to prove
+            // idempotence.
+            crate::Store::run_migrations(&guard).unwrap();
+            crate::Store::run_migrations(&guard).unwrap();
+
+            // The blob must have been slimmed and the messages exploded.
+            let slim: String = guard
+                .query_row(
+                    "SELECT data FROM conversations WHERE id = ?1",
+                    params![legacy.id.to_string()],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            let slim_conv: Conversation = serde_json::from_str(&slim).unwrap();
+            assert!(slim_conv.messages.is_empty(), "blob still embeds messages");
+            let n: i64 = guard
+                .query_row(
+                    "SELECT COUNT(*) FROM messages WHERE conversation_id = ?1",
+                    params![legacy.id.to_string()],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(n as usize, legacy.messages.len());
+        }
+
+        let store = ConversationStore::new(conn);
+        let reloaded = store.get(legacy.id).await.unwrap();
+        assert_conv_eq(&reloaded, &legacy);
+
+        let summaries = store.list_summaries().await.unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, legacy.id);
+        assert_eq!(summaries[0].title.as_deref(), Some("legacy"));
+        assert_eq!(summaries[0].created_at, legacy.created_at);
+        assert_eq!(summaries[0].updated_at, legacy.updated_at);
+    }
+
+    #[tokio::test]
     async fn list_summaries_returns_entries_sorted_desc_by_updated_at() {
         let store = in_memory_store();
         let mut a = store.create_with_title(Some("a".into())).await.unwrap();
@@ -215,6 +719,37 @@ mod tests {
         );
         assert_eq!(summaries[0].title.as_deref(), Some("a"));
         assert_eq!(summaries[1].id, b.id);
+    }
+
+    #[tokio::test]
+    async fn save_meta_updates_metadata_without_touching_messages() {
+        let store = in_memory_store();
+        let mut conv = store.create().await.unwrap();
+        conv.messages = vec![msg(Role::User, MessageContent::Text("hi".into()))];
+        store.save(&conv).await.unwrap();
+
+        conv.title = Some("renamed".into());
+        conv.updated_at = Utc::now();
+        store.save_meta(&conv).await.unwrap();
+
+        let reloaded = store.get(conv.id).await.unwrap();
+        assert_conv_eq(&reloaded, &conv);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_message_rows() {
+        let store = in_memory_store();
+        let mut conv = store.create().await.unwrap();
+        conv.messages = all_shapes();
+        store.save(&conv).await.unwrap();
+        store.delete(conv.id).await.unwrap();
+        let err = store.get(conv.id).await.unwrap_err();
+        assert!(matches!(err, Error::NotFound(_)));
+
+        // A new conversation reusing storage must not see orphan rows.
+        let fresh = store.create().await.unwrap();
+        let reloaded = store.get(fresh.id).await.unwrap();
+        assert!(reloaded.messages.is_empty());
     }
 
     #[tokio::test]

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -61,12 +61,22 @@ impl Store {
         })
     }
 
-    fn run_migrations(conn: &rusqlite::Connection) -> Result<(), Error> {
+    pub(crate) fn run_migrations(conn: &rusqlite::Connection) -> Result<(), Error> {
         conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS conversations (
-                id   TEXT PRIMARY KEY,
-                data TEXT NOT NULL
+                id         TEXT PRIMARY KEY,
+                data       TEXT NOT NULL,
+                title      TEXT,
+                created_at TEXT,
+                updated_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                conversation_id TEXT NOT NULL,
+                idx             INTEGER NOT NULL,
+                data            TEXT NOT NULL,
+                PRIMARY KEY (conversation_id, idx)
             );
 
             CREATE TABLE IF NOT EXISTS secrets (
@@ -154,6 +164,39 @@ impl Store {
             conn.execute("ALTER TABLE scheduled_jobs ADD COLUMN thread_id TEXT", [])
                 .map_err(|e| Error::Storage(e.to_string()))?;
         }
+
+        // Databases created before conversations were normalized have a
+        // two-column `conversations` table; add the promoted metadata
+        // columns so `list_summaries` never has to parse JSON.
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(conversations)")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let existing: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        drop(stmt);
+        for col in ["title", "created_at", "updated_at"] {
+            if !existing.iter().any(|c| c == col) {
+                conn.execute(
+                    &format!("ALTER TABLE conversations ADD COLUMN {col} TEXT"),
+                    [],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            }
+        }
+        // Index created after the ALTERs so it exists on both fresh and
+        // upgraded databases.
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_conversations_updated_at
+                 ON conversations (updated_at DESC);",
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+
+        // Explode legacy whole-conversation blobs into the normalized
+        // schema. Idempotent — see `conversation::migrate_legacy_blobs`.
+        conversation::migrate_legacy_blobs(conn)?;
 
         Ok(())
     }


### PR DESCRIPTION
Supersedes #484, which GitHub auto-closed when its stacked base branch (`claude/perf-01-store-async`) was deleted after #476's squash merge. The branch is now rebased directly onto `main` (post perf-series merges) and re-verified.

## Problem

Conversations persisted as one JSON blob: `ConversationStore::save` serialized the **entire** conversation (all messages) and upserted it into `conversations.data`, and the gateway called it after **every** turn — a conversation with N messages rewrites the full growing blob N times, O(N²) total write bytes, with the serialization on the request path. Reads were worse: `list_summaries` did `SELECT data FROM conversations` with no WHERE/LIMIT and fully deserialized every message of every conversation just to build id/title/timestamp summaries.

## Changes

- **New `messages` table** — `(conversation_id, idx, data)`, one JSON row per message (preserving the Message serde format including the untagged legacy fallback), with `title`/`created_at`/`updated_at` promoted to real columns on `conversations` (indexed on `updated_at`). The conversation row keeps a slimmed metadata-only blob.
- **Idempotent legacy migration** — on startup, rows still carrying embedded messages (detected via `updated_at IS NULL` as the legacy marker) are exploded into the messages table in a single transaction: interrupts roll back cleanly, completed sweeps are no-ops, and unparseable legacy blobs are left in place and skipped by summaries (matching prior behavior).
- **Per-turn appends** — new `save_turn(&conv, persisted_ids)` appends only the new tail of messages (re-upserting idx 0 because the orchestrator rewrites the system prompt in place) and falls back to a full rewrite when the persisted id-prefix no longer matches — i.e. the agent compacted history (stronger than count-shrink detection). Backed by `append_message`/`save_meta` primitives, all in the store's `spawn_blocking` style.
- **Indexed summaries** — `list_summaries` is now a column-only `SELECT ... ORDER BY updated_at DESC` with zero JSON parsing.
- **Callers updated** — gateway `send_message`/`send_message_stream`, Telegram and Slack loops use `save_turn`; metadata-only sites (channel backfill, job channel context) use `save_meta`.

## Tests

Eight new store tests: round-trip equality across all message shapes (text/tool-call/tool-result/multipart), legacy migration idempotence, append-then-get, compaction-rewrite fallback, system-prompt refresh, save_meta, delete cleanup.

`cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets` zero warnings · `cargo test --workspace` all suites green after the rebase onto current main.

## Notes

- The agent's oversized-summary repair mutates a mid-history message without changing its id; the append path intentionally doesn't persist that edit (it's deterministic and re-applied on every load) — documented on `save_turn`.
- Pre-existing behavior preserved: `task_queue.rs` never persisted the job conversation after the agent run; `save_meta` there is equivalent to the old full save at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXn2nFMNjjQh6ir1rpfpN2)_