### PR TITLE
fix: repair two lint failures from the Rust 1.98 toolchain bump

### DIFF
--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -66,11 +66,16 @@ impl TaskQueue {
 
     /// Submit a task to the queue. Returns `Err` if the queue is full
     /// or the worker has stopped.
+    ///
+    /// The error is boxed because tokio's `SendError` hands the unsent
+    /// `TaskRequest` back to the caller, which makes the `Err` variant far
+    /// larger than the `Ok` one — every caller would pay for that on the
+    /// success path. Boxing allocates only when the worker is already gone.
     pub async fn submit(
         &self,
         request: TaskRequest,
-    ) -> Result<(), mpsc::error::SendError<TaskRequest>> {
-        self.tx.send(request).await
+    ) -> Result<(), Box<mpsc::error::SendError<TaskRequest>>> {
+        self.tx.send(request).await.map_err(Box::new)
     }
 }
 

--- a/crates/rustykrab-memory/src/storage.rs
+++ b/crates/rustykrab-memory/src/storage.rs
@@ -213,8 +213,10 @@ fn embedding_to_blob(v: &[f32]) -> Vec<u8> {
 
 /// Decode a BLOB back to Vec<f32>.
 fn blob_to_embedding(blob: &[u8]) -> Vec<f32> {
-    blob.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    blob.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&c| f32::from_le_bytes(c))
         .collect()
 }
 


### PR DESCRIPTION
## `main` is red, and it isn't a code change

`rust-toolchain.toml` pins `channel = "stable"`, so CI floats to the latest stable Rust. Rust **1.98** (2026-08-18) promoted two lints that [ci.yml](.github/workflows/ci.yml) turns into errors via `RUSTFLAGS: -Dwarnings`.

No relevant commit sits between the last green run and the first red one:

| Run | Time | Result |
|---|---|---|
| #488 `perf(providers)` | 16:29Z | pass |
| #489 `feat(guard)` | 21:13Z | **fail** |

## Two failures, not one

CI only reports the first. The workspace build halts at `rustykrab-memory`, so `rustykrab-cli` is never compiled and its failure is invisible until the first one is fixed.

**1. `chunks_exact_to_as_chunks` — `rustykrab-memory/src/storage.rs`**

```rust
-    blob.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    blob.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|&c| f32::from_le_bytes(c))
```

Both forms discard a trailing partial chunk, so decode behaviour is identical for well-formed and malformed blobs alike.

**2. `result_large_err` — `rustykrab-cli/src/task_queue.rs`**

tokio's `SendError<T>` returns the unsent value, so the `Err` variant carries a whole `TaskRequest` (144 bytes). Boxed, so callers stop paying for it on the success path and the allocation happens only when the worker is already gone. The single caller formats the error and never touches the payload, so no call site changes.

## Why this blocks everything

Both lints fire on `main`'s own code, so **every open PR fails "Check & Clippy" regardless of what it touches** — #494, #496, and #493 alike.

## A note on verification

A bare `cargo clippy --workspace --all-targets` reports both of these as **passing** — it doesn't promote warnings. Reproducing CI takes the `RUSTFLAGS` too:

```
RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets
```

That's how the second failure surfaced. Without it, fixing only the first would have left `main` red with no prior signal the second existed.

## Verification

- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets` — clean
- `RUSTFLAGS=-Dwarnings cargo check --workspace --all-targets` — clean
- `cargo test --workspace` — no failures
- `cargo fmt --all -- --check` — clean

## Worth deciding separately

Floating `stable` means the next lint addition breaks `main` the same way, with no commit to point at. Pinning an explicit toolchain version would make that a deliberate upgrade instead of a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)