### PR TITLE
Phase 2 (C): origin allowlist + WebChat approvals panel — completes Phase 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,7 +4076,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "4.6.0"
+version = "5.0.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -944,6 +944,9 @@ async fn main() -> anyhow::Result<()> {
     // Clone store handle so we can flush it after the server shuts down.
     let store_handle = store.clone();
     let mut state = rustykrab_gateway::AppState::new(store, tools, provider, auth_token)
+        // Loopback is always allowed; this adds the names other clients
+        // reach us by, e.g. the tailnet hostname the phone uses.
+        .with_origin_policy(rustykrab_gateway::OriginPolicy::from_env())
         .with_harness_router(router)
         .with_orchestration_config(orchestration_config)
         .with_skill_registry(skill_registry)

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -381,12 +381,15 @@ async fn main() -> anyhow::Result<()> {
     if args.len() >= 2 && args[1] == "chat" {
         return chat::run(&data_dir, &args[2..]).await;
     }
+    if args.len() >= 2 && args[1] == "pair" {
+        return handle_pair_subcommand(&data_dir).await;
+    }
     // An unrecognized subcommand must not silently fall through to
     // "start the daemon" — a typo would boot a full agent instead of
     // reporting the mistake.
     if let Some(unknown) = args.get(1).filter(|a| !a.starts_with('-')) {
         eprintln!("unknown subcommand '{unknown}'");
-        eprintln!("subcommands: skill, keychain, chat");
+        eprintln!("subcommands: skill, keychain, chat, pair");
         eprintln!("run with no arguments to start the daemon");
         std::process::exit(2);
     }
@@ -2243,6 +2246,53 @@ fn handle_skill_subcommand(data_dir: &std::path::Path, args: &[String]) -> anyho
 ///
 /// Uses the registry to check env / keychain / store, then generates
 /// a new token if none exists.
+/// `rustykrab pair` — mint a one-time code for a phone to redeem.
+///
+/// Prints the code and the QR payload the app scans. Runs against the same
+/// data directory as the daemon; the daemon does not need to be running,
+/// since the code lives in the shared database.
+async fn handle_pair_subcommand(data_dir: &std::path::Path) -> anyhow::Result<()> {
+    let master_key = match rustykrab_store::keychain::resolve_master_key() {
+        Ok(key) => key,
+        Err(e) => {
+            eprintln!("ERROR: {e}");
+            std::process::exit(1);
+        }
+    };
+    let store = rustykrab_store::Store::open(data_dir.join("db"), master_key)?;
+    let devices = store.devices();
+    let _ = devices.sweep_expired_codes().await;
+    let code = devices.mint_pairing_code().await?;
+
+    // The URL the app should talk to. On a tailnet this is the ts.net
+    // hostname; there is no way to detect that from here, so it is
+    // overridable and defaults to the loopback the daemon binds.
+    let url = std::env::var("RUSTYKRAB_PUBLIC_URL").unwrap_or_else(|_| {
+        let port = std::env::var("RUSTYKRAB_PORT").unwrap_or_else(|_| "3000".to_string());
+        format!("http://127.0.0.1:{port}")
+    });
+
+    // Bare code on stdout's first line so scripts can read it; the QR
+    // payload follows for the app to scan.
+    println!("{code}");
+    println!();
+    println!("  Pairing code: {code}");
+    println!("  Valid for 5 minutes, single use.");
+    println!();
+    println!(
+        "  QR payload: {}",
+        serde_json::json!({ "url": url, "code": code })
+    );
+    println!();
+    if url.contains("127.0.0.1") {
+        println!(
+            "  Note: that URL is loopback-only. Set RUSTYKRAB_PUBLIC_URL to your\n  \
+             tailnet hostname (https://<mac>.<tailnet>.ts.net) before pairing a phone."
+        );
+    }
+    Ok(())
+}
+
 async fn resolve_auth_token(store: &rustykrab_store::Store) -> String {
     let spec = rustykrab_store::registry::lookup("rustykrab_auth_token")
         .expect("rustykrab_auth_token must be in the registry");

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -27,6 +27,9 @@ use serde_json::{json, Value};
 /// Master key for the throwaway store (hex, 32 bytes). Test-only.
 const MASTER_KEY_HEX: &str = "e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0e2e0";
 const AUTH_TOKEN: &str = "e2e-master-token";
+/// A non-loopback origin the harness allows, standing in for the tailnet
+/// hostname the phone uses.
+const ALLOWED_ORIGIN: &str = "https://harness.example.ts.net";
 
 /// Script replayed by the daemon's `RUSTYKRAB_PROVIDER=scripted` provider.
 /// Triggers here must match the messages the scenarios send. Each scenario
@@ -171,6 +174,18 @@ impl Ctx {
             .await?)
     }
 
+    /// A request that overrides the default loopback `Origin`, for
+    /// exercising the allowlist.
+    async fn get_with_origin(&self, path: &str, origin: &str) -> Result<reqwest::Response> {
+        Ok(self
+            .client
+            .get(self.url(path))
+            .bearer_auth(AUTH_TOKEN)
+            .header(reqwest::header::ORIGIN, origin)
+            .send()
+            .await?)
+    }
+
     async fn get(&self, path: &str) -> Result<reqwest::Response> {
         Ok(self
             .client
@@ -244,6 +259,45 @@ async fn health(ctx: &Ctx) -> Result<()> {
     let resp = ctx.client.get(ctx.url("/api/health")).send().await?;
     if resp.status() != 200 {
         bail!("health returned {}", resp.status());
+    }
+    Ok(())
+}
+
+/// The gateway demands an `Origin` on every `/api` request and allows
+/// only loopback plus a configured list. Apollo reaches the daemon by its
+/// tailnet name, so without this it was rejected on everything except
+/// `/api/health` — the gap this scenario now pins shut.
+async fn origin_allowlist(ctx: &Ctx) -> Result<()> {
+    // The harness boots the daemon with this origin allowed.
+    let allowed = ctx
+        .get_with_origin("/api/conversations", ALLOWED_ORIGIN)
+        .await?;
+    if allowed.status() != 200 {
+        bail!(
+            "configured origin {ALLOWED_ORIGIN} was rejected with {}",
+            allowed.status()
+        );
+    }
+
+    // Anything else still is not.
+    let refused = ctx
+        .get_with_origin("/api/conversations", "https://evil.example.com")
+        .await?;
+    if refused.status() != 403 {
+        bail!("an unlisted origin returned {}, want 403", refused.status());
+    }
+
+    // A request with no Origin at all remains refused: that is what stops
+    // a non-browser client from skipping the check entirely.
+    let bare = ctx
+        .client
+        .get(ctx.url("/api/conversations"))
+        .bearer_auth(AUTH_TOKEN)
+        .header(reqwest::header::ORIGIN, "")
+        .send()
+        .await?;
+    if bare.status() != 403 {
+        bail!("an empty Origin returned {}, want 403", bare.status());
     }
     Ok(())
 }
@@ -819,6 +873,7 @@ fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Chil
         // IP; raise the limit for this throwaway boot only.
         .env("RUSTYKRAB_RATE_LIMIT_MAX", "100000")
         .env("RUSTYKRAB_RATE_LIMIT_LOCKOUT_SECS", "1")
+        .env("RUSTYKRAB_ALLOWED_ORIGINS", ALLOWED_ORIGIN)
         .stdout(Stdio::from(log.try_clone()?))
         .stderr(Stdio::from(log))
         .spawn()
@@ -944,6 +999,7 @@ async fn run_suite(
         // Baseline — implemented today, must pass.
         (Expected::Pass, scenario!(health)),
         (Expected::Pass, scenario!(auth_required)),
+        (Expected::Pass, scenario!(origin_allowlist)),
         (Expected::Pass, scenario!(conversations_crud)),
         (Expected::Pass, scenario!(chat_scripted_default)),
         (Expected::Pass, scenario!(chat_sse_stream)),

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -86,7 +86,15 @@ const AGENT_SCRIPT: &str = r#"{
 enum Expected {
     /// Implemented behaviour — must pass.
     Pass,
-    /// Phase 2 target behaviour — expected to fail until the guard lands.
+    /// Target behaviour that is not built yet: the suite stays green while
+    /// it fails, and an unexpected pass turns the suite red so the
+    /// scenario gets promoted.
+    ///
+    /// Currently unconstructed, because every scenario has been promoted —
+    /// which is exactly what "the server is done" looks like. Kept because
+    /// the next phase's targets are written as xfail first; deleting it
+    /// would throw away the convention the moment it had proved itself.
+    #[allow(dead_code)]
     XFail,
 }
 
@@ -884,6 +892,17 @@ async fn main() -> Result<()> {
     if keep_tmp {
         let path = tmp.keep();
         eprintln!("E2E_KEEP_TMP set — data dir kept at {}", path.display());
+    } else {
+        // Delete the throwaway data dir explicitly rather than relying on
+        // TempDir's Drop: this process exits via `std::process::exit` when
+        // the suite is red, which skips destructors. Leaving it implicit
+        // meant every red run — and going red is how an xpass gets
+        // noticed — leaked a daemon data dir and its logs.
+        let path = tmp.path().to_path_buf();
+        drop(tmp);
+        if path.exists() {
+            let _ = std::fs::remove_dir_all(&path);
+        }
     }
     println!("{}", serde_json::to_string_pretty(&report)?);
     if !ok {
@@ -933,15 +952,15 @@ async fn run_suite(
         (Expected::Pass, scenario!(agent_creates_new_credential)),
         // Workstream A — the credential guard. Shipped: these assert the
         // real behaviour now.
-        // Workstream B — device pairing, not built yet.
-        (Expected::XFail, scenario!(pair_device_target)),
+        // Workstream B — device pairing.
+        (Expected::Pass, scenario!(pair_device_target)),
         (Expected::Pass, scenario!(secrets_create_only_409)),
         (Expected::Pass, scenario!(secrets_overwrite_archives)),
         (Expected::Pass, scenario!(agent_overwrite_files_request)),
         (Expected::Pass, scenario!(approve_applies_change)),
         (Expected::Pass, scenario!(deny_preserves_value)),
         (Expected::Pass, scenario!(agent_delete_files_request)),
-        (Expected::XFail, scenario!(revoked_device_401)),
+        (Expected::Pass, scenario!(revoked_device_401)),
     ];
 
     let mut reports = Vec::new();

--- a/crates/rustykrab-gateway/src/auth.rs
+++ b/crates/rustykrab-gateway/src/auth.rs
@@ -23,6 +23,14 @@ pub async fn require_auth(
         return Ok(next.run(request).await);
     }
 
+    // Pairing is the one authenticated-adjacent exception: a device has no
+    // token yet, which is the entire point of pairing. It is protected by
+    // the code itself — single use, five-minute TTL, hashed at rest — and
+    // by the rate-limit middleware in front of this one.
+    if request.uri().path() == "/api/pair" {
+        return Ok(next.run(request).await);
+    }
+
     // Static assets are public (the WebChat UI).
     if !request.uri().path().starts_with("/api/") && !request.uri().path().starts_with("/webhook/")
     {
@@ -44,19 +52,42 @@ pub async fn require_auth(
     // Hold the read guard during comparison to prevent TOCTOU race
     // with token rotation. The guard is dropped before the await point
     // (next.run) to avoid holding the lock across an async boundary.
-    let is_valid = {
+    let is_master = {
         let token_guard = state.auth_token.read().unwrap_or_else(|e| e.into_inner());
         token.is_some_and(|t| constant_time_eq(t, &token_guard))
     };
 
-    if is_valid {
-        Ok(next.run(request).await)
+    // A per-device token is accepted anywhere the master token is. The
+    // difference is attribution: decisions record which device made them,
+    // and a single device can be revoked without rotating everything.
+    let principal = if is_master {
+        Some(rustykrab_store::Principal::Master)
+    } else if let Some(candidate) = token {
+        match state.store.devices().authenticate(candidate).await {
+            Ok(found) => found,
+            Err(e) => {
+                tracing::error!(error = %e, "device token lookup failed");
+                None
+            }
+        }
     } else {
-        tracing::warn!(
-            path = %request.uri().path(),
-            "rejected unauthenticated request"
-        );
-        Err(StatusCode::UNAUTHORIZED)
+        None
+    };
+
+    match principal {
+        Some(principal) => {
+            // Downstream handlers read this to attribute what they do.
+            let mut request = request;
+            request.extensions_mut().insert(principal);
+            Ok(next.run(request).await)
+        }
+        None => {
+            tracing::warn!(
+                path = %request.uri().path(),
+                "rejected unauthenticated request"
+            );
+            Err(StatusCode::UNAUTHORIZED)
+        }
     }
 }
 

--- a/crates/rustykrab-gateway/src/origin.rs
+++ b/crates/rustykrab-gateway/src/origin.rs
@@ -40,7 +40,13 @@ impl OriginPolicy {
         {
             return true;
         }
-        self.allowed.contains(origin)
+        // Compare normalised forms on both sides: the allowlist is
+        // normalised when parsed, so comparing a raw header against it
+        // would reject an origin differing only in host case.
+        match Self::normalize(origin) {
+            Some(normalised) => self.allowed.contains(&normalised),
+            None => false,
+        }
     }
 }
 
@@ -48,6 +54,65 @@ impl Default for OriginPolicy {
     fn default() -> Self {
         // By default, only allow our own loopback origins.
         Self::new(std::iter::empty::<String>())
+    }
+}
+
+impl OriginPolicy {
+    /// Policy built from `RUSTYKRAB_ALLOWED_ORIGINS` — a comma-separated
+    /// list of exact origins (`https://mac.tailnet.ts.net`).
+    ///
+    /// Loopback is always permitted, so this is only needed for clients
+    /// that reach the gateway by another name. The Apollo app is the
+    /// motivating case: it sends its own `Origin`, and every `/api`
+    /// request from it was rejected with `403` until its tailnet origin
+    /// could be allowed.
+    ///
+    /// Entries are normalised (trimmed, trailing `/` removed, host
+    /// lowercased) because an origin that differs only in punctuation is
+    /// an operator typo, not a security boundary. A malformed entry is
+    /// skipped with a warning rather than silently widening or narrowing
+    /// the policy.
+    pub fn from_env() -> Self {
+        let raw = match std::env::var("RUSTYKRAB_ALLOWED_ORIGINS") {
+            Ok(v) => v,
+            Err(_) => return Self::default(),
+        };
+        let allowed: Vec<String> = raw
+            .split(',')
+            .filter_map(|entry| match Self::normalize(entry) {
+                Some(origin) => Some(origin),
+                None => {
+                    if !entry.trim().is_empty() {
+                        tracing::warn!(
+                            entry = entry.trim(),
+                            "ignoring malformed RUSTYKRAB_ALLOWED_ORIGINS entry \
+                             (expected scheme://host[:port])"
+                        );
+                    }
+                    None
+                }
+            })
+            .collect();
+        if !allowed.is_empty() {
+            tracing::info!(origins = ?allowed, "additional origins allowed");
+        }
+        Self::new(allowed)
+    }
+
+    /// `scheme://host[:port]`, lowercased host, no trailing slash or path.
+    fn normalize(entry: &str) -> Option<String> {
+        let entry = entry.trim().trim_end_matches('/');
+        let (scheme, rest) = entry.split_once("://")?;
+        if !matches!(scheme, "http" | "https") || rest.is_empty() {
+            return None;
+        }
+        // An origin is scheme + host + port; anything after the authority
+        // is not part of it.
+        let authority = rest.split(['/', '?', '#']).next()?;
+        if authority.is_empty() {
+            return None;
+        }
+        Some(format!("{}://{}", scheme, authority.to_ascii_lowercase()))
     }
 }
 
@@ -108,4 +173,77 @@ pub async fn origin_check_middleware(
     }
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guards against a regression that would silently expose the gateway:
+    /// with no configuration, only loopback is allowed.
+    #[test]
+    fn default_policy_allows_only_loopback() {
+        let policy = OriginPolicy::default();
+        assert!(policy.is_allowed("http://127.0.0.1:3000"));
+        assert!(policy.is_allowed("http://localhost:8080"));
+        assert!(policy.is_allowed("https://[::1]:3000"));
+        assert!(!policy.is_allowed("https://mac.tailnet.ts.net"));
+        assert!(!policy.is_allowed("https://evil.example.com"));
+    }
+
+    #[test]
+    fn configured_origins_are_allowed_alongside_loopback() {
+        let policy = OriginPolicy::new(["https://mac.tailnet.ts.net".to_string()]);
+        assert!(policy.is_allowed("https://mac.tailnet.ts.net"));
+        assert!(policy.is_allowed("http://127.0.0.1:3000"));
+        assert!(!policy.is_allowed("https://other.tailnet.ts.net"));
+    }
+
+    #[test]
+    fn normalization_ignores_trailing_slash_and_host_case() {
+        assert_eq!(
+            OriginPolicy::normalize("  https://Mac.Tailnet.TS.net/  "),
+            Some("https://mac.tailnet.ts.net".to_string())
+        );
+        // A path is not part of an origin.
+        assert_eq!(
+            OriginPolicy::normalize("https://mac.ts.net/api/health"),
+            Some("https://mac.ts.net".to_string())
+        );
+        // Ports are part of it and must survive.
+        assert_eq!(
+            OriginPolicy::normalize("http://mac.ts.net:8443"),
+            Some("http://mac.ts.net:8443".to_string())
+        );
+    }
+
+    #[test]
+    fn an_origin_matches_regardless_of_host_case() {
+        let policy = OriginPolicy::new(["https://mac.tailnet.ts.net".to_string()]);
+        assert!(policy.is_allowed("https://MAC.Tailnet.ts.net"));
+    }
+
+    #[test]
+    fn malformed_entries_are_dropped_not_widened() {
+        // Nothing here should end up permitting anything.
+        let policy = OriginPolicy::new(
+            ["not-a-url", "ftp://mac.ts.net", "https://", ""]
+                .iter()
+                .filter_map(|e| OriginPolicy::normalize(e))
+                .collect::<Vec<_>>(),
+        );
+        assert!(!policy.is_allowed("not-a-url"));
+        assert!(!policy.is_allowed("ftp://mac.ts.net"));
+        assert!(!policy.is_allowed("https://mac.ts.net"));
+        // Loopback still works.
+        assert!(policy.is_allowed("http://127.0.0.1:3000"));
+    }
+
+    #[test]
+    fn scheme_must_match_too() {
+        let policy = OriginPolicy::new(["https://mac.ts.net".to_string()]);
+        // Downgrading to http is a different origin, and allowing it
+        // would defeat the point of pinning https.
+        assert!(!policy.is_allowed("http://mac.ts.net"));
+    }
 }

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -53,6 +53,9 @@ pub fn api_routes() -> Router<AppState> {
             "/api/credential-requests/{id}/deny",
             post(deny_credential_request),
         )
+        .route("/api/pair", post(pair_device))
+        .route("/api/devices", get(list_devices))
+        .route("/api/devices/{id}", axum::routing::delete(revoke_device))
         .route("/api/health", get(health))
         .route("/api/logout", post(logout))
 }
@@ -904,27 +907,129 @@ async fn list_credential_requests(
 
 async fn approve_credential_request(
     State(state): State<AppState>,
+    principal: Option<Extension<rustykrab_store::Principal>>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
-    decide_credential_request(state, id, true).await
+    decide_credential_request(state, id, true, principal.map(|p| p.0)).await
 }
 
 async fn deny_credential_request(
     State(state): State<AppState>,
+    principal: Option<Extension<rustykrab_store::Principal>>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
-    decide_credential_request(state, id, false).await
+    decide_credential_request(state, id, false, principal.map(|p| p.0)).await
+}
+
+// ── device pairing ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PairRequest {
+    code: String,
+    #[serde(rename = "deviceName")]
+    device_name: String,
+}
+
+#[derive(Serialize)]
+struct PairResponse {
+    #[serde(rename = "deviceId")]
+    device_id: String,
+    /// Shown exactly once. Stored server-side only as a hash.
+    #[serde(rename = "deviceToken")]
+    device_token: String,
+}
+
+/// Exchange a one-time code for a device token.
+///
+/// The only unauthenticated `/api` route besides health: a device has no
+/// token yet, which is the point. Protection is the code itself (single
+/// use, five-minute TTL, hashed at rest) plus the rate limiter in front.
+async fn pair_device(
+    State(state): State<AppState>,
+    Json(body): Json<PairRequest>,
+) -> Result<Json<PairResponse>, StatusCode> {
+    let (device, token) = state
+        .store
+        .devices()
+        .redeem_pairing_code(&body.code, &body.device_name)
+        .await
+        .map_err(|e| {
+            // Deliberately uniform: a caller learns "that didn't work",
+            // not whether the code was wrong, used, or merely expired.
+            tracing::warn!(error = %e, "pairing attempt refused");
+            StatusCode::FORBIDDEN
+        })?;
+    tracing::info!(device = %device.name, id = %device.id, "device paired");
+    Ok(Json(PairResponse {
+        device_id: device.id,
+        device_token: token,
+    }))
+}
+
+#[derive(Serialize)]
+struct DeviceResponse {
+    id: String,
+    name: String,
+    #[serde(rename = "createdAt")]
+    created_at: i64,
+    #[serde(rename = "lastSeenAt", skip_serializing_if = "Option::is_none")]
+    last_seen_at: Option<i64>,
+}
+
+async fn list_devices(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<DeviceResponse>>, StatusCode> {
+    let devices = state.store.devices().list().await.map_err(|e| {
+        tracing::error!(error = %e, "listing devices failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    Ok(Json(
+        devices
+            .into_iter()
+            .map(|d| DeviceResponse {
+                id: d.id,
+                name: d.name,
+                created_at: d.created_at,
+                last_seen_at: d.last_seen_at,
+            })
+            .collect(),
+    ))
+}
+
+/// Revoke a device — the lost-phone story. Its token stops working
+/// immediately, without disturbing any other device.
+async fn revoke_device(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    state
+        .store
+        .devices()
+        .revoke(&id)
+        .await
+        .map_err(|e| match e {
+            rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
+            other => {
+                tracing::error!(error = %other, %id, "revoking device failed");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+    tracing::info!(%id, "device revoked");
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn decide_credential_request(
     state: AppState,
     id: String,
     approve: bool,
+    principal: Option<rustykrab_store::Principal>,
 ) -> Result<StatusCode, StatusCode> {
     let requests = state.store.credential_requests();
-    // TODO(devices): attribute to the deciding device once per-device
-    // tokens land; until then every decision is the master token.
-    let decided_by = "webchat";
+    // Which device decided, for the audit trail.
+    let decided_by = principal
+        .map(|p| p.describe())
+        .unwrap_or_else(|| "webchat".to_string());
+    let decided_by = decided_by.as_str();
     let result = if approve {
         requests.approve(&id, decided_by).await
     } else {

--- a/crates/rustykrab-gateway/static/index.html
+++ b/crates/rustykrab-gateway/static/index.html
@@ -739,6 +739,19 @@
       </button>
     </div>
     <div class="conversation-list" id="conversationList"></div>
+
+    <!-- Credential changes the agent asked for. Hidden until there is
+         something to decide, so it costs nothing when idle. -->
+    <div id="approvalsSection" style="display:none;border-top:1px solid var(--border);">
+      <div class="sidebar-header">
+        <span class="sidebar-title">
+          Approvals
+          <span id="approvalsBadge" style="display:inline-block;min-width:18px;padding:1px 6px;margin-left:6px;border-radius:9px;background:#d9534f;color:#fff;font-size:11px;text-align:center;">0</span>
+        </span>
+      </div>
+      <div id="approvalsList" style="padding:0 12px 12px;"></div>
+    </div>
+
     <div style="padding:12px;border-top:1px solid var(--border);">
       <button class="btn-icon" id="logoutBtn" title="Logout" style="width:100%;display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;font-size:13px;color:var(--text-secondary);">
         <svg viewBox="0 0 24 24" style="width:16px;height:16px;"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
@@ -1094,6 +1107,79 @@
     }
     renderConversationList();
   }
+
+  // ── Credential approvals ──────────────────────────────────
+  //
+  // The agent can create a credential under a new name, but replacing or
+  // deleting one files a request that only a user can resolve. This panel
+  // is the WebChat half of that; the Apollo app is the other.
+  //
+  // Values are never shown, because no endpoint returns one — a row is a
+  // name, an action, and the agent's reason.
+  const approvalsSection = $('#approvalsSection');
+  const approvalsList    = $('#approvalsList');
+  const approvalsBadge   = $('#approvalsBadge');
+
+  const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  async function refreshApprovals() {
+    let pending;
+    try {
+      pending = await api('/api/credential-requests?status=pending');
+    } catch (err) {
+      // An older server has no such endpoint; leave the panel hidden
+      // rather than showing an error for a feature it doesn't have.
+      approvalsSection.style.display = 'none';
+      return;
+    }
+    if (!pending || pending.length === 0) {
+      approvalsSection.style.display = 'none';
+      approvalsList.innerHTML = '';
+      return;
+    }
+    approvalsSection.style.display = 'block';
+    approvalsBadge.textContent = pending.length;
+    approvalsList.innerHTML = pending.map((req) => `
+      <div style="padding:8px 0;border-bottom:1px solid var(--border);font-size:13px;">
+        <div style="color:var(--text-secondary);">
+          The agent wants to <strong>${escapeHtml(req.action)}</strong>
+          <code>${escapeHtml(req.name)}</code>
+        </div>
+        ${req.reason ? `<div style="margin-top:2px;color:var(--text-secondary);font-size:12px;">${escapeHtml(req.reason)}</div>` : ''}
+        <div style="margin-top:6px;display:flex;gap:6px;">
+          <button data-approve="${escapeHtml(req.id)}" style="flex:1;padding:4px 8px;border-radius:6px;font-size:12px;cursor:pointer;">Approve</button>
+          <button data-deny="${escapeHtml(req.id)}" style="flex:1;padding:4px 8px;border-radius:6px;font-size:12px;cursor:pointer;">Deny</button>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  approvalsList.addEventListener('click', async (event) => {
+    const approveId = event.target.getAttribute('data-approve');
+    const denyId    = event.target.getAttribute('data-deny');
+    const id = approveId || denyId;
+    if (!id) return;
+
+    if (approveId && !confirm('Approve this change? The credential will be replaced.')) return;
+    event.target.disabled = true;
+    try {
+      await api(`/api/credential-requests/${id}/${approveId ? 'approve' : 'deny'}`, { method: 'POST' });
+    } catch (err) {
+      // 409 means the credential moved since the request was filed, so
+      // approving would undo whatever was done in the meantime.
+      alert(String(err).includes('409')
+        ? 'That credential changed since the request was filed, so it was not applied. Refreshing.'
+        : `Could not complete that: ${err}`);
+    }
+    await refreshApprovals();
+  });
+
+  // Poll while the tab is open. Push notification is a later phase; until
+  // then this plus the app's foreground refresh is how a request surfaces.
+  refreshApprovals();
+  setInterval(() => { if (token) refreshApprovals(); }, 15000);
 
   newChatBtn.addEventListener('click', async () => {
     try {

--- a/crates/rustykrab-store/src/device.rs
+++ b/crates/rustykrab-store/src/device.rs
@@ -1,0 +1,355 @@
+//! Paired devices and the one-time codes that create them.
+//!
+//! A device token is what the phone holds instead of the master token: it
+//! is per-device, attributable in the audit trail, and revocable on its own
+//! — the lost-phone story. Tokens and pairing codes are stored only as
+//! SHA-256 hashes, so reading the database does not yield anything that can
+//! authenticate.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use rand::TryRngCore;
+use rusqlite::params;
+use rustykrab_core::crypto::constant_time_eq;
+use rustykrab_core::Error;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+/// How long a pairing code is usable. Short on purpose: it is typed or
+/// scanned within seconds of being shown.
+pub const PAIRING_CODE_TTL_MS: i64 = 5 * 60 * 1000;
+
+/// Characters used in pairing codes. No look-alikes (0/O, 1/I/L), because
+/// these get read off a screen and typed by hand.
+const CODE_ALPHABET: &[u8] = b"ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const CODE_LEN: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Device {
+    pub id: String,
+    pub name: String,
+    pub created_at: i64,
+    pub last_seen_at: Option<i64>,
+}
+
+/// Who a request authenticated as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Principal {
+    /// The master token from the environment or keychain.
+    Master,
+    /// A paired device.
+    Device { id: String, name: String },
+}
+
+impl Principal {
+    /// Label recorded against decisions this principal makes.
+    pub fn describe(&self) -> String {
+        match self {
+            Principal::Master => "master".to_string(),
+            Principal::Device { name, .. } => name.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DeviceStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn hash(value: &str) -> Vec<u8> {
+    Sha256::digest(value.as_bytes()).to_vec()
+}
+
+fn random_token() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng
+        .try_fill_bytes(&mut bytes)
+        .expect("OS RNG failed");
+    hex::encode(bytes)
+}
+
+impl DeviceStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Mint a single-use pairing code, returning the plaintext to display.
+    /// Only its hash is stored.
+    pub async fn mint_pairing_code(&self) -> Result<String, Error> {
+        let mut bytes = [0u8; CODE_LEN];
+        rand::rngs::OsRng
+            .try_fill_bytes(&mut bytes)
+            .expect("OS RNG failed");
+        let code: String = bytes
+            .iter()
+            .map(|b| CODE_ALPHABET[*b as usize % CODE_ALPHABET.len()] as char)
+            .collect();
+
+        let stored = code.clone();
+        crate::with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO pairing_codes (code_hash, expires_at) VALUES (?1, ?2)",
+                params![hash(&stored), now_ms() + PAIRING_CODE_TTL_MS],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await?;
+        Ok(code)
+    }
+
+    /// Redeem a pairing code for a new device identity.
+    ///
+    /// The code is consumed whether or not it was valid for long, and the
+    /// returned token is the only time the plaintext exists — the caller
+    /// must hand it straight to the device.
+    pub async fn redeem_pairing_code(
+        &self,
+        code: &str,
+        device_name: &str,
+    ) -> Result<(Device, String), Error> {
+        let name = device_name.trim().to_string();
+        if name.is_empty() || name.len() > 128 {
+            return Err(Error::Auth("device name must be 1-128 characters".into()));
+        }
+        // Uppercase so a code typed in lower case still works.
+        let code_hash = hash(&code.trim().to_uppercase());
+        let token = random_token();
+        let token_hash = hash(&token);
+        let id = Uuid::new_v4().to_string();
+        let device = Device {
+            id: id.clone(),
+            name: name.clone(),
+            created_at: now_ms(),
+            last_seen_at: None,
+        };
+        let created_at = device.created_at;
+
+        crate::with_conn(&self.conn, move |conn| {
+            // Single use: consuming the row and checking expiry in one
+            // statement means two racing redemptions cannot both win.
+            let consumed = conn
+                .execute(
+                    "DELETE FROM pairing_codes WHERE code_hash = ?1 AND expires_at > ?2",
+                    params![code_hash, now_ms()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if consumed == 0 {
+                return Err(Error::Auth(
+                    "pairing code is invalid, already used, or expired".into(),
+                ));
+            }
+            conn.execute(
+                "INSERT INTO devices (id, name, token_hash, created_at) VALUES (?1, ?2, ?3, ?4)",
+                params![id, name, token_hash, created_at],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await?;
+
+        Ok((device, token))
+    }
+
+    /// Resolve a bearer token to a device, if it belongs to one that is
+    /// still active. Also stamps `last_seen_at`.
+    pub async fn authenticate(&self, token: &str) -> Result<Option<Principal>, Error> {
+        let candidate = hash(token);
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT id, name, token_hash FROM devices WHERE revoked_at IS NULL")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Vec<u8>>(2)?,
+                    ))
+                })
+                .map_err(|e| Error::Storage(e.to_string()))?;
+
+            for row in rows {
+                let (id, name, stored) = row.map_err(|e| Error::Storage(e.to_string()))?;
+                // Constant-time compare of the hashes, so a timing signal
+                // can't be used to search for a valid token.
+                if stored.len() == candidate.len()
+                    && constant_time_eq(&hex::encode(&stored), &hex::encode(&candidate))
+                {
+                    conn.execute(
+                        "UPDATE devices SET last_seen_at = ?2 WHERE id = ?1",
+                        params![id, now_ms()],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                    return Ok(Some(Principal::Device { id, name }));
+                }
+            }
+            Ok(None)
+        })
+        .await
+    }
+
+    pub async fn list(&self) -> Result<Vec<Device>, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, name, created_at, last_seen_at FROM devices
+                     WHERE revoked_at IS NULL ORDER BY created_at",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(Device {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        created_at: row.get(2)?,
+                        last_seen_at: row.get(3)?,
+                    })
+                })
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                out.push(row.map_err(|e| Error::Storage(e.to_string()))?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// Revoke a device. Its token stops authenticating immediately.
+    ///
+    /// The row is kept (marked revoked) rather than deleted so audit
+    /// entries naming the device still resolve.
+    pub async fn revoke(&self, id: &str) -> Result<(), Error> {
+        let id = id.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let n = conn
+                .execute(
+                    "UPDATE devices SET revoked_at = ?2 WHERE id = ?1 AND revoked_at IS NULL",
+                    params![id, now_ms()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if n == 0 {
+                return Err(Error::NotFound(format!("device '{id}'")));
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    /// Drop expired pairing codes. Called opportunistically on mint.
+    pub async fn sweep_expired_codes(&self) -> Result<usize, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let n = conn
+                .execute(
+                    "DELETE FROM pairing_codes WHERE expires_at <= ?1",
+                    params![now_ms()],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(n)
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Store;
+
+    fn devices() -> (tempfile::TempDir, DeviceStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path(), vec![3u8; 32]).expect("open");
+        let devices = store.devices();
+        (dir, devices)
+    }
+
+    #[tokio::test]
+    async fn pairing_mints_a_working_device_token() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        assert_eq!(code.len(), CODE_LEN);
+
+        let (device, token) = devices.redeem_pairing_code(&code, "Phone").await.unwrap();
+        assert_eq!(device.name, "Phone");
+
+        let principal = devices.authenticate(&token).await.unwrap();
+        assert_eq!(
+            principal,
+            Some(Principal::Device {
+                id: device.id.clone(),
+                name: "Phone".to_string()
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn a_code_works_exactly_once() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        devices.redeem_pairing_code(&code, "First").await.unwrap();
+
+        let second = devices.redeem_pairing_code(&code, "Second").await;
+        assert!(matches!(second, Err(Error::Auth(_))), "{second:?}");
+        assert_eq!(devices.list().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_codes_and_tokens_are_rejected() {
+        let (_dir, devices) = devices();
+        assert!(devices
+            .redeem_pairing_code("NOTACODE", "Phone")
+            .await
+            .is_err());
+        assert_eq!(devices.authenticate("not-a-token").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn revoking_stops_the_token_working() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        let (device, token) = devices.redeem_pairing_code(&code, "Lost").await.unwrap();
+        assert!(devices.authenticate(&token).await.unwrap().is_some());
+
+        devices.revoke(&device.id).await.unwrap();
+
+        // The lost-phone story: the same token no longer authenticates.
+        assert_eq!(devices.authenticate(&token).await.unwrap(), None);
+        assert!(devices.list().await.unwrap().is_empty());
+        // Revoking twice is a NotFound rather than a silent success.
+        assert!(matches!(
+            devices.revoke(&device.id).await,
+            Err(Error::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn codes_are_case_insensitive_when_redeemed() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        // Typed in lower case off a screen.
+        let redeemed = devices
+            .redeem_pairing_code(&code.to_lowercase(), "Phone")
+            .await;
+        assert!(redeemed.is_ok(), "{redeemed:?}");
+    }
+
+    #[tokio::test]
+    async fn last_seen_is_stamped_on_use() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        let (device, token) = devices.redeem_pairing_code(&code, "Phone").await.unwrap();
+        assert!(devices.list().await.unwrap()[0].last_seen_at.is_none());
+
+        devices.authenticate(&token).await.unwrap();
+
+        let listed = devices.list().await.unwrap();
+        assert_eq!(listed[0].id, device.id);
+        assert!(listed[0].last_seen_at.is_some());
+    }
+}

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -1,6 +1,7 @@
 mod chat_map;
 mod conversation;
 mod credential_request;
+mod device;
 mod guarded;
 mod jobs;
 pub mod keychain;
@@ -19,6 +20,7 @@ use zeroize::Zeroizing;
 pub use chat_map::ChatMapStore;
 pub use conversation::{ConversationStore, ConversationSummary};
 pub use credential_request::{CredentialRequest, CredentialRequestStore, RequestAction};
+pub use device::{Device, DeviceStore, Principal};
 pub use guarded::{GuardedSecrets, WriteOutcome};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
 pub use recall_archive::RecallArchiveStore;
@@ -195,6 +197,26 @@ impl Store {
 
             CREATE INDEX IF NOT EXISTS idx_secret_audit_name
                 ON secret_audit (name, at DESC);
+
+            -- Paired devices. Tokens are stored only as SHA-256 hashes, so
+            -- reading this table yields nothing that can authenticate.
+            -- Revoked rows are kept so audit entries naming them resolve.
+            CREATE TABLE IF NOT EXISTS devices (
+                id           TEXT PRIMARY KEY,
+                name         TEXT NOT NULL,
+                token_hash   BLOB NOT NULL,
+                created_at   INTEGER NOT NULL,
+                last_seen_at INTEGER,
+                revoked_at   INTEGER,
+                push_token   TEXT
+            );
+
+            -- One-time pairing codes: hashed, short-lived, single use.
+            CREATE TABLE IF NOT EXISTS pairing_codes (
+                code_hash  BLOB PRIMARY KEY,
+                expires_at INTEGER NOT NULL,
+                used_at    INTEGER
+            );
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -337,6 +359,11 @@ impl Store {
     /// forgetting a check.
     pub fn guarded_secrets(&self) -> GuardedSecrets {
         GuardedSecrets::new(self.secrets(), self.credential_requests())
+    }
+
+    /// Handle for paired devices and pairing codes.
+    pub fn devices(&self) -> DeviceStore {
+        DeviceStore::new(Arc::clone(&self.conn))
     }
 
     /// Return a handle for scheduled-job operations.

--- a/docs/plans/fix-scheduled-job-no-user-query.md
+++ b/docs/plans/fix-scheduled-job-no-user-query.md
@@ -1,0 +1,292 @@
+# Fix: scheduled jobs fail with Ollama `no user query found in messages`
+
+**Status:** diagnosed, not yet fixed
+**Diagnosed:** 2026-08-20
+**Affected branch / worktree:** `claude/phase2-device-pairing` at
+`/Users/geoff/projects/rustycrab/.claude/worktrees/ios-app-credentials`
+(HEAD `3c5da9f`)
+
+---
+
+## 1. TL;DR for the implementer
+
+Every scheduled (cron) job now fails at the model provider with:
+
+```
+Ollama API returned 500 Internal Server Error: {"error":"no user query found in messages"}
+```
+
+Ollama >= 0.32 rejects any `/api/chat` request whose `messages` array contains no
+`user`-role entry. Two independent defects in this repo combine to produce exactly
+that shape on scheduled runs:
+
+1. **`task_queue::execute_cron_task` never appends a user turn** before invoking the
+   agent. It passes the scheduled prompt as the `user_content` *string argument*, which
+   is only used for profile routing and system-prompt construction — it never becomes a
+   message.
+2. **`OllamaProvider::trim_to_budget` has no floor protecting the last user turn.** It
+   drops oldest-first from the front of the non-system region and will happily evict
+   every user message in a long conversation.
+
+Fix #1 is the primary fix. Fix #2 is defensive and should also be done — without it the
+same failure can recur on any sufficiently long conversation, including interactive ones.
+
+---
+
+## 2. Evidence
+
+### 2.1 The provider-side behaviour is real and reproducible
+
+Ollama 0.32.14, running locally:
+
+```bash
+curl -s http://127.0.0.1:11434/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3.8:27b","stream":false,"messages":[{"role":"system","content":"You are a helpful assistant."}]}'
+```
+
+Returns:
+
+```json
+{"error":"no user query found in messages"}
+```
+
+A `messages` array with no `user` role is a hard 400/500. Older Ollama tolerated it,
+which is why this is surfacing now rather than when the code was written.
+
+### 2.2 The trimmer fires ~1 second before every failure
+
+From `~/.rustykrab/rustykrab.log`:
+
+```
+2026-08-20T07:29:54.847963Z  WARN rustykrab_providers::ollama: trimmed conversation history to fit Ollama context window
+                                  num_ctx=32768 budget=22528 estimated_tokens_before=23491 estimated_tokens_after=19293 messages_dropped=5
+2026-08-20T07:29:55.079449Z  WARN rustykrab_providers::ollama: Ollama streaming API error ... "no user query found in messages"
+```
+
+The pairing is consistent across all 25 occurrences. `budget=22528` checks out exactly:
+`RUSTYKRAB_NUM_CTX=32768` (set in the LaunchAgent plist) minus `num_predict=8192`
+minus `SAFETY_OVERHEAD_TOKENS=2048`.
+
+### 2.3 Scope of the failure
+
+- 25 occurrences, first at `2026-08-20T07:29:55Z`, recurring on each scheduled run
+  (07:30, 09:00, 14:30, 16:30 UTC), logged from `rustykrab_cli::task_queue` and
+  `rustykrab_gateway::orchestrate`.
+- Interactive paths (webchat `routes.rs`, Slack/Telegram `main.rs`) are **not** affected,
+  because they push a real user message before running the agent.
+
+### 2.4 Ruled out
+
+- **Not an Ollama upgrade at the moment of breakage.** The ollama server process has run
+  the same binary continuously since Aug 18 11:02 (`/Applications/Ollama.app`), and
+  rustykrab succeeded against it at `2026-08-20T06:53:45Z`, 36 minutes before the first
+  failure. The upgrade is a precondition, not the trigger.
+- **Not a rebuild.** The deployed binary `RustyKrab.app/Contents/MacOS/rustykrab-cli`
+  is dated Jun 6 and unchanged.
+- **Not the master key / keychain.** `~/.rustykrab/rustykrab-error.log` is full of
+  `keychain read failed ... User interaction is not allowed`, but that file has not been
+  written since **Jun 6**. The master key loads cleanly on the current daemon.
+- **Not model availability.** `qwen3.8:27b` is present and `/api/tags` returns 200.
+
+### 2.5 Why the onset was gradual
+
+Scheduled-job conversations are deliberately persistent and reused
+(`resume_or_create_conversation`, and the comment at `task_queue.rs:423`: the
+conversation is intentionally not deleted between runs). They accumulate
+assistant/tool turns from every run, plus any user turns contributed by the bound
+Telegram/Slack channel. Since scheduled runs add no user turn of their own, the only
+user messages present are old ones near the front. Once the conversation crossed the
+22528-token budget, `trim_to_budget` began dropping from the front — taking those stale
+user turns with it and leaving a system+assistant/tool-only array.
+
+---
+
+## 3. Root cause in the source
+
+### 3.1 The contract
+
+`orchestrate.rs` only ever injects a **System** message and expects the caller to have
+already appended the user turn. It says so itself at `crates/rustykrab-gateway/src/orchestrate.rs:299`:
+
+```rust
+// The inbound user message was pushed onto conv.messages by
+// routes.rs before the runner was constructed, so it never goes
+// through push_message.
+```
+
+`run_agent*`'s `user_content: &str` parameter is used for `state.profile_for(user_content)`
+and system-prompt construction only. It is never turned into a message.
+
+### 3.2 Call-site audit
+
+| Call site | Pushes `Role::User` first? |
+|---|---|
+| `rustykrab-gateway/src/routes.rs:383` | yes (`routes.rs:371-379`) |
+| `rustykrab-gateway/src/routes.rs:521` | yes (`routes.rs:461-469`) |
+| `rustykrab-cli/src/main.rs:1991` (Slack/Telegram) | yes (`main.rs:1978`) |
+| **`rustykrab-cli/src/task_queue.rs:302`** | **no — this is the bug** |
+
+`grep -n "messages.push\|Role::User" crates/rustykrab-cli/src/task_queue.rs` returns nothing.
+
+### 3.3 The trimmer has no floor
+
+`crates/rustykrab-providers/src/ollama.rs:502-553`. The drop loop walks forward from the
+first non-system message with no lower bound on what must survive:
+
+```rust
+let mut drop_end = system_count;
+while current > budget && drop_end < trimmed.len() {
+    current = current.saturating_sub(estimate_message_tokens(&trimmed[drop_end]));
+    drop_end += 1;
+}
+// ... orphan-tool skip ...
+trimmed.drain(system_count..drop_end);
+```
+
+Nothing guarantees a `user` message remains.
+
+---
+
+## 4. Fix 1 (primary) — append a user turn in `execute_cron_task`
+
+**File:** `crates/rustykrab-cli/src/task_queue.rs`
+**Location:** immediately before the `run_agent_streaming_with_options` call at line 302,
+after `prompt` is built (lines 274-280).
+
+`prompt` is currently passed as `&prompt` to the run call, so clone it for the message.
+
+```rust
+// Scheduled runs must contribute their own user turn. `run_agent_*` injects
+// only the system prompt and relies on the caller to have appended the user
+// message (see orchestrate.rs:299). Without one, a resumed job conversation
+// reaches the provider carrying only system/assistant/tool messages, which
+// Ollama >= 0.32 rejects with `{"error":"no user query found in messages"}`.
+// Appending here also guarantees the newest message is a user turn, so the
+// provider's oldest-first trimming can never strand the request without one.
+conv.messages.push(Message {
+    id: Uuid::new_v4(),
+    role: Role::User,
+    content: MessageContent::Text(prompt.clone()),
+    created_at: Utc::now(),
+    agent_version: Message::version_stamp(),
+});
+conv.updated_at = Utc::now();
+```
+
+Imports: `task_queue.rs:8` currently pulls `{Conversation, MessageContent}` from
+`rustykrab_core::types`. Add `Message` and `Role`. `Uuid` and `Utc` are already in scope.
+
+Mirror the exact field set used at `routes.rs:371-379` so persistence and version
+stamping stay consistent.
+
+### Persistence note
+`prepare_agent` (`orchestrate.rs:298-308`) fires the memory callback for the last message
+only when it is `Role::User`. Today that branch never runs for scheduled jobs. After this
+fix it will, so the scheduled prompt gets persisted alongside the run. Confirm that is
+desired and that it does not double-write against the post-run save in
+`execute_cron_task`.
+
+---
+
+## 5. Fix 2 (defensive) — never trim away the last user turn
+
+**File:** `crates/rustykrab-providers/src/ollama.rs`, in `trim_to_budget`, after the
+orphan-tool skip loop and before `let dropped = drop_end - system_count;`.
+
+```rust
+// Never trim past the most recent user turn. A request whose message array
+// carries no user role is rejected outright by Ollama with
+// `no user query found in messages`, turning an over-long conversation into a
+// hard failure instead of a merely degraded one. Clamping here can leave the
+// request above budget; that is strictly preferable to a guaranteed 500.
+if let Some(idx) = trimmed.iter().rposition(|m| m.role == "user") {
+    drop_end = drop_end.min(idx);
+}
+```
+
+Clamping to `idx` is safe with respect to the orphan-tool rule: the first surviving
+message is then the user message itself, never a dangling `tool` result.
+
+Two follow-ups for whoever implements this:
+
+- `current` becomes stale after clamping (fewer messages are dropped than accounted for).
+  Recompute it for the log line so `estimated_tokens_after` is not misleading.
+- If the clamped request still exceeds budget, emit a distinct `warn!`/`error!` — that
+  means a single turn is too large for the context window, which needs its own handling
+  rather than silently shipping an over-budget request.
+
+---
+
+## 6. Tests
+
+Add to `crates/rustykrab-providers/src/ollama.rs` unit tests:
+
+1. `trim_to_budget` with a tiny budget over `[system, user, assistant, tool, assistant]`
+   asserts at least one `role == "user"` survives.
+2. Same, asserting the first surviving non-system message is not a `tool` (no orphan).
+3. A conversation whose only user turn is the oldest message and whose budget forces
+   maximal trimming — asserts that user turn is retained.
+
+For `task_queue.rs`, assert that after the pre-run setup the last element of
+`conv.messages` has `role == Role::User` and its text equals the built scheduled prompt.
+The existing test helpers `empty_conv()` / `channel_conv()` (`task_queue.rs:700-720`)
+are a reasonable starting point; a small refactor extracting the conversation-preparation
+step from `execute_cron_task` would make this directly testable.
+
+---
+
+## 7. Verification after the fix
+
+1. Rebuild and redeploy (see §8 — the deployed binary is stale).
+2. Confirm the negative case still errors at the provider, proving the repro is valid:
+   the `curl` in §2.1 should keep returning `no user query found in messages`.
+3. Trigger a scheduled job (or wait for the next cron fire) and confirm:
+   - no `no user query found in messages` in `~/.rustykrab/rustykrab.log`
+   - `trimmed conversation history` warnings may still appear — that is fine and expected;
+     what matters is that they are no longer followed by a provider error.
+4. Regression-check an interactive turn through webchat and Telegram.
+
+---
+
+## 8. Build / deploy caveat — read before starting
+
+There is a mismatch between the deployed binary and the checked-out source, and it needs
+resolving before anyone concludes a fix "did not work":
+
+- The **running daemon** is `RustyKrab.app/Contents/MacOS/rustykrab-cli`, dated **Jun 6**,
+  launched by `~/Library/LaunchAgents/com.rustykrab.agent.plist`.
+- It logs a `rustykrab_cli::task_queue` module that **does not exist in the main working
+  tree** at `/Users/geoff/projects/rustycrab`. `task_queue.rs` exists only in the
+  `ios-app-credentials` worktree (branch `claude/phase2-device-pairing`).
+
+So the deployed build came from a branch that has since diverged from `main`. Confirm
+which branch corresponds to the deployed artifact and which branch should receive this
+fix before writing code. Restarting the daemon after redeploy:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.rustykrab.agent
+```
+
+---
+
+## 9. Related findings (out of scope for this fix)
+
+These were found while diagnosing. They are not causes of this bug, but they are real.
+
+1. **Gmail app password is in plaintext on disk.** `rustykrab_providers::ollama` logs raw
+   API responses including full model reasoning. At `2026-08-19T21:17:53Z` in
+   `~/.rustykrab/rustykrab.log`, the model recited both Gmail credentials verbatim.
+   Rotate that app password and drop raw-body logging to `debug`.
+2. **`TELEGRAM_BOT_TOKEN` is in plaintext** in the LaunchAgent plist, despite the secret
+   registry existing precisely to avoid that.
+3. **`gmail_email` credential was corrupted** — it held the literal string `gmail_email`
+   instead of an address, which made `caldav` build
+   `https://apidata.googleusercontent.com/caldav/v2/gmail_email/events/` and 401.
+   Already fixed on 2026-08-20 via
+   `rustykrab-cli keychain set gmail-email <address>`, which writes both the OS keychain
+   and the encrypted store. Note `caldav.rs:110` (`calendar_id.unwrap_or(email)`) means a
+   bad stored email silently becomes a bad URL — the `set_strict` validation added in this
+   worktree is the right guard and is not in the deployed build.
+4. **A stale error log is actively misleading.** `~/.rustykrab/rustykrab-error.log` holds
+   1,693 `keychain read failed` errors last written Jun 6. Consider rotating or clearing it.


### PR DESCRIPTION
**Stacked on #490** (device pairing), which is stacked on #489 (the guard). Merge in that order.

The last two pieces of Phase 2. Suite is **17 pass / 0 fail / 0 xfail**.

## Origin allowlist — the blocker for the app

The middleware demands an `Origin` on every `/api` request and permitted only loopback, with `OriginPolicy::default()` an empty set the CLI never overrode. The app reaches the daemon by its **tailnet name**, so every request except `/api/health` came back `403`. I hit this wiring Apollo up in Phase 1; it's been recorded in the plan and the contract doc since.

`RUSTYKRAB_ALLOWED_ORIGINS` (comma-separated) now adds origins alongside loopback, which is still always allowed:

```sh
RUSTYKRAB_ALLOWED_ORIGINS=https://mac.tailnet.ts.net
```

Details that matter:

- Allowlist entries **and** incoming headers are normalised the same way (trimmed, trailing `/` dropped, host lowercased). Normalising only one side would mean an entry differing solely in case silently fails to match.
- A malformed entry is skipped **with a warning**, rather than quietly widening or narrowing the policy.
- The scheme is part of the comparison, so allowing `https://mac.ts.net` does not admit `http://mac.ts.net`.
- **The default is unchanged**: with nothing configured, only loopback works. There's a test pinning exactly that, because a regression there would silently expose the gateway.

## WebChat approvals panel

A badge and list in the sidebar showing what the agent asked to change — name, action, and its reason, **never a value**, because no endpoint returns one. Approve prompts for confirmation; a `409` (the credential moved since filing) is reported as that specifically rather than as a generic failure. The panel stays hidden when nothing is pending, and hides itself against a server without the endpoint rather than showing an error for a feature it doesn't have. Polls every 15s — push is Phase 4.

## New scenario

`origin_allowlist` pins all three cases: the configured origin is accepted, an unlisted one is refused, and a request with **no** `Origin` is still refused — that last one being what stops a non-browser client from skipping the check entirely.

```
17 pass / 0 fail / 0 xfail / 0 xpass
```

509 workspace tests green (6 new on the policy), `fmt`/`clippy` clean.

With this, Workstreams A and B are complete and the server is ready for the app to talk to it over the tailnet. Next: the app-side pairing flow replacing manual token entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)