### PR TITLE
Phase 2 (A): the agent can no longer overwrite or delete a credential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tracing",
  "uuid",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -757,7 +757,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // --- Tools ---
-    let mut tools = rustykrab_tools::builtin_tools(store.secrets());
+    let mut tools = rustykrab_tools::builtin_tools(store.secrets(), store.guarded_secrets());
     tools.extend(rustykrab_tools::memory_tools(memory_backend.clone()));
     tools.extend(rustykrab_tools::skill_tools(
         skills_dir.clone(),
@@ -2258,7 +2258,7 @@ async fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
     if rustykrab_store::keychain::keychain_available() {
         let _ = rustykrab_store::keychain::set_credential(svc, spec.keychain_account, &token);
     }
-    let _ = store.secrets().set(spec.store_name, &token).await;
+    let _ = store.secrets().upsert_system(spec.store_name, &token).await;
     token
 }
 
@@ -2411,7 +2411,7 @@ async fn handle_keychain_subcommand(
                 if db_path.exists() {
                     if let Ok(master_key) = rustykrab_store::keychain::resolve_master_key() {
                         if let Ok(store) = rustykrab_store::Store::open(&db_path, master_key) {
-                            let _ = store.secrets().set(sn, value).await;
+                            let _ = store.secrets().upsert_system(sn, value).await;
                             println!("Also stored in encrypted store as '{sn}'");
                         }
                     }

--- a/crates/rustykrab-core/src/error.rs
+++ b/crates/rustykrab-core/src/error.rs
@@ -168,6 +168,21 @@ pub enum Error {
     #[error("not found: {0}")]
     NotFound(String),
 
+    /// A create-only write hit an existing name. Distinct from `Storage` so
+    /// callers can offer "overwrite?" instead of reporting a failure.
+    #[error("already exists: {0}")]
+    AlreadyExists(String),
+
+    /// An agent-authored credential change was queued for the user to
+    /// approve rather than applied. Carries the request id so the agent can
+    /// tell the user what to look for.
+    ///
+    /// Not really an error — it is the guard working — but it travels the
+    /// error path so every tool that writes credentials reports it without
+    /// per-tool code.
+    #[error("change to '{name}' needs your approval (request {request_id})")]
+    PendingApproval { request_id: String, name: String },
+
     #[error("{0}")]
     Internal(String),
 }
@@ -184,6 +199,10 @@ impl Error {
             Error::ModelAuthError(_) | Error::Auth(_) => ToolErrorKind::PermissionDenied,
             Error::ModelBadRequest(_) => ToolErrorKind::InvalidInput,
             Error::NotFound(_) => ToolErrorKind::NotFound,
+            Error::AlreadyExists(_) => ToolErrorKind::InvalidInput,
+            // The agent asked for something it isn't allowed to do
+            // unilaterally; the user now has to decide.
+            Error::PendingApproval { .. } => ToolErrorKind::PermissionDenied,
             Error::ModelProvider(_) | Error::Channel(_) => ToolErrorKind::Transient,
             Error::Config(_)
             | Error::Storage(_)

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -931,14 +931,16 @@ async fn run_suite(
         (Expected::Pass, scenario!(chat_sse_stream_with_tools)),
         (Expected::Pass, scenario!(secrets_create_and_delete)),
         (Expected::Pass, scenario!(agent_creates_new_credential)),
-        // Phase 2 exit criteria — xfail until the guard lands.
+        // Workstream A — the credential guard. Shipped: these assert the
+        // real behaviour now.
+        // Workstream B — device pairing, not built yet.
         (Expected::XFail, scenario!(pair_device_target)),
-        (Expected::XFail, scenario!(secrets_create_only_409)),
-        (Expected::XFail, scenario!(secrets_overwrite_archives)),
-        (Expected::XFail, scenario!(agent_overwrite_files_request)),
-        (Expected::XFail, scenario!(approve_applies_change)),
-        (Expected::XFail, scenario!(deny_preserves_value)),
-        (Expected::XFail, scenario!(agent_delete_files_request)),
+        (Expected::Pass, scenario!(secrets_create_only_409)),
+        (Expected::Pass, scenario!(secrets_overwrite_archives)),
+        (Expected::Pass, scenario!(agent_overwrite_files_request)),
+        (Expected::Pass, scenario!(approve_applies_change)),
+        (Expected::Pass, scenario!(deny_preserves_value)),
+        (Expected::Pass, scenario!(agent_delete_files_request)),
         (Expected::XFail, scenario!(revoked_device_401)),
     ];
 

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -44,6 +44,15 @@ pub fn api_routes() -> Router<AppState> {
         .route("/api/secrets", get(list_secrets))
         .route("/api/secrets", post(set_secret))
         .route("/api/secrets/{name}", axum::routing::delete(delete_secret))
+        .route("/api/credential-requests", get(list_credential_requests))
+        .route(
+            "/api/credential-requests/{id}/approve",
+            post(approve_credential_request),
+        )
+        .route(
+            "/api/credential-requests/{id}/deny",
+            post(deny_credential_request),
+        )
         .route("/api/health", get(health))
         .route("/api/logout", post(logout))
 }
@@ -698,24 +707,60 @@ struct SetSecretRequest {
     /// macOS Keychain account name (required when `dest == "keychain"`).
     #[serde(default)]
     account: Option<String>,
+    /// Replace an existing credential rather than refusing with `409`.
+    ///
+    /// Clients send this only after an explicit confirmation — that flag
+    /// *is* the user's approval for a user-initiated overwrite.
+    #[serde(default)]
+    overwrite: bool,
+}
+
+/// Per-secret metadata. Values are never included.
+#[derive(serde::Serialize)]
+struct SecretEntry {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<i64>,
+    version: i64,
 }
 
 #[derive(serde::Serialize)]
 struct ListSecretsResponse {
+    /// Names only, kept so existing clients keep working.
     names: Vec<String>,
+    /// Name + timestamps + version.
+    secrets: Vec<SecretEntry>,
     keychain_available: bool,
+    /// Same value under the camelCase name the app's contract uses. Both
+    /// are emitted so the WebChat UI and Apollo can each read the shape
+    /// they expect without a flag day.
+    #[serde(rename = "keychainAvailable")]
+    keychain_available_camel: bool,
 }
 
 async fn list_secrets(
     State(state): State<AppState>,
 ) -> Result<Json<ListSecretsResponse>, StatusCode> {
-    let names = state.store.secrets().list_names().await.map_err(|e| {
+    let meta = state.store.secrets().metadata().await.map_err(|e| {
         tracing::error!(error = %e, "list_secrets failed");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
+    let available = rustykrab_store::keychain::keychain_available();
     Ok(Json(ListSecretsResponse {
-        names,
-        keychain_available: rustykrab_store::keychain::keychain_available(),
+        names: meta.iter().map(|m| m.name.clone()).collect(),
+        secrets: meta
+            .into_iter()
+            .map(|m| SecretEntry {
+                name: m.name,
+                created_at: m.created_at,
+                updated_at: m.updated_at,
+                version: m.version,
+            })
+            .collect(),
+        keychain_available: available,
+        keychain_available_camel: available,
     }))
 }
 
@@ -732,16 +777,38 @@ async fn set_secret(
 
     match body.dest {
         SecretDest::Store => {
-            state
-                .store
-                .secrets()
-                .set(&body.name, &body.value)
-                .await
-                .map_err(|e| {
-                    tracing::warn!(error = %e, name = %body.name, "set_secret: store write failed");
+            let secrets = state.store.secrets();
+            // Create-only by default. Replacing an existing credential is a
+            // separate, explicit act — the client must have asked the user
+            // first and sent `overwrite: true`.
+            let result = if body.overwrite {
+                secrets
+                    .overwrite(
+                        &body.name,
+                        &body.value,
+                        rustykrab_store::WriteAuthority::User { device: None },
+                    )
+                    .await
+            } else {
+                secrets.create(&body.name, &body.value).await
+            };
+            result.map_err(|e| match e {
+                rustykrab_core::Error::AlreadyExists(_) => {
+                    tracing::info!(name = %body.name, "set_secret: refused, name exists");
+                    StatusCode::CONFLICT
+                }
+                rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
+                other => {
+                    tracing::warn!(error = %other, name = %body.name, "set_secret: store write failed");
                     StatusCode::BAD_REQUEST
-                })?;
-            tracing::info!(name = %body.name, dest = "store", "secret stored");
+                }
+            })?;
+            tracing::info!(
+                name = %body.name,
+                dest = "store",
+                overwrite = body.overwrite,
+                "secret stored"
+            );
         }
         SecretDest::Keychain => {
             if !rustykrab_store::keychain::keychain_available() {
@@ -770,11 +837,113 @@ async fn delete_secret(
     State(state): State<AppState>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
-    state.store.secrets().delete(&name).await.map_err(|e| {
-        tracing::error!(error = %e, "delete_secret failed");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    state
+        .store
+        .secrets()
+        .delete(
+            &name,
+            rustykrab_store::WriteAuthority::User { device: None },
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "delete_secret failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     tracing::info!(name = %name, "secret deleted");
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── credential change requests ──────────────────────────────────────
+//
+// The agent files these; only an authenticated user resolves them. The
+// agent runs in-process and holds no HTTP credentials, so it physically
+// cannot reach these routes.
+
+/// A pending change, as the app and WebChat see it. Never the value.
+#[derive(serde::Serialize)]
+struct ChangeRequestResponse {
+    id: String,
+    name: String,
+    action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(rename = "conversationId", skip_serializing_if = "Option::is_none")]
+    conversation_id: Option<String>,
+    status: String,
+    #[serde(rename = "createdAt")]
+    created_at: i64,
+}
+
+async fn list_credential_requests(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ChangeRequestResponse>>, StatusCode> {
+    let pending = state
+        .store
+        .credential_requests()
+        .pending()
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "listing credential requests failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(
+        pending
+            .into_iter()
+            .map(|r| ChangeRequestResponse {
+                id: r.id,
+                name: r.name,
+                action: r.action.as_str().to_string(),
+                reason: r.reason,
+                conversation_id: r.conversation_id,
+                status: r.status,
+                created_at: r.created_at,
+            })
+            .collect(),
+    ))
+}
+
+async fn approve_credential_request(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    decide_credential_request(state, id, true).await
+}
+
+async fn deny_credential_request(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    decide_credential_request(state, id, false).await
+}
+
+async fn decide_credential_request(
+    state: AppState,
+    id: String,
+    approve: bool,
+) -> Result<StatusCode, StatusCode> {
+    let requests = state.store.credential_requests();
+    // TODO(devices): attribute to the deciding device once per-device
+    // tokens land; until then every decision is the master token.
+    let decided_by = "webchat";
+    let result = if approve {
+        requests.approve(&id, decided_by).await
+    } else {
+        requests.deny(&id, decided_by).await
+    };
+    result.map_err(|e| match e {
+        // Already decided, or the credential moved since the request was
+        // filed — approving now would undo whatever the user did instead.
+        rustykrab_core::Error::AlreadyExists(reason) => {
+            tracing::info!(%id, %reason, "credential request decision refused as stale");
+            StatusCode::CONFLICT
+        }
+        rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
+        other => {
+            tracing::error!(error = %other, %id, "credential request decision failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
+    tracing::info!(%id, approved = approve, "credential request decided");
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/rustykrab-store/Cargo.toml
+++ b/crates/rustykrab-store/Cargo.toml
@@ -25,3 +25,6 @@ zeroize.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -1,0 +1,371 @@
+//! Pending credential changes the agent asked for and the user must decide.
+//!
+//! The agent can create a credential under a new name, but replacing or
+//! deleting one it doesn't own is not its call to make. Those attempts land
+//! here as rows the user resolves from the app or WebChat.
+//!
+//! A queued proposal is encrypted exactly like a secret (AAD = the request
+//! id), so a pending request is never a plaintext copy of a credential
+//! sitting in the database.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use rusqlite::params;
+use rustykrab_core::Error;
+use uuid::Uuid;
+
+use crate::secret::{SecretStore, WriteAuthority};
+
+/// How long a pending request survives before it is swept.
+pub const REQUEST_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestAction {
+    Update,
+    Delete,
+}
+
+impl RequestAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RequestAction::Update => "update",
+            RequestAction::Delete => "delete",
+        }
+    }
+
+    fn parse(raw: &str) -> Result<Self, Error> {
+        match raw {
+            "update" => Ok(RequestAction::Update),
+            "delete" => Ok(RequestAction::Delete),
+            other => Err(Error::Storage(format!("unknown request action '{other}'"))),
+        }
+    }
+}
+
+/// A credential change request. Never carries the proposed value — no
+/// caller outside `approve` has any business seeing it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialRequest {
+    pub id: String,
+    pub name: String,
+    pub action: RequestAction,
+    pub reason: Option<String>,
+    pub conversation_id: Option<String>,
+    pub status: String,
+    pub created_at: i64,
+}
+
+#[derive(Clone)]
+pub struct CredentialRequestStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+    secrets: SecretStore,
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+impl CredentialRequestStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>, secrets: SecretStore) -> Self {
+        Self { conn, secrets }
+    }
+
+    /// Queue a replacement of an existing credential.
+    ///
+    /// Filing supersedes any earlier pending request for the same name: the
+    /// user should be deciding on the agent's latest intent, not working
+    /// through a backlog of stale proposals.
+    pub async fn file_update(
+        &self,
+        name: &str,
+        proposed_value: &str,
+        reason: Option<String>,
+        conversation_id: Option<Uuid>,
+    ) -> Result<String, Error> {
+        let id = Uuid::new_v4().to_string();
+        // AAD ties the ciphertext to this request: a proposal cannot be
+        // lifted into another request or applied to another name.
+        let encrypted = self
+            .secrets
+            .encrypt_with_aad(&id, proposed_value.as_bytes())?;
+        let target_version = self.secrets.version_of(name).await?;
+        self.insert(
+            id.clone(),
+            name,
+            RequestAction::Update,
+            Some(encrypted),
+            reason,
+            conversation_id,
+            target_version,
+        )
+        .await?;
+        Ok(id)
+    }
+
+    /// Queue a deletion.
+    pub async fn file_delete(
+        &self,
+        name: &str,
+        reason: Option<String>,
+        conversation_id: Option<Uuid>,
+    ) -> Result<String, Error> {
+        let id = Uuid::new_v4().to_string();
+        let target_version = self.secrets.version_of(name).await?;
+        self.insert(
+            id.clone(),
+            name,
+            RequestAction::Delete,
+            None,
+            reason,
+            conversation_id,
+            target_version,
+        )
+        .await?;
+        Ok(id)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert(
+        &self,
+        id: String,
+        name: &str,
+        action: RequestAction,
+        proposed: Option<Vec<u8>>,
+        reason: Option<String>,
+        conversation_id: Option<Uuid>,
+        target_version: Option<i64>,
+    ) -> Result<(), Error> {
+        let name = name.to_string();
+        let conversation = conversation_id.map(|c| c.to_string());
+        crate::with_conn(&self.conn, move |conn| {
+            // Newer intent replaces older intent for the same credential.
+            conn.execute(
+                "UPDATE credential_requests SET status = 'superseded', decided_at = ?2
+                 WHERE name = ?1 AND status = 'pending'",
+                params![name, now_ms()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            conn.execute(
+                "INSERT INTO credential_requests
+                    (id, name, action, proposed_data, reason, conversation_id,
+                     status, created_at, target_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?8)",
+                params![
+                    id,
+                    name,
+                    action.as_str(),
+                    proposed,
+                    reason,
+                    conversation,
+                    now_ms(),
+                    target_version
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Pending requests, newest first. Expired ones are swept on the way
+    /// through rather than by a background timer.
+    pub async fn pending(&self) -> Result<Vec<CredentialRequest>, Error> {
+        self.sweep_expired().await?;
+        crate::with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, name, action, reason, conversation_id, status, created_at
+                     FROM credential_requests WHERE status = 'pending'
+                     ORDER BY created_at DESC",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, String>(5)?,
+                        row.get::<_, i64>(6)?,
+                    ))
+                })
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                let (id, name, action, reason, conversation_id, status, created_at) =
+                    row.map_err(|e| Error::Storage(e.to_string()))?;
+                out.push(CredentialRequest {
+                    id,
+                    name,
+                    action: RequestAction::parse(&action)?,
+                    reason,
+                    conversation_id,
+                    status,
+                    created_at,
+                });
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// Mark long-untouched requests expired so they stop showing up as
+    /// things the user still has to decide.
+    pub async fn sweep_expired(&self) -> Result<usize, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let cutoff = now_ms() - REQUEST_TTL_MS;
+            let n = conn
+                .execute(
+                    "UPDATE credential_requests
+                     SET status = 'expired', decided_at = ?2, proposed_data = NULL
+                     WHERE status = 'pending' AND created_at < ?1",
+                    params![cutoff, now_ms()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(n)
+        })
+        .await
+    }
+
+    /// Apply a pending request with `User` authority.
+    ///
+    /// Refused with [`Error::AlreadyExists`] — surfaced as `409` — when the
+    /// credential moved after the request was filed. Approving then would
+    /// silently undo whatever the user did in the meantime, which is the
+    /// exact class of surprise this whole feature exists to prevent.
+    pub async fn approve(&self, id: &str, decided_by: &str) -> Result<(), Error> {
+        let row = self.load(id).await?;
+        if row.status != "pending" {
+            return Err(Error::AlreadyExists(format!(
+                "request {id} is already {}",
+                row.status
+            )));
+        }
+        let current_version = self.secrets.version_of(&row.name).await?;
+        if current_version != row.target_version {
+            return Err(Error::AlreadyExists(format!(
+                "'{}' changed since this request was filed",
+                row.name
+            )));
+        }
+
+        let authority = WriteAuthority::User {
+            device: Some(decided_by.to_string()),
+        };
+        match row.action {
+            RequestAction::Update => {
+                let proposed = row
+                    .proposed
+                    .ok_or_else(|| Error::Storage("request has no proposed value".into()))?;
+                let plaintext = self.secrets.decrypt_with_aad(id, &proposed)?;
+                let value = String::from_utf8(plaintext)
+                    .map_err(|e| Error::Storage(format!("invalid utf-8 in proposal: {e}")))?;
+                match current_version {
+                    Some(_) => self.secrets.overwrite(&row.name, &value, authority).await?,
+                    // The target was deleted after filing; honouring the
+                    // request means recreating it.
+                    None => self.secrets.create(&row.name, &value).await?,
+                }
+            }
+            RequestAction::Delete => {
+                self.secrets.delete(&row.name, authority).await?;
+            }
+        }
+
+        self.decide(id, "approved", decided_by, &row.name, "approve")
+            .await
+    }
+
+    /// Reject a request and wipe the proposal — a denied value should not
+    /// linger in the database.
+    pub async fn deny(&self, id: &str, decided_by: &str) -> Result<(), Error> {
+        let row = self.load(id).await?;
+        if row.status != "pending" {
+            return Err(Error::AlreadyExists(format!(
+                "request {id} is already {}",
+                row.status
+            )));
+        }
+        self.decide(id, "denied", decided_by, &row.name, "deny")
+            .await
+    }
+
+    async fn decide(
+        &self,
+        id: &str,
+        status: &str,
+        decided_by: &str,
+        name: &str,
+        audit_op: &str,
+    ) -> Result<(), Error> {
+        let id = id.to_string();
+        let status = status.to_string();
+        let decided_by = decided_by.to_string();
+        let name = name.to_string();
+        let audit_op = audit_op.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE credential_requests
+                 SET status = ?2, decided_at = ?3, decided_by = ?4, proposed_data = NULL
+                 WHERE id = ?1",
+                params![id, status, now_ms(), decided_by],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            conn.execute(
+                "INSERT INTO secret_audit (name, op, authority, request_id, at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![name, audit_op, format!("user:{decided_by}"), id, now_ms()],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn load(&self, id: &str) -> Result<StoredRequest, Error> {
+        let id = id.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name, action, proposed_data, status, target_version
+                     FROM credential_requests WHERE id = ?1",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let row = stmt
+                .query_row(params![id], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<Vec<u8>>>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<i64>>(4)?,
+                    ))
+                })
+                .map_err(|e| match e {
+                    rusqlite::Error::QueryReturnedNoRows => {
+                        Error::NotFound(format!("credential request '{id}'"))
+                    }
+                    other => Error::Storage(other.to_string()),
+                })?;
+            Ok(StoredRequest {
+                name: row.0,
+                action: RequestAction::parse(&row.1)?,
+                proposed: row.2,
+                status: row.3,
+                target_version: row.4,
+            })
+        })
+        .await
+    }
+}
+
+struct StoredRequest {
+    name: String,
+    action: RequestAction,
+    proposed: Option<Vec<u8>>,
+    status: String,
+    target_version: Option<i64>,
+}

--- a/crates/rustykrab-store/src/guarded.rs
+++ b/crates/rustykrab-store/src/guarded.rs
@@ -1,0 +1,188 @@
+//! The agent's view of credential storage.
+//!
+//! Every tool that can write a credential is handed a [`GuardedSecrets`]
+//! instead of a [`SecretStore`], so the policy lives in the type the tools
+//! hold rather than in a check each tool has to remember. Creating a new
+//! credential works normally; replacing or deleting one files a request for
+//! the user to decide.
+//!
+//! Reads are unchanged — the agent needs credentials to do its job, and
+//! restricting reads is a separate question (plan §14).
+
+use rustykrab_core::Error;
+use uuid::Uuid;
+
+use crate::credential_request::CredentialRequestStore;
+use crate::secret::SecretStore;
+
+/// What happened to an agent-initiated write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteOutcome {
+    /// The name was free; the credential now exists.
+    Created,
+    /// The name was taken, so the change is queued for the user.
+    PendingApproval { request_id: String },
+}
+
+#[derive(Clone)]
+pub struct GuardedSecrets {
+    secrets: SecretStore,
+    requests: CredentialRequestStore,
+    /// Conversation the current tool call belongs to, recorded on any
+    /// request filed so the user can see what prompted it.
+    conversation_id: Option<Uuid>,
+}
+
+impl GuardedSecrets {
+    pub(crate) fn new(secrets: SecretStore, requests: CredentialRequestStore) -> Self {
+        Self {
+            secrets,
+            requests,
+            conversation_id: None,
+        }
+    }
+
+    /// Attribute anything filed through this handle to a conversation.
+    pub fn for_conversation(&self, conversation_id: Uuid) -> Self {
+        Self {
+            secrets: self.secrets.clone(),
+            requests: self.requests.clone(),
+            conversation_id: Some(conversation_id),
+        }
+    }
+
+    /// Store a credential, or queue the change if the name is taken.
+    ///
+    /// Returns [`WriteOutcome`] rather than failing, so `credential_write`
+    /// can tell the user "waiting for your approval" as a normal result.
+    pub async fn set(&self, name: &str, value: &str) -> Result<WriteOutcome, Error> {
+        self.set_with_reason(name, value, None).await
+    }
+
+    pub async fn set_with_reason(
+        &self,
+        name: &str,
+        value: &str,
+        reason: Option<String>,
+    ) -> Result<WriteOutcome, Error> {
+        match self.secrets.create(name, value).await {
+            Ok(()) => Ok(WriteOutcome::Created),
+            Err(Error::AlreadyExists(_)) => {
+                let request_id = self
+                    .requests
+                    .file_update(name, value, reason, self.conversation_id)
+                    .await?;
+                Ok(WriteOutcome::PendingApproval { request_id })
+            }
+            Err(other) => Err(other),
+        }
+    }
+
+    /// Like [`set`](Self::set) but reports a queued change as an error.
+    ///
+    /// For the configure flows (Gmail, CalDAV, Obsidian) that have no place
+    /// to put a "pending" result: [`Error::PendingApproval`] carries the
+    /// request id and renders as a self-explanatory message.
+    pub async fn set_strict(&self, name: &str, value: &str) -> Result<(), Error> {
+        match self.set(name, value).await? {
+            WriteOutcome::Created => Ok(()),
+            WriteOutcome::PendingApproval { request_id } => Err(Error::PendingApproval {
+                request_id,
+                name: name.to_string(),
+            }),
+        }
+    }
+
+    /// Queue a deletion. Deleting is never immediate for the agent, even
+    /// for a credential it created itself — by the time it asks, the user
+    /// may be relying on it.
+    pub async fn delete(&self, name: &str) -> Result<WriteOutcome, Error> {
+        // Nothing to queue if the credential doesn't exist.
+        if self.secrets.version_of(name).await?.is_none() {
+            return Err(Error::NotFound(format!("secret '{name}'")));
+        }
+        let request_id = self
+            .requests
+            .file_delete(name, None, self.conversation_id)
+            .await?;
+        Ok(WriteOutcome::PendingApproval { request_id })
+    }
+
+    // -- reads pass straight through --------------------------------------
+
+    pub async fn get(&self, name: &str) -> Result<String, Error> {
+        self.secrets.get(name).await
+    }
+
+    pub async fn list_names(&self) -> Result<Vec<String>, Error> {
+        self.secrets.list_names().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn guarded() -> (tempfile::TempDir, GuardedSecrets, SecretStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path(), vec![9u8; 32]).expect("open");
+        (dir, store.guarded_secrets(), store.secrets())
+    }
+
+    #[tokio::test]
+    async fn new_names_are_created_outright() {
+        let (_dir, guard, secrets) = guarded();
+        let outcome = guard.set("fresh_token", "value").await.unwrap();
+        assert_eq!(outcome, WriteOutcome::Created);
+        assert_eq!(secrets.get("fresh_token").await.unwrap(), "value");
+    }
+
+    #[tokio::test]
+    async fn overwriting_queues_and_leaves_the_value_alone() {
+        let (_dir, guard, secrets) = guarded();
+        secrets.create("held", "original").await.unwrap();
+
+        let outcome = guard.set("held", "hijacked").await.unwrap();
+        let request_id = match outcome {
+            WriteOutcome::PendingApproval { request_id } => request_id,
+            other => panic!("expected a pending request, got {other:?}"),
+        };
+
+        // The credential is untouched until the user decides.
+        assert_eq!(secrets.get("held").await.unwrap(), "original");
+        assert_eq!(secrets.version_of("held").await.unwrap(), Some(1));
+
+        let pending = guard.requests.pending().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, request_id);
+        assert_eq!(pending[0].name, "held");
+    }
+
+    #[tokio::test]
+    async fn deleting_always_queues() {
+        let (_dir, guard, secrets) = guarded();
+        // Even a credential the agent created itself.
+        guard.set("agents_own", "v").await.unwrap();
+
+        let outcome = guard.delete("agents_own").await.unwrap();
+        assert!(matches!(outcome, WriteOutcome::PendingApproval { .. }));
+        assert_eq!(secrets.get("agents_own").await.unwrap(), "v");
+    }
+
+    #[tokio::test]
+    async fn strict_mode_reports_a_queued_change_as_an_error() {
+        let (_dir, guard, secrets) = guarded();
+        secrets.create("configured", "original").await.unwrap();
+
+        let result = guard.set_strict("configured", "new").await;
+        match result {
+            Err(Error::PendingApproval { name, request_id }) => {
+                assert_eq!(name, "configured");
+                assert!(!request_id.is_empty());
+            }
+            other => panic!("expected PendingApproval, got {other:?}"),
+        }
+        assert_eq!(secrets.get("configured").await.unwrap(), "original");
+    }
+}

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -1,5 +1,7 @@
 mod chat_map;
 mod conversation;
+mod credential_request;
+mod guarded;
 mod jobs;
 pub mod keychain;
 mod recall_archive;
@@ -16,9 +18,11 @@ use zeroize::Zeroizing;
 
 pub use chat_map::ChatMapStore;
 pub use conversation::{ConversationStore, ConversationSummary};
+pub use credential_request::{CredentialRequest, CredentialRequestStore, RequestAction};
+pub use guarded::{GuardedSecrets, WriteOutcome};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
 pub use recall_archive::RecallArchiveStore;
-pub use secret::SecretStore;
+pub use secret::{SecretMeta, SecretStore, WriteAuthority};
 pub use slack_chat_map::SlackChatMapStore;
 
 /// Top-level database handle wrapping a SQLite connection.
@@ -146,6 +150,51 @@ impl Store {
                 created_at      TEXT NOT NULL,
                 updated_at      TEXT NOT NULL
             );
+
+            -- Credential guard (docs/plans/apollo-ios-and-credential-guard.md).
+            -- An agent-authored change to an existing credential lands here
+            -- instead of being applied, and the user resolves it.
+            CREATE TABLE IF NOT EXISTS credential_requests (
+                id              TEXT PRIMARY KEY,
+                name            TEXT NOT NULL,
+                action          TEXT NOT NULL,      -- 'update' | 'delete'
+                proposed_data   BLOB,               -- encrypted; NULL for delete
+                reason          TEXT,
+                conversation_id TEXT,
+                status          TEXT NOT NULL DEFAULT 'pending',
+                created_at      INTEGER NOT NULL,
+                decided_at      INTEGER,
+                decided_by      TEXT,
+                -- Version of the target when the request was filed, so a
+                -- stale approval cannot clobber a newer user edit.
+                target_version  INTEGER
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_credential_requests_pending
+                ON credential_requests (name) WHERE status = 'pending';
+
+            -- Superseded values, kept encrypted, so an approved change or a
+            -- mistaken delete is recoverable.
+            CREATE TABLE IF NOT EXISTS secret_versions (
+                name        TEXT NOT NULL,
+                version     INTEGER NOT NULL,
+                data        BLOB NOT NULL,
+                replaced_at INTEGER NOT NULL,
+                replaced_by TEXT NOT NULL,
+                PRIMARY KEY (name, version)
+            );
+
+            CREATE TABLE IF NOT EXISTS secret_audit (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                name       TEXT NOT NULL,
+                op         TEXT NOT NULL,   -- create|overwrite|delete|approve|deny
+                authority  TEXT NOT NULL,
+                request_id TEXT,
+                at         INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_secret_audit_name
+                ON secret_audit (name, at DESC);
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -178,6 +227,39 @@ impl Store {
                 [],
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+
+        // Versioning columns on `secrets`. Rows written before the guard
+        // existed keep NULL timestamps — back-filling them with "now" would
+        // claim every old credential was created at upgrade time — and read
+        // as version 1.
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(secrets)")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let existing: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        drop(stmt);
+        for (column, ddl) in [
+            (
+                "created_at",
+                "ALTER TABLE secrets ADD COLUMN created_at INTEGER",
+            ),
+            (
+                "updated_at",
+                "ALTER TABLE secrets ADD COLUMN updated_at INTEGER",
+            ),
+            (
+                "version",
+                "ALTER TABLE secrets ADD COLUMN version INTEGER NOT NULL DEFAULT 1",
+            ),
+        ] {
+            if !existing.iter().any(|c| c == column) {
+                conn.execute(ddl, [])
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+            }
         }
 
         // `job_runs.rustykrab_version` records which build executed each run.
@@ -241,6 +323,20 @@ impl Store {
     /// Return a handle for encrypted secret operations.
     pub fn secrets(&self) -> SecretStore {
         SecretStore::new(Arc::clone(&self.conn), self.master_key.clone())
+    }
+
+    /// Handle for the credential-change requests the agent files and the
+    /// user resolves.
+    pub fn credential_requests(&self) -> CredentialRequestStore {
+        CredentialRequestStore::new(Arc::clone(&self.conn), self.secrets())
+    }
+
+    /// The agent-facing view of credential storage: create-only, with
+    /// overwrites and deletes queued for approval. Tools receive this
+    /// rather than [`SecretStore`], so the guard cannot be bypassed by
+    /// forgetting a check.
+    pub fn guarded_secrets(&self) -> GuardedSecrets {
+        GuardedSecrets::new(self.secrets(), self.credential_requests())
     }
 
     /// Return a handle for scheduled-job operations.

--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -115,7 +115,7 @@ pub async fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String>
             if keychain::keychain_available() {
                 let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
             }
-            let _ = secrets.set(spec.store_name, &val).await;
+            let _ = secrets.upsert_system(spec.store_name, &val).await;
             return Some(val);
         }
     }
@@ -123,7 +123,7 @@ pub async fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String>
     // 2. OS credential store.
     if keychain::keychain_available() {
         if let Ok(Some(cred)) = keychain::get_credential(KEYCHAIN_SERVICE, spec.keychain_account) {
-            let _ = secrets.set(spec.store_name, &cred.value).await;
+            let _ = secrets.upsert_system(spec.store_name, &cred.value).await;
             return Some(cred.value);
         }
     }

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -16,6 +16,58 @@ const SALT_LEN: usize = 16;
 /// The nonce length for AES-256-GCM (96 bits).
 const NONCE_LEN: usize = 12;
 
+/// Who is performing a credential write.
+///
+/// The whole point of the guard is that "the agent changed it" and "the user
+/// changed it" are different events, so authority is a parameter of the write
+/// rather than something inferred from context. `Agent` is refused by every
+/// destructive operation at this layer — not by a check in each tool — so a
+/// new tool cannot forget to ask.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteAuthority {
+    /// An explicit human action through an authenticated client.
+    User { device: Option<String> },
+    /// Startup mirroring: env var → keychain → store.
+    System,
+    /// A tool call. Create-only.
+    Agent { conversation_id: Option<uuid::Uuid> },
+}
+
+impl WriteAuthority {
+    /// Short description recorded in the audit trail.
+    pub fn describe(&self) -> String {
+        match self {
+            WriteAuthority::User { device: Some(d) } => format!("user:{d}"),
+            WriteAuthority::User { device: None } => "user".to_string(),
+            WriteAuthority::System => "system".to_string(),
+            WriteAuthority::Agent {
+                conversation_id: Some(c),
+            } => format!("agent:{c}"),
+            WriteAuthority::Agent {
+                conversation_id: None,
+            } => "agent".to_string(),
+        }
+    }
+
+    pub fn is_agent(&self) -> bool {
+        matches!(self, WriteAuthority::Agent { .. })
+    }
+}
+
+/// Per-secret metadata. Values are never included — no endpoint returns one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretMeta {
+    pub name: String,
+    /// Epoch milliseconds; `None` for rows written before versioning existed.
+    pub created_at: Option<i64>,
+    pub updated_at: Option<i64>,
+    pub version: i64,
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
 /// Encrypted credential store backed by SQLite.
 ///
 /// Secrets are encrypted at rest using AES-256-GCM (authenticated encryption
@@ -48,12 +100,17 @@ impl SecretStore {
         }
     }
 
-    /// Store a secret value under the given name.
+    /// Store a **new** secret. Fails with [`Error::AlreadyExists`] if the
+    /// name is taken.
+    ///
+    /// There is deliberately no `set()` that upserts: silently replacing a
+    /// credential is exactly the behaviour the guard exists to prevent, so
+    /// the API forces callers to say whether they mean create or overwrite,
+    /// and overwrite demands an authority.
     ///
     /// The Argon2id key derivation and SQLite write both run on tokio's
     /// blocking pool — neither may occupy an async worker thread.
-    pub async fn set(&self, name: &str, value: &str) -> Result<(), Error> {
-        // Validate secret name to prevent injection and normalization attacks
+    pub async fn create(&self, name: &str, value: &str) -> Result<(), Error> {
         Self::validate_name(name)?;
 
         let store = self.clone();
@@ -62,15 +119,83 @@ impl SecretStore {
         run_blocking(move || {
             let encrypted = store.encrypt(&name, value.as_bytes())?;
             let conn = store.conn.lock().unwrap();
-            conn.execute(
-                "INSERT INTO secrets (name, data) VALUES (?1, ?2)
-                 ON CONFLICT(name) DO UPDATE SET data = excluded.data",
-                params![name, encrypted],
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+            let now = now_ms();
+            let rows = conn
+                .execute(
+                    "INSERT INTO secrets (name, data, created_at, updated_at, version)
+                     VALUES (?1, ?2, ?3, ?3, 1)
+                     ON CONFLICT(name) DO NOTHING",
+                    params![name, encrypted, now],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if rows == 0 {
+                return Err(Error::AlreadyExists(format!("secret '{name}'")));
+            }
+            Self::audit(&conn, &name, "create", "create", None)?;
             Ok(())
         })
         .await
+    }
+
+    /// Replace an existing secret, archiving the superseded value.
+    ///
+    /// Refuses [`WriteAuthority::Agent`]: an agent that wants to replace a
+    /// credential must file a request instead (see `GuardedSecrets`).
+    pub async fn overwrite(
+        &self,
+        name: &str,
+        value: &str,
+        authority: WriteAuthority,
+    ) -> Result<(), Error> {
+        Self::validate_name(name)?;
+        if authority.is_agent() {
+            return Err(Error::Auth(format!(
+                "the agent cannot overwrite '{name}' directly"
+            )));
+        }
+
+        let store = self.clone();
+        let name = name.to_string();
+        let value = Zeroizing::new(value.to_string());
+        run_blocking(move || {
+            let encrypted = store.encrypt(&name, value.as_bytes())?;
+            let mut conn = store.conn.lock().unwrap();
+            let tx = conn
+                .transaction()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let (previous, version) = Self::current_row(&tx, &name)?
+                .ok_or_else(|| Error::NotFound(format!("secret '{name}'")))?;
+            Self::archive(&tx, &name, version, &previous, &authority)?;
+            tx.execute(
+                "UPDATE secrets SET data = ?2, updated_at = ?3, version = ?4 WHERE name = ?1",
+                params![name, encrypted, now_ms(), version + 1],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Self::audit(&tx, &name, "overwrite", &authority.describe(), None)?;
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Create the secret if absent, replace it if the value actually
+    /// changed, and do nothing when it already matches.
+    ///
+    /// This is the startup-mirroring path (env var → keychain → store).
+    /// Skipping no-op writes matters: the registry runs on every boot, and
+    /// rewriting an unchanged value would inflate the version and fill the
+    /// audit trail with events nobody performed.
+    pub async fn upsert_system(&self, name: &str, value: &str) -> Result<(), Error> {
+        match self.get(name).await {
+            Ok(existing) if existing == value => Ok(()),
+            Ok(_) => self.overwrite(name, value, WriteAuthority::System).await,
+            Err(Error::NotFound(_)) => match self.create(name, value).await {
+                // Lost a race with another writer; the value is present.
+                Err(Error::AlreadyExists(_)) => Ok(()),
+                other => other,
+            },
+            Err(e) => Err(e),
+        }
     }
 
     /// Retrieve and decrypt a secret by name.
@@ -100,15 +225,132 @@ impl SecretStore {
         .await
     }
 
-    /// Delete a secret.
-    pub async fn delete(&self, name: &str) -> Result<(), Error> {
+    /// Delete a secret, archiving the value first.
+    ///
+    /// Refuses [`WriteAuthority::Agent`], like [`overwrite`](Self::overwrite).
+    /// The archived row means an accidental approval is recoverable.
+    pub async fn delete(&self, name: &str, authority: WriteAuthority) -> Result<(), Error> {
+        if authority.is_agent() {
+            return Err(Error::Auth(format!(
+                "the agent cannot delete '{name}' directly"
+            )));
+        }
+        let store = self.clone();
         let name = name.to_string();
-        crate::with_conn(&self.conn, move |conn| {
-            conn.execute("DELETE FROM secrets WHERE name = ?1", params![name])
+        run_blocking(move || {
+            let mut conn = store.conn.lock().unwrap();
+            let tx = conn
+                .transaction()
                 .map_err(|e| Error::Storage(e.to_string()))?;
+            // Deleting something that isn't there is not an error, but
+            // there is also nothing to archive or audit.
+            if let Some((previous, version)) = Self::current_row(&tx, &name)? {
+                Self::archive(&tx, &name, version, &previous, &authority)?;
+                tx.execute("DELETE FROM secrets WHERE name = ?1", params![name])
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                Self::audit(&tx, &name, "delete", &authority.describe(), None)?;
+            }
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))?;
             Ok(())
         })
         .await
+    }
+
+    /// Names plus timestamps and version — never values.
+    pub async fn metadata(&self) -> Result<Vec<SecretMeta>, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name, created_at, updated_at, COALESCE(version, 1)
+                     FROM secrets ORDER BY name",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(SecretMeta {
+                        name: row.get(0)?,
+                        created_at: row.get(1)?,
+                        updated_at: row.get(2)?,
+                        version: row.get(3)?,
+                    })
+                })
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                out.push(row.map_err(|e| Error::Storage(e.to_string()))?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// The current version number for a secret, or `None` if absent. Used to
+    /// detect a credential that moved under a pending request.
+    pub async fn version_of(&self, name: &str) -> Result<Option<i64>, Error> {
+        let name = name.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT COALESCE(version, 1) FROM secrets WHERE name = ?1")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            match stmt.query_row(params![name], |row| row.get::<_, i64>(0)) {
+                Ok(v) => Ok(Some(v)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(Error::Storage(e.to_string())),
+            }
+        })
+        .await
+    }
+
+    // -- internals shared by the write paths -----------------------------
+
+    /// Current ciphertext and version for a name.
+    fn current_row(
+        conn: &rusqlite::Connection,
+        name: &str,
+    ) -> Result<Option<(Vec<u8>, i64)>, Error> {
+        let mut stmt = conn
+            .prepare("SELECT data, COALESCE(version, 1) FROM secrets WHERE name = ?1")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        match stmt.query_row(params![name], |row| Ok((row.get(0)?, row.get(1)?))) {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(Error::Storage(e.to_string())),
+        }
+    }
+
+    /// Copy the superseded ciphertext into `secret_versions`. Stored still
+    /// encrypted — archiving must not turn history into plaintext.
+    fn archive(
+        conn: &rusqlite::Connection,
+        name: &str,
+        version: i64,
+        data: &[u8],
+        authority: &WriteAuthority,
+    ) -> Result<(), Error> {
+        conn.execute(
+            "INSERT OR REPLACE INTO secret_versions
+                (name, version, data, replaced_at, replaced_by)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![name, version, data, now_ms(), authority.describe()],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    fn audit(
+        conn: &rusqlite::Connection,
+        name: &str,
+        op: &str,
+        authority: &str,
+        request_id: Option<&str>,
+    ) -> Result<(), Error> {
+        conn.execute(
+            "INSERT INTO secret_audit (name, op, authority, request_id, at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![name, op, authority, request_id, now_ms()],
+        )
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        Ok(())
     }
 
     /// List all secret names (does not decrypt values).
@@ -145,6 +387,19 @@ impl SecretStore {
             ));
         }
         Ok(())
+    }
+
+    /// Encrypt a payload that isn't a secret row, binding it to `aad`.
+    ///
+    /// Used for queued credential proposals, where the AAD is the request
+    /// id — so a proposal cannot be lifted into a different request or
+    /// applied to a different name.
+    pub(crate) fn encrypt_with_aad(&self, aad: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
+        self.encrypt(aad, data)
+    }
+
+    pub(crate) fn decrypt_with_aad(&self, aad: &str, data: &[u8]) -> Result<Vec<u8>, Error> {
+        self.decrypt(aad, data)
     }
 
     /// Encrypt data with AES-256-GCM. Returns `salt || nonce || ciphertext+tag`.
@@ -219,5 +474,176 @@ impl SecretStore {
             .hash_password_into(&self.master_key, salt, &mut *key)
             .map_err(|e| Error::Storage(format!("key derivation failed: {e}")))?;
         Ok(key)
+    }
+}
+
+/// Test-only views over the guard's bookkeeping tables. Production code
+/// reads these through the request/approval API, not raw rows.
+#[cfg(test)]
+impl SecretStore {
+    /// The most recently archived ciphertext for a name, and how many
+    /// archived versions exist.
+    async fn archived(&self, name: &str) -> (Vec<u8>, usize) {
+        let name = name.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT data FROM secret_versions WHERE name = ?1 ORDER BY version")
+                .unwrap();
+            let rows: Vec<Vec<u8>> = stmt
+                .query_map(params![name], |row| row.get::<_, Vec<u8>>(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            Ok((rows.last().cloned().unwrap_or_default(), rows.len()))
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn audit_ops(&self, name: &str) -> Vec<String> {
+        let name = name.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT op FROM secret_audit WHERE name = ?1 ORDER BY id")
+                .unwrap();
+            let rows: Vec<String> = stmt
+                .query_map(params![name], |row| row.get::<_, String>(0))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect();
+            Ok(rows)
+        })
+        .await
+        .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn test_store() -> (tempfile::TempDir, SecretStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path(), vec![7u8; 32]).expect("open store");
+        let secrets = store.secrets();
+        (dir, secrets)
+    }
+
+    fn user() -> WriteAuthority {
+        WriteAuthority::User { device: None }
+    }
+
+    #[tokio::test]
+    async fn create_is_create_only() {
+        let (_dir, secrets) = test_store();
+        secrets.create("token", "first").await.unwrap();
+
+        let again = secrets.create("token", "second").await;
+        assert!(
+            matches!(again, Err(Error::AlreadyExists(_))),
+            "second create should be refused, got {again:?}"
+        );
+        // The refusal must not have touched the stored value.
+        assert_eq!(secrets.get("token").await.unwrap(), "first");
+    }
+
+    #[tokio::test]
+    async fn overwrite_archives_the_previous_value() {
+        let (_dir, secrets) = test_store();
+        secrets.create("token", "v1").await.unwrap();
+        secrets.overwrite("token", "v2", user()).await.unwrap();
+
+        assert_eq!(secrets.get("token").await.unwrap(), "v2");
+        assert_eq!(secrets.version_of("token").await.unwrap(), Some(2));
+
+        // The superseded value is archived, still encrypted.
+        let (data, count) = secrets.archived("token").await;
+        assert_eq!(count, 1, "expected one archived version");
+        assert!(
+            !String::from_utf8_lossy(&data).contains("v1"),
+            "archived value must not be plaintext"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_authority_cannot_overwrite_or_delete() {
+        let (_dir, secrets) = test_store();
+        secrets.create("token", "original").await.unwrap();
+        let agent = WriteAuthority::Agent {
+            conversation_id: None,
+        };
+
+        let overwrite = secrets.overwrite("token", "hijacked", agent.clone()).await;
+        assert!(matches!(overwrite, Err(Error::Auth(_))), "{overwrite:?}");
+
+        let delete = secrets.delete("token", agent).await;
+        assert!(matches!(delete, Err(Error::Auth(_))), "{delete:?}");
+
+        // Neither attempt changed anything.
+        assert_eq!(secrets.get("token").await.unwrap(), "original");
+        assert_eq!(secrets.version_of("token").await.unwrap(), Some(1));
+    }
+
+    #[tokio::test]
+    async fn delete_archives_then_removes() {
+        let (_dir, secrets) = test_store();
+        secrets.create("token", "bye").await.unwrap();
+        secrets.delete("token", user()).await.unwrap();
+
+        assert!(matches!(
+            secrets.get("token").await,
+            Err(Error::NotFound(_))
+        ));
+        assert_eq!(secrets.archived("token").await.1, 1);
+        // Deleting again is a no-op rather than an error.
+        secrets.delete("token", user()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn metadata_reports_version_and_timestamps_but_no_values() {
+        let (_dir, secrets) = test_store();
+        secrets.create("a", "value-a").await.unwrap();
+        secrets.overwrite("a", "value-a2", user()).await.unwrap();
+        secrets.create("b", "value-b").await.unwrap();
+
+        let meta = secrets.metadata().await.unwrap();
+        let names: Vec<_> = meta.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"]);
+
+        let a = &meta[0];
+        assert_eq!(a.version, 2);
+        assert!(a.created_at.is_some() && a.updated_at.is_some());
+        assert!(a.updated_at >= a.created_at);
+        assert_eq!(meta[1].version, 1);
+    }
+
+    #[tokio::test]
+    async fn system_upsert_skips_unchanged_values() {
+        let (_dir, secrets) = test_store();
+        // First boot creates it.
+        secrets.upsert_system("mirrored", "same").await.unwrap();
+        assert_eq!(secrets.version_of("mirrored").await.unwrap(), Some(1));
+
+        // Later boots with an identical value must not churn the version
+        // or fill the audit trail with writes nobody made.
+        secrets.upsert_system("mirrored", "same").await.unwrap();
+        assert_eq!(secrets.version_of("mirrored").await.unwrap(), Some(1));
+
+        // A genuinely changed value does write.
+        secrets.upsert_system("mirrored", "rotated").await.unwrap();
+        assert_eq!(secrets.version_of("mirrored").await.unwrap(), Some(2));
+        assert_eq!(secrets.get("mirrored").await.unwrap(), "rotated");
+    }
+
+    #[tokio::test]
+    async fn writes_are_audited() {
+        let (_dir, secrets) = test_store();
+        secrets.create("token", "v1").await.unwrap();
+        secrets.overwrite("token", "v2", user()).await.unwrap();
+        secrets.delete("token", user()).await.unwrap();
+
+        let ops = secrets.audit_ops("token").await;
+        assert_eq!(ops, vec!["create", "overwrite", "delete"]);
     }
 }

--- a/crates/rustykrab-tools/src/caldav.rs
+++ b/crates/rustykrab-tools/src/caldav.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, SecondsFormat, Utc};
 use regex::Regex;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
-use rustykrab_store::SecretStore;
+use rustykrab_store::GuardedSecrets;
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -56,12 +56,12 @@ struct DavReq<'a> {
 }
 
 pub struct CalDavTool {
-    secrets: SecretStore,
+    secrets: GuardedSecrets,
     client: reqwest::Client,
 }
 
 impl CalDavTool {
-    pub fn new(secrets: SecretStore) -> Self {
+    pub fn new(secrets: GuardedSecrets) -> Self {
         Self {
             secrets,
             client: reqwest::Client::builder()
@@ -175,14 +175,17 @@ impl CalDavTool {
         // whatever the Gmail integration already stored.
         if let Some(email) = args["email"].as_str() {
             self.secrets
-                .set(KEY_EMAIL, email)
+                .set_strict(KEY_EMAIL, email)
                 .await
                 .map_err(|e| Error::ToolExecution(format!("failed to store email: {e}").into()))?;
         }
         if let Some(pw) = args["app_password"].as_str() {
-            self.secrets.set(KEY_APP_PASSWORD, pw).await.map_err(|e| {
-                Error::ToolExecution(format!("failed to store app password: {e}").into())
-            })?;
+            self.secrets
+                .set_strict(KEY_APP_PASSWORD, pw)
+                .await
+                .map_err(|e| {
+                    Error::ToolExecution(format!("failed to store app password: {e}").into())
+                })?;
         }
 
         let (email, password) = self.get_credentials().await?;

--- a/crates/rustykrab-tools/src/credential_write.rs
+++ b/crates/rustykrab-tools/src/credential_write.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, Tool};
-use rustykrab_store::SecretStore;
+use rustykrab_store::{GuardedSecrets, WriteOutcome};
 use serde_json::{json, Value};
 
 /// A tool that writes credentials to the encrypted SecretStore or macOS
@@ -11,11 +11,11 @@ use serde_json::{json, Value};
 /// action copies a credential from the macOS Keychain into the encrypted local
 /// store so it is available even when not running on macOS.
 pub struct CredentialWriteTool {
-    secrets: SecretStore,
+    secrets: GuardedSecrets,
 }
 
 impl CredentialWriteTool {
-    pub fn new(secrets: SecretStore) -> Self {
+    pub fn new(secrets: GuardedSecrets) -> Self {
         Self { secrets }
     }
 }
@@ -128,26 +128,56 @@ impl CredentialWriteTool {
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
 
-                self.secrets.set(name, value).await.map_err(|e| {
+                let outcome = self.secrets.set(name, value).await.map_err(|e| {
                     Error::ToolExecution(format!("failed to store secret: {e}").into())
                 })?;
 
-                Ok(json!({
-                    "status": "stored",
-                    "source": "store",
-                    "name": name,
-                }))
+                // A queued change is a normal result, not a failure: the
+                // model should relay what the user needs to approve rather
+                // than treat it as an error to retry around.
+                Ok(match outcome {
+                    WriteOutcome::Created => json!({
+                        "status": "stored",
+                        "source": "store",
+                        "name": name,
+                    }),
+                    WriteOutcome::PendingApproval { request_id } => json!({
+                        "status": "pending_approval",
+                        "source": "store",
+                        "name": name,
+                        "request_id": request_id,
+                        "message": format!(
+                            "'{name}' already exists, so replacing it needs the user's \
+                             approval. Tell them it is waiting in Apollo or WebChat \
+                             (request {request_id}); do not retry."
+                        ),
+                    }),
+                })
             }
             "delete" => {
-                self.secrets.delete(name).await.map_err(|e| {
+                let outcome = self.secrets.delete(name).await.map_err(|e| {
                     Error::ToolExecution(format!("failed to delete secret: {e}").into())
                 })?;
 
-                Ok(json!({
-                    "status": "deleted",
-                    "source": "store",
-                    "name": name,
-                }))
+                Ok(match outcome {
+                    WriteOutcome::PendingApproval { request_id } => json!({
+                        "status": "pending_approval",
+                        "source": "store",
+                        "name": name,
+                        "request_id": request_id,
+                        "message": format!(
+                            "Deleting '{name}' needs the user's approval (request \
+                             {request_id}); do not retry."
+                        ),
+                    }),
+                    // Deletes are always queued; this arm only makes the
+                    // match total.
+                    WriteOutcome::Created => json!({
+                        "status": "deleted",
+                        "source": "store",
+                        "name": name,
+                    }),
+                })
             }
             other => Err(Error::ToolExecution(
                 format!(
@@ -191,6 +221,32 @@ impl CredentialWriteTool {
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing value for 'set' action".into()))?;
 
+                // Same create-only rule as the store: an existing
+                // service/account pair is someone else's credential.
+                //
+                // Unlike a store write this is refused rather than queued —
+                // the request table applies approved changes to the store,
+                // and it cannot write the Keychain. Queuing Keychain
+                // changes is follow-up work; refusing keeps the guard
+                // honest in the meantime.
+                let occupied = rustykrab_store::keychain::get_credential(service, account)
+                    .map(|c| c.is_some())
+                    .unwrap_or(false);
+                if occupied {
+                    return Ok(json!({
+                        "status": "refused",
+                        "source": "keychain",
+                        "name": name,
+                        "service": service,
+                        "account": account,
+                        "message": format!(
+                            "A Keychain credential already exists for {service}/{account}. \
+                             Replacing it is the user's call — ask them to update it in \
+                             Keychain Access or via the app; do not retry."
+                        ),
+                    }));
+                }
+
                 rustykrab_store::keychain::set_credential(service, account, value).map_err(
                     |e| Error::ToolExecution(format!("failed to store in keychain: {e}").into()),
                 )?;
@@ -210,15 +266,17 @@ impl CredentialWriteTool {
                 }))
             }
             "delete" => {
-                rustykrab_store::keychain::delete_credential(service, account).map_err(|e| {
-                    Error::ToolExecution(format!("failed to delete from keychain: {e}").into())
-                })?;
-
+                // Destroying a Keychain item is not the agent's call, and
+                // there is nothing to archive if it gets it wrong.
                 Ok(json!({
-                    "status": "deleted",
+                    "status": "refused",
                     "source": "keychain",
                     "service": service,
                     "account": account,
+                    "message": format!(
+                        "Deleting the Keychain credential {service}/{account} is the \
+                         user's call. Ask them to remove it themselves; do not retry."
+                    ),
                 }))
             }
             other => Err(Error::ToolExecution(

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
-use rustykrab_store::SecretStore;
+use rustykrab_store::GuardedSecrets;
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -103,7 +103,7 @@ async fn select_mailbox(cached: &mut CachedSession, mailbox: &str) -> Result<()>
 // ---------------------------------------------------------------------------
 
 pub struct GmailTool {
-    secrets: SecretStore,
+    secrets: GuardedSecrets,
     /// Cached IMAP session, reused across calls. The lock is held for the
     /// duration of an operation — IMAP is stateful, so operations on one
     /// connection must not interleave.
@@ -111,7 +111,7 @@ pub struct GmailTool {
 }
 
 impl GmailTool {
-    pub fn new(secrets: SecretStore) -> Self {
+    pub fn new(secrets: GuardedSecrets) -> Self {
         Self {
             secrets,
             imap: tokio::sync::Mutex::new(None),
@@ -159,11 +159,11 @@ impl GmailTool {
             .ok_or_else(|| Error::ToolExecution("missing 'app_password' parameter".into()))?;
 
         self.secrets
-            .set(KEY_EMAIL, email)
+            .set_strict(KEY_EMAIL, email)
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to store email: {e}").into()))?;
         self.secrets
-            .set(KEY_APP_PASSWORD, app_password)
+            .set_strict(KEY_APP_PASSWORD, app_password)
             .await
             .map_err(|e| {
                 Error::ToolExecution(format!("failed to store app password: {e}").into())

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -203,10 +203,12 @@ pub use mcp_connector::{mcp_connector_tools, McpRemoteTool};
 
 /// Collect all built-in tools that require no external backend into a Vec.
 ///
-/// Tools that need access to the secret store (credential_read, credential_write)
-/// require a `SecretStore` handle. The remaining tools are stateless or self-contained.
+/// Tools that read credentials take a `SecretStore`; every tool that can
+/// *write* one takes [`GuardedSecrets`] instead, so the create-only policy
+/// is carried by the handle rather than by a check each tool remembers.
 pub fn builtin_tools(
     secrets: rustykrab_store::SecretStore,
+    guarded: rustykrab_store::GuardedSecrets,
 ) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
     vec![
         // Meta — tool discovery and lazy schema loading. Always registered.
@@ -243,16 +245,16 @@ pub fn builtin_tools(
         // net_scan/net_admin/net_audit/net_discovery tools were removed to
         // cut the tool-schema payload sent to the model.
         // Email
-        std::sync::Arc::new(GmailTool::new(secrets.clone())),
+        std::sync::Arc::new(GmailTool::new(guarded.clone())),
         // Calendar (CalDAV — reuses Gmail credentials)
-        std::sync::Arc::new(CalDavTool::new(secrets.clone())),
+        std::sync::Arc::new(CalDavTool::new(guarded.clone())),
         // Notion
-        std::sync::Arc::new(NotionTool::new(secrets.clone())),
+        std::sync::Arc::new(NotionTool::new(guarded.clone())),
         // Obsidian
-        std::sync::Arc::new(ObsidianTool::new(secrets.clone())),
+        std::sync::Arc::new(ObsidianTool::new(guarded.clone())),
         // Credentials
         std::sync::Arc::new(CredentialReadTool::new(secrets.clone())),
-        std::sync::Arc::new(CredentialWriteTool::new(secrets)),
+        std::sync::Arc::new(CredentialWriteTool::new(guarded)),
     ]
 }
 

--- a/crates/rustykrab-tools/src/mcp_connector.rs
+++ b/crates/rustykrab-tools/src/mcp_connector.rs
@@ -505,7 +505,7 @@ mod tests {
     async fn resolve_value_ref_store_lookup_succeeds_in_namespace() {
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.github.token", "stored-token-value")
+            .create("mcp.github.token", "stored-token-value")
             .await
             .unwrap();
         let v = resolve_value_ref("github", "ref:store:mcp.github.token", &secrets)
@@ -518,7 +518,7 @@ mod tests {
     async fn resolve_value_ref_store_lookup_is_case_insensitive_on_server() {
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.github.token", "stored-token-value")
+            .create("mcp.github.token", "stored-token-value")
             .await
             .unwrap();
         let v = resolve_value_ref("GitHub", "ref:store:mcp.github.token", &secrets)
@@ -531,7 +531,7 @@ mod tests {
     async fn resolve_value_ref_store_rejects_cross_server_lookup() {
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.notion.token", "other-server-token")
+            .create("mcp.notion.token", "other-server-token")
             .await
             .unwrap();
         let err = resolve_value_ref("github", "ref:store:mcp.notion.token", &secrets)
@@ -546,7 +546,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_value_ref_store_rejects_unnamespaced_keys() {
         let secrets = make_test_secrets();
-        secrets.set("global_secret", "x").await.unwrap();
+        secrets.create("global_secret", "x").await.unwrap();
         let err = resolve_value_ref("github", "ref:store:global_secret", &secrets)
             .await
             .unwrap_err();
@@ -629,7 +629,7 @@ mod tests {
         let upper = "TESTREF";
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.testref.token", "resolved-bearer")
+            .create("mcp.testref.token", "resolved-bearer")
             .await
             .unwrap();
         std::env::set_var(
@@ -652,7 +652,7 @@ mod tests {
         let upper = "TESTHDRREF";
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.testhdrref.api_key", "secret-key")
+            .create("mcp.testhdrref.api_key", "secret-key")
             .await
             .unwrap();
         std::env::set_var(
@@ -672,7 +672,7 @@ mod tests {
         let upper = "TESTXSERVER";
         let secrets = make_test_secrets();
         secrets
-            .set("mcp.notion.token", "wrong-server")
+            .create("mcp.notion.token", "wrong-server")
             .await
             .unwrap();
         std::env::set_var(

--- a/crates/rustykrab-tools/src/notion.rs
+++ b/crates/rustykrab-tools/src/notion.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
-use rustykrab_store::SecretStore;
+use rustykrab_store::GuardedSecrets;
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -23,12 +23,12 @@ const MAX_BLOCKS_PER_REQUEST: usize = 100;
 // ---------------------------------------------------------------------------
 
 pub struct NotionTool {
-    secrets: SecretStore,
+    secrets: GuardedSecrets,
     client: reqwest::Client,
 }
 
 impl NotionTool {
-    pub fn new(secrets: SecretStore) -> Self {
+    pub fn new(secrets: GuardedSecrets) -> Self {
         Self {
             secrets,
             client: reqwest::Client::builder()
@@ -104,14 +104,14 @@ impl NotionTool {
             .ok_or_else(|| Error::ToolExecution("missing 'api_token' parameter".into()))?;
 
         self.secrets
-            .set(KEY_API_TOKEN, api_token)
+            .set_strict(KEY_API_TOKEN, api_token)
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to store API token: {e}").into()))?;
 
         // Optionally store a default parent page ID.
         if let Some(parent_id) = args["default_parent_page_id"].as_str() {
             self.secrets
-                .set(KEY_DEFAULT_PARENT, parent_id)
+                .set_strict(KEY_DEFAULT_PARENT, parent_id)
                 .await
                 .map_err(|e| {
                     Error::ToolExecution(format!("failed to store default parent: {e}").into())

--- a/crates/rustykrab-tools/src/obsidian.rs
+++ b/crates/rustykrab-tools/src/obsidian.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
-use rustykrab_store::SecretStore;
+use rustykrab_store::GuardedSecrets;
 use serde_json::{json, Value};
 
 // ---------------------------------------------------------------------------
@@ -29,12 +29,12 @@ static SYNC_CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::
 // ---------------------------------------------------------------------------
 
 pub struct ObsidianTool {
-    secrets: SecretStore,
+    secrets: GuardedSecrets,
     client: reqwest::Client,
 }
 
 impl ObsidianTool {
-    pub fn new(secrets: SecretStore) -> Self {
+    pub fn new(secrets: GuardedSecrets) -> Self {
         // The Obsidian Local REST API uses a self-signed certificate by default.
         // Accept invalid certs since this is a localhost-only connection.
         let client = reqwest::Client::builder()
@@ -112,19 +112,22 @@ impl ObsidianTool {
             .ok_or_else(|| Error::ToolExecution("missing 'api_key' parameter".into()))?;
 
         self.secrets
-            .set(KEY_API_KEY, api_key)
+            .set_strict(KEY_API_KEY, api_key)
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to store API key: {e}").into()))?;
 
         if let Some(url) = args["api_url"].as_str() {
-            self.secrets.set(KEY_API_URL, url).await.map_err(|e| {
-                Error::ToolExecution(format!("failed to store API URL: {e}").into())
-            })?;
+            self.secrets
+                .set_strict(KEY_API_URL, url)
+                .await
+                .map_err(|e| {
+                    Error::ToolExecution(format!("failed to store API URL: {e}").into())
+                })?;
         }
 
         if let Some(folder) = args["sync_folder"].as_str() {
             self.secrets
-                .set(KEY_SYNC_FOLDER, folder)
+                .set_strict(KEY_SYNC_FOLDER, folder)
                 .await
                 .map_err(|e| {
                     Error::ToolExecution(format!("failed to store sync folder: {e}").into())
@@ -571,7 +574,7 @@ fn format_synced_note(
 /// Returns `Ok(Some(json))` on success, `Ok(None)` if Obsidian is not configured,
 /// or `Err(message)` if sync was attempted but failed.
 pub async fn try_sync_to_obsidian(
-    secrets: &SecretStore,
+    secrets: &GuardedSecrets,
     title: &str,
     content: Option<&str>,
     notion_id: Option<&str>,
@@ -627,7 +630,7 @@ pub async fn try_sync_to_obsidian(
 ///
 /// Same return semantics as [`try_sync_to_obsidian`].
 pub async fn try_sync_append_to_obsidian(
-    secrets: &SecretStore,
+    secrets: &GuardedSecrets,
     title: &str,
     content: &str,
 ) -> std::result::Result<Option<Value>, String> {


### PR DESCRIPTION
Workstream A of `docs/plans/apollo-ios-and-credential-guard.md`, on top of the Phase 1 harness merged in #487. This is the change the project exists for.

## The harness says it works

Six scenarios went `xfail → pass`, and the suite went **red** until they were promoted — the mechanism doing its job rather than me asserting success:

```
before:  8 pass /  8 xfail
after:  14 pass /  2 xfail   ← both remaining are device pairing (Workstream B)
```

`agent_overwrite_files_request` used to report *"agent overwrote an existing credential"*. It now asserts the value is untouched, that exactly one pending request exists, and that the proposal is not sitting in the database as plaintext.

## How it's enforced

The policy lives in the type a tool holds, not in a check each tool remembers.

- **`WriteAuthority`** (User / System / Agent) is a parameter of every destructive write. `overwrite` and `delete` refuse `Agent` outright, so a new tool cannot forget to ask.
- **The upserting `set()` is gone.** Callers say `create` (create-only, `AlreadyExists` on conflict) or `overwrite` (archives the superseded value, writes an audit row). Removing it made the compiler find every call site — that was the point.
- **`GuardedSecrets`** is what credential-writing tools receive. New name → created. Existing name → a `credential_requests` row and `PendingApproval`. Reads pass through unchanged.
- `credential_write` reports a queued change as a **normal tool result** ("waiting for approval, request `<id>`, do not retry"), so the model relays it rather than retrying. Configure flows (Gmail, CalDAV, Notion, Obsidian) have nowhere to show that, so they get `Error::PendingApproval` — one variant, no per-tool code.

## Storage

`secrets` gains `created_at`/`updated_at`/`version`; pre-existing rows keep NULL timestamps rather than claiming they were created at upgrade time. `secret_versions` keeps superseded values **still encrypted**. `secret_audit` records create/overwrite/delete/approve/deny with the authority behind each. A queued proposal is encrypted with the request id as AAD, so it can't be lifted into another request.

## REST

`POST /api/secrets` is create-only and answers `409` unless the client sends `overwrite: true` — that flag *is* the user's approval for a user-initiated replace. `GET /api/secrets` gains per-entry metadata (emitting both `keychain_available` and `keychainAvailable` so WebChat and Apollo each read what they expect). The three `/api/credential-requests` routes are new; **approve is refused with `409` when the credential moved since filing**, so a stale approval can't undo a newer user edit.

## Two deliberate departures from the plan

- **Agent Keychain overwrites/deletes are refused, not queued.** The request table applies approved changes to the *store* and cannot write the Keychain. Refusing closes the hole honestly rather than queueing something that could never be applied. Queued Keychain changes are follow-up.
- **`upsert_system` skips unchanged values.** The registry mirrors on every boot; rewriting an identical value would inflate the version and fill the audit trail with events nobody performed.

## Verification

497 workspace tests green (11 new, covering create-only semantics, authority refusal, archiving, and the queue-instead-of-write path), `cargo fmt` and `clippy` clean, `scripts/e2e.sh` green.

Next in the stack: device pairing + per-device auth (flips the last two xfails), then the WebChat approvals panel and the configurable origin allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)