### PR TITLE
Phase 1: evaluation harness for the credential guard

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,4 +29,14 @@ ignore = [
     # either does.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+
+    # number_prefix 0.4.0 is unmaintained (the crate is archived; the
+    # advisory recommends `unit-prefix`). No vulnerability is reported
+    # against it — it only formats byte counts as "1.2 KiB". It reaches us
+    # transitively and is not selectable: indicatif 0.17 -> hf-hub ->
+    # fastembed, i.e. progress bars for the embedding-model download.
+    # Nothing calls it outside that path, and it disappears entirely from
+    # `--no-default-features` builds (the E2E lane). Revisit when indicatif
+    # switches to unit-prefix.
+    "RUSTSEC-2025-0119",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # Feature branches build too, so cloud agents (which can't run the
+    # macOS/simulator lane) can iterate by pushing and reading checks.
+    branches: [main, 'claude/**']
   pull_request:
     branches: [main]
 
@@ -51,12 +53,32 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  e2e:
+    name: E2E Evaluation Harness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Builds with --no-default-features (no ONNX runtime download), boots
+      # the daemon on a temp dir, runs the exit-criteria scenarios with the
+      # scripted agent. Green = implemented scenarios pass and no Phase 2
+      # target scenario passes unexpectedly.
+      - run: scripts/e2e.sh
+      - name: Upload scenario report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-report
+          path: e2e-report.json
+          if-no-files-found: ignore
+
   # Gate job: add this as a required status check in branch protection
   # to block merges when any CI job fails.
   ci-pass:
     name: CI Pass
     if: always()
-    needs: [check, test, fmt, audit]
+    needs: [check, test, fmt, audit, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all checks passed
@@ -64,11 +86,13 @@ jobs:
           if [[ "${{ needs.check.result }}" != "success" ||
                 "${{ needs.test.result }}" != "success" ||
                 "${{ needs.fmt.result }}" != "success" ||
-                "${{ needs.audit.result }}" != "success" ]]; then
+                "${{ needs.audit.result }}" != "success" ||
+                "${{ needs.e2e.result }}" != "success" ]]; then
             echo "::error::One or more CI jobs failed"
             echo "  check:  ${{ needs.check.result }}"
             echo "  test:   ${{ needs.test.result }}"
             echo "  fmt:    ${{ needs.fmt.result }}"
             echo "  audit:  ${{ needs.audit.result }}"
+            echo "  e2e:    ${{ needs.e2e.result }}"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    # The action publishes its findings as a check run, which the default
+    # read-only token cannot create ("Resource not accessible by
+    # integration").
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,18 @@
 /target
+
+# Environment and secrets
+.env
+.env.*
+*.pem
+*.key
+
+# IDE
+.idea/
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# E2E harness report (written by scripts/e2e.sh)
 e2e-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,2 @@
 /target
-
-# Environment and secrets
-.env
-.env.*
-*.pem
-*.key
-
-# IDE
-.idea/
-.vscode/
-
-# OS
-.DS_Store
-Thumbs.db
+e2e-report.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,29 @@ Fix formatting automatically with `cargo fmt --all`.
 ```sh
 cargo build -p rustykrab-cli          # debug
 cargo build --release -p rustykrab-cli # release
+cargo build -p rustykrab-cli --no-default-features  # no ONNX download (sandboxes/CI)
 ```
+
+The `embeddings` feature (on by default) pulls fastembed/ONNX, which
+downloads a runtime from `cdn.pyke.io` at build time. Disable it in
+network-restricted environments — a deterministic `HashEmbedder` stands in.
+
+## End-to-end evaluation harness
+
+```sh
+scripts/e2e.sh          # build daemon, boot it, run the scenario suite
+```
+
+Boots the daemon on a throwaway data dir and an ephemeral port with a
+scripted (no-model, no-network) agent, then drives the scenarios in
+`crates/rustykrab-e2e`. Prints a JSON report to stdout and
+`e2e-report.json`; exit 0 means green.
+
+Scenarios encoding not-yet-built behaviour are marked **xfail** — the
+suite is green while they fail, and a phase ships by flipping its
+scenarios to must-pass. An unexpected pass (**xpass**) fails the suite so
+the scenario gets promoted. See
+`docs/plans/apollo-ios-and-credential-guard.md` §11.
 
 ## Project structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4074,7 +4074,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4159,7 +4159,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "axum",
  "chrono",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4238,7 +4238,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.12"
+version = "4.5.15"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3820,7 +3820,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -3836,6 +3836,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -3856,12 +3857,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4155,6 +4158,21 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "rustykrab-e2e"
+version = "4.5.15"
+dependencies = [
+ "anyhow",
+ "reqwest 0.13.3",
+ "rusqlite",
+ "rustykrab-store",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -5628,6 +5646,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -223,7 +223,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -241,7 +241,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix 1.1.4",
 ]
@@ -1416,11 +1416,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1431,7 +1430,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -6496,7 +6495,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-lite",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,7 +4076,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.5.15"
+version = "4.6.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/rustykrab-skills",
     "crates/rustykrab-cli",
     "crates/rustykrab-memory",
+    "crates/rustykrab-e2e",
 ]
 
 [workspace.package]

--- a/crates/rustykrab-cli/Cargo.toml
+++ b/crates/rustykrab-cli/Cargo.toml
@@ -14,7 +14,7 @@ rustykrab-tools.workspace = true
 rustykrab-channels.workspace = true
 rustykrab-skills.workspace = true
 rustykrab-providers.workspace = true
-rustykrab-memory = { workspace = true, features = ["fastembed"] }
+rustykrab-memory.workspace = true
 axum.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
@@ -39,5 +39,11 @@ enigo = { version = "0.6", optional = true }
 xcap = { version = "0.9", optional = true }
 
 [features]
+default = ["embeddings"]
+# Real ONNX embeddings for the memory system via fastembed. Disable
+# (`--no-default-features`) in network-restricted environments where
+# ort-sys cannot download the prebuilt ONNX runtime from cdn.pyke.io;
+# a deterministic hash embedder stands in for memory retrieval.
+embeddings = ["rustykrab-memory/fastembed"]
 # Concrete enigo + xcap implementation of the computer-use backend.
 computer-use = ["dep:enigo", "dep:xcap"]

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -31,6 +31,9 @@ use rustykrab_core::types::{ContentPart, MessageContent};
 use rustykrab_core::AgentRegistry;
 use rustykrab_gateway::AppState;
 use rustykrab_memory::backend::HybridMemoryBackend;
+#[cfg(not(feature = "embeddings"))]
+use rustykrab_memory::embedding::HashEmbedder;
+#[cfg(feature = "embeddings")]
 use rustykrab_memory::embedding::LazyFastEmbedder;
 use rustykrab_memory::storage::SqliteMemoryStorage;
 use rustykrab_memory::{MemoryConfig, MemorySystem};
@@ -313,9 +316,15 @@ async fn main() -> anyhow::Result<()> {
         .expect("Failed to install rustls crypto provider");
 
     // --- Data directory ---
-    let data_dir = dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join("rustykrab");
+    // RUSTYKRAB_DATA_DIR overrides the OS default so tests and the E2E
+    // harness can boot on a throwaway directory.
+    let data_dir = std::env::var_os("RUSTYKRAB_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("rustykrab")
+        });
     std::fs::create_dir_all(&data_dir)?;
 
     // --- Logging: stdout + rolling file ---
@@ -367,6 +376,15 @@ async fn main() -> anyhow::Result<()> {
     }
     if args.len() >= 2 && args[1] == "chat" {
         return chat::run(&data_dir, &args[2..]).await;
+    }
+    // An unrecognized subcommand must not silently fall through to
+    // "start the daemon" — a typo would boot a full agent instead of
+    // reporting the mistake.
+    if let Some(unknown) = args.get(1).filter(|a| !a.starts_with('-')) {
+        eprintln!("unknown subcommand '{unknown}'");
+        eprintln!("subcommands: skill, keychain, chat");
+        eprintln!("run with no arguments to start the daemon");
+        std::process::exit(2);
     }
 
     // --- Harness profile ---
@@ -458,6 +476,25 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("RUSTYKRAB_PROVIDER").unwrap_or_else(|_| "anthropic".to_string());
     let provider_name = provider_name.trim().to_lowercase();
     let provider: Arc<dyn ModelProvider> = match provider_name.as_str() {
+        // Deterministic replay provider for the E2E harness — no model,
+        // no network. Requires RUSTYKRAB_SCRIPT_PATH; refuses to start
+        // without it rather than silently answering every turn with the
+        // default text.
+        "scripted" => {
+            let path = std::env::var("RUSTYKRAB_SCRIPT_PATH").unwrap_or_else(|_| {
+                eprintln!("ERROR: RUSTYKRAB_PROVIDER=scripted requires RUSTYKRAB_SCRIPT_PATH");
+                std::process::exit(1);
+            });
+            let path = std::path::PathBuf::from(path);
+            tracing::warn!(
+                path = %path.display(),
+                "RUSTYKRAB_PROVIDER=scripted — replaying a fixed script instead of \
+                 calling a model. This is the E2E harness provider and must never \
+                 be set on a real deployment."
+            );
+            let p = rustykrab_providers::ScriptedProvider::from_path(&path)?;
+            Arc::new(p)
+        }
         "ollama" => {
             let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma4:26b".to_string());
             let base_url = std::env::var("OLLAMA_BASE_URL")
@@ -555,7 +592,16 @@ async fn main() -> anyhow::Result<()> {
     // happens off-thread on the first embed() call instead of blocking
     // boot. Init failures surface as clear errors from the first
     // embedding operation.
+    #[cfg(feature = "embeddings")]
     let embedder = Arc::new(LazyFastEmbedder::new(model_cache_dir));
+    // Without the `embeddings` feature there is no ONNX runtime; a
+    // deterministic hash embedder (same 768 dims as Nomic-embed-text-v1.5)
+    // keeps the memory system functional for tests and sandboxed builds.
+    #[cfg(not(feature = "embeddings"))]
+    let embedder = {
+        let _ = &model_cache_dir;
+        Arc::new(HashEmbedder::new(768))
+    };
     let memory_system = Arc::new(MemorySystem::new(
         MemoryConfig::default(),
         memory_storage,
@@ -1201,8 +1247,19 @@ async fn main() -> anyhow::Result<()> {
     // --- Gateway with security middleware ---
     let app = rustykrab_gateway::router(state);
 
-    // Bind to loopback only — never 0.0.0.0.
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    // Bind to loopback only — never 0.0.0.0. The port is overridable via
+    // RUSTYKRAB_PORT (the E2E harness boots on an ephemeral port so it
+    // never collides with a live instance); the loopback bind is not.
+    let port: u16 = std::env::var("RUSTYKRAB_PORT")
+        .ok()
+        .map(|p| {
+            p.trim().parse().unwrap_or_else(|_| {
+                eprintln!("ERROR: RUSTYKRAB_PORT must be a port number, got '{p}'");
+                std::process::exit(1);
+            })
+        })
+        .unwrap_or(3000);
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     tracing::info!(%addr, "RustyKrab gateway listening");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/rustykrab-core/src/recall.rs
+++ b/crates/rustykrab-core/src/recall.rs
@@ -156,13 +156,9 @@ impl RecallStore {
         self.hydrate(conversation_id);
         {
             let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
-            match guard.get(&conversation_id) {
-                None => return None,
-                Some(entry) => {
-                    if let Some(joined) = &entry.joined {
-                        return Some(Arc::clone(joined));
-                    }
-                }
+            let entry = guard.get(&conversation_id)?;
+            if let Some(joined) = &entry.joined {
+                return Some(Arc::clone(joined));
             }
         }
         // Joined view not built yet — take the write lock and cache it.

--- a/crates/rustykrab-e2e/Cargo.toml
+++ b/crates/rustykrab-e2e/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rustykrab-e2e"
+description = "End-to-end evaluation harness: boots the daemon and runs the phase exit-criteria scenarios"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+rustykrab-store.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+tempfile = "3"
+# Direct reads of the daemon's SQLite store, so scenarios can assert on
+# the tables the plan specifies (secret_versions, secret_audit,
+# credential_requests) and not just on what the REST API reveals.
+rusqlite = { version = "0.34", features = ["bundled"] }

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -1,0 +1,998 @@
+//! End-to-end evaluation harness (Workstream F3).
+//!
+//! Boots the daemon on a throwaway data dir and an ephemeral port, drives
+//! the phase exit-criteria scenarios over HTTP with a scripted agent, and
+//! asserts on responses **and** on store state. Scenarios that encode
+//! not-yet-implemented behaviour (the Phase 2 credential guard) are marked
+//! `XFail`: the suite is green while they fail, and a phase ships by
+//! flipping its scenarios to must-pass. An unexpected pass (XPASS) fails
+//! the suite — it means a scenario must be promoted.
+//!
+//! Output is a JSON report on stdout plus a matching exit code (0 = green),
+//! so agents and CI can assert mechanically. Run via `scripts/e2e.sh`, or
+//! directly:
+//!
+//! ```sh
+//! cargo build -p rustykrab-cli --no-default-features
+//! RUSTYKRAB_BIN=target/debug/rustykrab-cli cargo run -p rustykrab-e2e
+//! ```
+
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Master key for the throwaway store (hex, 32 bytes). Test-only.
+const MASTER_KEY_HEX: &str = "e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0";
+const AUTH_TOKEN: &str = "e2e-master-token";
+
+/// Script replayed by the daemon's `RUSTYKRAB_PROVIDER=scripted` provider.
+/// Triggers here must match the messages the scenarios send. Each scenario
+/// ends with `task_complete` — the runner's explicit completion signal,
+/// whose `summary` becomes the final assistant message.
+const AGENT_SCRIPT: &str = r#"{
+  "defaultText": "Done.",
+  "scenarios": [
+    {
+      "trigger": "e2e: create credential",
+      "steps": [
+        { "toolCalls": [ { "name": "credential_write",
+                           "arguments": { "action": "set",
+                                          "name": "e2e_scripted_token",
+                                          "value": "scripted-v1" } } ] },
+        { "toolCalls": [ { "name": "task_complete",
+                           "arguments": { "summary": "Created e2e_scripted_token." } } ] }
+      ]
+    },
+    {
+      "trigger": "e2e: streamed credential",
+      "steps": [
+        { "toolCalls": [ { "name": "credential_write",
+                           "arguments": { "action": "set",
+                                          "name": "e2e_streamed_token",
+                                          "value": "streamed-v1" } } ] },
+        { "toolCalls": [ { "name": "task_complete",
+                           "arguments": { "summary": "Created e2e_streamed_token." } } ] }
+      ]
+    },
+    {
+      "trigger": "e2e: overwrite credential",
+      "steps": [
+        { "toolCalls": [ { "name": "credential_write",
+                           "arguments": { "action": "set",
+                                          "name": "e2e_guard_token",
+                                          "value": "hijacked" } } ] },
+        { "toolCalls": [ { "name": "task_complete",
+                           "arguments": { "summary": "Attempted overwrite of e2e_guard_token." } } ] }
+      ]
+    },
+    {
+      "trigger": "e2e: delete credential",
+      "steps": [
+        { "toolCalls": [ { "name": "credential_write",
+                           "arguments": { "action": "delete",
+                                          "name": "e2e_delete_token" } } ] },
+        { "toolCalls": [ { "name": "task_complete",
+                           "arguments": { "summary": "Attempted delete of e2e_delete_token." } } ] }
+      ]
+    }
+  ]
+}"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Expected {
+    /// Implemented behaviour — must pass.
+    Pass,
+    /// Phase 2 target behaviour — expected to fail until the guard lands.
+    XFail,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioReport {
+    id: &'static str,
+    expected: Expected,
+    passed: bool,
+    /// "pass" | "fail" | "xfail" | "xpass"
+    outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+struct Ctx {
+    base: String,
+    client: reqwest::Client,
+    secrets: rustykrab_store::SecretStore,
+    /// Path to the daemon's SQLite database, for asserting on the tables
+    /// the plan specifies but no endpoint exposes.
+    db_path: std::path::PathBuf,
+    /// The daemon binary, used to drive CLI subcommands (`pair`).
+    bin: String,
+    /// The daemon's data dir — CLI subcommands must see the same store.
+    data_dir: std::path::PathBuf,
+}
+
+impl Ctx {
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base, path)
+    }
+
+    /// Count rows matching a query against the daemon's store. Returns 0
+    /// when the table doesn't exist yet (Phase 2 tables), so a scenario
+    /// fails on the assertion rather than on a SQL error.
+    fn count(&self, sql: &str, params: &[&dyn rusqlite::ToSql]) -> Result<i64> {
+        let conn = rusqlite::Connection::open_with_flags(
+            &self.db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
+        match conn.query_row(sql, params, |row| row.get::<_, i64>(0)) {
+            Ok(n) => Ok(n),
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg))) if msg.contains("no such table") => {
+                Ok(0)
+            }
+            Err(e) if e.to_string().contains("no such table") => Ok(0),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Run a daemon CLI subcommand with the harness environment.
+    fn cli(&self, args: &[&str]) -> Result<std::process::Output> {
+        Ok(Command::new(&self.bin)
+            .args(args)
+            .env_clear()
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .env("HOME", std::env::var("HOME").unwrap_or_default())
+            .env("RUSTYKRAB_DATA_DIR", &self.data_dir)
+            .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
+            .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
+            .env("RUSTYKRAB_DISABLE_KEYCHAIN", "1")
+            .env("NOTION_API_TOKEN", "e2e-dummy-notion")
+            .env("OBSIDIAN_API_KEY", "e2e-dummy-obsidian")
+            .output()?)
+    }
+
+    /// A request authenticated with an arbitrary token (device tokens).
+    async fn get_with_token(&self, path: &str, token: &str) -> Result<reqwest::Response> {
+        Ok(self
+            .client
+            .get(self.url(path))
+            .bearer_auth(token)
+            .send()
+            .await?)
+    }
+
+    async fn get(&self, path: &str) -> Result<reqwest::Response> {
+        Ok(self
+            .client
+            .get(self.url(path))
+            .bearer_auth(AUTH_TOKEN)
+            .send()
+            .await?)
+    }
+
+    async fn post(&self, path: &str, body: Value) -> Result<reqwest::Response> {
+        Ok(self
+            .client
+            .post(self.url(path))
+            .bearer_auth(AUTH_TOKEN)
+            .json(&body)
+            .send()
+            .await?)
+    }
+
+    async fn delete(&self, path: &str) -> Result<reqwest::Response> {
+        Ok(self
+            .client
+            .delete(self.url(path))
+            .bearer_auth(AUTH_TOKEN)
+            .send()
+            .await?)
+    }
+
+    /// Create a user-side secret via the REST API and verify it landed.
+    async fn create_secret(&self, name: &str, value: &str) -> Result<()> {
+        let resp = self
+            .post("/api/secrets", json!({"name": name, "value": value}))
+            .await?;
+        if resp.status() != 204 {
+            bail!("POST /api/secrets {name} returned {}", resp.status());
+        }
+        let stored = self.secrets.get(name).await?;
+        if stored != value {
+            bail!("store value for {name} is not what was just written");
+        }
+        Ok(())
+    }
+
+    /// Create a conversation, send one message, return the assistant reply.
+    async fn chat(&self, content: &str) -> Result<Value> {
+        let conv: Value = self
+            .post("/api/conversations", json!({}))
+            .await?
+            .json()
+            .await?;
+        let conv_id = conv["id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("conversation create returned no id: {conv}"))?
+            .to_string();
+        let resp = self
+            .post(
+                &format!("/api/conversations/{conv_id}/messages"),
+                json!({"content": content}),
+            )
+            .await?;
+        if resp.status() != 200 {
+            bail!("send_message returned {}", resp.status());
+        }
+        Ok(resp.json().await?)
+    }
+}
+
+// ── scenarios ────────────────────────────────────────────────────────
+
+async fn health(ctx: &Ctx) -> Result<()> {
+    let resp = ctx.client.get(ctx.url("/api/health")).send().await?;
+    if resp.status() != 200 {
+        bail!("health returned {}", resp.status());
+    }
+    Ok(())
+}
+
+async fn auth_required(ctx: &Ctx) -> Result<()> {
+    let resp = ctx.client.get(ctx.url("/api/conversations")).send().await?;
+    if resp.status() != 401 {
+        bail!(
+            "unauthenticated request returned {}, want 401",
+            resp.status()
+        );
+    }
+    Ok(())
+}
+
+async fn conversations_crud(ctx: &Ctx) -> Result<()> {
+    let conv: Value = ctx
+        .post("/api/conversations", json!({"title": "e2e"}))
+        .await?
+        .json()
+        .await?;
+    let id = conv["id"].as_str().ok_or_else(|| anyhow!("no id"))?;
+    if conv["title"] != "e2e" || conv["createdAt"].as_i64().is_none() {
+        bail!("conversation shape mismatch: {conv}");
+    }
+    let list: Value = ctx.get("/api/conversations").await?.json().await?;
+    let listed = list
+        .as_array()
+        .map(|a| a.iter().any(|c| c["id"] == conv["id"]))
+        .unwrap_or(false);
+    if !listed {
+        bail!("created conversation missing from list");
+    }
+    let got = ctx.get(&format!("/api/conversations/{id}")).await?;
+    if got.status() != 200 {
+        bail!("get conversation returned {}", got.status());
+    }
+    let del = ctx.delete(&format!("/api/conversations/{id}")).await?;
+    if del.status() != 204 {
+        bail!("delete conversation returned {}", del.status());
+    }
+    let gone = ctx.get(&format!("/api/conversations/{id}")).await?;
+    if gone.status() != 404 {
+        bail!("deleted conversation still returns {}", gone.status());
+    }
+    Ok(())
+}
+
+async fn chat_scripted_default(ctx: &Ctx) -> Result<()> {
+    let msg = ctx.chat("hello from the e2e harness").await?;
+    if msg["role"] != "assistant" {
+        bail!("reply role: {msg}");
+    }
+    if msg["content"] != "Done." {
+        bail!("expected scripted default text, got: {}", msg["content"]);
+    }
+    Ok(())
+}
+
+/// What a consumed SSE stream contained.
+struct StreamOutcome {
+    saw_text: bool,
+    /// Names from `tool_start` frames, in order.
+    tools: Vec<String>,
+    /// The message from the terminal `done` frame.
+    done: Option<Value>,
+}
+
+/// Drive `POST …/messages/stream` and consume the SSE response, applying
+/// the frame rules from docs/integrations/apollo.md: `text` deltas,
+/// a terminal `done` carrying the full message, and tool/heartbeat frames
+/// that clients may ignore.
+async fn stream_message(ctx: &Ctx, content: &str) -> Result<StreamOutcome> {
+    use tokio_stream::StreamExt;
+
+    let conv: Value = ctx
+        .post("/api/conversations", json!({}))
+        .await?
+        .json()
+        .await?;
+    let conv_id = conv["id"].as_str().ok_or_else(|| anyhow!("no id"))?;
+    let resp = ctx
+        .post(
+            &format!("/api/conversations/{conv_id}/messages/stream"),
+            json!({"content": content}),
+        )
+        .await?;
+    if resp.status() != 200 {
+        bail!("stream returned {}", resp.status());
+    }
+
+    let mut outcome = StreamOutcome {
+        saw_text: false,
+        tools: Vec::new(),
+        done: None,
+    };
+    let mut buf = String::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        buf.push_str(&String::from_utf8_lossy(&chunk?));
+        // SSE frames are separated by a blank line.
+        while let Some(pos) = buf.find("\n\n") {
+            let frame: String = buf.drain(..pos + 2).collect();
+            let mut event = "";
+            let mut data = "";
+            for line in frame.lines() {
+                if let Some(v) = line.strip_prefix("event:") {
+                    event = v.trim();
+                } else if let Some(v) = line.strip_prefix("data:") {
+                    data = v.trim();
+                }
+            }
+            match event {
+                "text" => outcome.saw_text = true,
+                "tool_start" => {
+                    if let Ok(p) = serde_json::from_str::<Value>(data) {
+                        if let Some(name) = p["delta"].as_str() {
+                            outcome.tools.push(name.to_string());
+                        }
+                    }
+                }
+                "error" => bail!("stream reported an error frame: {data}"),
+                "done" => {
+                    let payload: Value = serde_json::from_str(data)
+                        .with_context(|| format!("bad done payload: {data}"))?;
+                    // Progress frames are a bare {"type":"done"}; the
+                    // terminal frame carries the full message.
+                    if payload.get("message").is_some() {
+                        outcome.done = Some(payload["message"].clone());
+                    }
+                }
+                _ => {} // thinking, heartbeats — safe no-ops
+            }
+        }
+        if outcome.done.is_some() {
+            break;
+        }
+    }
+    Ok(outcome)
+}
+
+/// SSE contract smoke: the stream carries incremental `text` events and a
+/// terminal `done` event with the full message (docs/integrations/apollo.md).
+async fn chat_sse_stream(ctx: &Ctx) -> Result<()> {
+    let outcome = stream_message(ctx, "hello stream").await?;
+    let done = outcome
+        .done
+        .ok_or_else(|| anyhow!("stream ended without a done event"))?;
+    if !outcome.saw_text {
+        bail!("no text events before done");
+    }
+    if done["content"] != "Done." || done["role"] != "assistant" {
+        bail!("done message mismatch: {done}");
+    }
+    Ok(())
+}
+
+/// Tool calls must work over the **streaming** route too — that is the
+/// path Apollo actually uses for chat, and it goes through
+/// `chat_stream`, not `chat`. Asserts the tool lifecycle frames appear
+/// and that the tool's side effect really landed in the store.
+async fn chat_sse_stream_with_tools(ctx: &Ctx) -> Result<()> {
+    let outcome = stream_message(ctx, "e2e: streamed credential").await?;
+    let done = outcome
+        .done
+        .ok_or_else(|| anyhow!("stream ended without a done event"))?;
+    if !outcome.tools.iter().any(|t| t == "credential_write") {
+        bail!("no credential_write tool_start frame: {:?}", outcome.tools);
+    }
+    let text = done["content"].as_str().unwrap_or_default();
+    if !text.contains("e2e_streamed_token") {
+        bail!("unexpected final streamed message: {done}");
+    }
+    let stored = ctx.secrets.get("e2e_streamed_token").await?;
+    if stored != "streamed-v1" {
+        bail!("streamed tool call did not persist the credential");
+    }
+    Ok(())
+}
+
+async fn secrets_create_and_delete(ctx: &Ctx) -> Result<()> {
+    ctx.create_secret("e2e_lifecycle_token", "v1").await?;
+    let list: Value = ctx.get("/api/secrets").await?.json().await?;
+    let names = list["names"].as_array().cloned().unwrap_or_default();
+    if !names.iter().any(|n| n == "e2e_lifecycle_token") {
+        bail!("created secret missing from list: {list}");
+    }
+    let del = ctx.delete("/api/secrets/e2e_lifecycle_token").await?;
+    if del.status() != 204 {
+        bail!("delete secret returned {}", del.status());
+    }
+    if ctx.secrets.get("e2e_lifecycle_token").await.is_ok() {
+        bail!("secret still present in store after delete");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 3: the scripted agent creates a **new** credential —
+/// allowed silently under the create-only policy, and already true today.
+async fn agent_creates_new_credential(ctx: &Ctx) -> Result<()> {
+    let msg = ctx.chat("e2e: create credential").await?;
+    let text = msg["content"].as_str().unwrap_or_default();
+    if !text.contains("e2e_scripted_token") {
+        bail!("unexpected final reply: {msg}");
+    }
+    let stored = ctx.secrets.get("e2e_scripted_token").await?;
+    if stored != "scripted-v1" {
+        bail!("scripted credential has wrong value");
+    }
+    Ok(())
+}
+
+/// Mint a pairing code on the Mac side and exchange it for a device
+/// identity — the first half of plan §F3 scenario 1. Returns the device
+/// id and its one-time token.
+async fn pair_a_device(ctx: &Ctx, name: &str) -> Result<(String, String)> {
+    // `rustykrab pair` prints the code (and a QR payload) — the plan's
+    // Mac-side mint step.
+    let out = ctx.cli(&["pair"])?;
+    if !out.status.success() {
+        bail!(
+            "`rustykrab-cli pair` failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Accept either the bare 8-char code or the QR JSON payload.
+    let code = serde_json::from_str::<Value>(stdout.trim())
+        .ok()
+        .and_then(|v| v["code"].as_str().map(str::to_string))
+        .or_else(|| {
+            stdout
+                .split_whitespace()
+                .find(|t| t.len() == 8 && t.chars().all(|c| c.is_ascii_alphanumeric()))
+                .map(str::to_string)
+        })
+        .ok_or_else(|| anyhow!("no pairing code in `pair` output: {}", stdout.trim()))?;
+
+    let resp = ctx
+        .client
+        .post(ctx.url("/api/pair"))
+        .json(&json!({"code": code, "deviceName": name}))
+        .send()
+        .await?;
+    if resp.status() != 200 {
+        bail!("POST /api/pair returned {}", resp.status());
+    }
+    let body: Value = resp.json().await?;
+    let device_id = body["deviceId"]
+        .as_str()
+        .ok_or_else(|| anyhow!("pair response has no deviceId: {body}"))?
+        .to_string();
+    let token = body["deviceToken"]
+        .as_str()
+        .ok_or_else(|| anyhow!("pair response has no deviceToken: {body}"))?
+        .to_string();
+    Ok((device_id, token))
+}
+
+/// Plan §F3 scenario 1 (Phase 2): mint a code, exchange it, and call the
+/// API with the resulting **device token** — the token must be accepted
+/// anywhere the master token is. Also checks the code is single-use and
+/// that the device shows up in the management listing.
+async fn pair_device_target(ctx: &Ctx) -> Result<()> {
+    let (device_id, token) = pair_a_device(ctx, "e2e-phone").await?;
+
+    // The device token authenticates like the master token.
+    let resp = ctx.get_with_token("/api/conversations", &token).await?;
+    if resp.status() != 200 {
+        bail!(
+            "device token rejected on /api/conversations: {}",
+            resp.status()
+        );
+    }
+
+    // The paired device is listed and attributable.
+    let devices: Vec<Value> = ctx.get("/api/devices").await?.json().await?;
+    let listed = devices
+        .iter()
+        .find(|d| d["id"].as_str() == Some(device_id.as_str()))
+        .ok_or_else(|| anyhow!("paired device missing from /api/devices"))?;
+    if listed["name"] != "e2e-phone" {
+        bail!("device name not recorded: {listed}");
+    }
+    // Tokens are stored hashed — never echoed back by the listing.
+    if listed.get("token").is_some() || listed.get("deviceToken").is_some() {
+        bail!("device listing leaks the token");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 2 (Phase 2): POST /api/secrets is create-only — an
+/// existing name without `overwrite: true` is refused with 409 and the
+/// stored value is untouched.
+async fn secrets_create_only_409(ctx: &Ctx) -> Result<()> {
+    ctx.create_secret("e2e_createonly_token", "original")
+        .await?;
+    let resp = ctx
+        .post(
+            "/api/secrets",
+            json!({"name": "e2e_createonly_token", "value": "clobbered"}),
+        )
+        .await?;
+    if resp.status() != 409 {
+        bail!("repeat POST returned {}, want 409", resp.status());
+    }
+    let stored = ctx.secrets.get("e2e_createonly_token").await?;
+    if stored != "original" {
+        bail!("value changed despite create-only default");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 2 (Phase 2): `overwrite: true` applies the change and
+/// the secrets listing exposes per-entry metadata with a bumped version
+/// (the superseded value is archived server-side).
+async fn secrets_overwrite_archives(ctx: &Ctx) -> Result<()> {
+    ctx.create_secret("e2e_overwrite_token", "v1").await?;
+    let resp = ctx
+        .post(
+            "/api/secrets",
+            json!({"name": "e2e_overwrite_token", "value": "v2", "overwrite": true}),
+        )
+        .await?;
+    if resp.status() != 204 {
+        bail!("overwrite POST returned {}", resp.status());
+    }
+    let stored = ctx.secrets.get("e2e_overwrite_token").await?;
+    if stored != "v2" {
+        bail!("overwrite did not apply");
+    }
+    let list: Value = ctx.get("/api/secrets").await?.json().await?;
+    let entry = list["secrets"]
+        .as_array()
+        .and_then(|a| a.iter().find(|e| e["name"] == "e2e_overwrite_token"))
+        .cloned()
+        .ok_or_else(|| anyhow!("metadata listing missing entry: {list}"))?;
+    if entry["version"].as_i64() != Some(2) {
+        bail!("expected version 2 after overwrite, got: {entry}");
+    }
+    // The superseded value is archived, not dropped (plan §A1).
+    let archived = ctx.count(
+        "SELECT COUNT(*) FROM secret_versions WHERE name = ?1",
+        &[&"e2e_overwrite_token"],
+    )?;
+    if archived < 1 {
+        bail!("no secret_versions row archiving the superseded value");
+    }
+    // …and the write is audited.
+    let audited = ctx.count(
+        "SELECT COUNT(*) FROM secret_audit WHERE name = ?1 AND op = 'overwrite'",
+        &[&"e2e_overwrite_token"],
+    )?;
+    if audited < 1 {
+        bail!("no secret_audit row for the overwrite");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 4 (Phase 2): an agent `set` on an existing name
+/// leaves the value unchanged and files exactly one pending request.
+async fn agent_overwrite_files_request(ctx: &Ctx) -> Result<()> {
+    ctx.create_secret("e2e_guard_token", "original").await?;
+    ctx.chat("e2e: overwrite credential").await?;
+    let stored = ctx.secrets.get("e2e_guard_token").await?;
+    if stored != "original" {
+        bail!("agent overwrote an existing credential (value is now the proposed one)");
+    }
+    let pending = pending_requests(ctx).await?;
+    let matching: Vec<&Value> = pending
+        .iter()
+        .filter(|r| r["name"] == "e2e_guard_token" && r["action"] == "update")
+        .collect();
+    if matching.len() != 1 {
+        bail!(
+            "want exactly one pending update request, got {}",
+            matching.len()
+        );
+    }
+    if matching[0].get("proposedValue").is_some() || matching[0].get("value").is_some() {
+        bail!("pending request leaks the proposed value");
+    }
+    // Plan §A1: the proposal is encrypted at rest — a pending request is
+    // never a plaintext copy of the credential.
+    let plaintext = ctx.count(
+        "SELECT COUNT(*) FROM credential_requests \
+         WHERE name = ?1 AND CAST(proposed_data AS TEXT) LIKE '%hijacked%'",
+        &[&"e2e_guard_token"],
+    )?;
+    if plaintext != 0 {
+        bail!("proposed_data holds the proposed value in plaintext");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 5 (Phase 2): approving a pending request applies the
+/// stored change with User authority.
+async fn approve_applies_change(ctx: &Ctx) -> Result<()> {
+    // Reuses the request filed by the overwrite scenario; refile if absent.
+    let mut pending = pending_for(ctx, "e2e_guard_token").await?;
+    if pending.is_none() {
+        ctx.chat("e2e: overwrite credential").await?;
+        pending = pending_for(ctx, "e2e_guard_token").await?;
+    }
+    let req = pending.ok_or_else(|| anyhow!("no pending request to approve"))?;
+    let id = req["id"]
+        .as_str()
+        .ok_or_else(|| anyhow!("request has no id"))?;
+    let resp = ctx
+        .post(&format!("/api/credential-requests/{id}/approve"), json!({}))
+        .await?;
+    if resp.status() != 204 {
+        bail!("approve returned {}", resp.status());
+    }
+    let stored = ctx.secrets.get("e2e_guard_token").await?;
+    if stored != "hijacked" {
+        bail!("approved change was not applied");
+    }
+    // Plan criterion 5 in full: the superseded value is archived and the
+    // approval is audited against the request.
+    let archived = ctx.count(
+        "SELECT COUNT(*) FROM secret_versions WHERE name = ?1",
+        &[&"e2e_guard_token"],
+    )?;
+    if archived < 1 {
+        bail!("approved overwrite archived no previous version");
+    }
+    let audited = ctx.count(
+        "SELECT COUNT(*) FROM secret_audit WHERE request_id = ?1 AND op = 'approve'",
+        &[&id],
+    )?;
+    if audited < 1 {
+        bail!("no secret_audit row attributing the approval to request {id}");
+    }
+    // The decided request is no longer pending.
+    if pending_for(ctx, "e2e_guard_token").await?.is_some() {
+        bail!("approved request is still listed as pending");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 6 (Phase 2): denying a pending request leaves the
+/// value unchanged.
+async fn deny_preserves_value(ctx: &Ctx) -> Result<()> {
+    // The scripted overwrite scenario targets e2e_guard_token, so reset
+    // that name to a known value and refile a request against it.
+    let before = "deny-keeps-this";
+    ctx.delete("/api/secrets/e2e_guard_token").await?;
+    ctx.create_secret("e2e_guard_token", before).await?;
+    ctx.chat("e2e: overwrite credential").await?;
+    let req = pending_for(ctx, "e2e_guard_token")
+        .await?
+        .ok_or_else(|| anyhow!("no pending request to deny"))?;
+    let id = req["id"]
+        .as_str()
+        .ok_or_else(|| anyhow!("request has no id"))?;
+    let resp = ctx
+        .post(&format!("/api/credential-requests/{id}/deny"), json!({}))
+        .await?;
+    if resp.status() != 204 {
+        bail!("deny returned {}", resp.status());
+    }
+    if pending_for(ctx, "e2e_guard_token").await?.is_some() {
+        bail!("denied request still listed as pending");
+    }
+    // The point of the scenario: denying leaves the value untouched.
+    let stored = ctx.secrets.get("e2e_guard_token").await?;
+    if stored != before {
+        bail!("value changed despite the request being denied");
+    }
+    // Plan criterion 6: the proposal is wiped on deny, not merely marked.
+    let leftover = ctx.count(
+        "SELECT COUNT(*) FROM credential_requests \
+         WHERE id = ?1 AND proposed_data IS NOT NULL",
+        &[&id],
+    )?;
+    if leftover != 0 {
+        bail!("denied request still holds its proposed_data");
+    }
+    Ok(())
+}
+
+/// Plan §F3 scenario 7 (Phase 2): an agent `delete` always files a request
+/// and the credential survives until approval. (Expiry sweep and the
+/// stale-approval 409 are asserted in store/gateway tests where the clock
+/// can be manipulated.)
+async fn agent_delete_files_request(ctx: &Ctx) -> Result<()> {
+    ctx.create_secret("e2e_delete_token", "still-here").await?;
+    ctx.chat("e2e: delete credential").await?;
+    let stored = ctx.secrets.get("e2e_delete_token").await;
+    if stored.is_err() {
+        bail!("agent deleted an existing credential outright");
+    }
+    let req = pending_for(ctx, "e2e_delete_token").await?;
+    match req {
+        Some(r) if r["action"] == "delete" => Ok(()),
+        Some(r) => bail!("pending request has wrong action: {r}"),
+        None => bail!("no pending delete request filed"),
+    }
+}
+
+/// Plan §F3 scenario 8 (Phase 2): the lost-phone story — pair a device,
+/// confirm its token works, revoke it, and confirm the same token is
+/// then rejected with 401.
+async fn revoked_device_401(ctx: &Ctx) -> Result<()> {
+    let (device_id, token) = pair_a_device(ctx, "e2e-lost-phone").await?;
+
+    let before = ctx.get_with_token("/api/conversations", &token).await?;
+    if before.status() != 200 {
+        bail!("fresh device token rejected: {}", before.status());
+    }
+
+    let revoke = ctx.delete(&format!("/api/devices/{device_id}")).await?;
+    if revoke.status() != 204 {
+        bail!("revoking the device returned {}", revoke.status());
+    }
+
+    let after = ctx.get_with_token("/api/conversations", &token).await?;
+    if after.status() != 401 {
+        bail!("revoked device token returned {}, want 401", after.status());
+    }
+    Ok(())
+}
+
+async fn pending_requests(ctx: &Ctx) -> Result<Vec<Value>> {
+    let resp = ctx.get("/api/credential-requests?status=pending").await?;
+    if resp.status() != 200 {
+        bail!("GET /api/credential-requests returned {}", resp.status());
+    }
+    Ok(resp.json().await?)
+}
+
+async fn pending_for(ctx: &Ctx, name: &str) -> Result<Option<Value>> {
+    Ok(pending_requests(ctx)
+        .await?
+        .into_iter()
+        .find(|r| r["name"] == name))
+}
+
+// ── daemon lifecycle ─────────────────────────────────────────────────
+
+fn pick_free_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Child> {
+    let script_path = data_dir.join("e2e-script.json");
+    std::fs::write(&script_path, AGENT_SCRIPT)?;
+    let log = std::fs::File::create(data_dir.join("daemon.log"))?;
+    let child = Command::new(bin)
+        // Start from an empty environment: the developer's shell may hold
+        // real credentials (which would be written into this throwaway
+        // store) and RUSTYKRAB_* settings that would change behaviour and
+        // break determinism. Only PATH and HOME are carried over.
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("RUSTYKRAB_DATA_DIR", data_dir)
+        .env("RUSTYKRAB_PORT", port.to_string())
+        .env("RUSTYKRAB_PROVIDER", "scripted")
+        .env("RUSTYKRAB_SCRIPT_PATH", &script_path)
+        .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
+        .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
+        // Never touch the host's real Keychain from a throwaway boot.
+        .env("RUSTYKRAB_DISABLE_KEYCHAIN", "1")
+        // Dummy values for the registry's startup-required secrets.
+        .env("NOTION_API_TOKEN", "e2e-dummy-notion")
+        .env("OBSIDIAN_API_KEY", "e2e-dummy-obsidian")
+        .env("RUSTYKRAB_LOG_STDOUT", "1")
+        // The suite drives far more than the shipping 20 req/min from one
+        // IP; raise the limit for this throwaway boot only.
+        .env("RUSTYKRAB_RATE_LIMIT_MAX", "100000")
+        .env("RUSTYKRAB_RATE_LIMIT_LOCKOUT_SECS", "1")
+        .stdout(Stdio::from(log.try_clone()?))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .with_context(|| format!("failed to spawn daemon binary {bin}"))?;
+    Ok(child)
+}
+
+async fn wait_for_health(base: &str, client: &reqwest::Client, child: &mut Child) -> Result<()> {
+    for _ in 0..240 {
+        if let Some(status) = child.try_wait()? {
+            bail!("daemon exited during startup: {status}");
+        }
+        if let Ok(resp) = client.get(format!("{base}/api/health")).send().await {
+            if resp.status() == 200 {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("daemon did not become healthy within 120s");
+}
+
+// ── main ─────────────────────────────────────────────────────────────
+
+type ScenarioFn =
+    for<'a> fn(&'a Ctx) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + 'a>>;
+
+macro_rules! scenario {
+    ($f:ident) => {{
+        let f: ScenarioFn = |ctx| Box::pin($f(ctx));
+        (stringify!($f), f)
+    }};
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let bin =
+        std::env::var("RUSTYKRAB_BIN").unwrap_or_else(|_| "target/debug/rustykrab-cli".to_string());
+    if !std::path::Path::new(&bin).exists() {
+        bail!("daemon binary not found at {bin} — build it first or set RUSTYKRAB_BIN");
+    }
+
+    let tmp = tempfile::Builder::new()
+        .prefix("rustykrab-e2e-")
+        .tempdir()?;
+    let keep_tmp = std::env::var("E2E_KEEP_TMP").is_ok();
+    let data_dir = tmp.path().to_path_buf();
+    let port = pick_free_port()?;
+
+    let mut child = spawn_daemon(&bin, &data_dir, port)?;
+
+    let result = run_suite(&bin, &data_dir, port, &mut child).await;
+
+    // Graceful shutdown first (SIGTERM) so the store flushes; hard-kill on
+    // timeout or if TERM couldn't be sent.
+    let _ = Command::new("kill").arg(child.id().to_string()).status();
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if child.try_wait()?.is_some() {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let (report, ok) = result?;
+    if keep_tmp {
+        let path = tmp.keep();
+        eprintln!("E2E_KEEP_TMP set — data dir kept at {}", path.display());
+    }
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    if !ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn run_suite(
+    bin: &str,
+    data_dir: &std::path::Path,
+    port: u16,
+    child: &mut Child,
+) -> Result<(Value, bool)> {
+    let base = format!("http://127.0.0.1:{port}");
+    // The origin-check middleware requires an Origin header on every
+    // /api request (loopback origins are always allowed).
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::ORIGIN, base.parse()?);
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(Duration::from_secs(120))
+        .build()?;
+    wait_for_health(&base, &client, child).await?;
+
+    // Open the store only after the daemon is healthy — it owns the
+    // database and its migrations; this is a read handle for assertions.
+    let store = rustykrab_store::Store::open(data_dir.join("db"), hex_decode(MASTER_KEY_HEX)?)?;
+    let ctx = &Ctx {
+        base,
+        client,
+        secrets: store.secrets(),
+        db_path: data_dir.join("db").join("store.db"),
+        bin: bin.to_string(),
+        data_dir: data_dir.to_path_buf(),
+    };
+
+    let scenarios: Vec<(Expected, (&'static str, ScenarioFn))> = vec![
+        // Baseline — implemented today, must pass.
+        (Expected::Pass, scenario!(health)),
+        (Expected::Pass, scenario!(auth_required)),
+        (Expected::Pass, scenario!(conversations_crud)),
+        (Expected::Pass, scenario!(chat_scripted_default)),
+        (Expected::Pass, scenario!(chat_sse_stream)),
+        (Expected::Pass, scenario!(chat_sse_stream_with_tools)),
+        (Expected::Pass, scenario!(secrets_create_and_delete)),
+        (Expected::Pass, scenario!(agent_creates_new_credential)),
+        // Phase 2 exit criteria — xfail until the guard lands.
+        (Expected::XFail, scenario!(pair_device_target)),
+        (Expected::XFail, scenario!(secrets_create_only_409)),
+        (Expected::XFail, scenario!(secrets_overwrite_archives)),
+        (Expected::XFail, scenario!(agent_overwrite_files_request)),
+        (Expected::XFail, scenario!(approve_applies_change)),
+        (Expected::XFail, scenario!(deny_preserves_value)),
+        (Expected::XFail, scenario!(agent_delete_files_request)),
+        (Expected::XFail, scenario!(revoked_device_401)),
+    ];
+
+    let mut reports = Vec::new();
+    for (expected, (id, f)) in scenarios {
+        let outcome = tokio::time::timeout(Duration::from_secs(120), f(ctx)).await;
+        let (passed, detail) = match outcome {
+            Ok(Ok(())) => (true, None),
+            Ok(Err(e)) => (false, Some(format!("{e:#}"))),
+            Err(_) => (false, Some("scenario timed out after 120s".to_string())),
+        };
+        let outcome = match (expected, passed) {
+            (Expected::Pass, true) => "pass",
+            (Expected::Pass, false) => "fail",
+            (Expected::XFail, false) => "xfail",
+            (Expected::XFail, true) => "xpass",
+        };
+        eprintln!(
+            "[{outcome:>5}] {id}{}",
+            match &detail {
+                Some(d) if expected == Expected::Pass => format!(" — {d}"),
+                _ => String::new(),
+            }
+        );
+        reports.push(ScenarioReport {
+            id,
+            expected,
+            passed,
+            outcome,
+            detail,
+        });
+    }
+
+    let count = |o: &str| reports.iter().filter(|r| r.outcome == o).count();
+    let (pass, fail, xfail, xpass) = (count("pass"), count("fail"), count("xfail"), count("xpass"));
+    // Green means: every implemented scenario passes and no target
+    // scenario passes unexpectedly (an xpass must be promoted to Pass).
+    let ok = fail == 0 && xpass == 0;
+    let report = json!({
+        "scenarios": reports,
+        "summary": {
+            "pass": pass,
+            "fail": fail,
+            "xfail": xfail,
+            "xpass": xpass,
+            "ok": ok,
+        },
+    });
+    Ok((report, ok))
+}
+
+fn hex_decode(s: &str) -> Result<Vec<u8>> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).map_err(Into::into))
+        .collect()
+}

--- a/crates/rustykrab-gateway/src/rate_limit.rs
+++ b/crates/rustykrab-gateway/src/rate_limit.rs
@@ -42,6 +42,60 @@ impl Default for RateLimitConfig {
     }
 }
 
+impl RateLimitConfig {
+    /// Config with env-var overrides applied over the defaults:
+    /// `RUSTYKRAB_RATE_LIMIT_MAX`, `RUSTYKRAB_RATE_LIMIT_WINDOW_SECS`,
+    /// `RUSTYKRAB_RATE_LIMIT_LOCKOUT_SECS`.
+    ///
+    /// The defaults are the shipping posture; the overrides exist so a
+    /// test/E2E boot can drive hundreds of requests from one IP without
+    /// tripping the lockout. Unset or unparseable values keep the default.
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        // Zero and unparseable values fall back to the default: a limit of
+        // 0 would reject every request, and a 0-second window would disable
+        // limiting entirely — neither is ever what an operator meant.
+        fn positive(key: &str) -> Option<u64> {
+            let raw = std::env::var(key).ok()?;
+            let raw = raw.trim();
+            match raw.parse::<u64>() {
+                Ok(v) if v > 0 => Some(v),
+                _ => {
+                    tracing::warn!(
+                        var = key,
+                        value = raw,
+                        "ignoring invalid rate-limit override — using the default"
+                    );
+                    None
+                }
+            }
+        }
+        let config = Self {
+            max_requests: positive("RUSTYKRAB_RATE_LIMIT_MAX")
+                .and_then(|v| u32::try_from(v).ok())
+                .unwrap_or(default.max_requests),
+            window: positive("RUSTYKRAB_RATE_LIMIT_WINDOW_SECS")
+                .map(Duration::from_secs)
+                .unwrap_or(default.window),
+            lockout: positive("RUSTYKRAB_RATE_LIMIT_LOCKOUT_SECS")
+                .map(Duration::from_secs)
+                .unwrap_or(default.lockout),
+        };
+        if config.max_requests != default.max_requests
+            || config.window != default.window
+            || config.lockout != default.lockout
+        {
+            tracing::warn!(
+                max_requests = config.max_requests,
+                window_secs = config.window.as_secs(),
+                lockout_secs = config.lockout.as_secs(),
+                "rate limiter running with non-default limits from the environment"
+            );
+        }
+        config
+    }
+}
+
 struct IpRecord {
     attempts: Vec<Instant>,
     locked_until: Option<Instant>,

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -88,7 +88,7 @@ impl AppState {
             tools,
             provider,
             auth_token: Arc::new(RwLock::new(auth_token)),
-            rate_limiter: Arc::new(RateLimiter::new(RateLimitConfig::default())),
+            rate_limiter: Arc::new(RateLimiter::new(RateLimitConfig::from_env())),
             origin_policy: OriginPolicy::default(),
             telegram: None,
             signal: None,

--- a/crates/rustykrab-providers/src/lib.rs
+++ b/crates/rustykrab-providers/src/lib.rs
@@ -2,6 +2,8 @@ mod anthropic;
 mod backoff;
 mod line_buffer;
 mod ollama;
+mod scripted;
 
 pub use anthropic::AnthropicProvider;
 pub use ollama::{OllamaConfig, OllamaProvider};
+pub use scripted::{Scenario, Script, ScriptStep, ScriptToolCall, ScriptedProvider};

--- a/crates/rustykrab-providers/src/scripted.rs
+++ b/crates/rustykrab-providers/src/scripted.rs
@@ -188,6 +188,9 @@ fn assistant_message(content: MessageContent) -> Message {
         role: Role::Assistant,
         content,
         created_at: Utc::now(),
+        // Unstamped, like the other providers' wire conversions: the
+        // runner stamps the messages it keeps.
+        agent_version: None,
     }
 }
 
@@ -251,6 +254,7 @@ mod tests {
             role: Role::User,
             content: MessageContent::Text(text.to_string()),
             created_at: Utc::now(),
+            agent_version: None,
         }
     }
 
@@ -265,6 +269,7 @@ mod tests {
                 images: vec![],
             }),
             created_at: Utc::now(),
+            agent_version: None,
         }
     }
 

--- a/crates/rustykrab-providers/src/scripted.rs
+++ b/crates/rustykrab-providers/src/scripted.rs
@@ -205,14 +205,17 @@ impl ModelProvider for ScriptedProvider {
             if m.role != Role::User {
                 return None;
             }
-            let text = m.content.as_text()?;
+            let text = m.content.as_text()?.to_lowercase();
             // Longest trigger wins, so one trigger being a prefix or
             // substring of another resolves to the more specific scenario
             // rather than whichever happens to be declared first.
+            // Matching is case-insensitive: when a scenario is driven from
+            // a real keyboard, iOS autocapitalizes the first letter and a
+            // case-sensitive compare would silently miss.
             self.script
                 .scenarios
                 .iter()
-                .filter(|s| text.contains(&s.trigger))
+                .filter(|s| text.contains(&s.trigger.to_lowercase()))
                 .max_by_key(|s| s.trigger.len())
                 .map(|s| (i, s))
         });
@@ -304,6 +307,15 @@ mod tests {
         let r3 = p.chat(&msgs, &[]).await.unwrap();
         assert_eq!(r3.stop_reason, StopReason::EndTurn);
         assert_eq!(r3.message.content.as_text(), Some("Done."));
+    }
+
+    /// Driving a scenario from the iOS app means typing on a keyboard that
+    /// autocapitalizes: "e2e: set token" arrives as "E2e: set token".
+    #[tokio::test]
+    async fn trigger_matching_ignores_case() {
+        let p = ScriptedProvider::from_json(SCRIPT).unwrap();
+        let r = p.chat(&[user("E2E: Set Token now")], &[]).await.unwrap();
+        assert_eq!(r.stop_reason, StopReason::ToolUse);
     }
 
     #[tokio::test]

--- a/crates/rustykrab-providers/src/scripted.rs
+++ b/crates/rustykrab-providers/src/scripted.rs
@@ -1,0 +1,382 @@
+//! Deterministic, replayable model provider for end-to-end tests.
+//!
+//! `ScriptedProvider` never talks to a model. It matches the latest user
+//! message against a list of scenarios loaded from a JSON script and
+//! replays that scenario's steps — tool calls and text turns — one step
+//! per `chat()` call. Scenarios like "the agent tries to overwrite
+//! `notion_api_token`" thus run deterministically, fast, and free.
+//!
+//! Selected at daemon startup with `RUSTYKRAB_PROVIDER=scripted` and
+//! `RUSTYKRAB_SCRIPT_PATH=<file.json>`. Script format:
+//!
+//! ```json
+//! {
+//!   "defaultText": "Done.",
+//!   "scenarios": [
+//!     {
+//!       "trigger": "e2e: create credential",
+//!       "steps": [
+//!         { "toolCalls": [ { "name": "credential_write",
+//!                            "arguments": { "action": "set",
+//!                                           "name": "e2e_token",
+//!                                           "value": "s3cret" } } ] },
+//!         { "toolCalls": [ { "name": "task_complete",
+//!                            "arguments": { "summary": "Created e2e_token." } } ] }
+//!       ]
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! Note the closing `task_complete` rather than a bare text step: once a
+//! run has called any tool, the agent runner treats text alone as an
+//! incomplete turn and re-prompts, so a trailing text step would be
+//! replaced by the reminder loop instead of becoming the final message.
+//!
+//! Matching is stateless: on every `chat()` call the provider finds the
+//! **last user message that matches a scenario trigger** and counts the
+//! assistant turns after it to know which step to emit next. Anchoring on
+//! the matching message (rather than simply the last user message) is
+//! deliberate — the agent runner injects its own user-role nudges
+//! ("Continue.", the `task_complete` reminder) mid-run, and those must not
+//! reset the replay. Once a scenario's steps are exhausted — or when no
+//! scenario matches (e.g. internal classifier or memory-extraction calls
+//! sharing the provider) — it answers with `defaultText` and ends the turn.
+//!
+//! A scenario whose work is done should finish with a `task_complete`
+//! tool call: that is the runner's explicit completion signal, and its
+//! `summary` becomes the final assistant message.
+//!
+//! **Known limitation:** because the step index is derived from the
+//! transcript rather than held as state, anything that *rewrites* history
+//! desynchronises the replay — notably compaction, which collapses the
+//! conversation into a summary and would restart the scenario mid-run.
+//! Scenarios are therefore meant to be short (a handful of turns, well
+//! under the compaction threshold). If a scenario ever needs to be long
+//! enough to compact, give the provider explicit state instead of
+//! extending this counting scheme.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, Usage};
+use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolSchema};
+use rustykrab_core::{Error, Result};
+
+/// One scripted assistant turn: tool calls, text, or both. When both are
+/// present the text rides along like a mixed Anthropic response (text
+/// preserved in `ModelResponse::text`, tool calls in the message).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ScriptStep {
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<ScriptToolCall>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScriptToolCall {
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Scenario {
+    /// Substring matched against the latest user message.
+    pub trigger: String,
+    pub steps: Vec<ScriptStep>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Script {
+    /// Reply for unmatched or exhausted turns. Ends the turn.
+    #[serde(default = "default_text")]
+    pub default_text: String,
+    #[serde(default)]
+    pub scenarios: Vec<Scenario>,
+}
+
+fn default_text() -> String {
+    "Done.".to_string()
+}
+
+pub struct ScriptedProvider {
+    script: Script,
+}
+
+impl ScriptedProvider {
+    pub fn new(script: Script) -> Self {
+        Self { script }
+    }
+
+    pub fn from_json(json: &str) -> Result<Self> {
+        let script: Script = serde_json::from_str(json)
+            .map_err(|e| Error::Internal(format!("invalid scripted-provider script: {e}")))?;
+        // A step with neither text nor tool calls would silently replay as
+        // a turn-ending default — almost always an editing mistake, and one
+        // that would make a scenario fail for a confusing reason.
+        for scenario in &script.scenarios {
+            if scenario.steps.is_empty() {
+                return Err(Error::Internal(format!(
+                    "scripted scenario '{}' has no steps",
+                    scenario.trigger
+                )));
+            }
+            for (i, step) in scenario.steps.iter().enumerate() {
+                if step.text.is_none() && step.tool_calls.is_empty() {
+                    return Err(Error::Internal(format!(
+                        "scripted scenario '{}' step {i} has neither text nor toolCalls",
+                        scenario.trigger
+                    )));
+                }
+            }
+        }
+        Ok(Self::new(script))
+    }
+
+    pub fn from_path(path: &std::path::Path) -> Result<Self> {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| Error::Internal(format!("cannot read script {}: {e}", path.display())))?;
+        Self::from_json(&raw)
+    }
+
+    fn text_response(&self, text: &str) -> ModelResponse {
+        ModelResponse {
+            message: assistant_message(MessageContent::Text(text.to_string())),
+            usage: Usage::default(),
+            stop_reason: StopReason::EndTurn,
+            text: None,
+        }
+    }
+
+    fn step_response(&self, step: &ScriptStep) -> ModelResponse {
+        if step.tool_calls.is_empty() {
+            return self.text_response(step.text.as_deref().unwrap_or(&self.script.default_text));
+        }
+        let calls: Vec<ToolCall> = step
+            .tool_calls
+            .iter()
+            .map(|c| ToolCall {
+                id: format!("scripted-{}", Uuid::new_v4()),
+                name: c.name.clone(),
+                arguments: c.arguments.clone(),
+            })
+            .collect();
+        let content = if calls.len() == 1 {
+            MessageContent::ToolCall(calls.into_iter().next().expect("len checked"))
+        } else {
+            MessageContent::MultiToolCall(calls)
+        };
+        ModelResponse {
+            message: assistant_message(content),
+            usage: Usage::default(),
+            stop_reason: StopReason::ToolUse,
+            text: step.text.clone(),
+        }
+    }
+}
+
+fn assistant_message(content: MessageContent) -> Message {
+    Message {
+        id: Uuid::new_v4(),
+        role: Role::Assistant,
+        content,
+        created_at: Utc::now(),
+    }
+}
+
+#[async_trait]
+impl ModelProvider for ScriptedProvider {
+    fn name(&self) -> &str {
+        "scripted"
+    }
+
+    async fn chat(&self, messages: &[Message], _tools: &[ToolSchema]) -> Result<ModelResponse> {
+        // Anchor on the most recent user message that matches a trigger,
+        // then count the assistant turns after it — those are the steps
+        // already replayed.
+        let anchor = messages.iter().enumerate().rev().find_map(|(i, m)| {
+            if m.role != Role::User {
+                return None;
+            }
+            let text = m.content.as_text()?;
+            // Longest trigger wins, so one trigger being a prefix or
+            // substring of another resolves to the more specific scenario
+            // rather than whichever happens to be declared first.
+            self.script
+                .scenarios
+                .iter()
+                .filter(|s| text.contains(&s.trigger))
+                .max_by_key(|s| s.trigger.len())
+                .map(|s| (i, s))
+        });
+        let Some((idx, scenario)) = anchor else {
+            return Ok(self.text_response(&self.script.default_text));
+        };
+        let assistant_turns_since = messages[idx + 1..]
+            .iter()
+            .filter(|m| m.role == Role::Assistant)
+            .count();
+
+        match scenario.steps.get(assistant_turns_since) {
+            Some(step) => {
+                tracing::info!(
+                    trigger = %scenario.trigger,
+                    step = assistant_turns_since,
+                    "scripted provider replaying step"
+                );
+                Ok(self.step_response(step))
+            }
+            None => Ok(self.text_response(&self.script.default_text)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(text: &str) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content: MessageContent::Text(text.to_string()),
+            created_at: Utc::now(),
+        }
+    }
+
+    fn tool_result(call_id: &str) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role: Role::Tool,
+            content: MessageContent::ToolResult(rustykrab_core::types::ToolResult {
+                call_id: call_id.to_string(),
+                output: serde_json::json!({"ok": true}),
+                is_error: false,
+                images: vec![],
+            }),
+            created_at: Utc::now(),
+        }
+    }
+
+    const SCRIPT: &str = r#"{
+        "defaultText": "Done.",
+        "scenarios": [
+            {
+                "trigger": "e2e: set token",
+                "steps": [
+                    { "toolCalls": [ { "name": "credential_write",
+                                       "arguments": { "action": "set",
+                                                      "name": "t",
+                                                      "value": "v" } } ] },
+                    { "text": "Token stored." }
+                ]
+            }
+        ]
+    }"#;
+
+    #[tokio::test]
+    async fn replays_tool_call_then_text_then_default() {
+        let p = ScriptedProvider::from_json(SCRIPT).unwrap();
+        let mut msgs = vec![user("please e2e: set token now")];
+
+        let r1 = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r1.stop_reason, StopReason::ToolUse);
+        let calls = r1.message.content.tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "credential_write");
+
+        let call_id = calls[0].id.clone();
+        msgs.push(r1.message.clone());
+        msgs.push(tool_result(&call_id));
+
+        let r2 = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r2.stop_reason, StopReason::EndTurn);
+        assert_eq!(r2.message.content.as_text(), Some("Token stored."));
+
+        msgs.push(r2.message.clone());
+        let r3 = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r3.stop_reason, StopReason::EndTurn);
+        assert_eq!(r3.message.content.as_text(), Some("Done."));
+    }
+
+    #[tokio::test]
+    async fn unmatched_message_gets_default_text() {
+        let p = ScriptedProvider::from_json(SCRIPT).unwrap();
+        let msgs = vec![user("hello there")];
+        let r = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r.stop_reason, StopReason::EndTurn);
+        assert_eq!(r.message.content.as_text(), Some("Done."));
+    }
+
+    #[tokio::test]
+    async fn new_user_message_restarts_matching() {
+        let p = ScriptedProvider::from_json(SCRIPT).unwrap();
+        let mut msgs = vec![user("e2e: set token")];
+        let r1 = p.chat(&msgs, &[]).await.unwrap();
+        msgs.push(r1.message.clone());
+        msgs.push(tool_result("x"));
+        msgs.push(user("e2e: set token"));
+
+        // A fresh user message resets the step counter to zero.
+        let r2 = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r2.stop_reason, StopReason::ToolUse);
+    }
+
+    /// The agent runner injects user-role nudges mid-run; they must not
+    /// re-anchor the replay onto a non-matching message.
+    #[tokio::test]
+    async fn injected_user_nudge_does_not_reset_replay() {
+        let p = ScriptedProvider::from_json(SCRIPT).unwrap();
+        let mut msgs = vec![user("e2e: set token")];
+        let r1 = p.chat(&msgs, &[]).await.unwrap();
+        msgs.push(r1.message.clone());
+        msgs.push(tool_result("x"));
+        // The runner's own nudge, not a scenario trigger.
+        msgs.push(user("You produced text but did not call `task_complete`."));
+
+        let r2 = p.chat(&msgs, &[]).await.unwrap();
+        assert_eq!(r2.message.content.as_text(), Some("Token stored."));
+    }
+
+    #[test]
+    fn rejects_malformed_script() {
+        assert!(ScriptedProvider::from_json("{ nope }").is_err());
+        assert!(ScriptedProvider::from_json(r#"{"unknown": 1}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_or_contentless_steps() {
+        let no_steps = r#"{"scenarios":[{"trigger":"t","steps":[]}]}"#;
+        assert!(ScriptedProvider::from_json(no_steps).is_err());
+        let empty_step = r#"{"scenarios":[{"trigger":"t","steps":[{}]}]}"#;
+        assert!(ScriptedProvider::from_json(empty_step).is_err());
+    }
+
+    /// One trigger being a substring of another must resolve to the more
+    /// specific scenario, not to whichever is declared first.
+    #[tokio::test]
+    async fn longest_trigger_wins() {
+        let script = r#"{
+            "scenarios": [
+                { "trigger": "deploy", "steps": [ { "text": "generic" } ] },
+                { "trigger": "deploy to prod", "steps": [ { "text": "specific" } ] }
+            ]
+        }"#;
+        let p = ScriptedProvider::from_json(script).unwrap();
+        let r = p
+            .chat(&[user("please deploy to prod now")], &[])
+            .await
+            .unwrap();
+        assert_eq!(r.message.content.as_text(), Some("specific"));
+
+        let r = p.chat(&[user("please deploy now")], &[]).await.unwrap();
+        assert_eq!(r.message.content.as_text(), Some("generic"));
+    }
+}

--- a/crates/rustykrab-store/src/keychain.rs
+++ b/crates/rustykrab-store/src/keychain.rs
@@ -200,13 +200,31 @@ pub fn delete_master_key() -> Result<(), Error> {
 #[cfg(target_os = "macos")]
 pub fn resolve_master_key() -> Result<Vec<u8>, Error> {
     // Priority 1: environment variable (for CI, Docker, non-macOS deployments).
+    // An empty/whitespace value is treated as unset rather than decoding to
+    // a zero-length key — matching the non-macOS branch below.
     if let Ok(env_key) = std::env::var("RUSTYKRAB_MASTER_KEY") {
-        tracing::info!("using master key from RUSTYKRAB_MASTER_KEY env var");
-        return hex::decode(env_key.trim()).map_err(|e| {
-            Error::Storage(format!(
-                "RUSTYKRAB_MASTER_KEY must be a hex-encoded string: {e}"
-            ))
-        });
+        let trimmed = env_key.trim();
+        if !trimmed.is_empty() {
+            tracing::info!("using master key from RUSTYKRAB_MASTER_KEY env var");
+            return hex::decode(trimmed).map_err(|e| {
+                Error::Storage(format!(
+                    "RUSTYKRAB_MASTER_KEY must be a hex-encoded string: {e}"
+                ))
+            });
+        }
+        tracing::warn!("RUSTYKRAB_MASTER_KEY is set but empty — ignoring it");
+    }
+
+    // With the Keychain disabled (E2E harness) the env var is the only
+    // source — refuse to start rather than read or write the real
+    // Keychain, mirroring the non-macOS behaviour.
+    if keychain_disabled_by_env() {
+        return Err(Error::Storage(
+            "RUSTYKRAB_DISABLE_KEYCHAIN is set but RUSTYKRAB_MASTER_KEY is not — \
+             provide the master key via the environment (generate one with \
+             `openssl rand -hex 32`)."
+                .to_string(),
+        ));
     }
 
     // Priority 2: macOS Data Protection Keychain (no password prompt).
@@ -295,9 +313,29 @@ pub struct KeychainCredential {
 }
 
 /// Returns `true` on macOS (Data Protection Keychain), `false` elsewhere.
+///
+/// `RUSTYKRAB_DISABLE_KEYCHAIN=1` forces `false` on macOS too. The E2E
+/// harness sets it when booting a throwaway daemon with dummy secrets so
+/// the registry's persist-downward writes can never touch the real user
+/// Keychain.
 #[cfg(target_os = "macos")]
 pub fn keychain_available() -> bool {
-    true
+    !keychain_disabled_by_env()
+}
+
+/// A safety switch must fail **safe**: setting it to anything at all
+/// (`1`, `yes`, `on`, …) disables the Keychain. Only an absent, empty, or
+/// explicitly negative value keeps it enabled, so a typo can never
+/// silently leave the real Keychain live for a run that meant to avoid it.
+#[cfg(target_os = "macos")]
+fn keychain_disabled_by_env() -> bool {
+    match std::env::var("RUSTYKRAB_DISABLE_KEYCHAIN") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no" | "off"
+        ),
+        Err(_) => false,
+    }
 }
 
 /// No OS credential store on this platform.

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -38,6 +38,12 @@ impl Store {
     /// sourced from the OS keychain or an environment variable — never
     /// stored alongside the database.
     pub fn open(path: impl AsRef<Path>, master_key: Vec<u8>) -> Result<Self, Error> {
+        std::fs::create_dir_all(path.as_ref()).map_err(|e| {
+            Error::Storage(format!(
+                "cannot create store directory {}: {e}",
+                path.as_ref().display()
+            ))
+        })?;
         let db_path = path.as_ref().join("store.db");
         let conn =
             rusqlite::Connection::open(&db_path).map_err(|e| Error::Storage(e.to_string()))?;

--- a/docs/integrations/apollo.md
+++ b/docs/integrations/apollo.md
@@ -20,6 +20,13 @@ Conventions, all endpoints:
   `404` not found, `409` conflict, `413` too large, `429` rate limited.
 - Requests are rate-limited and origin-checked by gateway middleware;
   responses carry strict security headers.
+- **`Origin` is mandatory on every `/api/*` request** (not just browser
+  ones): the middleware rejects a missing `Origin` on sensitive paths with
+  `403`, and today only loopback origins are allowed —
+  `OriginPolicy::default()` starts with an empty allowlist. Apollo sends
+  `Origin: <scheme>://<host>[:port]` of its base URL, so **Phase 1 server
+  work must make the allowlist configurable** (the tailnet hostname needs
+  to be in it) or every app request past `/api/health` gets a `403`.
 
 ## Health — Implemented
 

--- a/docs/integrations/apollo.md
+++ b/docs/integrations/apollo.md
@@ -1,0 +1,169 @@
+# Apollo ↔ RustyKrab API contract
+
+The wire contract between the RustyKrab gateway and the **Apollo iOS app**
+(`gcbh/apollo-ios`). The conversation/message DTOs in
+`crates/rustykrab-gateway/src/routes.rs` implement the **Implemented** parts
+of this document; the sections marked **Planned** are specified by
+`docs/plans/apollo-ios-and-credential-guard.md` and are normative for the
+Phase 1 server work.
+
+Conventions, all endpoints:
+
+- Base URL: `https://<mac-hostname>.<tailnet>.ts.net` (Tailscale-served HTTPS
+  in front of the loopback-only gateway at `127.0.0.1:3000`).
+- JSON bodies, camelCase field names, timestamps as **epoch milliseconds**.
+- Auth: `Authorization: Bearer <token>` on every `/api/*` route except
+  `/api/health` (and, once pairing lands, `POST /api/pair`). The token is
+  today the single `RUSTYKRAB_AUTH_TOKEN`; after Phase 1 it may equally be a
+  per-device token issued by pairing.
+- Errors are bare HTTP status codes (no error body): `401` unauthenticated,
+  `404` not found, `409` conflict, `413` too large, `429` rate limited.
+- Requests are rate-limited and origin-checked by gateway middleware;
+  responses carry strict security headers.
+
+## Health — Implemented
+
+```
+GET /api/health → 200 "ok"        (no auth)
+```
+
+## Conversations — Implemented
+
+```
+GET    /api/conversations               → [Conversation]
+POST   /api/conversations {title?}      → Conversation
+GET    /api/conversations/{id}          → Conversation
+DELETE /api/conversations/{id}          → 204
+```
+
+```jsonc
+// Conversation
+{ "id": "uuid", "title": "string|null", "createdAt": 1704067200000, "updatedAt": 1704153600000 }
+```
+
+## Messages — Implemented
+
+```
+GET  /api/conversations/{id}/messages   → [Message]
+POST /api/conversations/{id}/messages   {content} → Message | {message, apps}
+POST /api/conversations/{id}/messages/stream {content} → SSE stream
+```
+
+```jsonc
+// Message
+{
+  "id": "uuid",
+  "conversationId": "uuid",
+  "role": "user" | "assistant" | "system",   // internal `tool` role is coerced to `assistant`
+  "content": "string",                        // tool calls render as "[tool_call:…]" text
+  "createdAt": 1704067200000
+}
+```
+
+- `content` in the send body is plain text, max **100 KB** (`413` beyond).
+- The non-stream response is a bare `Message` today; the envelope form
+  `{message, apps}` appears only if the agent produced app specs (it
+  currently never does).
+- Transcript replays (`GET …/messages`) include system/tool turns; clients
+  typically filter to `user`/`assistant` before rendering.
+
+### SSE stream events
+
+Apollo must handle three event types and ignore everything else:
+
+| event | data | meaning |
+|-------|------|---------|
+| `text` | `{"type":"text","delta":"…"}` | incremental assistant text |
+| `done` | `{"type":"done","message":Message,"apps":[…]?}` | terminal; carries the full assistant message (`apps` omitted when empty) |
+| `error` | `{"type":"error","message":"The agent is unavailable.","delta":"…"}` | terminal failure; the stream closes after it |
+
+Frames the gateway also emits for its own WebChat UI — `tool_start`,
+`tool_end`, `tool_error`, `tool_heartbeat`, `thinking`,
+`user_message_queued`, and a bare `{"type":"done"}` progress frame — are
+safe no-ops for Apollo (it may optionally surface tool names as a status
+line). Keep-alive comment pings arrive every 15 s. If the connection drops
+mid-stream with no `done`, Apollo synthesises an "agent unavailable" state
+and refetches the transcript.
+
+## Secrets — Implemented today, semantics change in Phase 1
+
+Implemented today:
+
+```
+GET    /api/secrets          → {names: [string], keychain_available: bool}
+POST   /api/secrets          {name, value, dest?: "store"|"keychain", service?, account?} → 204   // silently upserts
+DELETE /api/secrets/{name}   → 204
+```
+
+- `value` max **64 KB**, non-empty. Secret **values are never returned** by
+  any endpoint.
+- `name`: 1–256 chars of `[A-Za-z0-9_.-]`.
+
+**Planned (Phase 1) changes** — the create/overwrite split:
+
+```
+GET  /api/secrets   → {secrets: [{name, createdAt, updatedAt, version}], keychainAvailable}
+POST /api/secrets   {name, value, overwrite?: false, dest?, service?, account?}
+                    → 204, or 409 when the name exists and overwrite != true
+```
+
+Clients must send `overwrite: true` only after an explicit user confirmation
+dialog — that flag *is* the user's approval for user-initiated overwrites.
+
+## Credential change requests — Planned (Phase 1)
+
+The agent cannot overwrite or delete an existing credential; its attempt
+files a request the user resolves here.
+
+```
+GET  /api/credential-requests?status=pending → [ChangeRequest]
+POST /api/credential-requests/{id}/approve   → 204   (409 if stale/expired)
+POST /api/credential-requests/{id}/deny      → 204
+```
+
+```jsonc
+// ChangeRequest — never includes the proposed value
+{
+  "id": "uuid",
+  "name": "notion_api_token",
+  "action": "update" | "delete",
+  "reason": "string|null",            // agent-supplied justification
+  "conversationId": "uuid|null",
+  "status": "pending" | "approved" | "denied" | "expired",
+  "createdAt": 1704067200000
+}
+```
+
+- Requests expire after 7 days; a newer request for the same name supersedes
+  the older one.
+- `approve` applies the stored change server-side and is refused with `409`
+  if the target secret changed after the request was filed.
+
+## Device pairing — Planned (Phase 1)
+
+```
+POST   /api/pair {code, deviceName}  → {deviceId, deviceToken}   (no auth; rate-limited; code single-use, 5-min TTL)
+GET    /api/devices                  → [{id, name, createdAt, lastSeenAt}]
+DELETE /api/devices/{id}             → 204   (revocation)
+POST   /api/devices/{id}/push-token {token} → 204   (Phase 3, APNs)
+```
+
+The pairing code is minted on the Mac (`rustykrab pair` CLI subcommand or the
+WebChat "Pair device" button) and displayed as a QR payload:
+
+```json
+{"url": "https://<mac>.<tailnet>.ts.net", "code": "XXXXXXXX"}
+```
+
+`deviceToken` is shown exactly once and stored hashed server-side. It is
+accepted anywhere the master bearer token is, and identifies the device in
+approval audit records.
+
+## Auth token rotation — Implemented
+
+```
+POST /api/logout → 204
+```
+
+Rotates the **master** token (printed to the server's stderr); does not touch
+device tokens.

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -433,6 +433,32 @@ For the Claude cloud environment used on these repos:
 | `ANTHROPIC_API_KEY` as an environment secret | live-fire E2E lane (scripted mode needs nothing) | optional |
 | Apple signing: none needed for CI build/test; App Store Connect API key only if TestFlight upload should ever run from CI | automated TestFlight from CI (otherwise upload stays on the Mac) | later |
 
+### F7. Running the whole loop locally on the Mac
+The Mac is the fullest lane (Xcode, simulator, TestFlight, unrestricted
+network, real Keychain), so day-to-day development can move there entirely —
+the branch and these docs are the hand-off. Bootstrap:
+
+```sh
+mkdir -p ~/dev/apollo && cd ~/dev/apollo
+git clone https://github.com/gcbh/rustykrab.git
+git clone https://github.com/gcbh/apollo-ios.git
+(cd rustykrab  && git checkout claude/ios-app-credentials-ikd7bm)
+(cd apollo-ios && git checkout claude/ios-app-credentials-ikd7bm)
+cd rustykrab && claude --add-dir ../apollo-ios
+```
+
+Opening message for the local session:
+> Read docs/plans/apollo-ios-and-credential-guard.md and
+> docs/integrations/apollo.md, then start Phase 1 (Workstream F) on this
+> branch.
+
+Local sessions keep committing and pushing to the same branch, so cloud
+sessions and CI remain interchangeable with the Mac at any time. The
+sandbox-facing pieces of Workstream F (feature gate, ScriptedProvider,
+`scripts/e2e.sh`, CI lanes) stay in scope regardless of where development
+runs — they are what CI and any future cloud session use to verify the end
+state without a Mac.
+
 ### What each lane can verify
 
 | Capability | Cloud sandbox | GitHub Actions | Mac |

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -513,10 +513,31 @@ sandbox-facing pieces of Workstream F (feature gate, ScriptedProvider,
 runs — they are what CI and any future cloud session use to verify the end
 state without a Mac.
 
+### F8. The simulator lane (added 2026-08-19)
+
+A fourth harness, `apollo-ios/harness/simulator_e2e.py`, drives the **real
+app** in an iOS Simulator and then asserts on the daemon's SQLite store —
+the only lane that exercises SwiftUI. One command builds the daemon and
+the app, boots a device, installs, taps through the UI, and reads the
+store; everything it creates is thrown away (temp data dir, ephemeral
+port, fresh install, Keychain disabled).
+
+Today: 4 pass, 1 xfail, where the xfail is
+`agent_cannot_overwrite_a_user_credential` reporting *"the agent overwrote
+the user's credential with no approval"* — decision #1's premise,
+reproduced through the UI a user would actually touch. It flips when
+Workstream A lands.
+
+The harnesses are cross-repo by nature (they need the server binary *and*
+the app), so they are slated to move into a **third repo for agent code
+execution** — named later. The simulator harness is already written for
+that move: its paths come from flags or the environment.
+
 ### What each lane can verify
 
 | Capability | Cloud sandbox | GitHub Actions | Mac |
 |------------|---------------|----------------|-----|
+| Drive the app's UI + assert the store (F8) | ✗ | needs a macOS runner with `idb` | ✓ |
 | Build daemon + run guard E2E (scripted agent) | ✓ (after F1) | ✓ | ✓ |
 | Live-fire agent E2E | with env key | with secret | ✓ |
 | Build + test ApolloKit (Swift) | after F6 allowlist | ✓ (ubuntu) | ✓ |

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -1,6 +1,7 @@
 # Plan: Apollo iOS app + credential write-protection
 
-**Status:** approved plan, not yet implemented
+**Status:** Phase 1 (Workstream F, the evaluation harness) implemented on
+`claude/ios-app-credentials-ikd7bm` in both repos; Phases 2–5 not started.
 **Date:** 2026-08-19
 **Repos:** `gcbh/rustykrab` (server work), `gcbh/apollo-ios` (app work)
 
@@ -348,6 +349,43 @@ done*: the target scenarios are written on day one and marked expected-fail
 (`xfail`); shipping a phase means flipping its scenarios to must-pass. An
 agent has reached the agreed end state exactly when the suite is green with
 zero xfails.
+
+### F0. What Phase 1 actually shipped (2026-08-19)
+
+Implemented on `claude/ios-app-credentials-ikd7bm`:
+
+| Piece | Where |
+|-------|-------|
+| `embeddings` feature gate (default on; `HashEmbedder` fallback when off) | `crates/rustykrab-cli/Cargo.toml`, `main.rs` |
+| `ScriptedProvider` + 5 unit tests | `crates/rustykrab-providers/src/scripted.rs` |
+| E2E runner, 15 scenarios (7 must-pass, 8 xfail) | `crates/rustykrab-e2e/`, `scripts/e2e.sh` |
+| `ApolloKit` package, 18 tests, `apollo-e2e` runner (12 scenarios) | apollo-ios `ApolloKit/` |
+| CI: `e2e` job (rustykrab); ubuntu `swift test` + macOS lanes (apollo-ios) | both `.github/workflows/ci.yml` |
+
+Harness-only env knobs added to make a throwaway boot possible, all
+defaulting to today's shipping behaviour: `RUSTYKRAB_DATA_DIR`,
+`RUSTYKRAB_PORT` (loopback bind unchanged), `RUSTYKRAB_DISABLE_KEYCHAIN`
+(also forces the master key to come from the env — never reads or writes
+the real Keychain), `RUSTYKRAB_RATE_LIMIT_{MAX,WINDOW_SECS,LOCKOUT_SECS}`,
+and `RUSTYKRAB_PROVIDER=scripted` + `RUSTYKRAB_SCRIPT_PATH`.
+
+Measured state: `cargo fmt/clippy/test` green (477 tests); `scripts/e2e.sh`
+green (7 pass / 8 xfail / 0 fail / 0 xpass); `swift test` green (18);
+`apollo-e2e` against a live daemon green (6 pass / 6 xfail / 0 fail). The
+xfail details are the guard's own indictment — today they read
+"agent overwrote an existing credential" and "agent deleted an existing
+credential outright". Phase 2 is done when those flip.
+
+**Contract gap found while wiring the harness (Phase 2 work):** the
+gateway's origin-check middleware (`gateway/src/origin.rs`) *requires* an
+`Origin` header on every `/api/*` request and only allows loopback
+origins — `OriginPolicy::default()` is an empty allowlist and the CLI
+never calls `with_origin_policy`. An app on the tailnet sending
+`Origin: https://<mac>.<tailnet>.ts.net` is therefore rejected with `403`,
+and so is a client sending no `Origin` at all. Phase 2 must make the
+allowed origins configurable (env var and/or automatic tailnet hostname)
+before the app can reach anything but `/api/health`. ApolloKit already
+sends its own origin; the server side is the missing half.
 
 ### F1. Make the daemon buildable in agent sandboxes
 Empirical finding (2026-08-19, this Claude environment): the workspace fails

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -32,6 +32,7 @@ Two intertwined goals:
 | 6 | App auth | **Per-device pairing** with per-device tokens (revocable, attributable). |
 | 7 | Approval notifications | **In-app + badge in v1; APNs push in a later phase** (both wanted). |
 | 8 | Multi-server | **One gateway in v1, data model designed for multiple** server profiles. |
+| 9 | Evaluation | **Harness-first.** A build + end-to-end evaluation system is the first implementation stage, before any feature work. Every later phase's exit criteria are encoded as executable scenarios so agents can autonomously verify the agreed end state. |
 
 ## 3. Current state (what exists today)
 
@@ -338,20 +339,127 @@ The SQLite implementation is the only one for now (decision: keep the Macs as
 the credential home). Candidates later: HashiCorp Vault, 1Password Connect, or
 a small self-hosted service — swap without touching tools, policy, or the app.
 
-## 11. Phasing
+## 11. Workstream F — the evaluation harness (built first)
+
+**Goal:** any agent session — cloud sandbox, CI runner, or a Mac — can build
+every component, boot the system, and execute end-to-end scenarios that encode
+each phase's exit criteria. The harness is the *executable definition of
+done*: the target scenarios are written on day one and marked expected-fail
+(`xfail`); shipping a phase means flipping its scenarios to must-pass. An
+agent has reached the agreed end state exactly when the suite is green with
+zero xfails.
+
+### F1. Make the daemon buildable in agent sandboxes
+Empirical finding (2026-08-19, this Claude environment): the workspace fails
+to build because `ort-sys` (via `fastembed`) downloads a prebuilt ONNX
+runtime from `cdn.pyke.io`, which the environment's network policy blocks.
+But `rustykrab-memory` already feature-gates it (`default = []`,
+`fastembed = ["dep:fastembed"]`) and the gateway builds without it — only
+`rustykrab-cli` hard-enables the feature. Fix:
+
+- `rustykrab-cli` gains `[features] default = ["embeddings"];
+  embeddings = ["rustykrab-memory/fastembed"]`, with the embedding config
+  path in `main.rs` behind `#[cfg(feature = "embeddings")]`.
+- Release/Mac builds are unchanged (default on). Sandboxes and the E2E lane
+  build with `cargo build -p rustykrab-cli --no-default-features`.
+- Optionally, allowlisting `cdn.pyke.io` in the Claude environment's network
+  policy restores full-fidelity builds in sandboxes too.
+
+### F2. `ScriptedProvider` — deterministic agent for E2E
+A `ModelProvider` test double that replays a scripted sequence of tool calls
+and text turns, so scenarios like “the agent tries to overwrite
+`notion_api_token`” run deterministically, fast, and free — no live model.
+The same scenarios can run in **live-fire mode** against the real Anthropic
+provider when `ANTHROPIC_API_KEY` is present (optional env secret in the
+Claude environment; scripted mode is the default everywhere).
+
+### F3. E2E runner (`scripts/e2e.sh` + `crates/rustykrab-e2e`)
+Builds the daemon (`--no-default-features`), boots it on a temp data dir with
+`RUSTYKRAB_MASTER_KEY`, `RUSTYKRAB_AUTH_TOKEN`, and dummy values for the
+registry's `required` secrets (Notion, Obsidian — startup validation refuses
+to boot without them), waits for `/api/health`, then drives scenarios over
+HTTP and asserts on responses **and** on store state:
+
+1. pair a device (mint code → exchange → call API with device token)
+2. create a secret; `POST /api/secrets` on an existing name → `409`; with
+   `overwrite: true` → applied, old value archived
+3. scripted agent creates a new credential → succeeds silently
+4. scripted agent `set` on an existing name → value unchanged, one pending
+   request
+5. approve → new value live, version archived, audit row attributed to the
+   deciding device
+6. deny → value unchanged, proposal wiped
+7. agent `delete` → request; expiry sweep; stale approval → `409`
+8. revoked device → `401`
+
+Output is JSON + exit code so agents can assert mechanically. Every scenario
+maps to a phase exit criterion; a new feature ships with its scenario in the
+same PR. CI gains an `e2e` job running the same script.
+
+### F4. `ApolloKit` — the app's protocol layer, testable on Linux
+The app splits into a SwiftPM package + thin SwiftUI shell. `ApolloKit`
+(DTOs, API client, SSE parser, pairing, approvals flows) uses only
+Foundation/FoundationNetworking, so `swift build && swift test` works on
+Linux and macOS. An `apollo-e2e` executable target drives the *same scenario
+list* as F3 against a live gateway — one sandbox session can then run true
+cross-repo contract E2E: Rust daemon up, Swift client exercising it.
+Empirical finding: no Swift toolchain in the current sandbox and
+`download.swift.org` is blocked (the sandbox is Ubuntu 24.04, for which
+swift.org ships an official toolchain) — see F6. Until allowed, the Swift
+lane runs in CI.
+
+### F5. CI lanes (the only place an iOS `.app` can be verified from the cloud)
+Building the actual iOS app, simulator testing, and TestFlight are
+macOS-only — no sandbox configuration changes that. So:
+
+- **rustykrab `ci.yml`** (ubuntu): existing check/clippy/test/fmt/audit jobs
+  + new `e2e` job running `scripts/e2e.sh`.
+- **apollo-ios CI** (new): `swift test` for ApolloKit on `ubuntu-latest`;
+  `xcodebuild build test` for the app + unit tests on `macos-latest`.
+  Cloud agents iterate on the app by pushing and reading CI results (they
+  can subscribe to PR check events). macOS runner minutes bill at 10× on
+  private repos — keep the macOS job to build + unit tests per push; UI
+  tests (XCUITest) run nightly or on demand.
+- **The Mac** (local Claude Code session or the user): full-fidelity lane —
+  simulator, XCUITest against a local gateway, TestFlight archive/upload.
+
+### F6. Environment prerequisites (user-actionable)
+For the Claude cloud environment used on these repos:
+
+| Item | Unblocks | Priority |
+|------|----------|----------|
+| Allowlist `download.swift.org` (+ `swift.org`) and install the Swift toolchain in the environment setup script | F4's Swift lane inside sandboxes (build ApolloKit + run cross-repo E2E locally) | high |
+| Allowlist `cdn.pyke.io` | full-fidelity (embeddings-on) daemon builds in sandboxes; otherwise `--no-default-features` covers everything the guard needs | nice-to-have |
+| `ANTHROPIC_API_KEY` as an environment secret | live-fire E2E lane (scripted mode needs nothing) | optional |
+| Apple signing: none needed for CI build/test; App Store Connect API key only if TestFlight upload should ever run from CI | automated TestFlight from CI (otherwise upload stays on the Mac) | later |
+
+### What each lane can verify
+
+| Capability | Cloud sandbox | GitHub Actions | Mac |
+|------------|---------------|----------------|-----|
+| Build daemon + run guard E2E (scripted agent) | ✓ (after F1) | ✓ | ✓ |
+| Live-fire agent E2E | with env key | with secret | ✓ |
+| Build + test ApolloKit (Swift) | after F6 allowlist | ✓ (ubuntu) | ✓ |
+| Cross-repo contract E2E (Swift client ↔ Rust daemon) | after F6 allowlist | ✓ | ✓ |
+| Build the iOS app target | ✗ | ✓ (macos runner) | ✓ |
+| Simulator / XCUITest | ✗ | ✓ (macos runner) | ✓ |
+| TestFlight archive + upload | ✗ | possible, deferred | ✓ |
+
+## 12. Phasing
 
 | Phase | Contents | Exit criteria |
 |-------|----------|---------------|
 | **0 — Ops** | Tailscale on Mac + phone; `tailscale serve`; contract doc committed | `/api/health` reachable from the phone over HTTPS on cellular |
-| **1 — Server guard** | Workstream A (store, guard, requests, REST) + Workstream B (pairing, device auth) + WebChat approvals panel | Agent `set` on an existing name queues a request; approving from WebChat applies it; device pairs and calls the API; `cargo fmt/clippy/test` green |
-| **2 — App MVP** | Workstream C: pairing → credentials → approvals → chat (SSE) → **TestFlight build 1** to internal testers | Add a credential from the phone; approve an agent request from the phone; hold a streamed chat |
-| **3 — Notify & polish** | Workstream E (APNs), device management UI, version history + rollback UI | Lock-screen push on new request; revoke a device from the app |
-| **4 — Deferred** | `SecretsBackend` extraction; multi-server profile UI | — |
+| **1 — Evaluation harness** | Workstream F: cli `embeddings` feature gate, `ScriptedProvider`, E2E runner with the full scenario list (guard scenarios xfail), ApolloKit package skeleton + `swift test`, CI lanes in both repos | One command builds daemon (+ ApolloKit where Swift is available), boots, and runs the suite green in a fresh sandbox and in CI; target scenarios exist as xfail |
+| **2 — Server guard** | Workstream A (store, guard, requests, REST) + Workstream B (pairing, device auth) + WebChat approvals panel — each landing flips its xfail scenarios to must-pass | E2E scenarios 1–8 pass for real; `cargo fmt/clippy/test` green |
+| **3 — App MVP** | Workstream C: pairing → credentials → approvals → chat (SSE) → **TestFlight build 1** to internal testers | ApolloKit E2E green against a live gateway; macOS CI builds the app; add a credential and approve a request from the phone; hold a streamed chat |
+| **4 — Notify & polish** | Workstream E (APNs), device management UI, version history + rollback UI | Lock-screen push on new request; revoke a device from the app |
+| **5 — Deferred** | `SecretsBackend` extraction; multi-server profile UI | — |
 
-Phases 1 and 2 can overlap once Phase 1's REST surface is merged (the app can
-develop against it locally).
+Phases 2 and 3 can overlap once Phase 2's REST surface is merged (the app can
+develop against it, and the harness pins the contract from both sides).
 
-## 12. Threat-model notes
+## 13. Threat-model notes
 
 Protected against:
 - **Agent clobbering or deleting credentials** — enforced in the store layer
@@ -375,9 +483,11 @@ Explicitly out of scope:
 - The user rubber-stamping approvals without reading them.
 - Malicious tampering with the rustykrab binary itself.
 
-## 13. Open items (non-blocking, defaults chosen)
+## 14. Open items (non-blocking, defaults chosen)
 
 - Request expiry window: defaulting to 7 days.
+- macOS CI runner minutes bill at 10× on private repos — start with build +
+  unit tests per push and revisit if the bill matters.
 - Version history retention: unlimited for now; a purge command can come with
   the rollback UI in Phase 3.
 - Whether `credential_read` should ever gate value reads (e.g. per-name agent

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -357,9 +357,9 @@ Implemented on `claude/ios-app-credentials-ikd7bm`:
 | Piece | Where |
 |-------|-------|
 | `embeddings` feature gate (default on; `HashEmbedder` fallback when off) | `crates/rustykrab-cli/Cargo.toml`, `main.rs` |
-| `ScriptedProvider` + 5 unit tests | `crates/rustykrab-providers/src/scripted.rs` |
-| E2E runner, 15 scenarios (7 must-pass, 8 xfail) | `crates/rustykrab-e2e/`, `scripts/e2e.sh` |
-| `ApolloKit` package, 18 tests, `apollo-e2e` runner (12 scenarios) | apollo-ios `ApolloKit/` |
+| `ScriptedProvider` + 7 unit tests | `crates/rustykrab-providers/src/scripted.rs` |
+| E2E runner, 16 scenarios (8 must-pass, 8 xfail) | `crates/rustykrab-e2e/`, `scripts/e2e.sh` |
+| `ApolloKit` package, 20 tests, `apollo-e2e` runner (13 scenarios) | apollo-ios `ApolloKit/` |
 | CI: `e2e` job (rustykrab); ubuntu `swift test` + macOS lanes (apollo-ios) | both `.github/workflows/ci.yml` |
 
 Harness-only env knobs added to make a throwaway boot possible, all
@@ -369,12 +369,28 @@ defaulting to today's shipping behaviour: `RUSTYKRAB_DATA_DIR`,
 the real Keychain), `RUSTYKRAB_RATE_LIMIT_{MAX,WINDOW_SECS,LOCKOUT_SECS}`,
 and `RUSTYKRAB_PROVIDER=scripted` + `RUSTYKRAB_SCRIPT_PATH`.
 
-Measured state: `cargo fmt/clippy/test` green (477 tests); `scripts/e2e.sh`
-green (7 pass / 8 xfail / 0 fail / 0 xpass); `swift test` green (18);
-`apollo-e2e` against a live daemon green (6 pass / 6 xfail / 0 fail). The
+Measured state: `cargo fmt/clippy/test` green (479 tests); `scripts/e2e.sh`
+green (8 pass / 8 xfail / 0 fail / 0 xpass); `swift test` green (20);
+`apollo-e2e` against a live daemon green (6 pass / 7 xfail / 0 fail). The
 xfail details are the guard's own indictment — today they read
 "agent overwrote an existing credential" and "agent deleted an existing
 credential outright". Phase 2 is done when those flip.
+
+Each xfail is written against the **full** exit criterion, not a proxy
+for it, and asserts on the store tables the plan specifies
+(`secret_versions`, `secret_audit`, `credential_requests`) rather than
+only on what the REST API reveals — a scenario that could pass while the
+behaviour it names is still broken would let Phase 2 be declared done
+falsely. Concretely: the pairing scenarios mint a code via `rustykrab
+pair`, exchange it, and use the resulting device token as a bearer;
+revocation then re-uses that token and requires a `401`; deny requires
+the value unchanged *and* `proposed_data` wiped; the agent-overwrite
+scenario also greps `proposed_data` to prove the proposal is encrypted
+at rest.
+
+Phase 2 will also need a `rustykrab pair` CLI subcommand that prints the
+code and QR payload — both harnesses drive it, and both currently xfail
+with "unknown subcommand 'pair'".
 
 **Contract gap found while wiring the harness (Phase 2 work):** the
 gateway's origin-check middleware (`gateway/src/origin.rs`) *requires* an

--- a/docs/plans/apollo-ios-and-credential-guard.md
+++ b/docs/plans/apollo-ios-and-credential-guard.md
@@ -1,0 +1,384 @@
+# Plan: Apollo iOS app + credential write-protection
+
+**Status:** approved plan, not yet implemented
+**Date:** 2026-08-19
+**Repos:** `gcbh/rustykrab` (server work), `gcbh/apollo-ios` (app work)
+
+## 1. Problem
+
+Two intertwined goals:
+
+1. **The agent can overwrite credentials.** Today any agent turn can silently
+   replace or delete a stored credential. The requirement: the user can add
+   credentials to the agent, the agent can *add* credentials, but any
+   **overwrite or delete of an existing credential requires the user's
+   explicit approval**.
+2. **An iOS app ("Apollo")** that talks to a personal rustykrab instance over
+   a secure connection, so credentials can be entered on the phone, stored on
+   the Mac, and agent change-requests can be approved from the phone. Chat is
+   included in v1. Distribution via TestFlight. Credential storage stays local
+   to the Mac for now, with a clean seam to swap in an API-backed storage
+   solution later.
+
+## 2. Decisions (locked in with the user, 2026-08-19)
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Agent write policy | **Create-only.** Agent may create credentials under new names; any update/delete/keychain-overwrite of an existing credential files a pending request. Enforced at the store layer, not per-tool. |
+| 2 | Approval surface | **iOS app + WebChat.** One pending-requests REST API; the app is primary, WebChat gets an approvals panel. |
+| 3 | Phone → Mac connectivity | **Tailscale.** No ports exposed to the internet; `tailscale serve` provides real HTTPS on the tailnet. |
+| 4 | App v1 scope | **Credentials + approvals + chat.** |
+| 5 | Apple Developer Program | Already enrolled — TestFlight available immediately. |
+| 6 | App auth | **Per-device pairing** with per-device tokens (revocable, attributable). |
+| 7 | Approval notifications | **In-app + badge in v1; APNs push in a later phase** (both wanted). |
+| 8 | Multi-server | **One gateway in v1, data model designed for multiple** server profiles. |
+
+## 3. Current state (what exists today)
+
+### Secret storage
+- `SecretStore` (`crates/rustykrab-store/src/secret.rs`) — SQLite, AES-256-GCM
+  with per-secret Argon2id-derived keys. `set()` is a **silent upsert**
+  (`INSERT … ON CONFLICT(name) DO UPDATE`, secret.rs:66). `delete()` is
+  unconditional. No versioning, no provenance, no audit trail.
+- macOS Keychain integration (`crates/rustykrab-store/src/keychain.rs`) —
+  `set_credential()` **replaces** any existing item.
+- Secret registry (`crates/rustykrab-store/src/registry.rs`) — resolves each
+  known credential env var → keychain → store at startup and *persists
+  downward* (system-initiated writes).
+
+### Agent-reachable write paths (all currently unguarded)
+| Path | Location | Can overwrite? | Can delete? |
+|------|----------|----------------|-------------|
+| `credential_write` tool (`set`, `delete`, `import_from_keychain`) | `rustykrab-tools/src/credential_write.rs` | yes | yes |
+| Gmail configure flow | `rustykrab-tools/src/gmail.rs` | yes | — |
+| CalDAV configure flow (`KEY_APP_PASSWORD`) | `rustykrab-tools/src/caldav.rs:183` | yes | — |
+| Obsidian configure flow (`KEY_API_URL`) | `rustykrab-tools/src/obsidian.rs:120` | yes | — |
+| macOS Keychain via `credential_write` (`source: "keychain"`) | keychain.rs `set_credential` | yes | yes |
+
+### User/HTTP write paths
+- `POST /api/secrets` (upsert), `DELETE /api/secrets/{name}` —
+  `rustykrab-gateway/src/routes.rs:44-46`. Gated by a **single shared bearer
+  token** (`auth.rs`), rotatable via `POST /api/logout`.
+
+### Gateway
+- Axum server, loopback-only bind `127.0.0.1:3000` (hard-coded,
+  `rustykrab-cli/src/main.rs:1204`). Middleware stack: security headers →
+  request logging → rate limit → origin check → bearer auth
+  (`rustykrab-gateway/src/lib.rs:57`).
+- Apollo-shaped conversation/message DTOs and SSE streaming already exist in
+  `routes.rs` (camelCase, epoch-millis). The contract doc they cite was
+  missing; it now lives at `docs/integrations/apollo.md`.
+- WebChat UI is embedded static assets (`rust_embed`, `gateway/static/`).
+
+**Key observation:** the agent runs in-process with the gateway and its tools
+call `SecretStore` directly — the agent never holds the HTTP bearer token. So
+principal separation is enforced at the **store/tool layer** (agent side) and
+the **HTTP layer** (user side); the agent physically cannot call the approval
+endpoints.
+
+## 4. Target architecture
+
+```
+┌─────────────── iPhone ───────────────┐        ┌──────────────── Mac ────────────────┐
+│ Apollo app (SwiftUI)                 │        │ rustykrab daemon                    │
+│  • device token in iOS Keychain      │  HTTPS │  axum gateway (127.0.0.1:3000)      │
+│  • chat (REST + SSE)                 │◄──────►│   ├─ bearer auth: master OR device  │
+│  • add credential (create-only POST) │ tailnet│   ├─ /api/credential-requests       │
+│  • approvals (Face ID gate)          │  (ts.  │   ├─ /api/pair, /api/devices        │
+│  Tailscale VPN                       │  net   │   └─ WebChat UI + approvals panel   │
+└──────────────────────────────────────┘  cert) │  agent loop (in-process)            │
+                                                │   └─ tools → GuardedSecrets         │
+                                                │        create ✓ / overwrite → queue │
+                                                │  SecretStore (SQLite, AES-256-GCM)  │
+                                                │   ├─ secrets + versions + audit     │
+                                                │   ├─ credential_requests            │
+                                                │   └─ devices + pairing_codes        │
+                                                └─────────────────────────────────────┘
+```
+
+## 5. Workstream A — credential write-protection (rustykrab)
+
+### A1. Store layer: authority-aware writes
+Introduce an explicit write authority instead of one `set()` for everyone:
+
+```rust
+pub enum WriteAuthority {
+    /// Explicit human action via an authenticated client (REST/CLI/UI).
+    User { device: Option<String> },
+    /// Startup/registry persistence (env → keychain → store mirroring).
+    System,
+    /// Agent tool execution. Create-only.
+    Agent { conversation_id: Option<Uuid> },
+}
+```
+
+`SecretStore` gains:
+- `create(name, value)` — `INSERT` only; `Error::AlreadyExists` on conflict.
+- `overwrite(name, value, authority)` — refuses `Agent` authority; archives
+  the previous value into `secret_versions`; writes an audit row.
+- `delete(name, authority)` — refuses `Agent`; archives; audits.
+- The old upserting `set()` is **removed** (compile-time guarantee that no
+  call site keeps silent-overwrite semantics).
+
+New tables (added idempotently in `Store::run_migrations()`):
+
+```sql
+CREATE TABLE IF NOT EXISTS credential_requests (
+  id              TEXT PRIMARY KEY,            -- UUID
+  name            TEXT NOT NULL,
+  action          TEXT NOT NULL,               -- 'update' | 'delete'
+  proposed_data   BLOB,                        -- encrypted like secrets; NULL for delete
+  reason          TEXT,                        -- agent-supplied justification
+  conversation_id TEXT,
+  status          TEXT NOT NULL DEFAULT 'pending', -- pending|approved|denied|expired
+  created_at      INTEGER NOT NULL,
+  decided_at      INTEGER,
+  decided_by      TEXT                         -- device id / 'webchat' / 'cli'
+);
+
+CREATE TABLE IF NOT EXISTS secret_versions (
+  name        TEXT NOT NULL,
+  version     INTEGER NOT NULL,
+  data        BLOB NOT NULL,                   -- encrypted superseded value
+  replaced_at INTEGER NOT NULL,
+  replaced_by TEXT NOT NULL,                   -- authority description
+  PRIMARY KEY (name, version)
+);
+
+CREATE TABLE IF NOT EXISTS secret_audit (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  name       TEXT NOT NULL,
+  op         TEXT NOT NULL,                    -- create|overwrite|delete|approve|deny
+  authority  TEXT NOT NULL,
+  request_id TEXT,
+  at         INTEGER NOT NULL
+);
+```
+
+The proposed value inside a pending request is encrypted with the same
+AES-256-GCM scheme as secrets (AAD = request id) so a pending request is never
+a plaintext copy of a credential.
+
+### A2. `GuardedSecrets`: the only handle agent tools receive
+A wrapper in `rustykrab-store` holding `Agent` authority:
+
+- `set(name, value)` → if the name is **new**: creates it, returns
+  `Created`. If it **exists**: files a `credential_requests` row and returns
+  `PendingApproval { request_id }` (surfaced to the model as a normal tool
+  result, not an error — the agent should relay "waiting for your approval,
+  request `<id>`" to the user in-channel, which covers the v1 notification
+  decision alongside the app badge).
+- `delete(name)` → always files a request (`action='delete'`).
+- `get` / `list_names` → pass-through (read policy unchanged for now).
+- Keychain writes follow the same rule: existing service/account pair →
+  request; new pair → allowed. `import_from_keychain` is a `set` internally
+  and inherits the policy automatically.
+
+Wiring: every tool constructor that today takes `SecretStore`
+(`credential_write`, `credential_read`, `gmail`, `caldav`, `obsidian`,
+`mcp_connector`, …) takes `GuardedSecrets` instead — one type change in
+`rustykrab-cli/src/main.rs` where tools are built, matching the existing
+adapter-struct pattern. The raw `SecretStore` remains reachable only from:
+- `registry::resolve()` (System authority — startup mirroring only),
+- gateway REST handlers (User authority),
+- approval execution (below).
+
+A new `Error::PendingApproval { request_id, name }` variant in
+`rustykrab-core` lets non-credential tools (Gmail/CalDAV/Obsidian configure
+flows) propagate a friendly, self-explanatory message without per-tool code.
+
+### A3. Approval flow
+- `GET /api/credential-requests?status=pending` — list (name, action, reason,
+  createdAt, conversationId; **never** the proposed value).
+- `POST /api/credential-requests/{id}/approve` — executes the stored change
+  with `User` authority (archiving the old value), marks `approved`, audits
+  with the deciding device.
+- `POST /api/credential-requests/{id}/deny` — marks `denied`, wipes
+  `proposed_data`.
+- Requests expire after **7 days** (swept lazily on list/approve), and are
+  auto-superseded if a newer request targets the same name.
+- Approving is idempotent-safe: a request whose target changed since filing
+  (version bumped by the user) is rejected with `409` so a stale approval
+  can't clobber a fresher user edit.
+
+### A4. User-side REST hardening
+`POST /api/secrets` today silently upserts for any token holder. Change:
+- default becomes **create-only**; overwriting requires explicit
+  `"overwrite": true` in the body, which UIs send only after a native confirm
+  dialog (this is what "explicit user approval" means for user-initiated
+  writes).
+- `GET /api/secrets` response gains metadata per entry:
+  `{name, createdAt, updatedAt, version}` (values never returned by any
+  endpoint, unchanged).
+- `DELETE /api/secrets/{name}` stays, now archiving + auditing.
+
+### A5. WebChat approvals panel
+Small addition to the embedded static UI: a "Pending approvals" badge and
+panel (list → approve/deny buttons hitting A3 endpoints), plus a confirm
+dialog on credential overwrite in the existing secrets form. This is the
+"continuation of a front-end" — the same API the app uses.
+
+### A6. Tests
+- Store: create-vs-overwrite semantics, authority refusal, version archiving,
+  request lifecycle (pending → approved/denied/expired/superseded), stale
+  approval `409`.
+- Tool: `credential_write` `set` on existing name returns pending JSON with a
+  request id; `delete` always queues.
+- Gateway: endpoint auth (device + master), create-only default on
+  `POST /api/secrets`.
+
+## 6. Workstream B — device pairing & per-device auth (rustykrab)
+
+New tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS devices (
+  id           TEXT PRIMARY KEY,   -- UUID
+  name         TEXT NOT NULL,      -- "Graham's iPhone"
+  token_hash   BLOB NOT NULL,      -- SHA-256 of the opaque device token
+  created_at   INTEGER NOT NULL,
+  last_seen_at INTEGER,
+  revoked_at   INTEGER,
+  push_token   TEXT                -- APNs, phase 3
+);
+
+CREATE TABLE IF NOT EXISTS pairing_codes (
+  code_hash  BLOB PRIMARY KEY,     -- SHA-256; 8-char code, 5-min TTL, single use
+  expires_at INTEGER NOT NULL,
+  used_at    INTEGER
+);
+```
+
+Flow:
+1. On the Mac: `rustykrab pair` (new CLI subcommand) or a WebChat "Pair
+   device" button → prints/displays the code and a QR payload
+   `{"url": "https://<mac>.<tailnet>.ts.net", "code": "XXXXXXXX"}`.
+2. App calls `POST /api/pair {code, deviceName}` (the **only**
+   unauthenticated `/api` endpoint besides `/api/health`; strictly
+   rate-limited via the existing `rate_limit` middleware; code single-use).
+3. Response `{deviceId, deviceToken}` — token is random 32 bytes, stored
+   hashed server-side, shown exactly once.
+4. `auth::require_auth` extends to accept `Bearer <master-token>` **or**
+   `Bearer <device-token>` (hash lookup against non-revoked devices, then
+   constant-time compare), inserting a `Principal` request extension
+   (`Master` | `Device{id, name}`) used for approval attribution and audit.
+5. Device management: `GET /api/devices`, `DELETE /api/devices/{id}`
+   (revocation — lost-phone story), master token or another device required.
+
+Existing clients (CLI chat, WebChat) keep using the master token unchanged.
+
+## 7. Workstream C — Apollo iOS app (`gcbh/apollo-ios`)
+
+Full app-side details live in that repo's README. Summary:
+
+- **Stack:** SwiftUI, iOS 17+, Xcode project checked in, **zero third-party
+  dependencies** (URLSession incl. SSE via `bytes(for:)`, Security/Keychain,
+  LocalAuthentication, AVFoundation for QR scan).
+- **Screens:** Pairing (QR/manual) → tabs: Chat (conversations + streaming
+  thread), Credentials (list metadata / add / explicit overwrite / delete),
+  Approvals (badge, Face ID-gated approve/deny), Settings (server profile,
+  device management, health check).
+- **Security posture:** device token in iOS Keychain
+  (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — never syncs to iCloud);
+  credential values exist in memory only during entry and are never persisted
+  or echoed back; ATS stays fully on (real TLS via the ts.net cert);
+  Face ID (`LAContext`) before approve/deny; approvals list shows names and
+  reasons, never values.
+- **Server model:** `[ServerProfile]` array persisted from day one, UI pinned
+  to one profile in v1 (decision #8).
+- **TestFlight:** existing Apple Developer account; App Store Connect record,
+  automatic signing, `ITSAppUsesNonExemptEncryption=false` (standard TLS
+  only), archive → upload → **internal** testing group (no Beta App Review
+  wait).
+
+## 8. Workstream D — connectivity (Tailscale, ops only)
+
+1. Install Tailscale on the Mac and iPhone, same tailnet, MagicDNS on.
+2. On the Mac: `tailscale serve --bg 3000` (older CLIs:
+   `tailscale serve https / http://127.0.0.1:3000`) — publishes
+   `https://<mac-hostname>.<tailnet>.ts.net` with an auto-provisioned
+   Let's Encrypt certificate, proxying to the loopback-only gateway.
+3. Verify from the phone (Tailscale VPN on, any network incl. cellular):
+   `https://<mac>.<tailnet>.ts.net/api/health` → `ok`.
+
+Gateway keeps its `127.0.0.1:3000` bind — nothing is exposed beyond the
+tailnet, and the app needs no ATS exceptions. This is Phase 0 and requires no
+code.
+
+## 9. Workstream E — APNs push (phase 3)
+
+- Apple side: enable Push Notifications capability; create an APNs **key**
+  (.p8) in the developer account.
+- Gateway side: small push module (HTTP/2 to `api.push.apple.com`, ES256
+  JWT token auth — `a2` crate or hand-rolled with the existing HTTP stack);
+  fires on new `credential_requests` rows.
+- App side: register token via `POST /api/devices/{id}/push-token`; payload is
+  deliberately generic ("Apollo: approval requested for `<name>`" — never a
+  value); tap deep-links to the Approvals tab.
+- Until then (v1): approvals surface via app badge/refresh-on-foreground and
+  the agent saying so in-channel (decision #7).
+
+## 10. Later: swapping local storage for an API-backed secret store
+
+Per the repo's backend-trait pattern, define a `SecretsBackend` trait once
+Workstream A lands (the authority/guard/request layer sits **above** it, so
+the policy is backend-agnostic):
+
+```rust
+trait SecretsBackend: Send + Sync {
+    async fn create(&self, name: &str, value: &str) -> Result<()>;
+    async fn overwrite(&self, name: &str, value: &str) -> Result<()>;
+    async fn get(&self, name: &str) -> Result<String>;
+    async fn delete(&self, name: &str) -> Result<()>;
+    async fn list(&self) -> Result<Vec<SecretMeta>>;
+}
+```
+
+The SQLite implementation is the only one for now (decision: keep the Macs as
+the credential home). Candidates later: HashiCorp Vault, 1Password Connect, or
+a small self-hosted service — swap without touching tools, policy, or the app.
+
+## 11. Phasing
+
+| Phase | Contents | Exit criteria |
+|-------|----------|---------------|
+| **0 — Ops** | Tailscale on Mac + phone; `tailscale serve`; contract doc committed | `/api/health` reachable from the phone over HTTPS on cellular |
+| **1 — Server guard** | Workstream A (store, guard, requests, REST) + Workstream B (pairing, device auth) + WebChat approvals panel | Agent `set` on an existing name queues a request; approving from WebChat applies it; device pairs and calls the API; `cargo fmt/clippy/test` green |
+| **2 — App MVP** | Workstream C: pairing → credentials → approvals → chat (SSE) → **TestFlight build 1** to internal testers | Add a credential from the phone; approve an agent request from the phone; hold a streamed chat |
+| **3 — Notify & polish** | Workstream E (APNs), device management UI, version history + rollback UI | Lock-screen push on new request; revoke a device from the app |
+| **4 — Deferred** | `SecretsBackend` extraction; multi-server profile UI | — |
+
+Phases 1 and 2 can overlap once Phase 1's REST surface is merged (the app can
+develop against it locally).
+
+## 12. Threat-model notes
+
+Protected against:
+- **Agent clobbering or deleting credentials** — enforced in the store layer
+  under a compile-time-distinct authority, covering every tool path including
+  Gmail/CalDAV/Obsidian configure flows and keychain writes; not a
+  prompt-level restriction.
+- **Stale/spoofed approvals** — approvals require an authenticated User
+  principal over HTTP; the agent has no HTTP credentials and runs in-process
+  with no route to the approval endpoints; version check rejects stale
+  approvals.
+- **Lost phone** — per-device token, revocable server-side; token
+  non-exportable (Keychain, this-device-only); Face ID on approvals.
+- **Network exposure** — gateway stays loopback-only; tailnet-internal HTTPS;
+  no public ports; pairing codes short-lived, single-use, rate-limited.
+- **Value leakage** — no endpoint returns secret values; pending proposals
+  encrypted at rest; APNs payloads carry names only.
+
+Explicitly out of scope:
+- A compromised Mac user account (the master key and store live there — same
+  as today).
+- The user rubber-stamping approvals without reading them.
+- Malicious tampering with the rustykrab binary itself.
+
+## 13. Open items (non-blocking, defaults chosen)
+
+- Request expiry window: defaulting to 7 days.
+- Version history retention: unlimited for now; a purge command can come with
+  the rollback UI in Phase 3.
+- Whether `credential_read` should ever gate value reads (e.g. per-name agent
+  read policy) — out of scope here, worth revisiting after Phase 1.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# End-to-end evaluation harness (docs/plans/apollo-ios-and-credential-guard.md §11).
+#
+# Builds the daemon without the embeddings feature (buildable in
+# network-restricted sandboxes — no ONNX runtime download), then boots it
+# on a throwaway data dir and runs the exit-criteria scenario suite with a
+# scripted agent. Prints a JSON report; exit code 0 means green
+# (implemented scenarios pass, Phase 2 target scenarios are xfail).
+#
+# Usage: scripts/e2e.sh [--release]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PROFILE=debug
+CARGO_FLAGS=()
+if [[ "${1:-}" == "--release" ]]; then
+  PROFILE=release
+  CARGO_FLAGS+=(--release)
+fi
+
+echo "building daemon (--no-default-features)..." >&2
+cargo build -p rustykrab-cli --no-default-features "${CARGO_FLAGS[@]+"${CARGO_FLAGS[@]}"}"
+echo "building e2e runner..." >&2
+cargo build -p rustykrab-e2e "${CARGO_FLAGS[@]+"${CARGO_FLAGS[@]}"}"
+
+# Report goes to stdout and to e2e-report.json (CI uploads it as an
+# artifact); the exit code is the runner's.
+set +e
+RUSTYKRAB_BIN="target/$PROFILE/rustykrab-cli" "target/$PROFILE/rustykrab-e2e" \
+  | tee e2e-report.json
+status=${PIPESTATUS[0]}
+exit "$status"


### PR DESCRIPTION
Implements **Workstream F** of `docs/plans/apollo-ios-and-credential-guard.md`: the executable definition of done for the credential guard. No guard behaviour ships here — the target behaviour is encoded as scenarios now and marked expected-fail, so Phase 2 ships by flipping them to must-pass.

## What's here

- **`ScriptedProvider`** (`rustykrab-providers`) — a deterministic replay `ModelProvider` driven by a JSON script. No model, no network, so agent scenarios run identically every time. It anchors on the last *trigger-matching* user message rather than the last user message, because the agent runner injects its own user-role nudges mid-run that would otherwise reset the replay.
- **`rustykrab-e2e` + `scripts/e2e.sh`** — boots the daemon on a throwaway data dir and ephemeral port, drives 16 scenarios over HTTP, and asserts on responses, store state, and the SQLite tables the plan specifies (`secret_versions`, `secret_audit`, `credential_requests`). JSON report + exit code.
- **`embeddings` feature gate** on `rustykrab-cli` (default on) so the daemon builds without the ONNX download in network-restricted sandboxes and CI.
- **CI**: new `e2e` job, wired into the `ci-pass` gate. Feature branches build so cloud agents can iterate by reading checks.

## Current state

`8 pass / 8 xfail / 0 fail / 0 xpass`. The xfails are the guard's own indictment — today they read *"agent overwrote an existing credential"* and *"agent deleted an existing credential outright"*.

Each xfail is written against the **full** exit criterion rather than a proxy, and asserts on store tables rather than only on what the REST API reveals. A scenario that could pass while the behaviour it names is still broken would let Phase 2 be declared done falsely. The pairing scenarios mint a code via `rustykrab pair`, exchange it, and use the resulting device token as a bearer; revocation reuses that token and requires a `401`; deny requires the value unchanged *and* `proposed_data` wiped.

## Bugs found while building this

- `resolve_master_key` on macOS accepted an **empty** `RUSTYKRAB_MASTER_KEY` and decoded it to a zero-length encryption key. Now treated as unset, matching the Linux branch.
- `RUSTYKRAB_DISABLE_KEYCHAIN` failed **open** — only `1`/`true` disabled it, so a typo left the real Keychain live. A safety switch now fails safe.
- An unknown CLI subcommand silently **started the daemon** instead of erroring (`rustykrab-cli pair` booted a whole agent).
- `Store::open` now creates its directory instead of failing.

Two CI lanes were already red on `main` before this branch (toolchain and advisory-database drift). Fixed here so the harness result means something: a clippy lint in `recall.rs`, and the audit lane via `crossbeam-epoch` + `event-listener` bumps, a `checks: write` permission, and one documented ignore for an unmaintained transitive crate with no upstream fix.

## Contract gap for Phase 2

The origin-check middleware **requires** an `Origin` header on every `/api/*` request and only allows loopback origins (`OriginPolicy::default()` is an empty allowlist and the CLI never calls `with_origin_policy`). An app on the tailnet gets `403` on everything except `/api/health` until the allowlist is configurable. Documented in the plan and the contract doc; ApolloKit already sends its origin.

Phase 2 also needs a `rustykrab pair` subcommand — both harnesses drive it, and both currently xfail with "unknown subcommand 'pair'".

## Verification

`cargo fmt`, `clippy`, and 479 tests green; `scripts/e2e.sh` green; CI green across all five jobs.

Companion PR in `apollo-ios` adds the app and the Swift/simulator harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)