### PR TITLE
Phase 4 (E): APNs push for pending credential requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1815,9 +1815,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2757,7 +2757,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4009,7 +4009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4068,7 +4068,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4673,7 +4673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4867,7 +4867,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5366,7 +5366,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5887,7 +5887,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +1981,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -3836,6 +3856,7 @@ dependencies = [
  "cookie_store",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4179,10 +4200,13 @@ name = "rustykrab-gateway"
 version = "5.0.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "mime_guess",
  "rand 0.9.4",
+ "reqwest 0.13.3",
+ "ring",
  "rust-embed",
  "rustykrab-agent",
  "rustykrab-channels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots", "connect"] }
 axum = "0.8"
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "query"] }
+# `http2` is required for APNs, which refuses HTTP/1.1. It was absent, so
+# `h2` was not in the tree at all and a push would have failed at connect.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "query", "http2"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -63,6 +65,9 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"
+# ES256 for APNs provider tokens. Already in the tree via rustls, so
+# this adds no new code — only a direct dependency edge.
+ring = "0.17"
 aes-gcm = "0.10"
 argon2 = "0.5"
 security-framework = { version = "3", features = ["OSX_10_15"] }

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -312,12 +312,6 @@ impl MessageBackend for MessageAdapter {
     }
 }
 
-/// Store name for the APNs signing key (the `.p8` file's contents).
-/// Set it with `credential_write` or `POST /api/secrets`, so the key lives
-/// encrypted alongside every other credential rather than as a file path
-/// in configuration.
-const APNS_KEY_SECRET: &str = "apns_auth_key";
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // --- TLS crypto provider (must be set before any rustls usage) ---
@@ -467,43 +461,25 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // --- APNs push (optional) ---
-    // Only the non-secret settings come from the environment; the signing
-    // key is read from the encrypted store like any other credential, so
-    // it is never a file path baked into config. Absent configuration is
-    // the normal state and simply means no notifications.
+    // Only the non-secret settings come from the environment. The signing
+    // key is resolved on first use, not here: it is a credential, so it
+    // can be stored from the app or the CLI while the daemon is running,
+    // and rotating it does not need a restart.
     let push_notifier: Option<std::sync::Arc<dyn rustykrab_store::RequestNotifier>> =
-        match rustykrab_gateway::ApnsConfig::from_env() {
-            Some(config) => match store.secrets().get(APNS_KEY_SECRET).await {
-                Ok(key_pem) => match rustykrab_gateway::ApnsClient::new(config.clone(), &key_pem) {
-                    Ok(client) => {
-                        tracing::info!(
-                            topic = %config.topic,
-                            environment = ?config.environment,
-                            "APNs push enabled"
-                        );
-                        Some(std::sync::Arc::new(rustykrab_gateway::PushNotifier::new(
-                            std::sync::Arc::new(client),
-                            store.devices(),
-                        )))
-                    }
-                    Err(e) => {
-                        // Loud, but not fatal: approvals still work through
-                        // the app and WebChat without a notification.
-                        tracing::error!(error = %e, "APNs key rejected — push disabled");
-                        None
-                    }
-                },
-                Err(_) => {
-                    tracing::warn!(
-                        "APNs is configured but no '{APNS_KEY_SECRET}' credential is stored — \
-                         push disabled. Store the .p8 contents under that name."
-                    );
-                    None
-                }
-            },
-            None => None,
-        };
+        rustykrab_gateway::ApnsConfig::from_env().map(|config| {
+            tracing::info!(
+                topic = %config.topic,
+                environment = ?config.environment,
+                "APNs push configured (key resolved on first notification)"
+            );
+            std::sync::Arc::new(rustykrab_gateway::PushNotifier::new(
+                config,
+                store.secrets(),
+                store.devices(),
+            )) as std::sync::Arc<dyn rustykrab_store::RequestNotifier>
+        });
 
+    // Hand the notifier to the store so filing a request tells the user.
     let store = match push_notifier {
         Some(notifier) => store.with_request_notifier(notifier),
         None => store,

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -312,6 +312,12 @@ impl MessageBackend for MessageAdapter {
     }
 }
 
+/// Store name for the APNs signing key (the `.p8` file's contents).
+/// Set it with `credential_write` or `POST /api/secrets`, so the key lives
+/// encrypted alongside every other credential rather than as a file path
+/// in configuration.
+const APNS_KEY_SECRET: &str = "apns_auth_key";
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // --- TLS crypto provider (must be set before any rustls usage) ---
@@ -459,6 +465,49 @@ async fn main() -> anyhow::Result<()> {
             );
         }
     }
+
+    // --- APNs push (optional) ---
+    // Only the non-secret settings come from the environment; the signing
+    // key is read from the encrypted store like any other credential, so
+    // it is never a file path baked into config. Absent configuration is
+    // the normal state and simply means no notifications.
+    let push_notifier: Option<std::sync::Arc<dyn rustykrab_store::RequestNotifier>> =
+        match rustykrab_gateway::ApnsConfig::from_env() {
+            Some(config) => match store.secrets().get(APNS_KEY_SECRET).await {
+                Ok(key_pem) => match rustykrab_gateway::ApnsClient::new(config.clone(), &key_pem) {
+                    Ok(client) => {
+                        tracing::info!(
+                            topic = %config.topic,
+                            environment = ?config.environment,
+                            "APNs push enabled"
+                        );
+                        Some(std::sync::Arc::new(rustykrab_gateway::PushNotifier::new(
+                            std::sync::Arc::new(client),
+                            store.devices(),
+                        )))
+                    }
+                    Err(e) => {
+                        // Loud, but not fatal: approvals still work through
+                        // the app and WebChat without a notification.
+                        tracing::error!(error = %e, "APNs key rejected — push disabled");
+                        None
+                    }
+                },
+                Err(_) => {
+                    tracing::warn!(
+                        "APNs is configured but no '{APNS_KEY_SECRET}' credential is stored — \
+                         push disabled. Store the .p8 contents under that name."
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
+    let store = match push_notifier {
+        Some(notifier) => store.with_request_notifier(notifier),
+        None => store,
+    };
 
     // --- Auth token ---
     // Resolution order (via registry):

--- a/crates/rustykrab-gateway/Cargo.toml
+++ b/crates/rustykrab-gateway/Cargo.toml
@@ -21,6 +21,10 @@ tracing.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 rust-embed.workspace = true
+# APNs push: HTTP/2 client, base64url for the JWT, ES256 signing.
+reqwest.workspace = true
+base64.workspace = true
+ring.workspace = true
 mime_guess = "2"
 rand.workspace = true
 hex.workspace = true

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod logging;
 mod orchestrate;
 pub mod origin;
+pub mod push;
 pub mod rate_limit;
 mod routes;
 mod signal_webhook;
@@ -15,6 +16,7 @@ pub use orchestrate::{
     run_agent_with_options, RunOptions,
 };
 pub use origin::OriginPolicy;
+pub use push::{ApnsClient, ApnsConfig, ApnsEnvironment, PushNotifier};
 pub use rate_limit::RateLimitConfig;
 pub use state::AppState;
 

--- a/crates/rustykrab-gateway/src/push.rs
+++ b/crates/rustykrab-gateway/src/push.rs
@@ -271,8 +271,15 @@ impl ApnsClient {
         )))
     }
 
-    /// True when Apple says the token is no longer valid for this app, so
-    /// the caller can stop sending to it.
+    /// True when Apple rejected our *provider* token — a rotated key or a
+    /// token outside its validity window — as opposed to the device's.
+    pub fn is_stale_provider_token(error: &Error) -> bool {
+        let text = error.to_string();
+        text.contains("InvalidProviderToken") || text.contains("ExpiredProviderToken")
+    }
+
+    /// True when Apple says the *device* token is no longer valid for this
+    /// app, so the caller can stop sending to it.
     pub fn is_dead_token(error: &Error) -> bool {
         let text = error.to_string();
         text.contains("BadDeviceToken") || text.contains("Unregistered")
@@ -280,18 +287,27 @@ impl ApnsClient {
 }
 
 /// Sends a notification to every registered device.
+///
+/// The signing key is resolved **lazily**, not at startup. It is a
+/// credential like any other, so it can be stored from the app or the CLI
+/// while the daemon is already running — reading it at boot would mean
+/// storing the key appeared to do nothing until a restart. The same
+/// property makes key rotation work: an authentication failure drops the
+/// cached client so the next notification picks up the new key.
 #[derive(Clone)]
 pub struct PushNotifier {
-    client: Arc<ApnsClient>,
+    config: ApnsConfig,
+    secrets: rustykrab_store::SecretStore,
     devices: rustykrab_store::DeviceStore,
+    client: Arc<RwLock<Option<Arc<ApnsClient>>>>,
 }
 
 impl std::fmt::Debug for PushNotifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // No key material or tokens in the debug output.
         f.debug_struct("PushNotifier")
-            .field("topic", &self.client.config.topic)
-            .field("environment", &self.client.config.environment)
+            .field("topic", &self.config.topic)
+            .field("environment", &self.config.environment)
             .finish()
     }
 }
@@ -313,8 +329,62 @@ impl rustykrab_store::RequestNotifier for PushNotifier {
 }
 
 impl PushNotifier {
-    pub fn new(client: Arc<ApnsClient>, devices: rustykrab_store::DeviceStore) -> Self {
-        Self { client, devices }
+    pub fn new(
+        config: ApnsConfig,
+        secrets: rustykrab_store::SecretStore,
+        devices: rustykrab_store::DeviceStore,
+    ) -> Self {
+        Self {
+            config,
+            secrets,
+            devices,
+            client: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// The client, building it from the stored key on first use.
+    ///
+    /// Returns `None` when no key is stored yet — push is optional, and a
+    /// deployment that never sets one should not produce errors.
+    async fn client(&self) -> Option<Arc<ApnsClient>> {
+        if let Some(existing) = self
+            .client
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            return Some(Arc::clone(existing));
+        }
+
+        // Resolve through the registry so the key can come from an env
+        // var, the OS keychain, or the encrypted store — the same
+        // resolution order as every other credential.
+        let spec = rustykrab_store::registry::lookup("apns_auth_key")?;
+        let key_pem = rustykrab_store::registry::resolve(spec, &self.secrets).await?;
+
+        match ApnsClient::new(self.config.clone(), &key_pem) {
+            Ok(built) => {
+                let built = Arc::new(built);
+                *self.client.write().unwrap_or_else(|e| e.into_inner()) = Some(Arc::clone(&built));
+                tracing::info!(
+                    topic = %self.config.topic,
+                    environment = ?self.config.environment,
+                    "APNs client ready"
+                );
+                Some(built)
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "stored APNs key is unusable — push disabled");
+                None
+            }
+        }
+    }
+
+    /// Drop the cached client so the next send re-reads the key. Used when
+    /// Apple rejects the provider token, which is what a rotated key looks
+    /// like from here.
+    fn invalidate_client(&self) {
+        *self.client.write().unwrap_or_else(|e| e.into_inner()) = None;
     }
 
     /// Notify all devices about a filed request.
@@ -324,6 +394,10 @@ impl PushNotifier {
     /// credential. The app and WebChat both show pending requests without
     /// any notification at all.
     pub async fn announce(&self, credential_name: &str, action: &str) {
+        let Some(client) = self.client().await else {
+            tracing::debug!("no APNs key stored — skipping push");
+            return;
+        };
         let devices = match self.devices.with_push_tokens().await {
             Ok(devices) => devices,
             Err(e) => {
@@ -332,12 +406,17 @@ impl PushNotifier {
             }
         };
         for (device_id, token) in devices {
-            match self
-                .client
+            match client
                 .notify_pending_request(&token, credential_name, action)
                 .await
             {
                 Ok(()) => tracing::info!(device = %device_id, "approval push sent"),
+                Err(e) if ApnsClient::is_stale_provider_token(&e) => {
+                    // The key was rotated, or the token drifted out of
+                    // Apple's window. Rebuild on the next notification.
+                    tracing::info!("APNs provider token rejected — rebuilding client");
+                    self.invalidate_client();
+                }
                 Err(e) if ApnsClient::is_dead_token(&e) => {
                     // The app was deleted or the token was reissued. Drop it
                     // rather than retrying forever.

--- a/crates/rustykrab-gateway/src/push.rs
+++ b/crates/rustykrab-gateway/src/push.rs
@@ -1,0 +1,459 @@
+//! APNs push for pending credential requests (Workstream E).
+//!
+//! When the agent asks to change a credential it cannot change itself, the
+//! user has to hear about it. Until now that meant opening the app or
+//! WebChat; this sends a notification instead.
+//!
+//! **The payload carries the credential's name and nothing else.** A push
+//! traverses Apple's infrastructure and lands on a lock screen, so a value
+//! must never be in it — the threat model says the same.
+//!
+//! Authentication is a token, not a certificate: an ES256 JWT signed with
+//! the team's `.p8` key. One key covers every app and both environments,
+//! which is why the endpoint has to be configured rather than inferred.
+
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+use rustykrab_core::Error;
+
+/// Apple rejects a token older than an hour and refuses one refreshed more
+/// often than every 20 minutes. Sit in the middle.
+const TOKEN_REFRESH: Duration = Duration::from_secs(45 * 60);
+
+/// Which APNs environment to talk to.
+///
+/// This is not detectable at runtime: a development-signed build talks to
+/// sandbox and a TestFlight or App Store build talks to production, and
+/// sending to the wrong one fails with `BadDeviceToken`. Getting it wrong
+/// is silent from the app's side, which is why it is explicit here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApnsEnvironment {
+    Sandbox,
+    Production,
+}
+
+impl ApnsEnvironment {
+    fn host(&self) -> &'static str {
+        match self {
+            ApnsEnvironment::Sandbox => "api.sandbox.push.apple.com",
+            ApnsEnvironment::Production => "api.push.apple.com",
+        }
+    }
+
+    fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "production" | "prod" => ApnsEnvironment::Production,
+            // Default to sandbox: a development build is what someone has
+            // in hand while setting this up, and sending a real push to
+            // production by accident is the worse mistake.
+            _ => ApnsEnvironment::Sandbox,
+        }
+    }
+}
+
+/// Everything needed to authenticate to APNs, minus the key material.
+#[derive(Debug, Clone)]
+pub struct ApnsConfig {
+    /// 10-character key identifier, e.g. `NP9F64W9GB`.
+    pub key_id: String,
+    /// 10-character team identifier, e.g. `3RRX845C4X`.
+    pub team_id: String,
+    /// The app's bundle id, sent as `apns-topic`.
+    pub topic: String,
+    pub environment: ApnsEnvironment,
+}
+
+impl ApnsConfig {
+    /// Read the non-secret settings from the environment. The signing key
+    /// is deliberately not here — it lives in the encrypted store.
+    ///
+    /// Returns `None` when push isn't configured, which is the normal state
+    /// for a deployment that hasn't set it up.
+    pub fn from_env() -> Option<Self> {
+        let key_id = non_empty("RUSTYKRAB_APNS_KEY_ID")?;
+        let team_id = non_empty("RUSTYKRAB_APNS_TEAM_ID")?;
+        let topic = non_empty("RUSTYKRAB_APNS_TOPIC")?;
+        let environment = std::env::var("RUSTYKRAB_APNS_ENVIRONMENT")
+            .map(|v| ApnsEnvironment::parse(&v))
+            .unwrap_or(ApnsEnvironment::Sandbox);
+        Some(Self {
+            key_id,
+            team_id,
+            topic,
+            environment,
+        })
+    }
+}
+
+fn non_empty(key: &str) -> Option<String> {
+    let value = std::env::var(key).ok()?;
+    let value = value.trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// Strip the PEM armour from a `.p8` and return the PKCS#8 DER inside.
+///
+/// Apple hands out the key as PEM; `ring` wants DER.
+pub fn pkcs8_from_pem(pem: &str) -> Result<Vec<u8>, Error> {
+    let body: String = pem
+        .lines()
+        .filter(|line| !line.starts_with("-----"))
+        .collect::<Vec<_>>()
+        .join("");
+    if body.trim().is_empty() {
+        return Err(Error::Config(
+            "APNs key is empty or not PEM — expected a .p8 with a \
+             BEGIN PRIVATE KEY header"
+                .into(),
+        ));
+    }
+    base64::engine::general_purpose::STANDARD
+        .decode(body.trim())
+        .map_err(|e| Error::Config(format!("APNs key is not valid base64: {e}")))
+}
+
+/// Mints and caches the provider token.
+struct TokenCache {
+    token: String,
+    issued_at: SystemTime,
+}
+
+/// Client for one team's APNs connection.
+pub struct ApnsClient {
+    config: ApnsConfig,
+    key_der: Vec<u8>,
+    http: reqwest::Client,
+    cached: RwLock<Option<TokenCache>>,
+}
+
+impl ApnsClient {
+    /// Build a client from the config and the PEM contents of the `.p8`.
+    ///
+    /// The key is parsed once here so a malformed one is a startup error
+    /// rather than a surprise at the moment a notification matters.
+    pub fn new(config: ApnsConfig, key_pem: &str) -> Result<Self, Error> {
+        let key_der = pkcs8_from_pem(key_pem)?;
+        // Parse once to validate; the parsed pair is not Send+Sync so it is
+        // rebuilt per signature.
+        let rng = SystemRandom::new();
+        EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &key_der, &rng).map_err(
+            |_| {
+                Error::Config(
+                    "APNs key is not a P-256 private key — check that the .p8 \
+                     is the APNs auth key and not another credential"
+                        .into(),
+                )
+            },
+        )?;
+        Ok(Self {
+            config,
+            key_der,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .map_err(|e| Error::Config(format!("APNs HTTP client: {e}")))?,
+            cached: RwLock::new(None),
+        })
+    }
+
+    /// The current provider token, minting a fresh one when it ages out.
+    fn provider_token(&self) -> Result<String, Error> {
+        if let Some(cached) = self
+            .cached
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            if cached.issued_at.elapsed().unwrap_or(TOKEN_REFRESH) < TOKEN_REFRESH {
+                return Ok(cached.token.clone());
+            }
+        }
+        let token = self.mint_token()?;
+        *self.cached.write().unwrap_or_else(|e| e.into_inner()) = Some(TokenCache {
+            token: token.clone(),
+            issued_at: SystemTime::now(),
+        });
+        Ok(token)
+    }
+
+    /// Build and sign the ES256 JWT Apple expects.
+    fn mint_token(&self) -> Result<String, Error> {
+        let issued_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Error::Internal(format!("system clock before epoch: {e}")))?
+            .as_secs();
+
+        let header = serde_json::json!({
+            "alg": "ES256",
+            "kid": self.config.key_id,
+        });
+        let claims = serde_json::json!({
+            "iss": self.config.team_id,
+            "iat": issued_at,
+        });
+
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header)?),
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims)?)
+        );
+
+        let rng = SystemRandom::new();
+        let key = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &self.key_der, &rng)
+            .map_err(|_| Error::Config("APNs key could not be loaded".into()))?;
+        let signature = key
+            .sign(&rng, signing_input.as_bytes())
+            .map_err(|_| Error::Internal("signing the APNs token failed".into()))?;
+
+        Ok(format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.as_ref())
+        ))
+    }
+
+    /// Tell one device that a credential change is waiting.
+    ///
+    /// `credential_name` is the only detail that travels: enough for the
+    /// user to know what they are being asked about, and nothing that would
+    /// be damaging on a lock screen or in Apple's logs.
+    pub async fn notify_pending_request(
+        &self,
+        device_token: &str,
+        credential_name: &str,
+        action: &str,
+    ) -> Result<(), Error> {
+        let body = serde_json::json!({
+            "aps": {
+                "alert": {
+                    "title": "Approval needed",
+                    "body": format!("The agent wants to {action} “{credential_name}”."),
+                },
+                "sound": "default",
+                // Drives the app's badge; the app recomputes it on launch.
+                "badge": 1,
+            },
+            // Deep-links to the Approvals tab. A name, never a value.
+            "credentialName": credential_name,
+            "action": action,
+        });
+
+        let url = format!(
+            "https://{}/3/device/{}",
+            self.config.environment.host(),
+            device_token
+        );
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(self.provider_token()?)
+            .header("apns-topic", &self.config.topic)
+            .header("apns-push-type", "alert")
+            // Approval prompts are worth waking the device for.
+            .header("apns-priority", "10")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Channel(format!("APNs request failed: {e}")))?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        // Apple explains refusals in the body; without it "410" is a riddle.
+        let reason = response.text().await.unwrap_or_default();
+        Err(Error::Channel(format!(
+            "APNs rejected the push ({status}): {reason}"
+        )))
+    }
+
+    /// True when Apple says the token is no longer valid for this app, so
+    /// the caller can stop sending to it.
+    pub fn is_dead_token(error: &Error) -> bool {
+        let text = error.to_string();
+        text.contains("BadDeviceToken") || text.contains("Unregistered")
+    }
+}
+
+/// Sends a notification to every registered device.
+#[derive(Clone)]
+pub struct PushNotifier {
+    client: Arc<ApnsClient>,
+    devices: rustykrab_store::DeviceStore,
+}
+
+impl std::fmt::Debug for PushNotifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // No key material or tokens in the debug output.
+        f.debug_struct("PushNotifier")
+            .field("topic", &self.client.config.topic)
+            .field("environment", &self.client.config.environment)
+            .finish()
+    }
+}
+
+/// Bridges the store's notification hook to APNs.
+///
+/// `request_filed` is synchronous and must not block the write that
+/// triggered it, so the send is spawned. A credential change is protected
+/// by the request row, not by the notification.
+impl rustykrab_store::RequestNotifier for PushNotifier {
+    fn request_filed(&self, credential_name: &str, action: &str) {
+        let notifier = self.clone();
+        let name = credential_name.to_string();
+        let action = action.to_string();
+        tokio::spawn(async move {
+            notifier.announce(&name, &action).await;
+        });
+    }
+}
+
+impl PushNotifier {
+    pub fn new(client: Arc<ApnsClient>, devices: rustykrab_store::DeviceStore) -> Self {
+        Self { client, devices }
+    }
+
+    /// Notify all devices about a filed request.
+    ///
+    /// Best-effort by design: a push that fails must never stop a request
+    /// being recorded, because the request is the thing that protects the
+    /// credential. The app and WebChat both show pending requests without
+    /// any notification at all.
+    pub async fn announce(&self, credential_name: &str, action: &str) {
+        let devices = match self.devices.with_push_tokens().await {
+            Ok(devices) => devices,
+            Err(e) => {
+                tracing::warn!(error = %e, "could not list devices for push");
+                return;
+            }
+        };
+        for (device_id, token) in devices {
+            match self
+                .client
+                .notify_pending_request(&token, credential_name, action)
+                .await
+            {
+                Ok(()) => tracing::info!(device = %device_id, "approval push sent"),
+                Err(e) if ApnsClient::is_dead_token(&e) => {
+                    // The app was deleted or the token was reissued. Drop it
+                    // rather than retrying forever.
+                    tracing::info!(device = %device_id, "clearing dead push token");
+                    let _ = self.devices.clear_push_token(&device_id).await;
+                }
+                Err(e) => tracing::warn!(device = %device_id, error = %e, "approval push failed"),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A P-256 key in PKCS#8 PEM, generated for this test only.
+    fn test_key_pem() -> String {
+        let rng = SystemRandom::new();
+        let doc = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+            .expect("generate key");
+        let b64 = base64::engine::general_purpose::STANDARD.encode(doc.as_ref());
+        format!("-----BEGIN PRIVATE KEY-----\n{b64}\n-----END PRIVATE KEY-----\n")
+    }
+
+    fn config() -> ApnsConfig {
+        ApnsConfig {
+            key_id: "NP9F64W9GB".into(),
+            team_id: "3RRX845C4X".into(),
+            topic: "com.gcbh.apollo".into(),
+            environment: ApnsEnvironment::Sandbox,
+        }
+    }
+
+    #[test]
+    fn pem_armour_is_stripped() {
+        let pem = test_key_pem();
+        let der = pkcs8_from_pem(&pem).expect("decode");
+        assert!(!der.is_empty());
+        // The armour lines must not survive into the DER.
+        assert!(!String::from_utf8_lossy(&der).contains("BEGIN"));
+    }
+
+    #[test]
+    fn a_key_that_is_not_pem_is_rejected_at_construction() {
+        // A bad key should fail at startup, not at the moment a
+        // notification matters.
+        let err = match ApnsClient::new(config(), "not a key at all") {
+            Err(e) => e,
+            Ok(_) => panic!("garbage was accepted as an APNs key"),
+        };
+        assert!(
+            err.to_string().contains("base64") || err.to_string().contains("PEM"),
+            "unhelpful error: {err}"
+        );
+    }
+
+    #[test]
+    fn token_has_three_parts_with_apples_header_and_claims() {
+        let client = ApnsClient::new(config(), &test_key_pem()).expect("client");
+        let token = client.provider_token().expect("token");
+
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3, "a JWT has three parts: {token}");
+
+        let header: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[0]).unwrap()).unwrap();
+        assert_eq!(header["alg"], "ES256");
+        assert_eq!(header["kid"], "NP9F64W9GB");
+
+        let claims: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(claims["iss"], "3RRX845C4X");
+        assert!(claims["iat"].as_u64().unwrap() > 1_700_000_000);
+        // A provider token must not carry an expiry; Apple derives it.
+        assert!(claims.get("exp").is_none());
+
+        // Base64url, not base64: no padding or non-URL-safe characters.
+        assert!(!token.contains('=') && !token.contains('+') && !token.contains('/'));
+    }
+
+    #[test]
+    fn the_token_is_reused_until_it_ages_out() {
+        let client = ApnsClient::new(config(), &test_key_pem()).expect("client");
+        let first = client.provider_token().unwrap();
+        let second = client.provider_token().unwrap();
+        // Apple refuses tokens refreshed more often than every 20 minutes,
+        // so minting per request would get us throttled.
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn environment_defaults_to_sandbox_and_picks_the_right_host() {
+        assert_eq!(
+            ApnsEnvironment::parse("production"),
+            ApnsEnvironment::Production
+        );
+        assert_eq!(ApnsEnvironment::parse("PROD"), ApnsEnvironment::Production);
+        assert_eq!(ApnsEnvironment::parse("sandbox"), ApnsEnvironment::Sandbox);
+        // Anything unrecognised is sandbox: sending a real push to
+        // production by accident is the worse mistake.
+        assert_eq!(ApnsEnvironment::parse("typo"), ApnsEnvironment::Sandbox);
+
+        assert_eq!(ApnsEnvironment::Production.host(), "api.push.apple.com");
+        assert_eq!(
+            ApnsEnvironment::Sandbox.host(),
+            "api.sandbox.push.apple.com"
+        );
+    }
+
+    #[test]
+    fn dead_tokens_are_recognised() {
+        let dead =
+            Error::Channel("APNs rejected the push (410): {\"reason\":\"Unregistered\"}".into());
+        assert!(ApnsClient::is_dead_token(&dead));
+        let transient = Error::Channel("APNs request failed: connection reset".into());
+        assert!(!ApnsClient::is_dead_token(&transient));
+    }
+}

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -56,6 +56,7 @@ pub fn api_routes() -> Router<AppState> {
         .route("/api/pair", post(pair_device))
         .route("/api/devices", get(list_devices))
         .route("/api/devices/{id}", axum::routing::delete(revoke_device))
+        .route("/api/devices/{id}/push-token", post(set_push_token))
         .route("/api/health", get(health))
         .route("/api/logout", post(logout))
 }
@@ -994,6 +995,42 @@ async fn list_devices(
             })
             .collect(),
     ))
+}
+
+#[derive(Deserialize)]
+struct PushTokenRequest {
+    token: String,
+}
+
+/// Register the APNs token a device wants approval prompts on.
+///
+/// The app calls this after iOS hands it a token, and again whenever iOS
+/// reissues one.
+async fn set_push_token(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<PushTokenRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let token = body.token.trim();
+    // An APNs token is hex; anything else is a client bug worth rejecting
+    // rather than storing and failing on later.
+    if token.is_empty() || token.len() > 200 || !token.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    state
+        .store
+        .devices()
+        .set_push_token(&id, token)
+        .await
+        .map_err(|e| match e {
+            rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
+            other => {
+                tracing::error!(error = %other, %id, "storing push token failed");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
+    tracing::info!(%id, "push token registered");
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Revoke a device — the lost-phone story. Its token stops working

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -2030,9 +2030,12 @@ mod tests {
 
     #[test]
     fn trim_always_leaves_a_user_turn() {
-        // Ollama >= 0.32 rejects any /api/chat request whose message array
-        // carries no `user` role, so an over-long conversation must degrade
-        // rather than become a hard failure.
+        // Some model chat templates reject an /api/chat request whose
+        // message array carries no `user` role, so an over-long conversation
+        // must degrade rather than become a hard failure. Verified against
+        // Ollama 0.32.14: qwen3.8:27b returns 500 `no user query found in
+        // messages`; gemma4:26b and qwen3:32b accept the same array. It is
+        // the template, not the Ollama version.
         let big = "x".repeat(40_000); // ~10k tokens each
         let msgs = vec![
             system_msg("sys"),
@@ -2120,6 +2123,152 @@ mod tests {
         assert!(
             trimmed.iter().any(|m| m.role == "user"),
             "a user turn must survive even when the history ends in a tool result"
+        );
+    }
+
+    // ---- Live tests against a real Ollama daemon -------------------------
+    //
+    // Ignored by default: they need a running Ollama and the model named by
+    // RK_LIVE_MODEL (default qwen3.8:27b). Run with:
+    //
+    //   cargo test -p rustykrab-providers --  --ignored --test-threads=1
+    //
+    // These exist because the failure they cover is not reproducible in a
+    // unit test: it lives in the model's chat template, server-side. Note
+    // that the rejection is template-specific, NOT a blanket Ollama
+    // behaviour — qwen3.8:27b rejects a user-less message array while
+    // gemma4:26b, qwen3:32b and qwen3:30b-a3b all accept one.
+
+    fn live_model() -> String {
+        std::env::var("RK_LIVE_MODEL").unwrap_or_else(|_| "qwen3.8:27b".to_string())
+    }
+
+    fn live_provider() -> OllamaProvider {
+        let mut cfg = OllamaConfig {
+            num_predict: 8,
+            ..Default::default()
+        };
+        cfg.num_ctx = Some(8192);
+        OllamaProvider::new(live_model())
+            .with_base_url("http://127.0.0.1:11434")
+            .with_config(cfg)
+    }
+
+    fn core_msg(role: Role, text: &str) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role,
+            content: MessageContent::Text(text.to_string()),
+            created_at: Utc::now(),
+            agent_version: None,
+        }
+    }
+
+    /// Negative control. The exact array a resumed job conversation produced
+    /// before the fix — system + assistant, no user turn — must still be
+    /// rejected by the live model. If this ever starts passing, the premise
+    /// behind the fix has changed and the other live tests prove nothing.
+    #[tokio::test]
+    #[ignore = "requires a live Ollama daemon"]
+    async fn live_resumed_job_shape_without_a_user_turn_is_rejected() {
+        let provider = live_provider();
+        let msgs = vec![
+            core_msg(Role::System, "You are a helpful assistant."),
+            core_msg(Role::Assistant, "result of the previous scheduled run"),
+        ];
+
+        let err = provider
+            .chat(&msgs, &[])
+            .await
+            .expect_err("a user-less array must be rejected by the live model");
+
+        let text = err.to_string();
+        assert!(
+            text.contains("no user query found in messages"),
+            "expected the documented provider rejection, got: {text}"
+        );
+    }
+
+    /// Fix 1, end to end: the same conversation with the scheduled prompt
+    /// appended as a real user turn goes through the live model.
+    #[tokio::test]
+    #[ignore = "requires a live Ollama daemon"]
+    async fn live_resumed_job_shape_with_a_user_turn_succeeds() {
+        let provider = live_provider();
+        let msgs = vec![
+            core_msg(Role::System, "You are a helpful assistant."),
+            core_msg(Role::Assistant, "result of the previous scheduled run"),
+            core_msg(
+                Role::User,
+                "[Scheduled task] Execute it and reply concisely.",
+            ),
+        ];
+
+        provider
+            .chat(&msgs, &[])
+            .await
+            .expect("appending the scheduled user turn must make the request valid");
+    }
+
+    /// Fix 2 on the shape production actually produces once Fix 1 is in
+    /// place: a long history whose newest message is the scheduled user turn.
+    /// Trimming must drop the old bulk and keep the request valid.
+    #[tokio::test]
+    #[ignore = "requires a live Ollama daemon"]
+    async fn live_overlong_history_ending_in_a_user_turn_succeeds() {
+        let provider = live_provider();
+        let big = "x".repeat(40_000); // ~10k tokens each
+
+        let mut msgs = vec![core_msg(Role::System, "You are a helpful assistant.")];
+        msgs.push(core_msg(Role::User, "an old user turn"));
+        for _ in 0..3 {
+            msgs.push(core_msg(Role::Assistant, &big));
+        }
+        // Fix 1 puts the scheduled prompt last; this is the live shape.
+        msgs.push(core_msg(
+            Role::User,
+            "[Scheduled task] Execute it and reply concisely.",
+        ));
+
+        provider
+            .chat(&msgs, &[])
+            .await
+            .expect("a history ending in a user turn must survive trimming");
+    }
+
+    /// KNOWN LIMITATION, asserted so it cannot regress silently.
+    ///
+    /// When the last user turn is old and large content follows it, the clamp
+    /// pins `drop_end` to that turn and the trimmer — which only drops from
+    /// the front — can free nothing. The over-budget request is then truncated
+    /// server-side, oldest-first, which discards the user turn and reproduces
+    /// the very rejection the clamp exists to prevent. `trim_to_budget` logs
+    /// this via the `error!` branch but cannot currently fix it: escaping it
+    /// requires dropping from the middle, which trades away the KV-cache
+    /// prefix stability #488 was built for.
+    ///
+    /// Flip this assertion to `expect(...)` when that is addressed.
+    #[tokio::test]
+    #[ignore = "requires a live Ollama daemon"]
+    async fn live_old_user_turn_followed_by_bulk_is_a_known_failure() {
+        let provider = live_provider();
+        let big = "x".repeat(40_000);
+
+        let mut msgs = vec![
+            core_msg(Role::System, "You are a helpful assistant."),
+            core_msg(Role::User, "the only user turn"),
+        ];
+        for _ in 0..3 {
+            msgs.push(core_msg(Role::Assistant, &big));
+        }
+
+        let err = provider
+            .chat(&msgs, &[])
+            .await
+            .expect_err("documented limitation: an old user turn buried under bulk still fails");
+        assert!(
+            err.to_string().contains("no user query found in messages"),
+            "expected the documented rejection, got: {err}"
         );
     }
 

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -709,22 +709,58 @@ impl OllamaProvider {
         // If trimming left a leading orphan tool-result (no preceding
         // assistant tool_call), drop it so Ollama doesn't reject the request.
         while drop_end < trimmed.len() && trimmed[drop_end].role == "tool" {
-            current = current.saturating_sub(estimate_message_tokens(&trimmed[drop_end]));
             drop_end += 1;
+        }
+
+        // Never trim past the most recent user turn. A request whose message
+        // array carries no `user` role is rejected outright by Ollama with
+        // `no user query found in messages`, turning an over-long conversation
+        // into a hard failure instead of a merely degraded one.
+        //
+        // The `drop_end < last` bound above already spares the final message,
+        // but that is not the same guarantee: the final message is only a user
+        // turn on some paths (a scheduled run whose conversation ends in an
+        // assistant or tool turn is the motivating case), and the orphan-tool
+        // loop is bounded by `trimmed.len()` rather than `last`, so it can walk
+        // past the end and drain everything but the system prompt. Clamp
+        // explicitly.
+        //
+        // Clamping can leave the request above budget; that is strictly
+        // preferable to a guaranteed provider rejection.
+        if let Some(idx) = trimmed.iter().rposition(|m| m.role == "user") {
+            drop_end = drop_end.min(idx);
         }
 
         let dropped = drop_end - system_count;
         trimmed.drain(system_count..drop_end);
+
+        // `current` was accumulated by the drop loops and goes stale whenever
+        // the clamp above spared messages they had already counted. Recompute
+        // from what actually survived so the log line is truthful.
+        let remaining: u32 = trimmed.iter().map(estimate_message_tokens).sum();
 
         tracing::warn!(
             num_ctx = total_ctx,
             budget,
             target,
             estimated_tokens_before = total,
-            estimated_tokens_after = current,
+            estimated_tokens_after = remaining,
             messages_dropped = dropped,
             "trimmed conversation history to fit Ollama context window"
         );
+
+        // Preserving the last user turn can leave us over budget. That means a
+        // single turn is too large for the context window, which needs its own
+        // handling rather than silently shipping an over-budget request.
+        if remaining > budget {
+            tracing::error!(
+                num_ctx = total_ctx,
+                budget,
+                estimated_tokens_after = remaining,
+                "conversation still exceeds the Ollama input budget after trimming; \
+                 a single turn is larger than the context window"
+            );
+        }
 
         trimmed
     }
@@ -1981,6 +2017,110 @@ mod tests {
         // System and latest user message survive.
         assert_eq!(trimmed[0].role, "system");
         assert_eq!(trimmed.last().unwrap().content.as_deref(), Some("latest"));
+    }
+
+    fn assistant_msg(content: &str) -> OllamaMessage {
+        OllamaMessage {
+            role: "assistant".to_string(),
+            content: Some(content.to_string()),
+            tool_calls: None,
+            images: None,
+        }
+    }
+
+    #[test]
+    fn trim_always_leaves_a_user_turn() {
+        // Ollama >= 0.32 rejects any /api/chat request whose message array
+        // carries no `user` role, so an over-long conversation must degrade
+        // rather than become a hard failure.
+        let big = "x".repeat(40_000); // ~10k tokens each
+        let msgs = vec![
+            system_msg("sys"),
+            user_msg(&big),
+            assistant_msg(&big),
+            tool_msg(&big),
+            assistant_msg(&big),
+        ];
+
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
+
+        assert!(
+            trimmed.iter().any(|m| m.role == "user"),
+            "a user turn must survive trimming, got roles {:?}",
+            trimmed.iter().map(|m| &m.role).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn trim_leaves_no_orphan_tool_result_when_clamped_to_the_user_turn() {
+        // Clamping to the last user turn must not reintroduce the orphan the
+        // skip loop exists to prevent: the first surviving non-system message
+        // is the user turn itself, never a dangling tool result.
+        let big = "x".repeat(40_000);
+        let msgs = vec![
+            system_msg("sys"),
+            user_msg(&big),
+            assistant_msg(&big),
+            tool_msg(&big),
+            assistant_msg(&big),
+        ];
+
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
+
+        assert_ne!(
+            trimmed.get(1).map(|m| m.role.as_str()),
+            Some("tool"),
+            "trimming must not leave a leading orphan tool result"
+        );
+    }
+
+    #[test]
+    fn trim_retains_the_oldest_user_turn_when_it_is_the_only_one() {
+        // Maximal trimming pressure with the sole user turn at the front: it
+        // must survive even though it is the oldest droppable message.
+        let big = "x".repeat(80_000); // ~20k tokens each
+        let msgs = vec![
+            system_msg("sys"),
+            user_msg("the only user turn"),
+            assistant_msg(&big),
+            assistant_msg(&big),
+            assistant_msg(&big),
+        ];
+
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
+
+        assert!(
+            trimmed
+                .iter()
+                .any(|m| m.content.as_deref() == Some("the only user turn")),
+            "the sole user turn must be retained under maximal trimming"
+        );
+    }
+
+    #[test]
+    fn trim_does_not_strand_a_conversation_ending_in_a_tool_result() {
+        // The orphan-tool skip loop is bounded by `trimmed.len()`, not by the
+        // `drop_end < last` guard, so a history ending in a tool result could
+        // walk past the end and drain everything but the system prompt —
+        // exactly the system-only array the provider rejects.
+        let big = "x".repeat(40_000);
+        let msgs = vec![
+            system_msg("sys"),
+            user_msg(&big),
+            assistant_msg(&big),
+            tool_msg(&big),
+        ];
+
+        let trimmed = OllamaProvider::trim_to_budget(msgs, Some(4096), 256, TEST_TOOL_TOKENS);
+
+        assert!(
+            trimmed.len() > 1,
+            "trimming must not reduce the request to the system prompt alone"
+        );
+        assert!(
+            trimmed.iter().any(|m| m.role == "user"),
+            "a user turn must survive even when the history ends in a tool result"
+        );
     }
 
     /// Run `f` with the two num_ctx env vars set to `rk` / `ollama`.

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -56,10 +56,25 @@ pub struct CredentialRequest {
     pub created_at: i64,
 }
 
+/// Told when a request is filed, so something can go and tell the user.
+///
+/// Implemented outside this crate (the gateway sends the push) so storage
+/// stays unaware of notification transports, matching the backend-trait
+/// pattern used elsewhere in the workspace.
+///
+/// Deliberately fire-and-forget: a notification that fails must never stop
+/// a request being recorded, because the record is what protects the
+/// credential. The app and WebChat both list pending requests without any
+/// notification at all.
+pub trait RequestNotifier: Send + Sync + std::fmt::Debug {
+    fn request_filed(&self, credential_name: &str, action: &str);
+}
+
 #[derive(Clone)]
 pub struct CredentialRequestStore {
     conn: Arc<Mutex<rusqlite::Connection>>,
     secrets: SecretStore,
+    notifier: Option<Arc<dyn RequestNotifier>>,
 }
 
 fn now_ms() -> i64 {
@@ -68,7 +83,17 @@ fn now_ms() -> i64 {
 
 impl CredentialRequestStore {
     pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>, secrets: SecretStore) -> Self {
-        Self { conn, secrets }
+        Self {
+            conn,
+            secrets,
+            notifier: None,
+        }
+    }
+
+    /// Attach something that tells the user a request is waiting.
+    pub fn with_notifier(mut self, notifier: Arc<dyn RequestNotifier>) -> Self {
+        self.notifier = Some(notifier);
+        self
     }
 
     /// Queue a replacement of an existing credential.
@@ -137,6 +162,7 @@ impl CredentialRequestStore {
         target_version: Option<i64>,
     ) -> Result<(), Error> {
         let name = name.to_string();
+        let announce_name = name.clone();
         let conversation = conversation_id.map(|c| c.to_string());
         crate::with_conn(&self.conn, move |conn| {
             // Newer intent replaces older intent for the same credential.
@@ -165,7 +191,14 @@ impl CredentialRequestStore {
             .map_err(|e| Error::Storage(e.to_string()))?;
             Ok(())
         })
-        .await
+        .await?;
+
+        // Only after the row is durable: a notification about a request
+        // that failed to record would send the user looking for nothing.
+        if let Some(notifier) = &self.notifier {
+            notifier.request_filed(&announce_name, action.as_str());
+        }
+        Ok(())
     }
 
     /// Pending requests, newest first. Expired ones are swept on the way

--- a/crates/rustykrab-store/src/device.rs
+++ b/crates/rustykrab-store/src/device.rs
@@ -242,6 +242,64 @@ impl DeviceStore {
         .await
     }
 
+    /// Record the APNs token a device wants notifications on.
+    ///
+    /// Replaces any previous token for that device: iOS reissues them, and
+    /// keeping a stale one only produces failed sends.
+    pub async fn set_push_token(&self, id: &str, push_token: &str) -> Result<(), Error> {
+        let id = id.to_string();
+        let push_token = push_token.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let n = conn
+                .execute(
+                    "UPDATE devices SET push_token = ?2 WHERE id = ?1 AND revoked_at IS NULL",
+                    params![id, push_token],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if n == 0 {
+                return Err(Error::NotFound(format!("device '{id}'")));
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    /// Forget a push token Apple has told us is dead.
+    pub async fn clear_push_token(&self, id: &str) -> Result<(), Error> {
+        let id = id.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE devices SET push_token = NULL WHERE id = ?1",
+                params![id],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Active devices that have registered for notifications, as
+    /// `(device id, push token)`.
+    pub async fn with_push_tokens(&self) -> Result<Vec<(String, String)>, Error> {
+        crate::with_conn(&self.conn, |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, push_token FROM devices
+                     WHERE revoked_at IS NULL AND push_token IS NOT NULL",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                out.push(row.map_err(|e| Error::Storage(e.to_string()))?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
     /// Drop expired pairing codes. Called opportunistically on mint.
     pub async fn sweep_expired_codes(&self) -> Result<usize, Error> {
         crate::with_conn(&self.conn, |conn| {
@@ -324,6 +382,58 @@ mod tests {
         // Revoking twice is a NotFound rather than a silent success.
         assert!(matches!(
             devices.revoke(&device.id).await,
+            Err(Error::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn push_tokens_are_recorded_replaced_and_cleared() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        let (device, _) = devices.redeem_pairing_code(&code, "Phone").await.unwrap();
+
+        // Nothing registered yet.
+        assert!(devices.with_push_tokens().await.unwrap().is_empty());
+
+        devices
+            .set_push_token(&device.id, "apns-token-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            devices.with_push_tokens().await.unwrap(),
+            vec![(device.id.clone(), "apns-token-1".to_string())]
+        );
+
+        // iOS reissues tokens; the new one replaces the old.
+        devices
+            .set_push_token(&device.id, "apns-token-2")
+            .await
+            .unwrap();
+        assert_eq!(
+            devices.with_push_tokens().await.unwrap(),
+            vec![(device.id.clone(), "apns-token-2".to_string())]
+        );
+
+        devices.clear_push_token(&device.id).await.unwrap();
+        assert!(devices.with_push_tokens().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_revoked_device_stops_receiving_pushes() {
+        let (_dir, devices) = devices();
+        let code = devices.mint_pairing_code().await.unwrap();
+        let (device, _) = devices.redeem_pairing_code(&code, "Lost").await.unwrap();
+        devices
+            .set_push_token(&device.id, "apns-token")
+            .await
+            .unwrap();
+
+        devices.revoke(&device.id).await.unwrap();
+
+        // A revoked phone must not keep getting approval prompts.
+        assert!(devices.with_push_tokens().await.unwrap().is_empty());
+        assert!(matches!(
+            devices.set_push_token(&device.id, "new-token").await,
             Err(Error::NotFound(_))
         ));
     }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -19,7 +19,9 @@ use zeroize::Zeroizing;
 
 pub use chat_map::ChatMapStore;
 pub use conversation::{ConversationStore, ConversationSummary};
-pub use credential_request::{CredentialRequest, CredentialRequestStore, RequestAction};
+pub use credential_request::{
+    CredentialRequest, CredentialRequestStore, RequestAction, RequestNotifier,
+};
 pub use device::{Device, DeviceStore, Principal};
 pub use guarded::{GuardedSecrets, WriteOutcome};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
@@ -35,6 +37,9 @@ pub use slack_chat_map::SlackChatMapStore;
 pub struct Store {
     conn: Arc<Mutex<rusqlite::Connection>>,
     master_key: Zeroizing<Vec<u8>>,
+    /// Told when the agent files a credential change, so the user can be
+    /// notified. `None` when push isn't configured, which is normal.
+    request_notifier: Option<Arc<dyn credential_request::RequestNotifier>>,
 }
 
 impl Store {
@@ -70,6 +75,7 @@ impl Store {
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             master_key: Zeroizing::new(master_key),
+            request_notifier: None,
         })
     }
 
@@ -347,10 +353,23 @@ impl Store {
         SecretStore::new(Arc::clone(&self.conn), self.master_key.clone())
     }
 
+    /// Attach a notifier that is told whenever the agent files a change.
+    pub fn with_request_notifier(
+        mut self,
+        notifier: Arc<dyn credential_request::RequestNotifier>,
+    ) -> Self {
+        self.request_notifier = Some(notifier);
+        self
+    }
+
     /// Handle for the credential-change requests the agent files and the
     /// user resolves.
     pub fn credential_requests(&self) -> CredentialRequestStore {
-        CredentialRequestStore::new(Arc::clone(&self.conn), self.secrets())
+        let requests = CredentialRequestStore::new(Arc::clone(&self.conn), self.secrets());
+        match &self.request_notifier {
+            Some(notifier) => requests.with_notifier(Arc::clone(notifier)),
+            None => requests,
+        }
     }
 
     /// The agent-facing view of credential storage: create-only, with

--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -72,6 +72,13 @@ pub static REGISTRY: &[SecretSpec] = &[
         required: false,
     },
     SecretSpec {
+        store_name: "apns_auth_key",
+        env_var: "APNS_AUTH_KEY",
+        keychain_account: "apns-auth-key",
+        description: "APNs signing key (.p8 contents) for push notifications",
+        required: false, // push is optional
+    },
+    SecretSpec {
         store_name: "rustykrab_auth_token",
         env_var: "RUSTYKRAB_AUTH_TOKEN",
         keychain_account: "auth-token",


### PR DESCRIPTION
**Stacked on #491**, which is stacked on #490 → #489. Server side of Workstream E; the app-side registration and deep link are yours.

When the agent asks to change a credential it cannot change itself, the phone now hears about it instead of the user having to go and look.

## The payload carries the credential's name and nothing else

A push crosses Apple's infrastructure and lands on a lock screen. The threat model says APNs payloads carry names only, and this does:

```json
{ "aps": { "alert": { "title": "Approval needed",
                      "body": "The agent wants to update “notion_api_token”." } },
  "credentialName": "notion_api_token", "action": "update" }
```

## Design decisions worth reviewing

- **ES256 with `ring`**, which was already in the tree via rustls — no new crypto code or dependency. Tokens are cached for 45 minutes: Apple rejects one older than an hour and throttles refreshes more often than every 20 minutes, so minting per request would get us rate-limited.
- **The `.p8` lives in the encrypted store** under `apns_auth_key`, not as a file path in config. It is a credential, and this repo already has somewhere safe to keep one. Only the non-secret Key ID, Team ID, topic and environment come from the environment.
- **The environment is explicit** (`RUSTYKRAB_APNS_ENVIRONMENT`, default sandbox). It can't be inferred at runtime — a development build talks to sandbox, a TestFlight build to production, and the wrong one fails with `BadDeviceToken` and no clue from the app's side. Defaulting to sandbox makes an accidental real push the harder mistake.
- **Firing is a `RequestNotifier` trait in the store, implemented by the gateway**, so storage stays unaware of notification transports — the same backend-trait pattern as recall persistence. It runs *after* the row is durable and never blocks or fails the write: the request row is what protects the credential; the notification is a courtesy.
- **Dead tokens are dropped, not retried.** `Unregistered`/`BadDeviceToken` clears the stored token; revoking a device stops its pushes.

## One latent bug this surfaced

`reqwest` was built with `default-features = false` and no `http2`, so **`h2` was not in the dependency tree at all**. APNs refuses HTTP/1.1, so every push would have failed at connect. Enabled.

## Setup

```sh
RUSTYKRAB_APNS_KEY_ID=NP9F64W9GB
RUSTYKRAB_APNS_TEAM_ID=3RRX845C4X
RUSTYKRAB_APNS_TOPIC=com.gcbh.apollo
RUSTYKRAB_APNS_ENVIRONMENT=sandbox     # production for TestFlight
```

…plus the `.p8` contents stored as `apns_auth_key`. Absent configuration simply means no notifications.

## Verification

517 workspace tests green, including a real ES256 JWT checked against the header and claims Apple requires, base64url encoding, token reuse, and the push-token lifecycle (register, replace, clear, revoke).

**Not covered by the harness:** an actual send. That needs Apple's servers and a real device token, so it stays a manual check — `xcrun simctl push` exercises the app's handling with APNs out of the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)