### PR TITLE
fix(cron): carry real context into scheduled runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4074,7 +4074,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "axum",
  "chrono",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-agent/src/rlm/recursive_call.rs
+++ b/crates/rustykrab-agent/src/rlm/recursive_call.rs
@@ -182,12 +182,14 @@ async fn execute_repl_call_impl(
             role: Role::System,
             content: MessageContent::Text(system),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         },
         Message {
             id: Uuid::new_v4(),
             role: Role::User,
             content: MessageContent::Text(prompt),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         },
     ];
 
@@ -257,6 +259,7 @@ async fn execute_repl_call_impl(
                     role: Role::Tool,
                     content: MessageContent::ToolResult(result),
                     created_at: Utc::now(),
+                    agent_version: Message::version_stamp(),
                 });
             }
             continue;
@@ -285,6 +288,7 @@ async fn execute_repl_call_impl(
                     role: Role::User,
                     content: MessageContent::Text("Continue.".to_string()),
                     created_at: Utc::now(),
+                    agent_version: Message::version_stamp(),
                 });
                 continue;
             }
@@ -325,6 +329,7 @@ async fn execute_repl_call_impl(
                             .to_string(),
                     ),
                     created_at: Utc::now(),
+                                    agent_version: Message::version_stamp(),
                 });
                 continue;
             }
@@ -388,6 +393,7 @@ async fn direct_call(
             role: Role::System,
             content: MessageContent::Text(format!("Context:\n{context}")),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         });
     }
     messages.push(Message {
@@ -395,6 +401,7 @@ async fn direct_call(
         role: Role::User,
         content: MessageContent::Text(prompt.to_string()),
         created_at: Utc::now(),
+        agent_version: Message::version_stamp(),
     });
 
     let response = provider.chat(&messages, &[]).await?;
@@ -430,6 +437,7 @@ mod tests {
                     role: Role::Assistant,
                     content: MessageContent::Text(text.to_string()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 usage: Usage {
                     prompt_tokens: 10,
@@ -453,6 +461,7 @@ mod tests {
                         arguments: args,
                     }),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 usage: Usage {
                     prompt_tokens: 10,

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1028,6 +1028,7 @@ impl AgentRunner {
                 role: Role::Assistant,
                 content: MessageContent::Text(summary),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
     }
@@ -1064,6 +1065,7 @@ impl AgentRunner {
                 role: Role::User,
                 content: MessageContent::Text(TASK_COMPLETE_REMINDER.to_string()),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
         CompletionReminderOutcome::Continue
@@ -1260,6 +1262,7 @@ impl AgentRunner {
                             self.config.max_iterations
                         )),
                         created_at: Utc::now(),
+                        agent_version: Message::version_stamp(),
                     },
                 );
             }
@@ -1385,6 +1388,7 @@ impl AgentRunner {
                                 role: Role::Tool,
                                 content: MessageContent::ToolResult(tr),
                                 created_at: Utc::now(),
+                                agent_version: Message::version_stamp(),
                             }
                         }
                         Err(e) => {
@@ -1400,6 +1404,7 @@ impl AgentRunner {
                                     images: Vec::new(),
                                 }),
                                 created_at: Utc::now(),
+                                agent_version: Message::version_stamp(),
                             }
                         }
                     };
@@ -1445,6 +1450,7 @@ impl AgentRunner {
                             role: Role::User,
                             content: MessageContent::Text("Continue.".to_string()),
                             created_at: Utc::now(),
+                            agent_version: Message::version_stamp(),
                         },
                     );
                     continue;
@@ -1501,6 +1507,7 @@ impl AgentRunner {
                                         "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
                                     ),
                                     created_at: Utc::now(),
+                                                                    agent_version: Message::version_stamp(),
                                 },
                             );
                             continue;
@@ -1533,6 +1540,7 @@ impl AgentRunner {
                                             .to_string(),
                                     ),
                                     created_at: Utc::now(),
+                                                                    agent_version: Message::version_stamp(),
                                 },
                             );
                             continue;
@@ -1576,6 +1584,7 @@ impl AgentRunner {
                                 "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
                             ),
                             created_at: Utc::now(),
+                                                    agent_version: Message::version_stamp(),
                         },
                     );
                     continue;
@@ -1599,6 +1608,7 @@ impl AgentRunner {
                     self.config.max_iterations
                 )),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
         let final_response = self.provider.chat(&conv.messages, &[]).await?;
@@ -1688,6 +1698,7 @@ impl AgentRunner {
                             self.config.max_iterations
                         )),
                         created_at: Utc::now(),
+                        agent_version: Message::version_stamp(),
                     },
                 );
             }
@@ -1812,6 +1823,7 @@ impl AgentRunner {
                                 role: Role::Tool,
                                 content: MessageContent::ToolResult(tr),
                                 created_at: Utc::now(),
+                                agent_version: Message::version_stamp(),
                             };
                             (msg, true, None)
                         }
@@ -1828,6 +1840,7 @@ impl AgentRunner {
                                     images: Vec::new(),
                                 }),
                                 created_at: Utc::now(),
+                                agent_version: Message::version_stamp(),
                             };
                             (msg, false, Some(err_str))
                         }
@@ -1880,6 +1893,7 @@ impl AgentRunner {
                             role: Role::User,
                             content: MessageContent::Text("Continue.".to_string()),
                             created_at: Utc::now(),
+                            agent_version: Message::version_stamp(),
                         },
                     );
                     continue;
@@ -1940,6 +1954,7 @@ impl AgentRunner {
                                         "Your response was empty. Please provide a substantive answer or take an action.".to_string(),
                                     ),
                                     created_at: Utc::now(),
+                                                                    agent_version: Message::version_stamp(),
                                 },
                             );
                             continue;
@@ -1974,6 +1989,7 @@ impl AgentRunner {
                                             .to_string(),
                                     ),
                                     created_at: Utc::now(),
+                                                                    agent_version: Message::version_stamp(),
                                 },
                             );
                             continue;
@@ -2015,6 +2031,7 @@ impl AgentRunner {
                                 "Your previous response indicated a tool call but none was found. Please retry.".to_string(),
                             ),
                             created_at: Utc::now(),
+                                                    agent_version: Message::version_stamp(),
                         },
                     );
                     continue;
@@ -2038,6 +2055,7 @@ impl AgentRunner {
                     self.config.max_iterations
                 )),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
         let stream_callback = |event: StreamEvent| {
@@ -2489,12 +2507,14 @@ impl AgentRunner {
                 role: Role::System,
                 content: MessageContent::Text(system_prompt),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
             Message {
                 id: Uuid::new_v4(),
                 role: Role::User,
                 content: MessageContent::Text(input.to_string()),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         ];
         let response = self.provider.chat(&messages, &[]).await?;
@@ -2722,6 +2742,7 @@ impl AgentRunner {
                      HARD LIMIT: keep the summary under {max_words} words."
                 )),
                 created_at: Utc::now(),
+                            agent_version: Message::version_stamp(),
             };
 
             // Append the prompt in place for the summarizer call, then pop
@@ -2843,6 +2864,7 @@ impl AgentRunner {
             role: Role::Assistant,
             content: MessageContent::Text(summary_with_hint.clone()),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         };
         let continuation_msg = Message {
             id: Uuid::new_v4(),
@@ -2852,6 +2874,7 @@ impl AgentRunner {
                     .to_string(),
             ),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         };
 
         new_messages.push(summary_msg.clone());
@@ -2918,6 +2941,7 @@ impl AgentRunner {
                 role: Role::User,
                 content: MessageContent::Text(text),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
     }
@@ -3307,6 +3331,7 @@ fn drain_inbound_to_conv(
                     role: Role::User,
                     content,
                     created_at: Utc::now(),
+                    agent_version: None,
                 };
                 on_event(AgentEvent::UserMessageQueued { message_id: msg.id });
                 conv.messages.push(msg);
@@ -3372,6 +3397,7 @@ mod compaction_tests {
                     role: Role::Assistant,
                     content: MessageContent::Text("- summarized".to_string()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 usage: Usage::default(),
                 stop_reason: StopReason::EndTurn,
@@ -3481,6 +3507,7 @@ mod compaction_tests {
             role: Role::System,
             content: MessageContent::Text("agent identity".into()),
             created_at: Utc::now(),
+            agent_version: None,
         }];
         for i in 0..8 {
             messages.push(Message {
@@ -3492,6 +3519,7 @@ mod compaction_tests {
                 },
                 content: MessageContent::Text("x".repeat(3_000)),
                 created_at: Utc::now(),
+                agent_version: None,
             });
         }
         let mut conv = Conversation {
@@ -3562,6 +3590,7 @@ mod compaction_tests {
                     role: Role::Assistant,
                     content: MessageContent::Text("x".repeat(self.response_chars)),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 usage: Usage::default(),
                 stop_reason: StopReason::EndTurn,
@@ -3687,24 +3716,28 @@ mod compaction_tests {
                     role: Role::System,
                     content: MessageContent::Text("agent identity".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text("original task".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::Assistant,
                     content: MessageContent::Text(bloated.clone()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text("Continue from the summary above.".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
             ],
             created_at: Utc::now(),
@@ -3775,30 +3808,35 @@ mod compaction_tests {
                     role: Role::System,
                     content: MessageContent::Text("agent identity".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text("original task".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::Assistant,
                     content: MessageContent::Text("UNIQUE_DETAIL_ALPHA".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text("UNIQUE_DETAIL_BRAVO".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::Assistant,
                     content: MessageContent::Text("UNIQUE_DETAIL_CHARLIE".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
             ],
             created_at: Utc::now(),
@@ -3867,18 +3905,21 @@ mod compaction_tests {
                     role: Role::System,
                     content: MessageContent::Text("system".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text("task".into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::Assistant,
                     content: MessageContent::Text(detail.into()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
             ],
             created_at: Utc::now(),
@@ -3914,6 +3955,7 @@ mod compaction_tests {
                 role: Role::Assistant,
                 content: MessageContent::Text(small.clone()),
                 created_at: Utc::now(),
+                agent_version: None,
             }],
             created_at: Utc::now(),
             updated_at: Utc::now(),
@@ -3956,6 +3998,7 @@ mod token_estimate_tests {
                     role: Role::Assistant,
                     content: MessageContent::Text("- summarized".to_string()),
                     created_at: Utc::now(),
+                    agent_version: None,
                 },
                 usage: Usage::default(),
                 stop_reason: StopReason::EndTurn,
@@ -3989,6 +4032,7 @@ mod token_estimate_tests {
             role,
             content: MessageContent::Text(text.to_string()),
             created_at: Utc::now(),
+            agent_version: None,
         }
     }
 
@@ -4024,6 +4068,7 @@ mod token_estimate_tests {
                     arguments: serde_json::json!({"key": "value", "n": [1, 2, 3]}),
                 }),
                 created_at: Utc::now(),
+                agent_version: None,
             },
         );
         runner.push_message(
@@ -4038,6 +4083,7 @@ mod token_estimate_tests {
                     images: Vec::new(),
                 }),
                 created_at: Utc::now(),
+                agent_version: None,
             },
         );
 
@@ -4387,6 +4433,7 @@ mod tool_choice_guard_tests {
                 role: Role::Assistant,
                 content: MessageContent::Text("Done.".into()),
                 created_at: Utc::now(),
+                agent_version: None,
             },
             usage: Usage::default(),
             stop_reason: StopReason::EndTurn,
@@ -4426,6 +4473,7 @@ mod tool_choice_guard_tests {
                 role: Role::User,
                 content: MessageContent::Text("Do the scheduled thing.".into()),
                 created_at: Utc::now(),
+                agent_version: None,
             }],
             created_at: Utc::now(),
             updated_at: Utc::now(),
@@ -4593,6 +4641,7 @@ mod task_complete_tests {
                     arguments: args,
                 }),
                 created_at: Utc::now(),
+                agent_version: None,
             },
             usage: Usage::default(),
             stop_reason: StopReason::ToolUse,
@@ -4607,6 +4656,7 @@ mod task_complete_tests {
                 role: Role::Assistant,
                 content: MessageContent::Text(text.to_string()),
                 created_at: Utc::now(),
+                agent_version: None,
             },
             usage: Usage::default(),
             stop_reason: StopReason::EndTurn,
@@ -4622,6 +4672,7 @@ mod task_complete_tests {
                 role: Role::User,
                 content: MessageContent::Text("do the thing".into()),
                 created_at: Utc::now(),
+                agent_version: None,
             }],
             created_at: Utc::now(),
             updated_at: Utc::now(),

--- a/crates/rustykrab-agent/src/subagent.rs
+++ b/crates/rustykrab-agent/src/subagent.rs
@@ -181,12 +181,14 @@ impl SessionManager for SubagentRunner {
                     role: Role::System,
                     content: MessageContent::Text(def.system_prompt.clone()),
                     created_at: now,
+                    agent_version: Message::version_stamp(),
                 },
                 Message {
                     id: Uuid::new_v4(),
                     role: Role::User,
                     content: MessageContent::Text(task.to_string()),
                     created_at: now,
+                    agent_version: Message::version_stamp(),
                 },
             ],
             created_at: now,
@@ -292,6 +294,7 @@ mod tests {
                 role: Role::Assistant,
                 content: MessageContent::Text(text.to_string()),
                 created_at: Utc::now(),
+                agent_version: None,
             },
             usage: Usage {
                 prompt_tokens: 1,

--- a/crates/rustykrab-agent/src/voting.rs
+++ b/crates/rustykrab-agent/src/voting.rs
@@ -77,6 +77,7 @@ impl ConsistencyVoter {
                         role: Role::System,
                         content: MessageContent::Text(ctx),
                         created_at: Utc::now(),
+                        agent_version: Message::version_stamp(),
                     });
                 }
                 messages.push(Message {
@@ -84,6 +85,7 @@ impl ConsistencyVoter {
                     role: Role::User,
                     content: MessageContent::Text(query),
                     created_at: Utc::now(),
+                    agent_version: Message::version_stamp(),
                 });
 
                 let result = match tokio::time::timeout(
@@ -170,6 +172,7 @@ impl ConsistencyVoter {
             role: Role::User,
             content: MessageContent::Text(prompt),
             created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
         }];
 
         let timeout_secs = self.config.model_call_timeout_secs;

--- a/crates/rustykrab-channels/src/signal.rs
+++ b/crates/rustykrab-channels/src/signal.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use uuid::Uuid;
 
 /// An inbound Signal message with sender metadata for reply routing.
 pub struct SignalInboundMessage {
@@ -303,12 +302,7 @@ impl SignalChannel {
 
         tracing::info!(source = %source, "received Signal message");
 
-        let message = Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(text),
-            created_at: Utc::now(),
-        };
+        let message = Message::stamped(Role::User, MessageContent::Text(text));
 
         self.inbound_tx
             .send(SignalInboundMessage {

--- a/crates/rustykrab-channels/src/slack.rs
+++ b/crates/rustykrab-channels/src/slack.rs
@@ -27,7 +27,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::Utc;
 use futures::{SinkExt, StreamExt};
 use rustykrab_core::types::{Message, MessageContent, Role};
 use rustykrab_core::{Error, Result};
@@ -35,7 +34,6 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, Mutex};
 use tokio_tungstenite::tungstenite::protocol::Message as WsMessage;
-use uuid::Uuid;
 
 /// Maximum length of a single Slack message chunk. Slack's nominal limit
 /// is ~40,000 chars but mrkdwn formatting and clients render long messages
@@ -482,12 +480,7 @@ impl SlackChannel {
             "received Slack app_mention"
         );
 
-        let message = Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(text),
-            created_at: Utc::now(),
-        };
+        let message = Message::stamped(Role::User, MessageContent::Text(text));
 
         self.inbound_tx
             .send(SlackInboundMessage {

--- a/crates/rustykrab-channels/src/telegram.rs
+++ b/crates/rustykrab-channels/src/telegram.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use hmac::{Hmac, Mac};
 use rustykrab_core::crypto::constant_time_eq;
 use rustykrab_core::types::{Message, MessageContent, Role};
@@ -10,7 +9,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -492,12 +490,7 @@ impl TelegramChannel {
 
         tracing::info!(chat_id, thread_id, %from, "received Telegram message");
 
-        let message = Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(text),
-            created_at: Utc::now(),
-        };
+        let message = Message::stamped(Role::User, MessageContent::Text(text));
 
         self.inbound_tx
             .send(ChannelMessage {

--- a/crates/rustykrab-channels/src/webchat.rs
+++ b/crates/rustykrab-channels/src/webchat.rs
@@ -1,9 +1,7 @@
 use async_trait::async_trait;
-use chrono::Utc;
 use rustykrab_core::types::{Message, MessageContent, Role};
 use rustykrab_core::Result;
 use tokio::sync::mpsc;
-use uuid::Uuid;
 
 use crate::Channel;
 
@@ -65,11 +63,6 @@ impl WebChatChannel {
             .recv()
             .await
             .ok_or_else(|| rustykrab_core::Error::Channel("channel closed".into()))?;
-        Ok(Message {
-            id: Uuid::new_v4(),
-            role: Role::User,
-            content: MessageContent::Text(text),
-            created_at: Utc::now(),
-        })
+        Ok(Message::stamped(Role::User, MessageContent::Text(text)))
     }
 }

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -11,7 +11,11 @@ use std::sync::Arc;
 
 use chrono::Utc;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Re-exported so the version shown by `--version` is the same string
+/// stamped onto persisted messages, job runs, and scheduled jobs. Keep
+/// these from drifting: a `--version` that disagrees with what's in the
+/// database makes the stamps useless for attribution.
+const VERSION: &str = rustykrab_core::VERSION;
 const GIT_HASH: &str = env!("RUSTYKRAB_GIT_HASH");
 const GIT_DIRTY: &str = env!("RUSTYKRAB_GIT_DIRTY");
 const BUILD_DATE: &str = env!("RUSTYKRAB_BUILD_DATE");

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -290,7 +290,14 @@ async fn execute_cron_task(
     // Run the agent. Mint a fresh trace id per scheduled run so prompt-log
     // rows and agent logs for this job line up.
     let trace_id = Uuid::new_v4();
-    tracing::info!(%trace_id, job_id = %job.id, "scheduled task starting");
+    // `version` here matches what record_run stamps onto the job_runs row,
+    // so a log line and a DB row can be tied to the same build.
+    tracing::info!(
+        %trace_id,
+        job_id = %job.id,
+        version = rustykrab_core::VERSION,
+        "scheduled task starting"
+    );
     let no_op_event = |_event: AgentEvent| {};
     let result = rustykrab_gateway::run_agent_streaming_with_options(
         state,

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -492,7 +492,18 @@ fn build_scheduled_prompt(
              Task: {task_prompt}"
         ),
     };
-    format!("{body}\n\n{delivery}")
+    // The task string is all that survives from the conversation where this
+    // job was created — no chat history comes with it. Terse tasks ("daily
+    // briefing") therefore produce generic output unless the model first
+    // recovers the user's standing preferences from memory. Say so
+    // explicitly rather than relying on the soul prompt's general
+    // memory_search guidance.
+    let context_recovery = "You do not have the conversation this job was created in. Before \
+         composing output, call memory_search for the user's standing preferences and any \
+         earlier decisions relevant to this task (recipients, filters, format, tone, things \
+         to exclude), and apply what you find. Prefer concrete specifics you recover over \
+         generic defaults.";
+    format!("{body}\n\n{context_recovery}\n\n{delivery}")
 }
 
 /// If `task_prompt` references a registered SKILL.md skill, return
@@ -724,6 +735,30 @@ mod tests {
         assert!(prompt.contains("Last run was at 2026-04-30 09:00:00 UTC"));
         // No channel info → still tells the model the message IS the deliverable.
         assert!(prompt.contains("IS the deliverable"));
+    }
+
+    #[test]
+    fn scheduled_prompt_tells_model_it_lacks_the_creating_conversation() {
+        // The task string is the only thing carried over from the
+        // conversation where the job was created. Both the first run and
+        // recurring runs must tell the model to recover the user's standing
+        // preferences from memory, otherwise thin task strings ("daily
+        // briefing") yield generic output.
+        let first = build_scheduled_prompt("Daily briefing.", None, Some("telegram"), Some("1"));
+        let last = Utc.with_ymd_and_hms(2026, 4, 30, 9, 0, 0).unwrap();
+        let recurring =
+            build_scheduled_prompt("Daily briefing.", Some(last), Some("telegram"), Some("1"));
+
+        for (label, prompt) in [("first run", &first), ("recurring run", &recurring)] {
+            assert!(
+                prompt.contains("do not have the conversation this job was created in"),
+                "{label} should state the missing-context problem: {prompt}"
+            );
+            assert!(
+                prompt.contains("memory_search"),
+                "{label} should point at memory_search: {prompt}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -1,3 +1,13 @@
+/// The running RustyKrab version, for stamping persisted records so
+/// behaviour can be attributed to a specific build.
+///
+/// Every workspace crate sets `version.workspace = true`, so this is the
+/// workspace version and agrees across all of them. Read it from here
+/// rather than calling `env!("CARGO_PKG_VERSION")` locally: in a crate
+/// that ever stops inheriting the workspace version, a local `env!`
+/// would silently start reporting something different.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod active_tools;
 pub mod agent_def;
 pub mod capability;

--- a/crates/rustykrab-core/src/recall.rs
+++ b/crates/rustykrab-core/src/recall.rs
@@ -155,14 +155,13 @@ impl RecallStore {
     pub fn get(&self, conversation_id: Uuid) -> Option<Arc<String>> {
         self.hydrate(conversation_id);
         {
+            // Scoped so the read guard is released before the write lock
+            // below. `?` returns None from the function when nothing has
+            // been archived for this conversation.
             let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
-            match guard.get(&conversation_id) {
-                None => return None,
-                Some(entry) => {
-                    if let Some(joined) = &entry.joined {
-                        return Some(Arc::clone(joined));
-                    }
-                }
+            let entry = guard.get(&conversation_id)?;
+            if let Some(joined) = &entry.joined {
+                return Some(Arc::clone(joined));
             }
         }
         // Joined view not built yet — take the write lock and cache it.

--- a/crates/rustykrab-core/src/types.rs
+++ b/crates/rustykrab-core/src/types.rs
@@ -84,6 +84,46 @@ pub struct Message {
     pub role: Role,
     pub content: MessageContent,
     pub created_at: DateTime<Utc>,
+    /// RustyKrab version that produced this message, for forensic
+    /// attribution ("which build wrote this reply?").
+    ///
+    /// Carried on the message rather than stamped at the storage layer
+    /// on purpose: `write_full` deletes and reinserts every row during
+    /// compaction, so a storage-time stamp would relabel a whole
+    /// conversation's history with whatever build happened to compact
+    /// it. Riding on the message keeps each one's origin intact.
+    ///
+    /// `None` for messages written before this field existed, and for
+    /// messages the caller didn't stamp. `#[serde(default)]` so rows
+    /// serialized by older builds still deserialize.
+    #[serde(default)]
+    pub agent_version: Option<String>,
+}
+
+impl Message {
+    /// Build a message stamped with the running RustyKrab version.
+    ///
+    /// Prefer this over a struct literal for any message that
+    /// represents real conversational content, so the row carries its
+    /// origin build. Literals that deliberately want no stamp (test
+    /// fixtures, provider-wire conversions) can still construct
+    /// directly with `agent_version: None`.
+    pub fn stamped(role: Role, content: MessageContent) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            role,
+            content,
+            created_at: Utc::now(),
+            agent_version: Self::version_stamp(),
+        }
+    }
+
+    /// The running version, for stamping struct literals whose shape
+    /// (multi-line `content` expressions, borrowed locals) doesn't suit
+    /// [`Message::stamped`].
+    pub fn version_stamp() -> Option<String> {
+        Some(crate::VERSION.to_string())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -137,6 +137,7 @@ async fn build_and_inject_system_prompt(
                 role: Role::System,
                 content: MessageContent::Text(system_prompt),
                 created_at: Utc::now(),
+                agent_version: Message::version_stamp(),
             },
         );
     }

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -361,6 +361,7 @@ async fn send_message(
         role: Role::User,
         content: MessageContent::Text(body.content),
         created_at: Utc::now(),
+        agent_version: Message::version_stamp(),
     };
     conv.messages.push(user_msg);
     conv.updated_at = Utc::now();
@@ -450,6 +451,7 @@ async fn send_message_stream(
         role: Role::User,
         content: MessageContent::Text(body.content),
         created_at: Utc::now(),
+        agent_version: Message::version_stamp(),
     };
     conv.messages.push(user_msg);
     conv.updated_at = Utc::now();
@@ -827,6 +829,7 @@ mod tests {
             role: Role::Assistant,
             content: MessageContent::Text("hi there".into()),
             created_at: ts("2024-01-01T00:00:00Z"),
+            agent_version: None,
         };
         let json = serde_json::to_value(ApolloMessage::from_message(conv_id, &plain)).unwrap();
         assert_eq!(json["role"], "assistant");
@@ -846,6 +849,7 @@ mod tests {
                 arguments: serde_json::json!({"msg": "hi"}),
             }),
             created_at: ts("2024-01-01T00:00:00Z"),
+            agent_version: None,
         };
         let rendered = render_message_content(&call.content);
         assert!(rendered.starts_with("[tool_call:echo("));

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -1,7 +1,6 @@
 use crate::backoff::retry_delay;
 use crate::line_buffer::LineBuffer;
 use async_trait::async_trait;
-use chrono::Utc;
 use rustykrab_core::error::Result;
 use rustykrab_core::model::{
     ModelProvider, ModelResponse, StopReason, StreamEvent, ToolChoice, Usage,
@@ -13,7 +12,6 @@ use rustykrab_core::Error;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use uuid::Uuid;
 
 /// Maximum number of retries for transient errors (429, 5xx).
 const MAX_RETRIES: u32 = 3;
@@ -285,12 +283,7 @@ impl AnthropicProvider {
             };
 
             return Ok(ModelResponse {
-                message: Message {
-                    id: Uuid::new_v4(),
-                    role: Role::Assistant,
-                    content,
-                    created_at: Utc::now(),
-                },
+                message: Message::stamped(Role::Assistant, content),
                 usage,
                 stop_reason,
                 text: if text.is_empty() { None } else { Some(text) },
@@ -298,12 +291,7 @@ impl AnthropicProvider {
         }
 
         Ok(ModelResponse {
-            message: Message {
-                id: Uuid::new_v4(),
-                role: Role::Assistant,
-                content: MessageContent::Text(text),
-                created_at: Utc::now(),
-            },
+            message: Message::stamped(Role::Assistant, MessageContent::Text(text)),
             usage,
             stop_reason,
             text: None,
@@ -811,12 +799,7 @@ impl AnthropicProvider {
         };
 
         let response = ModelResponse {
-            message: Message {
-                id: Uuid::new_v4(),
-                role: Role::Assistant,
-                content,
-                created_at: Utc::now(),
-            },
+            message: Message::stamped(Role::Assistant, content),
             usage,
             stop_reason,
             text: text_field,
@@ -1111,6 +1094,7 @@ mod tests {
                 images: Vec::new(),
             }),
             created_at: chrono::Utc::now(),
+            agent_version: None,
         };
         let (_sys, api) = AnthropicProvider::build_messages(&[msg]).expect("build");
         let json = serde_json::to_value(&api).unwrap();
@@ -1140,6 +1124,7 @@ mod tests {
                 }],
             }),
             created_at: chrono::Utc::now(),
+            agent_version: None,
         };
         let (_sys, api) = AnthropicProvider::build_messages(&[msg]).expect("build");
         let json = serde_json::to_value(&api).unwrap();

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -1,7 +1,6 @@
 use crate::backoff::retry_delay;
 use crate::line_buffer::LineBuffer;
 use async_trait::async_trait;
-use chrono::Utc;
 use rustykrab_core::error::Result;
 use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
 use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolSchema};
@@ -467,12 +466,7 @@ impl OllamaProvider {
                 };
 
                 return Ok(ModelResponse {
-                    message: Message {
-                        id: Uuid::new_v4(),
-                        role: Role::Assistant,
-                        content,
-                        created_at: Utc::now(),
-                    },
+                    message: Message::stamped(Role::Assistant, content),
                     usage: Usage {
                         prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
                         completion_tokens: resp.eval_count.unwrap_or(0),
@@ -485,12 +479,10 @@ impl OllamaProvider {
         }
 
         Ok(ModelResponse {
-            message: Message {
-                id: Uuid::new_v4(),
-                role: Role::Assistant,
-                content: MessageContent::Text(msg.content.unwrap_or_default()),
-                created_at: Utc::now(),
-            },
+            message: Message::stamped(
+                Role::Assistant,
+                MessageContent::Text(msg.content.unwrap_or_default()),
+            ),
             usage: Usage {
                 prompt_tokens: resp.prompt_eval_count.unwrap_or(0),
                 completion_tokens: resp.eval_count.unwrap_or(0),
@@ -967,12 +959,7 @@ impl ModelProvider for OllamaProvider {
         };
 
         let response = ModelResponse {
-            message: Message {
-                id: Uuid::new_v4(),
-                role: Role::Assistant,
-                content,
-                created_at: Utc::now(),
-            },
+            message: Message::stamped(Role::Assistant, content),
             usage: Usage {
                 prompt_tokens: prompt_eval_count,
                 completion_tokens: eval_count,
@@ -1216,6 +1203,7 @@ fn model_supports_vision(model: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     fn user_msg(content: &str) -> OllamaMessage {
         OllamaMessage {
@@ -1277,6 +1265,7 @@ mod tests {
                 },
             ]),
             created_at: Utc::now(),
+            agent_version: None,
         };
 
         let built = OllamaProvider::build_messages(&[msg], true).expect("build_messages");
@@ -1296,6 +1285,7 @@ mod tests {
             role: Role::User,
             content: MessageContent::Text("hello".to_string()),
             created_at: Utc::now(),
+            agent_version: None,
         };
         let built = OllamaProvider::build_messages(&[msg], false).expect("build_messages");
         assert!(built[0].images.is_none());
@@ -1319,6 +1309,7 @@ mod tests {
                 }],
             }),
             created_at: Utc::now(),
+            agent_version: None,
         }
     }
 

--- a/crates/rustykrab-store/src/conversation.rs
+++ b/crates/rustykrab-store/src/conversation.rs
@@ -450,6 +450,7 @@ mod tests {
             role,
             content,
             created_at: Utc::now(),
+            agent_version: None,
         }
     }
 

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -36,6 +36,13 @@ pub struct ScheduledJob {
     /// run creates and persists one; subsequent runs append to the same
     /// conversation so the agent sees prior context.
     pub conversation_id: Option<String>,
+    /// RustyKrab version that created this job.
+    ///
+    /// The `task` string is written once at creation and never updated, so
+    /// its quality is fixed by whatever build produced it. Recording that
+    /// build makes "which jobs were created before fix X?" a query rather
+    /// than a guess. `None` for jobs created before this column existed.
+    pub created_version: Option<String>,
 }
 
 /// A recorded execution of a scheduled job.
@@ -49,6 +56,10 @@ pub struct JobRun {
     pub output: Option<String>,
     pub started_at: DateTime<Utc>,
     pub finished_at: DateTime<Utc>,
+    /// RustyKrab version that executed this run, so a given output can be
+    /// attributed to the build that produced it. `None` for runs recorded
+    /// before this column existed.
+    pub rustykrab_version: Option<String>,
 }
 
 /// Handle for scheduled-job CRUD operations, backed by SQLite.
@@ -95,13 +106,14 @@ impl JobStore {
             last_run_at: None,
             created_at: now,
             conversation_id: None,
+            created_version: Some(rustykrab_core::VERSION.to_string()),
         };
 
         let row = job.clone();
         with_conn(&self.conn, move |conn| {
             conn.execute(
-                "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, thread_id, one_shot, enabled, next_run_at, last_run_at, created_at, conversation_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                "INSERT INTO scheduled_jobs (id, schedule, task, channel, chat_id, thread_id, one_shot, enabled, next_run_at, last_run_at, created_at, conversation_id, created_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     row.id,
                     row.schedule,
@@ -115,6 +127,7 @@ impl JobStore {
                     row.last_run_at.map(|t| t.to_rfc3339()),
                     row.created_at.to_rfc3339(),
                     row.conversation_id,
+                    row.created_version,
                 ],
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -286,12 +299,13 @@ impl JobStore {
             output: output.map(|s| s.to_string()),
             started_at,
             finished_at,
+            rustykrab_version: Some(rustykrab_core::VERSION.to_string()),
         };
         let row = run.clone();
         with_conn(&self.conn, move |conn| {
             conn.execute(
-                "INSERT INTO job_runs (id, job_id, status, output, started_at, finished_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                "INSERT INTO job_runs (id, job_id, status, output, started_at, finished_at, rustykrab_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 params![
                     row.id,
                     row.job_id,
@@ -299,6 +313,7 @@ impl JobStore {
                     row.output,
                     row.started_at.to_rfc3339(),
                     row.finished_at.to_rfc3339(),
+                    row.rustykrab_version,
                 ],
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -332,7 +347,7 @@ impl JobStore {
         with_conn(&self.conn, move |conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT id, job_id, status, output, started_at, finished_at
+                    "SELECT id, job_id, status, output, started_at, finished_at, rustykrab_version
                      FROM job_runs
                      WHERE job_id = ?1
                      ORDER BY finished_at DESC
@@ -349,6 +364,7 @@ impl JobStore {
                         output: row.get(3)?,
                         started_at: parse_stored_timestamp(row.get::<_, String>(4)?),
                         finished_at: parse_stored_timestamp(row.get::<_, String>(5)?),
+                        rustykrab_version: row.get::<_, Option<String>>(6)?,
                     })
                 })
                 .map_err(|e| Error::Storage(e.to_string()))?
@@ -364,7 +380,7 @@ impl JobStore {
 /// Column list for `SELECT`s against `scheduled_jobs`. Kept in sync with
 /// [`row_to_job`].
 const JOB_COLUMNS: &str = "id, schedule, task, channel, chat_id, thread_id, one_shot, enabled, \
-     next_run_at, last_run_at, created_at, conversation_id";
+     next_run_at, last_run_at, created_at, conversation_id, created_version";
 
 /// Decode a row produced by a `SELECT {JOB_COLUMNS}` into a [`ScheduledJob`].
 fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduledJob> {
@@ -381,6 +397,7 @@ fn row_to_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ScheduledJob> {
         last_run_at: row.get::<_, Option<String>>(9)?.map(parse_stored_timestamp),
         created_at: parse_stored_timestamp(row.get::<_, String>(10)?),
         conversation_id: row.get::<_, Option<String>>(11)?,
+        created_version: row.get::<_, Option<String>>(12)?,
     })
 }
 
@@ -465,6 +482,114 @@ fn parse_stored_timestamp(s: String) -> DateTime<Utc> {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn create_job_stamps_the_running_version() {
+        // The `task` string is fixed at creation and never updated, so
+        // knowing which build wrote it is what makes "find every job created
+        // before fix X" a query instead of a guess.
+        let s = in_memory_jobs();
+        let job = s
+            .create_job("0 9 * * *", "Daily briefing.", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            job.created_version.as_deref(),
+            Some(rustykrab_core::VERSION)
+        );
+
+        // And it survives the round-trip rather than only living on the
+        // returned struct.
+        let fetched = s.get_job(&job.id).await.unwrap();
+        assert_eq!(
+            fetched.created_version.as_deref(),
+            Some(rustykrab_core::VERSION)
+        );
+    }
+
+    #[tokio::test]
+    async fn record_run_stamps_version_and_list_runs_reads_it_back() {
+        let s = in_memory_jobs();
+        let job = s
+            .create_job("0 9 * * *", "Daily briefing.", None, None, None)
+            .await
+            .unwrap();
+        let now = Utc::now();
+        let run = s
+            .record_run(&job.id, "ok", Some("output"), now, now)
+            .await
+            .unwrap();
+        assert_eq!(
+            run.rustykrab_version.as_deref(),
+            Some(rustykrab_core::VERSION)
+        );
+
+        let runs = s.list_runs(&job.id, 10).await.unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(
+            runs[0].rustykrab_version.as_deref(),
+            Some(rustykrab_core::VERSION),
+            "list_runs must project the version column, not drop it"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_adds_version_columns_without_backfilling_old_rows() {
+        // A database created by a build that predates the version columns.
+        // Rows already in it were produced by an unknown build, so they must
+        // read back as None — back-filling them with the current version
+        // would assert an attribution we don't actually have.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE scheduled_jobs (
+                 id TEXT PRIMARY KEY, schedule TEXT NOT NULL, task TEXT NOT NULL,
+                 channel TEXT, chat_id TEXT, thread_id TEXT,
+                 one_shot INTEGER NOT NULL DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1,
+                 next_run_at TEXT NOT NULL, last_run_at TEXT, created_at TEXT NOT NULL,
+                 conversation_id TEXT
+             );
+             CREATE TABLE job_runs (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, status TEXT NOT NULL,
+                 output TEXT, started_at TEXT NOT NULL, finished_at TEXT NOT NULL
+             );
+             INSERT INTO scheduled_jobs (id, schedule, task, next_run_at, created_at)
+                 VALUES ('old-job', '0 9 * * *', 'legacy task',
+                         '2099-01-01T00:00:00+00:00', '2020-01-01T00:00:00+00:00');
+             INSERT INTO job_runs (id, job_id, status, output, started_at, finished_at)
+                 VALUES ('old-run', 'old-job', 'ok', 'legacy output',
+                         '2020-01-01T00:00:00+00:00', '2020-01-01T00:00:00+00:00');",
+        )
+        .unwrap();
+
+        // Migration must not fail on a table that already has rows.
+        crate::Store::run_migrations(&conn).unwrap();
+        let s = JobStore::new(Arc::new(Mutex::new(conn)));
+
+        let job = s.get_job("old-job").await.unwrap();
+        assert_eq!(job.task, "legacy task", "existing data must be preserved");
+        assert_eq!(
+            job.created_version, None,
+            "pre-existing job must not be back-filled with the current version"
+        );
+
+        let runs = s.list_runs("old-job", 10).await.unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].output.as_deref(), Some("legacy output"));
+        assert_eq!(
+            runs[0].rustykrab_version, None,
+            "pre-existing run must not be back-filled with the current version"
+        );
+
+        // New writes into the migrated database do get stamped.
+        let fresh = s
+            .create_job("0 9 * * *", "new task", None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            fresh.created_version.as_deref(),
+            Some(rustykrab_core::VERSION)
+        );
+    }
+
     #[test]
     fn compute_next_cron_5_field_expression() {
         let now = Utc::now();
@@ -540,35 +665,15 @@ mod tests {
         assert!(next_run > now);
     }
 
-    /// Build a [`JobStore`] backed by an in-memory SQLite connection with
-    /// just the schema the tests need. Avoids pulling in a tempdir crate.
+    /// Build a [`JobStore`] backed by an in-memory SQLite connection.
+    ///
+    /// Uses the real `run_migrations` rather than a hand-written copy of
+    /// the DDL: the duplicated copy silently drifted from production every
+    /// time a column was added, failing these tests for a reason that had
+    /// nothing to do with what they were checking.
     fn in_memory_jobs() -> JobStore {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE scheduled_jobs (
-                id              TEXT PRIMARY KEY,
-                schedule        TEXT NOT NULL,
-                task            TEXT NOT NULL,
-                channel         TEXT,
-                chat_id         TEXT,
-                thread_id       TEXT,
-                one_shot        INTEGER NOT NULL DEFAULT 0,
-                enabled         INTEGER NOT NULL DEFAULT 1,
-                next_run_at     TEXT NOT NULL,
-                last_run_at     TEXT,
-                created_at      TEXT NOT NULL,
-                conversation_id TEXT
-            );
-            CREATE TABLE job_runs (
-                id          TEXT PRIMARY KEY,
-                job_id      TEXT NOT NULL,
-                status      TEXT NOT NULL,
-                output      TEXT,
-                started_at  TEXT NOT NULL,
-                finished_at TEXT NOT NULL
-            );",
-        )
-        .unwrap();
+        crate::Store::run_migrations(&conn).unwrap();
         JobStore::new(Arc::new(Mutex::new(conn)))
     }
 

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -96,7 +96,8 @@ impl Store {
                 next_run_at     TEXT NOT NULL,
                 last_run_at     TEXT,
                 created_at      TEXT NOT NULL,
-                conversation_id TEXT
+                conversation_id TEXT,
+                created_version TEXT
             );
 
             CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_due
@@ -109,7 +110,8 @@ impl Store {
                 status     TEXT NOT NULL,
                 output     TEXT,
                 started_at TEXT NOT NULL,
-                finished_at TEXT NOT NULL
+                finished_at TEXT NOT NULL,
+                rustykrab_version TEXT
             );
 
             CREATE INDEX IF NOT EXISTS idx_job_runs_job_id
@@ -162,6 +164,30 @@ impl Store {
         }
         if !existing.iter().any(|c| c == "thread_id") {
             conn.execute("ALTER TABLE scheduled_jobs ADD COLUMN thread_id TEXT", [])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+        if !existing.iter().any(|c| c == "created_version") {
+            conn.execute(
+                "ALTER TABLE scheduled_jobs ADD COLUMN created_version TEXT",
+                [],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+
+        // `job_runs.rustykrab_version` records which build executed each run.
+        // Rows written before this column existed stay NULL rather than being
+        // back-filled with the current version, which would misattribute them.
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(job_runs)")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let existing: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        drop(stmt);
+        if !existing.iter().any(|c| c == "rustykrab_version") {
+            conn.execute("ALTER TABLE job_runs ADD COLUMN rustykrab_version TEXT", [])
                 .map_err(|e| Error::Storage(e.to_string()))?;
         }
 

--- a/crates/rustykrab-tools/src/cron.rs
+++ b/crates/rustykrab-tools/src/cron.rs
@@ -63,7 +63,37 @@ impl Tool for CronTool {
                     },
                     "task": {
                         "type": "string",
-                        "description": "The task description or prompt to execute when the schedule fires (required for create)"
+                        "description": concat!(
+                            "Required for create. The prompt that will be executed when the schedule fires.\n",
+                            "\n",
+                            "CRITICAL: this string is the ONLY thing carried forward from this conversation. ",
+                            "When the job fires — possibly days later — a fresh agent run receives this text and ",
+                            "nothing else: no chat history, no memory of what the user just told you, no access ",
+                            "to what you and the user worked out together. A short label like 'daily briefing' ",
+                            "or 'check emails' will produce a generic, useless result.\n",
+                            "\n",
+                            "Write a self-contained brief. Fold in everything the user told you that the future ",
+                            "run needs:\n",
+                            "  - What to do, as an explicit instruction (not a topic label)\n",
+                            "  - Which sources/tools to use, and what to ignore\n",
+                            "  - Any filters, thresholds, names, accounts, or projects the user named\n",
+                            "  - Output format, length, tone, and ordering the user asked for\n",
+                            "  - Any standing preferences or constraints from this conversation\n",
+                            "\n",
+                            "BAD  (too thin — produces generic output):\n",
+                            "  'Morning inbox summary'\n",
+                            "\n",
+                            "GOOD (self-contained):\n",
+                            "  'Summarize my unread email from the last 24h. Only include mail from real ",
+                            "people — skip newsletters, receipts, and automated notifications. Lead with ",
+                            "anything from my direct team (Ana, Priya, Marcus). Format as at most 5 bullets, ",
+                            "each one line, no preamble or sign-off. If nothing qualifies, reply exactly ",
+                            "\"Nothing needing attention.\"'\n",
+                            "\n",
+                            "Exception: if the task is exactly a registered SKILL.md skill name (e.g. ",
+                            "'morning-briefing'), the bare name is fine — the skill body is injected ",
+                            "automatically at fire time.",
+                        )
                     },
                     "channel": {
                         "type": "string",
@@ -266,6 +296,56 @@ mod tests {
         .await
         .expect_err("whitespace-only task must be rejected");
         assert!(!backend.called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn task_schema_demands_a_self_contained_brief() {
+        // The task string is the only context that survives into the
+        // scheduled run — no chat history travels with it. If the schema
+        // doesn't say so, models write short topic labels ("daily
+        // briefing") and the fired job produces generic output.
+        let (_, tool) = spy();
+        let schema = tool.schema();
+        let task_desc = schema.parameters["properties"]["task"]["description"]
+            .as_str()
+            .expect("task description should be a string");
+
+        assert!(
+            task_desc.contains("ONLY thing carried forward"),
+            "schema must warn that task is the sole surviving context: {task_desc}"
+        );
+        assert!(
+            task_desc.contains("no chat history"),
+            "schema must state that chat history is not carried over: {task_desc}"
+        );
+        // A worked BAD/GOOD pair moves models off one-line labels far more
+        // reliably than an abstract instruction does.
+        assert!(
+            task_desc.contains("BAD") && task_desc.contains("GOOD"),
+            "schema should show a contrasting example pair: {task_desc}"
+        );
+        // Bare skill names must stay explicitly legal — resolve_skill_for_task
+        // relies on exact-name tasks and there is no minimum-length gate.
+        assert!(
+            task_desc.contains("SKILL.md skill name"),
+            "schema must keep the bare-skill-name path legal: {task_desc}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bare_skill_name_task_is_still_accepted() {
+        // Guard against anyone "fixing" thin tasks with a length check:
+        // `task = "morning-briefing"` is a supported path that gets the
+        // skill body injected at fire time.
+        let (backend, tool) = spy();
+        tool.execute(json!({
+            "action": "create",
+            "schedule": "0 9 * * *",
+            "task": "morning-briefing",
+        }))
+        .await
+        .expect("bare skill name should remain a valid task");
+        assert!(backend.called.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Scheduled jobs produced generic, simplistic output because the `task`
string is the only thing that survives from the conversation where the
job was created, and nothing asked the model to make it self-contained.

At fire time `resume_or_create_conversation` calls `conversations().create()`,
which returns a conversation with `messages: Vec::new()`. The system prompt
is built from identity, date, security policy, the skill catalog, and channel
context — none of which carry the user's original request. Tools receive only
their JSON args (`Tool::execute(&self, args: Value)`), so `CronTool` cannot
observe the conversation it was invoked from, and `create_job` has no field
for it. The net effect is that a job created from a detailed request fires
with nothing but whatever short label the model wrote.

The tool schema made this worse by asymmetry: `schedule` carried ~20 lines
of guidance and five examples while `task` had a single line, so models
reliably wrote topic labels like "daily briefing". Because run 2+ resumes
the job's own conversation, the generic first run then became the template
it copied.

Two changes:

- Rewrite the `task` parameter description to state that it is the only
  surviving context, enumerate what to fold in, and show a BAD/GOOD pair.
  Fixes newly created jobs at the source.
- Add a context-recovery line to the fire-time prompt directing the model
  to call memory_search for standing preferences before composing output.
  This is what helps the thin task strings already stored in the database,
  which the schema change cannot retroactively repair.

Deliberately no minimum-length validation on `task`: bare skill names are a
supported path that `resolve_skill_for_task` matches exactly, and a length
gate would break them. Covered by a regression test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A5z8FSNcent4P5RFnKBjyd