### PR TITLE
perf(providers): make Ollama requests KV-cache friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ Two consequences worth knowing:
   pre-empt compaction" warning, the loaded tool schemas have grown large
   enough to invert it — raise `RUSTYKRAB_NUM_CTX` or load fewer tools.
 
+- **Going above ~64k takes two settings, not one.** `RUSTYKRAB_NUM_CTX` sizes
+  the window; `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` caps the budget the agent
+  loop will actually grow into, and defaults to 65,536. Raise only the first
+  and compaction still fires at ~56k — the extra window goes unused. RustyKrab
+  logs a warning when the ceiling is clipping the window, but the pairing is
+  easy to miss:
+
+  ```bash
+  export RUSTYKRAB_NUM_CTX=131072
+  export OLLAMA_CONTEXT_LENGTH=131072
+  export RUSTYKRAB_COMPACTION_CONTEXT_CEILING=131072
+  ```
+
+  The default is deliberately below what a long-context model advertises.
+  A model supporting 256k does not mean 256k is the right operating point:
+  the KV cache is allocated for the whole window up front, and attention cost
+  grows with how much of it is filled. At startup RustyKrab logs the measured
+  footprint for your model and window (`estimated KV cache footprint`, with
+  both f16 and q8_0 figures and what the model's native maximum would cost) —
+  pick a window from those numbers and your free VRAM rather than from the
+  model's advertised limit.
+
 - **Loading tools invalidates the KV cache.** Tool definitions render into the
   prompt *prefix*, ahead of the conversation, so a tool set that changes
   mid-run moves every token after it and forces a full prompt re-evaluation.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ export RUSTYKRAB_PROVIDER=ollama
 cargo run --release -p rustykrab-cli
 ```
 
+#### Tuning the Ollama server for KV-cache reuse
+
+An agent loop re-sends the whole conversation on every iteration, so almost
+all of its prompt is a prefix Ollama already evaluated on the previous turn.
+Reusing the cached KV for that prefix is the difference between a fast turn
+and one that re-reads the entire history. RustyKrab does its part on the
+client — it pins one `num_ctx` for the process, sends `keep_alive` so the
+runner stays resident, and trims history in infrequent deep cuts rather than
+a little every turn — but three settings on the server side matter just as
+much:
+
+```bash
+# Must be >= RUSTYKRAB_NUM_CTX, or the server silently truncates prompts.
+export OLLAMA_CONTEXT_LENGTH=32768
+
+# One slot keeps a single conversation pinned to a single warm cache.
+# Raising this splits KV memory across slots and round-robins requests, so
+# consecutive turns of one conversation can land on a cold slot.
+export OLLAMA_NUM_PARALLEL=1
+
+# Halves KV-cache memory, buying back the VRAM a larger window costs.
+# q8_0 requires flash attention and is close to lossless; q4_0 is cheaper
+# but degrades quality on long contexts.
+export OLLAMA_FLASH_ATTENTION=1
+export OLLAMA_KV_CACHE_TYPE=q8_0
+```
+
+Keep `OLLAMA_CONTEXT_LENGTH` and `RUSTYKRAB_NUM_CTX` in sync. If the server
+window is the smaller of the two, RustyKrab's own trimming budget is too
+generous and the server truncates from the front of the prompt — which moves
+the truncation point every turn and throws away the cached prefix each time.
+
 ## Configuration
 
 All configuration is via environment variables. No plaintext config files.
@@ -67,8 +99,11 @@ All configuration is via environment variables. No plaintext config files.
 | `RUSTYKRAB_COMPACTION_SUMMARY_MAX_TOKENS` | `8192` | Env-configurable upper bound on the final compaction summary. The effective cap is further bounded by `RUSTYKRAB_MAX_CONTEXT_TOKENS / 4`, so on a 32k local-Ollama deployment the summary stays under 8k regardless of this value. If the summarizer returns a summary larger than the effective cap, it is re-summarized (up to 3 passes) and eventually truncated |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
-| `RUSTYKRAB_NUM_CTX` | — | Explicit client-side `num_ctx` override for local providers. Takes precedence over `OLLAMA_NUM_CTX`. Omitted by default so the server's own `OLLAMA_CONTEXT_LENGTH` (or per-model default) wins |
+| `RUSTYKRAB_NUM_CTX` | `32768` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
 | `OLLAMA_NUM_CTX` | — | Legacy alias for `RUSTYKRAB_NUM_CTX`. Used only when `RUSTYKRAB_NUM_CTX` is unset |
+| `OLLAMA_KEEP_ALIVE` | `30m` | How long Ollama keeps the model and its KV cache resident after a request (Ollama duration syntax; `-1` for forever). Ollama's own default is 5 minutes, short enough that a sporadically-used gateway reloads the model on most messages. Set to `server` to omit the field |
+| `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to decide from the model tag. Ollama returns a 400 for `think` against models that don't support it, so `auto` only enables it for known thinking families |
+| `OLLAMA_VISION` | `auto` | Whether the model accepts image input: `true`, `false`, or `auto` to decide from the model tag |
 | `OLLAMA_TIMEOUT_SECS` | `900` | HTTP request timeout for Ollama in seconds |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ much:
 
 ```bash
 # Must be >= RUSTYKRAB_NUM_CTX, or the server silently truncates prompts.
-export OLLAMA_CONTEXT_LENGTH=32768
+export OLLAMA_CONTEXT_LENGTH=65536
 
 # One slot keeps a single conversation pinned to a single warm cache.
 # Raising this splits KV memory across slots and round-robins requests, so
@@ -84,6 +84,36 @@ window is the smaller of the two, RustyKrab's own trimming budget is too
 generous and the server truncates from the front of the prompt — which moves
 the truncation point every turn and throws away the cached prefix each time.
 
+#### Where the context window goes
+
+The pinned window is not all available for conversation history. On the 64k
+default, a turn is budgeted roughly like this:
+
+| Reservation | Tokens | Why |
+|---|---|---|
+| `num_predict` (output) | 4,096 | The turn's own response has to fit alongside the prompt |
+| Tool schemas | ~1,800–10,000 | Measured per request; grows as the model loads tools |
+| Template framing | 512 | Role tags, tool preamble, BOS/EOS |
+| **Usable for history** | **~50,000–58,000** | Compaction fires at 85% of this |
+
+Two consequences worth knowing:
+
+- **Compaction runs before trimming, by design.** Compaction summarizes
+  displaced history into the `recall_*` archive, so detail stays reachable;
+  trimming just drops the oldest turns. RustyKrab derives both budgets from
+  the same figure to keep that order. If you see the "history trimming will
+  pre-empt compaction" warning, the loaded tool schemas have grown large
+  enough to invert it — raise `RUSTYKRAB_NUM_CTX` or load fewer tools.
+
+- **Loading tools invalidates the KV cache.** Tool definitions render into the
+  prompt *prefix*, ahead of the conversation, so a tool set that changes
+  mid-run moves every token after it and forces a full prompt re-evaluation.
+  This is the price of the `tools_list` / `tools_load` design, which exists
+  because the full catalog is ~10k tokens and cannot be sent every turn. The
+  cost is per *change*, not per tool, so loading everything a task needs in
+  one `tools_load` call is much cheaper than discovering tools incrementally.
+  The `tool set changed since the last request` log line marks each one.
+
 ## Configuration
 
 All configuration is via environment variables. No plaintext config files.
@@ -99,7 +129,7 @@ All configuration is via environment variables. No plaintext config files.
 | `RUSTYKRAB_COMPACTION_SUMMARY_MAX_TOKENS` | `8192` | Env-configurable upper bound on the final compaction summary. The effective cap is further bounded by `RUSTYKRAB_MAX_CONTEXT_TOKENS / 4`, so on a 32k local-Ollama deployment the summary stays under 8k regardless of this value. If the summarizer returns a summary larger than the effective cap, it is re-summarized (up to 3 passes) and eventually truncated |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
-| `RUSTYKRAB_NUM_CTX` | `32768` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
+| `RUSTYKRAB_NUM_CTX` | `65536` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. The whole window is allocated as KV cache when the model loads, so lower this (or enable KV quantization, below) if the model won't fit in VRAM. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
 | `OLLAMA_NUM_CTX` | — | Legacy alias for `RUSTYKRAB_NUM_CTX`. Used only when `RUSTYKRAB_NUM_CTX` is unset |
 | `OLLAMA_KEEP_ALIVE` | `30m` | How long Ollama keeps the model and its KV cache resident after a request (Ollama duration syntax; `-1` for forever). Ollama's own default is 5 minutes, short enough that a sporadically-used gateway reloads the model on most messages. Set to `server` to omit the field |
 | `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to decide from the model tag. Ollama returns a 400 for `think` against models that don't support it, so `auto` only enables it for known thinking families |

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -2318,10 +2318,30 @@ impl AgentRunner {
     /// so runaway local-model context windows still trigger compaction
     /// at a sane size.
     fn effective_context_limit(&self) -> usize {
-        self.provider
+        let reported = self
+            .provider
             .context_limit()
-            .unwrap_or(self.config.max_context_tokens)
-            .min(compaction_context_ceiling())
+            .unwrap_or(self.config.max_context_tokens);
+        let ceiling = compaction_context_ceiling();
+        if reported > ceiling {
+            // The ceiling exists to stop a model that *advertises* a huge
+            // window from driving compaction budgets its GPU can't sustain.
+            // But it applies just as bluntly to a window the operator pinned
+            // on purpose, which then does nothing above the ceiling — the
+            // symptom being "I raised RUSTYKRAB_NUM_CTX and nothing changed".
+            // Say so once rather than silently discarding the setting.
+            static WARNED: std::sync::Once = std::sync::Once::new();
+            WARNED.call_once(|| {
+                tracing::warn!(
+                    provider_context_limit = reported,
+                    compaction_context_ceiling = ceiling,
+                    "provider reports more usable context than the compaction ceiling allows; \
+                     compaction will fire at 85% of the ceiling. Raise \
+                     RUSTYKRAB_COMPACTION_CONTEXT_CEILING to use the full window"
+                );
+            });
+        }
+        reported.min(ceiling)
     }
 
     /// Effective cap on the compacted-history summary in tokens. Combines

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -508,7 +508,8 @@ async fn main() -> anyhow::Result<()> {
                 %model,
                 %base_url,
                 num_ctx = ?config.num_ctx,
-                "using Ollama provider (num_ctx=None defers to server's OLLAMA_CONTEXT_LENGTH)"
+                keep_alive = ?config.keep_alive,
+                "using Ollama provider (set RUSTYKRAB_NUM_CTX=server to defer to OLLAMA_CONTEXT_LENGTH)"
             );
             let p = rustykrab_providers::OllamaProvider::new(model)
                 .with_base_url(base_url)
@@ -518,6 +519,8 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!(
                 num_ctx = ?p.num_ctx(),
                 effective_ctx = ?p.effective_ctx(),
+                keep_alive = ?p.keep_alive(),
+                think = p.resolved_think(),
                 "Ollama client-side context settings"
             );
             Arc::new(p)

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -6,6 +6,9 @@ use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEven
 use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolSchema};
 use rustykrab_core::Error;
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -26,8 +29,15 @@ const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 /// prompt that overshoots gets silently truncated server-side — which moves
 /// the truncation point every turn and defeats prefix caching completely.
 ///
-/// 32k matches the local-Ollama compaction budget the CLI already assumes.
-const DEFAULT_NUM_CTX: u32 = 32_768;
+/// 64k matches `DEFAULT_COMPACTION_CONTEXT_CEILING` in the agent runner, so
+/// the provider's window and the compaction budget agree instead of one
+/// silently capping the other. It is clamped down to the model's own native
+/// length at startup, so a smaller model still gets a sane value.
+///
+/// This costs VRAM: the KV cache is allocated for the whole window when the
+/// runner loads. Lower it with `RUSTYKRAB_NUM_CTX` if the model won't fit, or
+/// halve the cache with `OLLAMA_KV_CACHE_TYPE=q8_0` (see README).
+const DEFAULT_NUM_CTX: u32 = 65_536;
 
 /// Default `keep_alive` sent with every request: how long Ollama keeps the
 /// model (and its KV cache) resident after the request finishes. Ollama's own
@@ -124,9 +134,22 @@ const CHARS_PER_TOKEN: usize = 4;
 /// Per-message overhead (role tag, framing) the server adds on top of content.
 const PER_MESSAGE_OVERHEAD_TOKENS: u32 = 4;
 
-/// Tokens reserved for tool schemas in the prompt and other framing the
-/// client can't easily measure (chat template, system tool preamble, etc.).
-const SAFETY_OVERHEAD_TOKENS: u32 = 2048;
+/// Tokens reserved for chat-template framing the client can't measure:
+/// role tags, the tool-call preamble most templates emit, BOS/EOS scaffolding.
+///
+/// Tool schemas used to be lumped in here at a flat 2048. They aren't any
+/// more — they're measured per request, because the real figure moves by an
+/// order of magnitude as the model loads tools (~1.8k tokens for the set
+/// seeded at turn 0, ~10k with the full catalog loaded). A flat guess
+/// over-reserved on a fresh conversation and badly under-reserved on a
+/// tool-heavy one, which is how a "trimmed" prompt could still overflow.
+const FRAMING_OVERHEAD_TOKENS: u32 = 512;
+
+/// Stand-in for the tool-schema block used by [`OllamaProvider::context_limit`],
+/// which is called without knowing the conversation's active tool set. Sized
+/// for a typical mid-conversation set; the per-request path measures the real
+/// thing instead.
+const ASSUMED_TOOL_TOKENS: u32 = 2048;
 
 /// Percentage of the trimming budget to cut down to once trimming fires.
 /// See `trim_to_budget` for why this is well below 100.
@@ -139,7 +162,7 @@ impl Default for OllamaConfig {
             num_ctx: num_ctx_from_env(),
             keep_alive: keep_alive_from_env(),
             top_p: 0.9,
-            num_predict: 8192,
+            num_predict: 4096,
             think: None,
         }
     }
@@ -182,6 +205,10 @@ pub struct OllamaProvider {
     /// serve, and as the client-side prompt-trimming budget when `num_ctx`
     /// has been explicitly set to defer to the server.
     detected_ctx: Option<u32>,
+    /// Fingerprint of the tool block sent on the previous request, so a
+    /// change can be reported.  See [`OllamaProvider::note_tool_block`].
+    /// `0` means "nothing sent yet".
+    last_tool_fingerprint: AtomicU64,
 }
 
 impl OllamaProvider {
@@ -204,6 +231,7 @@ impl OllamaProvider {
             model: model.into(),
             config: OllamaConfig::default(),
             detected_ctx: None,
+            last_tool_fingerprint: AtomicU64::new(0),
         }
     }
 
@@ -592,14 +620,12 @@ impl OllamaProvider {
         messages: Vec<OllamaMessage>,
         total_ctx: Option<u32>,
         num_predict: i32,
+        tool_tokens: u32,
     ) -> Vec<OllamaMessage> {
         let Some(total_ctx) = total_ctx else {
             return messages;
         };
-        let reserved_output = num_predict.max(0) as u32;
-        let budget = total_ctx
-            .saturating_sub(reserved_output)
-            .saturating_sub(SAFETY_OVERHEAD_TOKENS);
+        let budget = input_budget(total_ctx, num_predict, tool_tokens);
 
         let total: u32 = messages.iter().map(estimate_message_tokens).sum();
         if total <= budget {
@@ -651,6 +677,64 @@ impl OllamaProvider {
         trimmed
     }
 
+    /// Record the tool block about to be sent, and report when it differs
+    /// from the previous request's.
+    ///
+    /// This is not bookkeeping for its own sake. Chat templates render tool
+    /// definitions into the prompt *prefix*, ahead of the conversation, so
+    /// changing the tool set moves every subsequent token — the cached prefix
+    /// stops matching at the tool block and the server re-evaluates the whole
+    /// prompt. On a long conversation that is by far the most expensive thing
+    /// that can happen to a turn, and it is invisible without this log line.
+    ///
+    /// The set is driven by the `tools_load` meta-tool, so it changes when the
+    /// model discovers and loads new tools. That is the intended design — the
+    /// full catalog is far too large to send every turn — but it means tool
+    /// loading is best done in one batch early, not drip-fed across a run.
+    fn note_tool_block(&self, tools: &[OllamaTool], tool_tokens: u32) {
+        // Names alone, in order: that is what the prompt prefix is sensitive
+        // to, and it avoids re-hashing the (much larger) parameter schemas.
+        let mut hasher = DefaultHasher::new();
+        for t in tools {
+            t.function.name.hash(&mut hasher);
+        }
+        // Reserve 0 for "nothing sent yet" so the first request isn't
+        // mistaken for a change.
+        let fingerprint = hasher.finish() | 1;
+
+        let previous = self
+            .last_tool_fingerprint
+            .swap(fingerprint, Ordering::Relaxed);
+        if previous != 0 && previous != fingerprint {
+            tracing::info!(
+                num_tools = tools.len(),
+                tool_tokens,
+                "tool set changed since the last request — Ollama must re-evaluate                  the whole prompt, since tool definitions sit in the cached prefix"
+            );
+        }
+
+        // Compaction is supposed to run before trimming: it summarizes and
+        // archives, where trimming just drops the oldest turns. The runner
+        // derives its threshold from `context_limit()`, which has to assume a
+        // typical tool block; if the real one is much bigger, the trimming
+        // budget falls below that threshold and trimming pre-empts compaction.
+        if let Some(window) = self.effective_ctx() {
+            let assumed = input_budget(window, self.config.num_predict, ASSUMED_TOOL_TOKENS);
+            let actual = input_budget(window, self.config.num_predict, tool_tokens);
+            // The runner compacts at 85% of the budget it was told about.
+            let compaction_threshold = assumed / 100 * 85;
+            if actual < compaction_threshold {
+                tracing::warn!(
+                    num_ctx = window,
+                    tool_tokens,
+                    trim_budget = actual,
+                    compaction_threshold,
+                    "loaded tool schemas are large enough that history trimming will                      pre-empt compaction — raise RUSTYKRAB_NUM_CTX or load fewer tools"
+                );
+            }
+        }
+    }
+
     /// Map an HTTP status code to a specific error variant (#186).
     fn map_status_error(status: reqwest::StatusCode, body: &str) -> Error {
         match status.as_u16() {
@@ -668,8 +752,23 @@ impl ModelProvider for OllamaProvider {
         "ollama"
     }
 
+    /// Reports the usable *input* budget rather than the raw window.
+    ///
+    /// The trait documents this as the single source of truth for downstream
+    /// budgets — compaction thresholds, prompt trimming — and those budgets
+    /// are about how much history fits, not how big the window is. Reporting
+    /// the raw window put the runner's compaction threshold (85% of the
+    /// window) *above* this provider's trimming budget (window minus output
+    /// and overhead), so trimming always fired first and compaction was
+    /// effectively unreachable on Ollama. Subtracting the same reservations
+    /// here restores the intended order: compact first, trim only as a
+    /// backstop.
     fn context_limit(&self) -> Option<usize> {
-        self.effective_ctx().map(|v| v as usize)
+        self.effective_ctx()
+            .map(|window| {
+                input_budget(window, self.config.num_predict, ASSUMED_TOOL_TOKENS) as usize
+            })
+            .filter(|&v| v > 0)
     }
 
     fn supports_vision(&self) -> bool {
@@ -686,13 +785,16 @@ impl ModelProvider for OllamaProvider {
             ));
         }
 
+        let ollama_tools = Self::build_tools(tools);
+        let tool_tokens = estimate_tool_tokens(&ollama_tools);
+        self.note_tool_block(&ollama_tools, tool_tokens);
+
         let ollama_messages = Self::trim_to_budget(
             ollama_messages,
             self.effective_ctx(),
             self.config.num_predict,
+            tool_tokens,
         );
-
-        let ollama_tools = Self::build_tools(tools);
 
         let mut options = serde_json::json!({
             "temperature": self.config.temperature,
@@ -733,6 +835,8 @@ impl ModelProvider for OllamaProvider {
             base_url = %self.base_url,
             num_messages = ollama_messages.len(),
             num_ctx = ?self.config.num_ctx,
+            num_tools = ollama_tools.len(),
+            tool_tokens,
             trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
             "calling Ollama chat API"
         );
@@ -857,13 +961,16 @@ impl ModelProvider for OllamaProvider {
             ));
         }
 
+        let ollama_tools = Self::build_tools(tools);
+        let tool_tokens = estimate_tool_tokens(&ollama_tools);
+        self.note_tool_block(&ollama_tools, tool_tokens);
+
         let ollama_messages = Self::trim_to_budget(
             ollama_messages,
             self.effective_ctx(),
             self.config.num_predict,
+            tool_tokens,
         );
-
-        let ollama_tools = Self::build_tools(tools);
 
         let mut options = serde_json::json!({
             "temperature": self.config.temperature,
@@ -901,6 +1008,8 @@ impl ModelProvider for OllamaProvider {
             base_url = %self.base_url,
             num_messages = ollama_messages.len(),
             num_ctx = ?self.config.num_ctx,
+            num_tools = ollama_tools.len(),
+            tool_tokens,
             trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
             "calling Ollama chat API (streaming)"
         );
@@ -1195,6 +1304,31 @@ struct OllamaStreamMessage {
     tool_calls: Option<Vec<OllamaToolCall>>,
 }
 
+/// Usable input budget: what's left of the context window once the output
+/// reservation, the tool-schema block, and chat-template framing are taken
+/// out. This is the single figure both the client-side trimmer and
+/// [`OllamaProvider::context_limit`] derive from, so the agent runner's
+/// compaction threshold and this provider's trimming budget can't drift into
+/// disagreeing about how much room there is.
+fn input_budget(window: u32, num_predict: i32, tool_tokens: u32) -> u32 {
+    window
+        .saturating_sub(num_predict.max(0) as u32)
+        .saturating_sub(tool_tokens)
+        .saturating_sub(FRAMING_OVERHEAD_TOKENS)
+}
+
+/// Measure the tool-schema block exactly as it will be serialized into the
+/// request body. Tool definitions are rendered into the prompt *prefix* by
+/// essentially every chat template Ollama ships, so this is both a real cost
+/// against the window and — when the set changes mid-conversation — the point
+/// at which the cached prefix stops matching.
+fn estimate_tool_tokens(tools: &[OllamaTool]) -> u32 {
+    let mut w = CountingWriter(0);
+    // Serializing into an infallible sink cannot fail.
+    let _ = serde_json::to_writer(&mut w, tools);
+    w.0.div_ceil(CHARS_PER_TOKEN) as u32
+}
+
 /// Approximate the number of prompt tokens an `OllamaMessage` will cost.
 /// Errs on the high side so trimming converges instead of oscillating.
 fn estimate_message_tokens(msg: &OllamaMessage) -> u32 {
@@ -1363,6 +1497,11 @@ fn model_supports_vision(model: &str) -> bool {
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    /// Tool-block size used by the trimming tests. Chosen so that
+    /// `TEST_TOOL_TOKENS + FRAMING_OVERHEAD_TOKENS` equals the flat 2048 these
+    /// cases were originally written against, keeping their arithmetic intact.
+    const TEST_TOOL_TOKENS: u32 = 1536;
 
     fn user_msg(content: &str) -> OllamaMessage {
         OllamaMessage {
@@ -1541,7 +1680,7 @@ mod tests {
     fn trim_returns_unchanged_when_under_budget() {
         let msgs = vec![system_msg("sys"), user_msg("hi")];
         let original_len = msgs.len();
-        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024, TEST_TOOL_TOKENS);
         assert_eq!(trimmed.len(), original_len);
     }
 
@@ -1552,7 +1691,7 @@ mod tests {
         let big = "x".repeat(40_000);
         let msgs = vec![system_msg("sys"), user_msg(&big), user_msg("latest")];
         let original_len = msgs.len();
-        let trimmed = OllamaProvider::trim_to_budget(msgs, None, 256);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, None, 256, TEST_TOOL_TOKENS);
         assert_eq!(trimmed.len(), original_len);
     }
 
@@ -1569,7 +1708,7 @@ mod tests {
             user_msg("latest"),
         ];
         // budget = 4096 - 256 - SAFETY_OVERHEAD_TOKENS(2048) = 1792 tokens
-        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
         // System message must survive.
         assert_eq!(trimmed[0].role, "system");
         // Latest message must survive.
@@ -1591,7 +1730,7 @@ mod tests {
         }
         msgs.push(user_msg("latest"));
 
-        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024, TEST_TOOL_TOKENS);
 
         // budget = 8192 - 1024 - 2048 = 5120; target = 75% = 3840.
         let after: u32 = trimmed.iter().map(estimate_message_tokens).sum();
@@ -1603,7 +1742,7 @@ mod tests {
         // Re-trimming the same history must now be a no-op — that is the
         // property that keeps the prefix stable across subsequent turns.
         let len_before = trimmed.len();
-        let again = OllamaProvider::trim_to_budget(trimmed, Some(8192), 1024);
+        let again = OllamaProvider::trim_to_budget(trimmed, Some(8192), 1024, TEST_TOOL_TOKENS);
         assert_eq!(again.len(), len_before);
     }
 
@@ -1613,7 +1752,7 @@ mod tests {
         // dropping it would leave the model nothing to answer.
         let huge = "z".repeat(200_000); // ~50k tokens
         let msgs = vec![system_msg("sys"), user_msg(&huge)];
-        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024, TEST_TOOL_TOKENS);
         assert_eq!(trimmed.len(), 2);
         assert_eq!(trimmed[0].role, "system");
         assert_eq!(trimmed[1].role, "user");
@@ -1628,7 +1767,7 @@ mod tests {
             tool_msg("orphaned tool result"),
             user_msg("latest"),
         ];
-        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256);
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
         // Orphan tool result must not become the first non-system message.
         assert_ne!(trimmed.get(1).map(|m| m.role.as_str()), Some("tool"));
         // System and latest user message survive.
@@ -1722,6 +1861,103 @@ mod tests {
         assert!(!model_supports_thinking("llama3.1:8b"));
         assert!(!model_supports_thinking("mistral:7b"));
         assert!(!model_supports_thinking("qwen2.5:7b"));
+    }
+
+    #[test]
+    fn compaction_threshold_sits_below_the_trimming_budget() {
+        // The regression this guards: compaction (summarize + archive) must
+        // fire before trimming (drop the oldest turns outright). The runner
+        // compacts at 85% of what `context_limit()` reports, so that figure
+        // has to be the *usable* budget, not the raw window — otherwise the
+        // threshold lands above the trim budget and trimming always wins.
+        for window in [8_192u32, 16_384, 32_768, 65_536, 131_072] {
+            let provider = OllamaProvider::new("probe").with_config(OllamaConfig {
+                num_ctx: Some(window),
+                num_predict: 4096,
+                ..OllamaConfig::default()
+            });
+
+            let reported = provider.context_limit().expect("limit") as u32;
+            let compaction_threshold = (reported as f64 * 0.85) as u32;
+            let trim_budget = input_budget(window, 4096, ASSUMED_TOOL_TOKENS);
+
+            assert!(
+                compaction_threshold < trim_budget,
+                "window {window}: compaction at {compaction_threshold} must precede \
+                 trimming at {trim_budget}"
+            );
+        }
+    }
+
+    #[test]
+    fn context_limit_excludes_output_and_overhead_reservations() {
+        let provider = OllamaProvider::new("probe").with_config(OllamaConfig {
+            num_ctx: Some(32_768),
+            num_predict: 4096,
+            ..OllamaConfig::default()
+        });
+        let expected = 32_768 - 4096 - ASSUMED_TOOL_TOKENS - FRAMING_OVERHEAD_TOKENS;
+        assert_eq!(provider.context_limit(), Some(expected as usize));
+    }
+
+    #[test]
+    fn context_limit_is_none_when_reservations_exceed_the_window() {
+        // A window smaller than the reservations would otherwise report 0 and
+        // make every downstream budget collapse to nothing.
+        let provider = OllamaProvider::new("probe").with_config(OllamaConfig {
+            num_ctx: Some(1024),
+            num_predict: 4096,
+            ..OllamaConfig::default()
+        });
+        assert_eq!(provider.context_limit(), None);
+    }
+
+    #[test]
+    fn trim_budget_shrinks_as_the_tool_block_grows() {
+        // Tool schemas are part of the prompt, so loading more tools has to
+        // leave less room for history. The old flat 2048 reservation missed
+        // this entirely: a conversation with the full catalog loaded could be
+        // "trimmed" and still overflow the window.
+        let big = "x".repeat(4000); // ~1000 tokens each
+        let build = || {
+            let mut msgs = vec![system_msg("sys")];
+            for _ in 0..10 {
+                msgs.push(user_msg(&big));
+            }
+            msgs.push(user_msg("latest"));
+            msgs
+        };
+
+        let few = OllamaProvider::trim_to_budget(build(), Some(16_384), 1024, 500);
+        let many = OllamaProvider::trim_to_budget(build(), Some(16_384), 1024, 10_000);
+        assert!(
+            many.len() < few.len(),
+            "a 10k-token tool block must force more history out than a 500-token one \
+             (kept {} vs {})",
+            many.len(),
+            few.len()
+        );
+    }
+
+    #[test]
+    fn estimate_tool_tokens_tracks_serialized_size() {
+        let tools = vec![OllamaTool {
+            r#type: "function".to_string(),
+            function: OllamaToolDef {
+                name: "read".to_string(),
+                description: "Read a file".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": { "path": { "type": "string" } },
+                    "required": ["path"],
+                }),
+            },
+        }];
+        let serialized_len = serde_json::to_string(&tools).unwrap().len();
+        assert_eq!(
+            estimate_tool_tokens(&tools),
+            serialized_len.div_ceil(CHARS_PER_TOKEN) as u32
+        );
     }
 
     #[test]

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -286,6 +286,12 @@ impl OllamaProvider {
     /// unfamiliar (e.g. an architecture we don't recognize).  Network and
     /// HTTP errors are propagated so the caller can decide how to react.
     pub async fn detect_context_window(&self) -> Result<Option<u32>> {
+        Ok(self.detect_model_shape().await?.0)
+    }
+
+    /// Query `/api/show` for both the model's native context length and the
+    /// attention geometry needed to size its KV cache.
+    async fn detect_model_shape(&self) -> Result<(Option<u32>, Option<KvGeometry>)> {
         let url = format!("{}/api/show", self.base_url);
         let resp = self
             .client
@@ -304,7 +310,38 @@ impl OllamaProvider {
         let raw: serde_json::Value = resp.json().await.map_err(|e| {
             Error::ModelProvider(format!("failed to parse /api/show response: {e}"))
         })?;
-        Ok(parse_context_length_from_show(&raw))
+        Ok((
+            parse_context_length_from_show(&raw),
+            parse_kv_geometry_from_show(&raw),
+        ))
+    }
+
+    /// Report what the pinned window will cost in KV cache.
+    ///
+    /// Choosing `num_ctx` is a VRAM decision, and without this the operator
+    /// has no way to make it except trial and error against an OOM. Logged at
+    /// startup for the window actually in use, plus the model's native
+    /// maximum so the gap between "what it supports" and "what it costs" is
+    /// visible in one place.
+    fn log_kv_cache_estimate(&self, geometry: KvGeometry, native_ctx: Option<u32>) {
+        let Some(window) = self.effective_ctx() else {
+            return;
+        };
+        // f16 is Ollama's default; OLLAMA_KV_CACHE_TYPE=q8_0 halves it.
+        const F16: u64 = 2;
+        let gib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        tracing::info!(
+            num_ctx = window,
+            layers = geometry.layers,
+            kv_heads = geometry.kv_heads,
+            kv_cache_gib_f16 = format!("{:.1}", gib(geometry.cache_bytes(window, F16))),
+            kv_cache_gib_q8_0 = format!("{:.1}", gib(geometry.cache_bytes(window, 1))),
+            native_ctx_kv_cache_gib_f16 = native_ctx
+                .map(|n| format!("{:.1}", gib(geometry.cache_bytes(n, F16))))
+                .unwrap_or_else(|| "unknown".to_string()),
+            "estimated KV cache footprint (upper bound; sliding-window layers cost less)"
+        );
     }
 
     /// Detect the model's native context length and cache it for client-side
@@ -314,41 +351,8 @@ impl OllamaProvider {
     /// is logged — startup must not fail just because Ollama is momentarily
     /// unreachable.
     pub async fn with_detected_context_window(mut self) -> Self {
-        match self.detect_context_window().await {
-            Ok(Some(detected)) => {
-                self.detected_ctx = Some(detected);
-                if let Some(requested) = self.config.num_ctx {
-                    if requested > detected {
-                        tracing::info!(
-                            model = %self.model,
-                            requested_num_ctx = requested,
-                            detected_num_ctx = detected,
-                            "clamping explicit num_ctx to model's native context length"
-                        );
-                        self.config.num_ctx = Some(detected);
-                    } else {
-                        tracing::debug!(
-                            model = %self.model,
-                            num_ctx = requested,
-                            detected_num_ctx = detected,
-                            "explicit num_ctx fits within model's native context length"
-                        );
-                    }
-                } else {
-                    tracing::debug!(
-                        model = %self.model,
-                        detected_num_ctx = detected,
-                        "no explicit num_ctx set; deferring to server while using detected value for client-side trimming"
-                    );
-                }
-            }
-            Ok(None) => {
-                tracing::warn!(
-                    model = %self.model,
-                    num_ctx = ?self.config.num_ctx,
-                    "could not detect model context length from /api/show"
-                );
-            }
+        let (detected, geometry) = match self.detect_model_shape().await {
+            Ok(pair) => pair,
             Err(e) => {
                 tracing::warn!(
                     model = %self.model,
@@ -356,7 +360,55 @@ impl OllamaProvider {
                     error = %e,
                     "failed to query /api/show"
                 );
+                return self;
             }
+        };
+
+        match detected {
+            Some(detected) => {
+                self.detected_ctx = Some(detected);
+                match self.config.num_ctx {
+                    Some(requested) if requested > detected => {
+                        tracing::info!(
+                            model = %self.model,
+                            requested_num_ctx = requested,
+                            detected_num_ctx = detected,
+                            "clamping num_ctx to model's native context length"
+                        );
+                        self.config.num_ctx = Some(detected);
+                    }
+                    Some(requested) => {
+                        tracing::debug!(
+                            model = %self.model,
+                            num_ctx = requested,
+                            detected_num_ctx = detected,
+                            "num_ctx fits within model's native context length"
+                        );
+                    }
+                    None => {
+                        tracing::debug!(
+                            model = %self.model,
+                            detected_num_ctx = detected,
+                            "no explicit num_ctx set; deferring to server while using detected value for client-side trimming"
+                        );
+                    }
+                }
+            }
+            None => {
+                tracing::warn!(
+                    model = %self.model,
+                    num_ctx = ?self.config.num_ctx,
+                    "could not detect model context length from /api/show"
+                );
+            }
+        }
+
+        match geometry {
+            Some(geometry) => self.log_kv_cache_estimate(geometry, detected),
+            None => tracing::debug!(
+                model = %self.model,
+                "could not read attention geometry from /api/show; skipping KV cache estimate"
+            ),
         }
         self
     }
@@ -1377,6 +1429,83 @@ fn estimate_text_tokens(s: &str) -> u32 {
     chars.div_ceil(CHARS_PER_TOKEN) as u32
 }
 
+/// Attention geometry needed to size a model's KV cache, read from
+/// `/api/show`'s `model_info` (which surfaces the GGUF metadata).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvGeometry {
+    /// Number of transformer blocks (layers).
+    pub layers: u32,
+    /// Key/value heads per layer. Smaller than the query head count on any
+    /// model using grouped-query attention, which is what makes long
+    /// contexts affordable at all.
+    pub kv_heads: u32,
+    /// Per-head key dimension.
+    pub key_length: u32,
+    /// Per-head value dimension.
+    pub value_length: u32,
+}
+
+impl KvGeometry {
+    /// Bytes of KV cache a context of `num_ctx` tokens needs, at
+    /// `bytes_per_element` per stored scalar (2 for the f16 default, 1 for
+    /// `OLLAMA_KV_CACHE_TYPE=q8_0`).
+    ///
+    /// This is an **upper bound**. Models that interleave sliding-window
+    /// local attention with global attention — Gemma's architecture does
+    /// exactly this — only allocate the full window for the global layers,
+    /// so their real footprint is a fraction of this figure. Treat it as
+    /// "no more than", not "exactly".
+    pub fn cache_bytes(&self, num_ctx: u32, bytes_per_element: u64) -> u64 {
+        let per_token = self.layers as u64
+            * self.kv_heads as u64
+            * (self.key_length as u64 + self.value_length as u64)
+            * bytes_per_element;
+        per_token * num_ctx as u64
+    }
+}
+
+/// Read a `model_info` field that may be stored as a scalar or as a
+/// per-layer array. Arrays take the maximum, so the estimate stays an
+/// upper bound for models with heterogeneous layers.
+fn model_info_u32(info: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<u32> {
+    let v = info.get(key)?;
+    let n = match v {
+        serde_json::Value::Array(items) => items.iter().filter_map(|i| i.as_u64()).max()?,
+        other => other.as_u64()?,
+    };
+    u32::try_from(n).ok().filter(|&n| n > 0)
+}
+
+/// Pull the attention geometry out of a `/api/show` response, so the KV
+/// cache cost of a given window can be reported rather than guessed at.
+/// Returns `None` when the metadata doesn't carry enough to compute it.
+fn parse_kv_geometry_from_show(raw: &serde_json::Value) -> Option<KvGeometry> {
+    let info = raw.get("model_info")?.as_object()?;
+    let arch = info.get("general.architecture")?.as_str()?;
+
+    let layers = model_info_u32(info, &format!("{arch}.block_count"))?;
+    let kv_heads = model_info_u32(info, &format!("{arch}.attention.head_count_kv"))?;
+
+    // `key_length`/`value_length` are optional in GGUF; when absent the head
+    // dimension is embedding_length / head_count.
+    let fallback_head_dim = || {
+        let embedding = model_info_u32(info, &format!("{arch}.embedding_length"))?;
+        let heads = model_info_u32(info, &format!("{arch}.attention.head_count"))?;
+        Some(embedding / heads).filter(|&d| d > 0)
+    };
+    let key_length =
+        model_info_u32(info, &format!("{arch}.attention.key_length")).or_else(fallback_head_dim)?;
+    let value_length = model_info_u32(info, &format!("{arch}.attention.value_length"))
+        .or_else(fallback_head_dim)?;
+
+    Some(KvGeometry {
+        layers,
+        kv_heads,
+        key_length,
+        value_length,
+    })
+}
+
 /// Pull a context-length value out of a `/api/show` response.  Ollama reports
 /// it under `model_info` keyed by architecture (e.g. `llama.context_length`,
 /// `qwen3.context_length`).  We accept any key suffixed `.context_length`.
@@ -1658,6 +1787,85 @@ mod tests {
             }
         });
         assert_eq!(parse_context_length_from_show(&raw), Some(16384));
+    }
+
+    #[test]
+    fn parses_kv_geometry_from_explicit_key_value_lengths() {
+        let raw = serde_json::json!({
+            "model_info": {
+                "general.architecture": "gemma4",
+                "gemma4.block_count": 62u64,
+                "gemma4.attention.head_count_kv": 8u64,
+                "gemma4.attention.key_length": 256u64,
+                "gemma4.attention.value_length": 256u64,
+            }
+        });
+        assert_eq!(
+            parse_kv_geometry_from_show(&raw),
+            Some(KvGeometry {
+                layers: 62,
+                kv_heads: 8,
+                key_length: 256,
+                value_length: 256,
+            })
+        );
+    }
+
+    #[test]
+    fn kv_geometry_falls_back_to_embedding_over_head_count() {
+        // key_length/value_length are optional in GGUF; the head dimension
+        // is then embedding_length / head_count.
+        let raw = serde_json::json!({
+            "model_info": {
+                "general.architecture": "llama",
+                "llama.block_count": 32u64,
+                "llama.attention.head_count_kv": 8u64,
+                "llama.attention.head_count": 32u64,
+                "llama.embedding_length": 4096u64,
+            }
+        });
+        let geo = parse_kv_geometry_from_show(&raw).expect("geometry");
+        assert_eq!(geo.key_length, 128);
+        assert_eq!(geo.value_length, 128);
+    }
+
+    #[test]
+    fn kv_geometry_takes_the_max_of_per_layer_arrays() {
+        // Some GGUFs store head_count_kv per layer. Taking the max keeps the
+        // estimate an upper bound rather than an optimistic one.
+        let raw = serde_json::json!({
+            "model_info": {
+                "general.architecture": "novel",
+                "novel.block_count": 4u64,
+                "novel.attention.head_count_kv": [2u64, 8u64, 2u64, 4u64],
+                "novel.attention.key_length": 64u64,
+                "novel.attention.value_length": 64u64,
+            }
+        });
+        assert_eq!(parse_kv_geometry_from_show(&raw).unwrap().kv_heads, 8);
+    }
+
+    #[test]
+    fn kv_geometry_is_none_without_enough_metadata() {
+        let raw = serde_json::json!({
+            "model_info": { "general.architecture": "llama", "llama.block_count": 32u64 }
+        });
+        assert_eq!(parse_kv_geometry_from_show(&raw), None);
+    }
+
+    #[test]
+    fn kv_cache_bytes_scale_linearly_with_window_and_element_size() {
+        let geo = KvGeometry {
+            layers: 62,
+            kv_heads: 8,
+            key_length: 256,
+            value_length: 256,
+        };
+        // 62 layers * 8 heads * 512 dims * 2 bytes = 507,904 bytes per token.
+        assert_eq!(geo.cache_bytes(1, 2), 507_904);
+        assert_eq!(geo.cache_bytes(1024, 2), 507_904 * 1024);
+        // q8_0 halves it.
+        assert_eq!(geo.cache_bytes(1024, 1), 507_904 * 512);
     }
 
     #[test]

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -14,44 +14,106 @@ const MAX_RETRIES: u32 = 3;
 /// Base delay for exponential backoff (doubles each retry, with jitter).
 const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 
+/// Context window RustyKrab pins by default when the operator hasn't chosen
+/// one.
+///
+/// Pinning matters for KV-cache reuse. Ollama sizes a model runner's KV cache
+/// from the `num_ctx` of the request that loads it; a later request asking for
+/// a different `num_ctx` forces the scheduler to tear the runner down and
+/// reload it, discarding every cached prefix. Omitting `num_ctx` entirely is
+/// worse still: the client then has no idea how much context the server
+/// actually allocated, so its own trimming budget (below) is a guess, and a
+/// prompt that overshoots gets silently truncated server-side — which moves
+/// the truncation point every turn and defeats prefix caching completely.
+///
+/// 32k matches the local-Ollama compaction budget the CLI already assumes.
+const DEFAULT_NUM_CTX: u32 = 32_768;
+
+/// Default `keep_alive` sent with every request: how long Ollama keeps the
+/// model (and its KV cache) resident after the request finishes. Ollama's own
+/// default is 5 minutes, which is far too short for a chat gateway that sees
+/// sporadic traffic — every message after a quiet spell pays a full model
+/// reload plus a cold-cache prompt eval. Override with `OLLAMA_KEEP_ALIVE`.
+const DEFAULT_KEEP_ALIVE: &str = "30m";
+
 /// Configuration for Ollama model inference.
 #[derive(Debug, Clone)]
 pub struct OllamaConfig {
     /// Temperature for sampling (0.0 = deterministic, 0.7 = creative).
     pub temperature: f32,
-    /// Explicit context-window size to send to the Ollama server as
-    /// `options.num_ctx`. When `None` (the default), the value is omitted
-    /// from the request so the server's own configuration is used — e.g.
-    /// its `OLLAMA_CONTEXT_LENGTH` env var or the per-model default.
-    /// Set `OLLAMA_NUM_CTX` on the client to force a specific override.
+    /// Explicit context-window size sent to the Ollama server as
+    /// `options.num_ctx`. Defaults to [`DEFAULT_NUM_CTX`] so client and
+    /// server agree on one stable window; see that constant for why pinning
+    /// beats deferring. `None` restores the old behaviour of omitting the
+    /// field so the server's `OLLAMA_CONTEXT_LENGTH` (or the per-model
+    /// default) wins — select it with `RUSTYKRAB_NUM_CTX=server`.
     pub num_ctx: Option<u32>,
-    /// Number of parallel inference slots.
-    pub num_parallel: u32,
+    /// How long Ollama should keep the model resident after a request, in
+    /// Ollama's duration syntax (`"30m"`, `"1h"`, `"-1"` for forever).
+    /// `None` omits the field and takes the server's 5-minute default.
+    pub keep_alive: Option<String>,
     /// Top-p nucleus sampling threshold.
     pub top_p: f32,
     /// Number of tokens to predict (-1 = unlimited, 0 = fill context).
     pub num_predict: i32,
-    /// Enable thinking mode for models that support it (e.g. Gemma 4).
-    /// When enabled, the model produces `<think>…</think>` reasoning
-    /// blocks before its answer, improving tool-calling accuracy.
-    pub think: bool,
+    /// Enable thinking mode. `None` (the default) decides per model via
+    /// [`think_support`]; `Some(_)` forces the answer. Ollama rejects
+    /// `think` outright for models that don't support it, so this must not
+    /// be sent unconditionally.
+    pub think: Option<bool>,
 }
 
-/// Read `num_ctx` from the environment. Checks `RUSTYKRAB_NUM_CTX` first
-/// (the canonical RustyKrab-namespaced name), then falls back to
-/// `OLLAMA_NUM_CTX` for backward compatibility. Returns `None` when
-/// neither var is set or parseable, so the request omits `num_ctx` and
-/// the Ollama server's own configuration (e.g. `OLLAMA_CONTEXT_LENGTH`)
-/// wins.
+/// Resolve the `num_ctx` to pin from the environment.
+///
+/// Checks `RUSTYKRAB_NUM_CTX` first (the canonical RustyKrab-namespaced
+/// name), then falls back to `OLLAMA_NUM_CTX`. A numeric value pins that
+/// window; `server`/`default`/`0` defers to the Ollama server's own
+/// configuration (returning `None`); anything unset falls back to
+/// [`DEFAULT_NUM_CTX`].
 fn num_ctx_from_env() -> Option<u32> {
-    std::env::var("RUSTYKRAB_NUM_CTX")
+    let raw = std::env::var("RUSTYKRAB_NUM_CTX")
         .ok()
-        .and_then(|v| v.parse::<u32>().ok())
-        .or_else(|| {
-            std::env::var("OLLAMA_NUM_CTX")
-                .ok()
-                .and_then(|v| v.parse::<u32>().ok())
-        })
+        .or_else(|| std::env::var("OLLAMA_NUM_CTX").ok());
+
+    let Some(raw) = raw else {
+        return Some(DEFAULT_NUM_CTX);
+    };
+    let trimmed = raw.trim();
+
+    if matches!(
+        trimmed.to_ascii_lowercase().as_str(),
+        "server" | "default" | "0" | ""
+    ) {
+        return None;
+    }
+
+    match trimmed.parse::<u32>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(
+                value = %raw,
+                default_num_ctx = DEFAULT_NUM_CTX,
+                "could not parse num_ctx override; falling back to the default"
+            );
+            Some(DEFAULT_NUM_CTX)
+        }
+    }
+}
+
+/// Resolve `keep_alive` from `OLLAMA_KEEP_ALIVE`. An empty value or the
+/// literal `server` omits the field and takes Ollama's own default.
+fn keep_alive_from_env() -> Option<String> {
+    match std::env::var("OLLAMA_KEEP_ALIVE") {
+        Ok(v) => {
+            let trimmed = v.trim();
+            if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("server") {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Err(_) => Some(DEFAULT_KEEP_ALIVE.to_string()),
+    }
 }
 
 /// Rough characters-per-token ratio used for client-side context budgeting.
@@ -66,15 +128,19 @@ const PER_MESSAGE_OVERHEAD_TOKENS: u32 = 4;
 /// client can't easily measure (chat template, system tool preamble, etc.).
 const SAFETY_OVERHEAD_TOKENS: u32 = 2048;
 
+/// Percentage of the trimming budget to cut down to once trimming fires.
+/// See `trim_to_budget` for why this is well below 100.
+const TRIM_TARGET_PCT: u32 = 75;
+
 impl Default for OllamaConfig {
     fn default() -> Self {
         Self {
             temperature: 0.1,
             num_ctx: num_ctx_from_env(),
-            num_parallel: 6,
+            keep_alive: keep_alive_from_env(),
             top_p: 0.9,
             num_predict: 8192,
-            think: true,
+            think: None,
         }
     }
 }
@@ -84,23 +150,23 @@ impl OllamaConfig {
     pub fn tool_calling() -> Self {
         Self {
             temperature: 0.0,
-            num_ctx: num_ctx_from_env(),
-            num_parallel: 6,
-            top_p: 0.9,
             num_predict: 4096,
-            think: true,
+            ..Self::default()
         }
     }
 
     /// Configuration for creative drafting (higher temperature).
+    ///
+    /// Note that `num_predict` is a sampling parameter, so varying it
+    /// between presets does not force Ollama to reload the model runner —
+    /// unlike `num_ctx`, which is deliberately shared across all presets so
+    /// a process that mixes them keeps hitting the same warm KV cache.
     pub fn creative() -> Self {
         Self {
             temperature: 0.7,
-            num_ctx: num_ctx_from_env(),
-            num_parallel: 6,
             top_p: 0.95,
             num_predict: 16384,
-            think: true,
+            ..Self::default()
         }
     }
 }
@@ -111,9 +177,10 @@ pub struct OllamaProvider {
     base_url: String,
     model: String,
     config: OllamaConfig,
-    /// Model's native context length discovered from `/api/show`.  Used
-    /// only as a client-side prompt-trimming budget when the user hasn't
-    /// set an explicit `num_ctx`; never sent to the server.
+    /// Model's native context length discovered from `/api/show`.  Used to
+    /// clamp the pinned `num_ctx` down to something the model can actually
+    /// serve, and as the client-side prompt-trimming budget when `num_ctx`
+    /// has been explicitly set to defer to the server.
     detected_ctx: Option<u32>,
 }
 
@@ -164,6 +231,19 @@ impl OllamaProvider {
     /// `None` means the server's own configuration is used.
     pub fn num_ctx(&self) -> Option<u32> {
         self.config.num_ctx
+    }
+
+    /// Get the `keep_alive` that will be sent with each request, if any.
+    pub fn keep_alive(&self) -> Option<&str> {
+        self.config.keep_alive.as_deref()
+    }
+
+    /// Whether `think` will be sent, and with what value. An explicit
+    /// `config.think` wins; otherwise the model tag decides.
+    pub fn resolved_think(&self) -> bool {
+        self.config
+            .think
+            .unwrap_or_else(|| think_support(&self.model))
     }
 
     /// Effective context window used for client-side prompt trimming.
@@ -499,6 +579,15 @@ impl OllamaProvider {
     /// dropped along with any preceding orphaned tool-call assistant turn so
     /// the request stays well-formed.  When `total_ctx` is `None` we have no
     /// budget to enforce so messages pass through unchanged.
+    ///
+    /// Trimming is deliberately hysteretic: once it fires it drops down to
+    /// [`TRIM_TARGET_PCT`] of the budget rather than to the first arrangement
+    /// that fits.  Dropping the oldest messages rewrites the prompt directly
+    /// after the system block, which invalidates every cached token past that
+    /// point.  Trimming to exactly-fits means the very next turn overflows
+    /// again, so *every* subsequent request re-evaluates the whole prompt from
+    /// scratch.  Cutting deeper, less often, confines that cost to one turn in
+    /// many.
     fn trim_to_budget(
         messages: Vec<OllamaMessage>,
         total_ctx: Option<u32>,
@@ -517,6 +606,10 @@ impl OllamaProvider {
             return messages;
         }
 
+        // Target for this trim. `budget` remains the trigger; this is how far
+        // below it we cut once triggered.
+        let target = (budget as u64 * TRIM_TARGET_PCT as u64 / 100) as u32;
+
         let system_count = messages.iter().take_while(|m| m.role == "system").count();
         let mut trimmed = messages;
         let mut current = total;
@@ -524,8 +617,13 @@ impl OllamaProvider {
         // Walk forward from the first non-system message counting how many
         // to drop, then remove them with a single `drain` — per-message
         // `Vec::remove` would shift the entire tail once per drop (O(n·k)).
+        //
+        // The final message is always the turn we are actually asking about,
+        // so stop one short of the end: cutting to `target` must never eat
+        // the live request.
+        let last = trimmed.len().saturating_sub(1);
         let mut drop_end = system_count;
-        while current > budget && drop_end < trimmed.len() {
+        while current > target && drop_end < last {
             current = current.saturating_sub(estimate_message_tokens(&trimmed[drop_end]));
             drop_end += 1;
         }
@@ -543,6 +641,7 @@ impl OllamaProvider {
         tracing::warn!(
             num_ctx = total_ctx,
             budget,
+            target,
             estimated_tokens_before = total,
             estimated_tokens_after = current,
             messages_dropped = dropped,
@@ -611,9 +710,19 @@ impl ModelProvider for OllamaProvider {
             "model": self.model,
             "messages": ollama_messages,
             "stream": false,
-            "think": self.config.think,
             "options": options,
         });
+        // `think` is rejected outright by models that don't support it, so
+        // it is only sent when the model (or an explicit override) says yes.
+        if self.resolved_think() {
+            body["think"] = serde_json::json!(true);
+        }
+        // Keep the model — and with it the KV cache built from this prompt —
+        // resident between turns. Without this Ollama evicts after five idle
+        // minutes and the next message pays a reload plus a cold prompt eval.
+        if let Some(keep_alive) = &self.config.keep_alive {
+            body["keep_alive"] = serde_json::json!(keep_alive);
+        }
 
         if !ollama_tools.is_empty() {
             body["tools"] = serde_json::to_value(&ollama_tools).map_err(Error::Serialization)?;
@@ -769,9 +878,19 @@ impl ModelProvider for OllamaProvider {
             "model": self.model,
             "messages": ollama_messages,
             "stream": true,
-            "think": self.config.think,
             "options": options,
         });
+        // `think` is rejected outright by models that don't support it, so
+        // it is only sent when the model (or an explicit override) says yes.
+        if self.resolved_think() {
+            body["think"] = serde_json::json!(true);
+        }
+        // Keep the model — and with it the KV cache built from this prompt —
+        // resident between turns. Without this Ollama evicts after five idle
+        // minutes and the next message pays a reload plus a cold prompt eval.
+        if let Some(keep_alive) = &self.config.keep_alive {
+            body["keep_alive"] = serde_json::json!(keep_alive);
+        }
 
         if !ollama_tools.is_empty() {
             body["tools"] = serde_json::to_value(&ollama_tools).map_err(Error::Serialization)?;
@@ -1172,6 +1291,46 @@ fn vision_support(model: &str) -> bool {
     }
 }
 
+/// Decide whether to ask the configured Ollama model to think.
+///
+/// Ollama returns a 400 for `think: true` against a model that has no
+/// thinking capability, so this cannot be sent unconditionally. The
+/// `OLLAMA_THINK` env var overrides the heuristic with the same
+/// `true`/`false`/`auto` vocabulary as `OLLAMA_VISION`.
+fn think_support(model: &str) -> bool {
+    match std::env::var("OLLAMA_THINK").ok().as_deref() {
+        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "on" | "yes" => true,
+            "false" | "0" | "off" | "no" => false,
+            // "auto" or anything unrecognized: fall through to the heuristic.
+            _ => model_supports_thinking(model),
+        },
+        None => model_supports_thinking(model),
+    }
+}
+
+/// Heuristic match against known thinking-capable Ollama model families.
+///
+/// Thinking costs output tokens on every turn and its reasoning is stripped
+/// from history before the next call, so it is worth enabling only where it
+/// measurably helps tool-call accuracy. Users can force the answer either
+/// way with `OLLAMA_THINK`.
+fn model_supports_thinking(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    const THINKING_FAMILIES: &[&str] = &[
+        "gemma4",
+        "deepseek-r1",
+        "deepseek-v3.1",
+        "qwen3",
+        "qwq",
+        "gpt-oss",
+        "magistral",
+        "cogito",
+        "smallthinker",
+    ];
+    THINKING_FAMILIES.iter().any(|fam| m.contains(fam))
+}
+
 /// Heuristic match against known vision-capable Ollama model families.
 ///
 /// Matches on the model tag (e.g. `gemma4:26b`, `llava:13b`). New multimodal
@@ -1420,6 +1579,47 @@ mod tests {
     }
 
     #[test]
+    fn trim_cuts_below_budget_so_the_next_turn_does_not_retrim() {
+        // Hysteresis check: trimming to exactly-fits would make the very next
+        // turn overflow again, and each trim rewrites the prompt right after
+        // the system block — invalidating the whole cached prefix. One deep
+        // cut must leave room for several turns of growth.
+        let big = "x".repeat(4000); // ~1000 tokens each
+        let mut msgs = vec![system_msg("sys")];
+        for _ in 0..10 {
+            msgs.push(user_msg(&big));
+        }
+        msgs.push(user_msg("latest"));
+
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024);
+
+        // budget = 8192 - 1024 - 2048 = 5120; target = 75% = 3840.
+        let after: u32 = trimmed.iter().map(estimate_message_tokens).sum();
+        assert!(
+            after <= 3840,
+            "expected trim to reach the 75% target, got {after} tokens"
+        );
+
+        // Re-trimming the same history must now be a no-op — that is the
+        // property that keeps the prefix stable across subsequent turns.
+        let len_before = trimmed.len();
+        let again = OllamaProvider::trim_to_budget(trimmed, Some(8192), 1024);
+        assert_eq!(again.len(), len_before);
+    }
+
+    #[test]
+    fn trim_never_drops_the_live_request() {
+        // A single message larger than the whole target must still be sent:
+        // dropping it would leave the model nothing to answer.
+        let huge = "z".repeat(200_000); // ~50k tokens
+        let msgs = vec![system_msg("sys"), user_msg(&huge)];
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(8192), 1024);
+        assert_eq!(trimmed.len(), 2);
+        assert_eq!(trimmed[0].role, "system");
+        assert_eq!(trimmed[1].role, "user");
+    }
+
+    #[test]
     fn trim_drops_orphan_tool_results_after_truncation() {
         let big = "y".repeat(20_000); // ~5000 tokens
         let msgs = vec![
@@ -1436,36 +1636,92 @@ mod tests {
         assert_eq!(trimmed.last().unwrap().content.as_deref(), Some("latest"));
     }
 
-    #[test]
-    fn default_config_omits_num_ctx_when_env_unset() {
-        // Guard: when neither RUSTYKRAB_NUM_CTX nor OLLAMA_NUM_CTX is set,
-        // constructors leave num_ctx as None so the server's own
-        // OLLAMA_CONTEXT_LENGTH wins.
-        //
-        // std::env is process-global; restore it after the test so we don't
-        // contaminate sibling tests that may set it themselves.
-        let saved_ollama = std::env::var("OLLAMA_NUM_CTX").ok();
+    /// Run `f` with the two num_ctx env vars set to `rk` / `ollama`.
+    ///
+    /// `std::env` is process-global and `cargo test` is multi-threaded, so
+    /// every test that touches these vars serialises on one mutex and
+    /// restores the prior values on the way out.
+    fn with_num_ctx_env<T>(rk: Option<&str>, ollama: Option<&str>, f: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         let saved_rk = std::env::var("RUSTYKRAB_NUM_CTX").ok();
-        // SAFETY: single-threaded section of this test. `cargo test` runs
-        // tests on separate threads by default but we're only reading/writing
-        // our own var and restoring it.
+        let saved_ollama = std::env::var("OLLAMA_NUM_CTX").ok();
+        // SAFETY: all writers of these vars hold ENV_LOCK for the duration.
         unsafe {
-            std::env::remove_var("OLLAMA_NUM_CTX");
-            std::env::remove_var("RUSTYKRAB_NUM_CTX");
-        }
-        assert_eq!(OllamaConfig::default().num_ctx, None);
-        assert_eq!(OllamaConfig::tool_calling().num_ctx, None);
-        assert_eq!(OllamaConfig::creative().num_ctx, None);
-        unsafe {
-            match saved_ollama {
+            match rk {
+                Some(v) => std::env::set_var("RUSTYKRAB_NUM_CTX", v),
+                None => std::env::remove_var("RUSTYKRAB_NUM_CTX"),
+            }
+            match ollama {
                 Some(v) => std::env::set_var("OLLAMA_NUM_CTX", v),
                 None => std::env::remove_var("OLLAMA_NUM_CTX"),
             }
+        }
+        let out = f();
+        unsafe {
             match saved_rk {
                 Some(v) => std::env::set_var("RUSTYKRAB_NUM_CTX", v),
                 None => std::env::remove_var("RUSTYKRAB_NUM_CTX"),
             }
+            match saved_ollama {
+                Some(v) => std::env::set_var("OLLAMA_NUM_CTX", v),
+                None => std::env::remove_var("OLLAMA_NUM_CTX"),
+            }
         }
+        out
+    }
+
+    #[test]
+    fn default_config_pins_num_ctx_when_env_unset() {
+        // Pinning one stable window is what lets Ollama keep a warm runner
+        // across requests, so every preset must land on the same value.
+        with_num_ctx_env(None, None, || {
+            assert_eq!(OllamaConfig::default().num_ctx, Some(DEFAULT_NUM_CTX));
+            assert_eq!(OllamaConfig::tool_calling().num_ctx, Some(DEFAULT_NUM_CTX));
+            assert_eq!(OllamaConfig::creative().num_ctx, Some(DEFAULT_NUM_CTX));
+        });
+    }
+
+    #[test]
+    fn num_ctx_env_override_is_honoured_with_rustykrab_taking_precedence() {
+        with_num_ctx_env(Some("16384"), None, || {
+            assert_eq!(num_ctx_from_env(), Some(16384));
+        });
+        with_num_ctx_env(None, Some("8192"), || {
+            assert_eq!(num_ctx_from_env(), Some(8192));
+        });
+        with_num_ctx_env(Some("16384"), Some("8192"), || {
+            assert_eq!(num_ctx_from_env(), Some(16384));
+        });
+    }
+
+    #[test]
+    fn num_ctx_server_sentinel_defers_to_ollama() {
+        for sentinel in ["server", "SERVER", "default", "0", " "] {
+            with_num_ctx_env(Some(sentinel), None, || {
+                assert_eq!(num_ctx_from_env(), None, "sentinel {sentinel:?}");
+            });
+        }
+    }
+
+    #[test]
+    fn unparseable_num_ctx_falls_back_to_default_rather_than_deferring() {
+        with_num_ctx_env(Some("thirty-two thousand"), None, || {
+            assert_eq!(num_ctx_from_env(), Some(DEFAULT_NUM_CTX));
+        });
+    }
+
+    #[test]
+    fn model_supports_thinking_matches_known_families() {
+        assert!(model_supports_thinking("gemma4:26b"));
+        assert!(model_supports_thinking("qwen3:32b"));
+        assert!(model_supports_thinking("DeepSeek-R1:14b")); // case-insensitive
+
+        // Sending `think` to these would be a 400 from Ollama.
+        assert!(!model_supports_thinking("llama3.1:8b"));
+        assert!(!model_supports_thinking("mistral:7b"));
+        assert!(!model_supports_thinking("qwen2.5:7b"));
     }
 
     #[test]


### PR DESCRIPTION
An agent loop re-sends the whole conversation every iteration, so nearly
all of each prompt is a prefix Ollama already evaluated. The wrapper was
losing that cache in four separate ways:

- num_ctx was omitted by default, so the client could not know what
  window the server allocated. Its trimming budget fell back to the
  model's *native* context length from /api/show, which on a
  long-context model is several times what the server actually
  allocates — so oversized prompts got truncated server-side, at a
  point that moves every turn. Pin one window (default 32k, clamped to
  the model's native length) and send it on every request, so client
  and server agree and the runner is never rebuilt for a size change.
  RUSTYKRAB_NUM_CTX=server restores the old deferring behaviour.

- keep_alive was never sent, leaving Ollama's 5-minute default. A
  gateway that sees sporadic traffic reloaded the model — and threw
  away its cache — on most messages. Default to 30m.

- trim_to_budget cut history down to exactly-fits. Dropping the oldest
  messages rewrites the prompt right after the system block, so the
  whole cached prefix dies; trimming to exactly-fits then overflows
  again on the very next turn, making that a per-turn cost. Cut to 75%
  of budget instead, and never drop the live request.

- num_parallel sat in OllamaConfig but was never sent anywhere. It is a
  server-side setting, and raising it actively hurts cache hits by
  round-robining a conversation across cold slots. Drop the dead field
  and document the server-side tuning (OLLAMA_NUM_PARALLEL,
  OLLAMA_CONTEXT_LENGTH, KV cache quantization) in the README.

Also stop sending `think` unconditionally: Ollama rejects it for models
without thinking support, so it is now gated on the model tag with an
OLLAMA_THINK override, matching the existing OLLAMA_VISION pattern.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018sx9RFWqkt5b6QSbziGxGc