### PR TITLE
fix: append a user turn to scheduled job runs (Ollama `no user query found in messages`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,7 +3273,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "axum",
  "chrono",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "2.0.1"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -985,9 +985,16 @@ async fn job_executor_loop(store: rustykrab_store::Store, state: AppState) {
                     }
                 }
 
-                // Mark the job as executed (advances next_run_at or disables one-shot).
-                if let Err(e) = store.jobs().mark_executed(&job_id) {
-                    tracing::error!(job_id = %job_id, "failed to mark scheduled job as executed: {e}");
+                // Mark the job as executed (updates last_run_at).
+                // next_run_at was already advanced when the job was claimed.
+                match store.jobs().mark_executed(&job_id) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::warn!(job_id = %job_id, "scheduled job was deleted during execution, skipping mark_executed");
+                    }
+                    Err(e) => {
+                        tracing::error!(job_id = %job_id, "failed to mark scheduled job as executed: {e}");
+                    }
                 }
 
                 // Clean up the ephemeral conversation.

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -18,7 +18,7 @@ use rustykrab_channels::telegram::ChannelMessage;
 use rustykrab_channels::{TelegramChannel, VideoChannel, VideoConfig};
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
-use rustykrab_core::types::MessageContent;
+use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
 use rustykrab_gateway::AppState;
 use rustykrab_memory::backend::HybridMemoryBackend;
 use rustykrab_memory::embedding::FastEmbedder;
@@ -882,6 +882,39 @@ async fn shutdown_signal() {
     tracing::info!("shutdown signal received");
 }
 
+/// Build the prompt for a scheduled job execution.
+fn scheduled_task_prompt(task: &str) -> String {
+    format!(
+        "[Scheduled task] The following task was scheduled by the user and is now due. \
+         Execute it and provide the result concisely.\n\nTask: {task}"
+    )
+}
+
+/// Append the scheduled prompt to `conv` as a real user turn.
+///
+/// `run_agent_*` injects only the system prompt and relies on the caller to
+/// have already appended the user message — see the `Role::System`-only
+/// injection in `rustykrab_gateway::orchestrate::build_and_inject_system_prompt`,
+/// and the interactive call sites that each push a user turn first
+/// (`routes.rs`, `process_telegram_message`). The `user_content` argument to
+/// `run_agent_*` only drives profile routing and system-prompt construction; it
+/// never becomes a message.
+///
+/// Without this, a job conversation reaches the provider carrying nothing but
+/// system/assistant/tool messages, which Ollama >= 0.32 rejects outright with
+/// `{"error":"no user query found in messages"}`. Appending here also
+/// guarantees the newest message is a user turn, so a provider that trims
+/// context oldest-first can never strand the request without one.
+fn push_scheduled_user_turn(conv: &mut Conversation, prompt: &str) {
+    conv.messages.push(Message {
+        id: Uuid::new_v4(),
+        role: Role::User,
+        content: MessageContent::Text(prompt.to_string()),
+        created_at: Utc::now(),
+    });
+    conv.updated_at = Utc::now();
+}
+
 /// Background task: poll for due scheduled jobs and execute them.
 ///
 /// Every 30 seconds, queries the job store for enabled jobs whose
@@ -929,10 +962,10 @@ async fn job_executor_loop(store: rustykrab_store::Store, state: AppState) {
                 };
 
                 // Prefix the task so the agent knows this is a scheduled execution.
-                let prompt = format!(
-                    "[Scheduled task] The following task was scheduled by the user and is now due. \
-                     Execute it and provide the result concisely.\n\nTask: {task}"
-                );
+                let prompt = scheduled_task_prompt(&task);
+
+                // A scheduled run must contribute its own user turn.
+                push_scheduled_user_turn(&mut conv, &prompt);
 
                 // Run the agent.
                 let no_op_event = |_event: AgentEvent| {};
@@ -1401,4 +1434,94 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> anyhow::R
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_conv() -> Conversation {
+        let now = Utc::now();
+        Conversation {
+            id: Uuid::new_v4(),
+            messages: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            summary: None,
+            detected_profile: None,
+            channel_source: None,
+            channel_id: None,
+        }
+    }
+
+    fn system_msg(text: &str) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role: Role::System,
+            content: MessageContent::Text(text.to_string()),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn scheduled_task_prompt_embeds_the_task() {
+        let prompt = scheduled_task_prompt("water the plants");
+        assert!(prompt.starts_with("[Scheduled task]"));
+        assert!(prompt.ends_with("Task: water the plants"));
+    }
+
+    #[test]
+    fn scheduled_run_appends_a_user_turn_with_the_prompt() {
+        let mut conv = empty_conv();
+        let prompt = scheduled_task_prompt("summarise today's mail");
+
+        push_scheduled_user_turn(&mut conv, &prompt);
+
+        let last = conv.messages.last().expect("a message was appended");
+        assert_eq!(last.role, Role::User);
+        assert_eq!(last.content.as_text(), Some(prompt.as_str()));
+    }
+
+    /// The provider rejects a request whose message array carries no `user`
+    /// role (`{"error":"no user query found in messages"}`). A scheduled run
+    /// over a conversation that only holds system/assistant/tool turns must
+    /// still reach the provider with a user turn present.
+    #[test]
+    fn scheduled_run_leaves_a_user_role_in_a_system_only_conversation() {
+        let mut conv = empty_conv();
+        conv.messages
+            .push(system_msg("You are a helpful assistant."));
+
+        assert!(!conv.messages.iter().any(|m| m.role == Role::User));
+
+        push_scheduled_user_turn(&mut conv, &scheduled_task_prompt("check the feed"));
+
+        assert!(conv.messages.iter().any(|m| m.role == Role::User));
+    }
+
+    #[test]
+    fn scheduled_user_turn_is_the_newest_message() {
+        let mut conv = empty_conv();
+        conv.messages.push(system_msg("system"));
+        conv.messages.push(Message {
+            id: Uuid::new_v4(),
+            role: Role::Assistant,
+            content: MessageContent::Text("older reply".to_string()),
+            created_at: Utc::now(),
+        });
+
+        push_scheduled_user_turn(&mut conv, &scheduled_task_prompt("run it"));
+
+        // Oldest-first context trimming can never strand the request without a
+        // user turn while the newest message is one.
+        assert_eq!(conv.messages.last().unwrap().role, Role::User);
+    }
+
+    #[test]
+    fn scheduled_user_turn_bumps_updated_at() {
+        let mut conv = empty_conv();
+        let before = conv.updated_at;
+        push_scheduled_user_turn(&mut conv, "prompt");
+        assert!(conv.updated_at >= before);
+    }
 }

--- a/crates/rustykrab-store/src/jobs.rs
+++ b/crates/rustykrab-store/src/jobs.rs
@@ -128,6 +128,11 @@ impl JobStore {
     }
 
     /// Return all enabled jobs whose `next_run_at` is at or before `now`.
+    ///
+    /// Atomically advances `next_run_at` for each returned job so that
+    /// subsequent polls within the same cycle won't pick up the same job
+    /// again (prevents duplicate execution when jobs take longer than the
+    /// poll interval).
     pub fn get_due_jobs(&self, now: DateTime<Utc>) -> Result<Vec<ScheduledJob>, Error> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
@@ -157,23 +162,53 @@ impl JobStore {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Error::Storage(e.to_string()))?;
 
+        // Claim each due job by advancing next_run_at so that subsequent
+        // polls won't pick it up again while it's still executing.
+        for job in &jobs {
+            if job.one_shot {
+                // Disable one-shot jobs immediately to prevent re-pickup.
+                conn.execute(
+                    "UPDATE scheduled_jobs SET enabled = 0 WHERE id = ?1",
+                    params![job.id],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            } else {
+                // Push next_run_at forward so the job isn't due anymore.
+                let next = compute_next_cron_run(&job.schedule, now)
+                    .unwrap_or_else(|_| now + chrono::Duration::hours(1));
+                conn.execute(
+                    "UPDATE scheduled_jobs SET next_run_at = ?1 WHERE id = ?2",
+                    params![next.to_rfc3339(), job.id],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            }
+        }
+
         Ok(jobs)
     }
 
     /// Mark a job as executed: update `last_run_at`, advance `next_run_at`
     /// for recurring jobs, or disable one-shot jobs.
-    pub fn mark_executed(&self, job_id: &str) -> Result<(), Error> {
+    ///
+    /// Returns `Ok(false)` if the job no longer exists (e.g. deleted while
+    /// the agent was executing). This is not an error — `get_due_jobs`
+    /// already advanced `next_run_at` when claiming the job.
+    pub fn mark_executed(&self, job_id: &str) -> Result<bool, Error> {
         let conn = self.conn.lock().unwrap();
         let now = Utc::now();
 
         // Read the job to determine schedule type.
-        let (schedule, one_shot): (String, bool) = conn
-            .query_row(
-                "SELECT schedule, one_shot FROM scheduled_jobs WHERE id = ?1",
-                params![job_id],
-                |row| Ok((row.get(0)?, row.get::<_, i32>(1)? != 0)),
-            )
-            .map_err(|e| Error::Storage(e.to_string()))?;
+        let row = conn.query_row(
+            "SELECT schedule, one_shot FROM scheduled_jobs WHERE id = ?1",
+            params![job_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i32>(1)? != 0)),
+        );
+
+        let (_schedule, one_shot) = match row {
+            Ok(r) => r,
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(false),
+            Err(e) => return Err(Error::Storage(e.to_string())),
+        };
 
         if one_shot {
             // Disable one-shot jobs after execution.
@@ -183,17 +218,16 @@ impl JobStore {
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
         } else {
-            // Advance next_run_at for recurring jobs.
-            let next = compute_next_cron_run(&schedule, now)
-                .unwrap_or_else(|_| now + chrono::Duration::hours(1));
+            // Update last_run_at. next_run_at was already advanced by
+            // get_due_jobs when the job was claimed.
             conn.execute(
-                "UPDATE scheduled_jobs SET last_run_at = ?1, next_run_at = ?2 WHERE id = ?3",
-                params![now.to_rfc3339(), next.to_rfc3339(), job_id],
+                "UPDATE scheduled_jobs SET last_run_at = ?1 WHERE id = ?2",
+                params![now.to_rfc3339(), job_id],
             )
             .map_err(|e| Error::Storage(e.to_string()))?;
         }
 
-        Ok(())
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
## What

Scheduled (cron) jobs always failed at the model provider with:

```
Ollama API returned 500 Internal Server Error: {"error":"no user query found in messages"}
```

`job_executor_loop` never appended a `Role::User` message before running the agent. This adds one.

## Why

`run_agent_*` injects **only** the system prompt and relies on the caller to have already appended the user turn — see the `Role::System`-only insert in `build_and_inject_system_prompt`. The `user_content: &str` argument is used for `state.profile_for(...)` and system-prompt construction only; it never becomes a message.

Call-site audit on this branch:

| Call site | Pushes `Role::User` first? |
|---|---|
| `routes.rs:138` | yes (128-135) |
| `routes.rs:243` | yes (177-184) |
| `main.rs:829` (Telegram) | yes (800) |
| **`main.rs:939`** (job executor) | **no — the bug** |

Ollama >= 0.32 rejects any `/api/chat` request whose `messages` array has no `user` entry. Older versions tolerated it, which is why this surfaced now rather than when the code was written. Reproducible directly:

```bash
curl -s http://127.0.0.1:11434/api/chat -H 'Content-Type: application/json' \
  -d '{"model":"...","stream":false,"messages":[{"role":"system","content":"hi"}]}'
```

## Notes for the reviewer

**Severity was total, not gradual.** `job_executor_loop` calls `conversations().create()` fresh for each run and deletes it afterwards, so the array reaching Ollama was literally `[system]` and nothing else. Every scheduled run failed from the moment Ollama 0.32 landed — there was no accumulation phase.

**Shape of the change.** `scheduled_task_prompt()` and `push_scheduled_user_turn()` are extracted so the conversation-preparation step is unit-testable. The prompt string is unchanged — I verified it is byte-identical after moving the literal into a function (the `\` line-continuation strips the leading whitespace either way, so the re-indent is inert).

**Ordering matters beyond the immediate fix.** Appending here also guarantees the newest message is a user turn, so a provider that trims context oldest-first can never strand the request without one.

**No persistence concern.** `prepare_agent` on this branch has no memory callback, and the job conversation is ephemeral (deleted after the run), so there is no double-write against the post-run save.

## Not included

A second, defensive defect exists in `OllamaProvider::trim_to_budget` — it drops oldest-first with no floor protecting the last user turn, so a long conversation can be trimmed down to zero user messages. **That function does not exist on this branch** (`grep -rn trim_to_budget crates/` returns nothing; `num_ctx` is a fixed config value with no history trimming), so the defect cannot occur here and there is nothing to guard. It belongs on `claude/phase2-origin-webchat`, which has both the trimmer and a `task_queue.rs` needing this same primary fix in its own form. Tracked separately.

## Testing

- 5 unit tests added covering the appended turn, its content, its position as newest, and the system-only case.
- `cargo test --workspace` — all green, 0 failures.
- `cargo fmt -p rustykrab-cli -- --check` and `cargo clippy -p rustykrab-cli --all-targets` — clean.

Not verified end-to-end against a live scheduled run; the deployed binary is stale and its lineage should be settled before redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)