### PR TITLE
fix(cron): append a user turn to scheduled job runs

### DIFF
--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -5,7 +5,7 @@ use tokio::sync::{mpsc, Mutex, Semaphore};
 
 use chrono::Utc;
 use rustykrab_agent::AgentEvent;
-use rustykrab_core::types::{Conversation, MessageContent};
+use rustykrab_core::types::{Conversation, Message, MessageContent, Role};
 use rustykrab_gateway::AppState;
 use rustykrab_skills::SkillRegistry;
 use uuid::Uuid;
@@ -148,6 +148,33 @@ async fn execute_task(task: &TaskRequest, state: &AppState, store: &rustykrab_st
     }
 }
 
+/// Append the scheduled prompt to `conv` as a real user turn.
+///
+/// `run_agent_*` injects only the system prompt and relies on the caller to
+/// have already appended the user message — see the comment in
+/// `orchestrate::prepare_agent` noting that routes.rs pushes the inbound user
+/// message before the runner is constructed. The `user_content` argument only
+/// drives profile routing and system-prompt construction; it never becomes a
+/// message.
+///
+/// Without this, a resumed job conversation reaches the provider carrying only
+/// system/assistant/tool messages. Some model chat templates reject that
+/// outright: verified against Ollama 0.32.14, `qwen3.8:27b` (the deployed
+/// model) returns 500 `{"error":"no user query found in messages"}`, while
+/// gemma4:26b and qwen3:32b accept it. Appending here also
+/// guarantees the newest message is a user turn, so the provider's oldest-first
+/// trimming can never strand the request without one.
+fn push_scheduled_user_turn(conv: &mut Conversation, prompt: &str) {
+    conv.messages.push(Message {
+        id: Uuid::new_v4(),
+        role: Role::User,
+        content: MessageContent::Text(prompt.to_string()),
+        created_at: Utc::now(),
+        agent_version: Message::version_stamp(),
+    });
+    conv.updated_at = Utc::now();
+}
+
 async fn execute_cron_task(
     job_id: &str,
     task_prompt: &str,
@@ -283,6 +310,9 @@ async fn execute_cron_task(
         effective_channel.as_deref(),
         effective_chat_id.as_deref(),
     );
+
+    // A scheduled run must contribute its own user turn.
+    push_scheduled_user_turn(&mut conv, &prompt);
 
     let run_options = rustykrab_gateway::RunOptions {
         active_skill: resolved_skill,
@@ -723,6 +753,45 @@ mod tests {
         c.channel_id = Some(id.to_string());
         c.channel_thread_id = thread.map(|s| s.to_string());
         c
+    }
+
+    #[test]
+    fn scheduled_run_appends_a_user_turn_carrying_the_prompt() {
+        let mut conv = empty_conv();
+        let prompt = build_scheduled_prompt("Write the daily briefing.", None, None, None);
+
+        push_scheduled_user_turn(&mut conv, &prompt);
+
+        let last = conv.messages.last().expect("a message was appended");
+        assert_eq!(last.role, Role::User);
+        assert_eq!(last.content.as_text(), Some(prompt.as_str()));
+    }
+
+    /// Some model chat templates reject a request whose message array carries
+    /// no `user` role (qwen3.8:27b does; gemma4:26b does not). A resumed job
+    /// conversation holding only system/assistant/tool turns must still reach
+    /// the provider with a user turn present.
+    #[test]
+    fn scheduled_run_leaves_a_user_role_in_a_conversation_without_one() {
+        let mut conv = channel_conv("telegram", "12345", None);
+        conv.messages.push(Message {
+            id: Uuid::new_v4(),
+            role: Role::Assistant,
+            content: MessageContent::Text("result of the previous run".to_string()),
+            created_at: Utc::now(),
+            agent_version: Message::version_stamp(),
+        });
+        assert!(!conv.messages.iter().any(|m| m.role == Role::User));
+
+        push_scheduled_user_turn(
+            &mut conv,
+            &build_scheduled_prompt("Check the feed.", None, Some("telegram"), Some("12345")),
+        );
+
+        assert!(conv.messages.iter().any(|m| m.role == Role::User));
+        // Newest message being a user turn is what keeps oldest-first
+        // trimming from stranding the request without one.
+        assert_eq!(conv.messages.last().unwrap().role, Role::User);
     }
 
     #[test]


### PR DESCRIPTION
## What

Scheduled (cron) jobs fail at the model provider with:

```
Ollama API returned 500 Internal Server Error: {"error":"no user query found in messages"}
```

`execute_cron_task` never appended a `Role::User` message before running the agent. This adds one.

## Why

`run_agent_*` injects **only** the system prompt and relies on the caller to have already appended the user turn — `orchestrate::prepare_agent` says so itself, noting that `routes.rs` pushes the inbound user message before the runner is constructed. The `user_content: &str` argument only drives profile routing and system-prompt construction; it never becomes a message.

Every interactive call site pushes a `Role::User` message first. `execute_cron_task` did not.

Job conversations are deliberately persistent and resumed across runs, so the only user messages present were old ones near the front. Once a conversation crossed the trimming budget those got dropped, leaving a system+assistant/tool-only array.

## The premise, measured

The rejection is **model-specific — not an Ollama version behaviour**. I'd assumed otherwise; testing against Ollama 0.32.14 with a system-only array says otherwise:

| Model | Result |
|---|---|
| `qwen3.8:27b` (deployed) | **500** `no user query found in messages` |
| `gemma4:26b` | 200 |
| `qwen3:32b` | 200 |
| `qwen3:30b-a3b` | 200 |

It comes from the chat template, so the invariant has to hold for whatever model is configured. The differentiator is exact — on `qwen3.8:27b`, `[system, assistant]` (the resumed-job shape) returns 500 and `[system, user]` returns 200.

## Verification

Unit tests cover the appended turn, its content, and the system/assistant-only case.

The shape is also proven end-to-end against a live Ollama daemon, in #493:

- `live_resumed_job_shape_without_a_user_turn_is_rejected` — negative control, so the rest can't pass vacuously
- `live_resumed_job_shape_with_a_user_turn_succeeds` — this fix, through the real provider and HTTP

`cargo test -p rustykrab-cli`, `cargo fmt --check`, `cargo clippy --all-targets` — all clean.

## Notes for the reviewer

**Memory callback.** This makes the callback in `prepare_agent` fire for scheduled runs, since it only triggers when the last message is `Role::User`. That's the same path interactive turns already take, and it writes to the memory system rather than the conversation store — so it does not double-write against the post-run save in `execute_cron_task`.

**Ordering.** Appending here also guarantees the newest message is a user turn, which is what keeps the provider's oldest-first trimming from stranding the request without one.

**Relationship to other PRs.** This is the primary fix and stands alone. #493 carries the defensive half (a floor in `OllamaProvider::trim_to_budget`) plus the live-Ollama test suite. #492 was an earlier attempt built on a stale local `main` that predated #486 moving this logic into `task_queue.rs`; it is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)