### PR TITLE
feat(memory): admission control, duplicate-write counter split, and scoped recall

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -64,8 +64,24 @@ impl MemoryBackend for MemoryAdapter {
         query: &str,
         tags: &[String],
         limit: usize,
+        session_id: Option<&str>,
     ) -> rustykrab_core::Result<serde_json::Value> {
-        self.inner.search(query, tags, limit).await
+        match session_id {
+            Some(raw) => match Uuid::parse_str(raw.trim()) {
+                Ok(sid) => self.inner.search(query, tags, limit, Some(sid)).await,
+                Err(_) => {
+                    // Degrade to a global search, but say so — a silently
+                    // widened scope would let the model attribute other
+                    // conversations' memories to this one.
+                    let mut result = self.inner.search(query, tags, limit, None).await?;
+                    result["session_scope"] = serde_json::json!(
+                        "session_id was not a valid conversation id; results are global"
+                    );
+                    Ok(result)
+                }
+            },
+            None => self.inner.search(query, tags, limit, None).await,
+        }
     }
     async fn get(&self, memory_id: &str) -> rustykrab_core::Result<serde_json::Value> {
         self.inner.get(memory_id).await

--- a/crates/rustykrab-memory/src/admission.rs
+++ b/crates/rustykrab-memory/src/admission.rs
@@ -1,0 +1,263 @@
+//! Admission control for the memory write path.
+//!
+//! Decides *whether* content deserves a memory record at all, before
+//! importance scoring decides how it ranks. Without this gate, raw tool
+//! output and agent-loop control messages accumulate in the store and —
+//! because the importance heuristic rewards length — end up outranking
+//! genuine facts (observed live: 91.7% of a 26k-row corpus was
+//! `tool_call:`/`tool_result:` dumps before the 2026-08 purge).
+//!
+//! The gate is deliberately conservative: it rejects only content that is
+//! structurally machine output or known agent-loop chatter. Anything that
+//! reads like prose is admitted and left to the scorer.
+
+/// Why a piece of content was refused admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rejection {
+    /// Empty or whitespace-only.
+    Empty,
+    /// Too short to be a retrievable fact.
+    TooShort,
+    /// Raw tool output, JSON, or other machine-generated structure.
+    MachineOutput,
+    /// Agent-loop control chatter (iteration warnings, retry nags, todo dumps).
+    LoopControl,
+}
+
+impl Rejection {
+    /// Human-readable reason, suitable for tool feedback to the model.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Rejection::Empty => "content is empty",
+            Rejection::TooShort => "content is too short to be a useful memory",
+            Rejection::MachineOutput => {
+                "content looks like raw tool output or serialized data; \
+                 save a concise factual statement instead"
+            }
+            Rejection::LoopControl => {
+                "content is agent-loop control chatter, not a fact worth remembering"
+            }
+        }
+    }
+}
+
+/// Minimum content length in characters for ASCII-only content. Shorter
+/// strings cannot carry a retrievable fact ("ok", "done", "yes").
+const MIN_ASCII_CHARS: usize = 8;
+
+/// Minimum content length for content containing non-ASCII characters.
+/// Information-dense scripts (CJK) pack a full fact into a few characters,
+/// so the ASCII floor would wrongly reject them.
+const MIN_ANY_CHARS: usize = 4;
+
+/// Fraction of non-whitespace characters that may be structural symbols
+/// (braces, brackets, quotes, colons) before content is treated as
+/// serialized data rather than prose.
+const MAX_STRUCTURAL_RATIO: f64 = 0.30;
+
+/// Tighter structural bound for content that opens with `{`. Prose almost
+/// never starts with a brace, so any real structure past this point marks a
+/// truncated/unparseable JSON dump.
+const BRACE_LED_STRUCTURAL_RATIO: f64 = 0.15;
+
+/// Prefixes that identify machine-generated content. Matched after trimming
+/// leading whitespace.
+const MACHINE_PREFIXES: &[&str] = &["tool_call:", "tool_result:"];
+
+/// Prefixes of agent-loop control messages injected by the harness or the
+/// agent loop itself. These describe the machinery, not the conversation.
+/// Each entry is anchored to the harness's exact wording — a legitimate
+/// reply that merely opens with similar words ("Current task list: 1. Book
+/// flights…") must not be silently dropped from memory.
+const LOOP_CONTROL_PREFIXES: &[&str] = &[
+    "Multiple consecutive tool calls have failed",
+    "Your response was empty",
+    "[Harness observation]",
+    "[Earlier messages in this conversation were omitted",
+    "[CONVERSATION SUMMARY",
+    "Current task list (maintained via todo_write",
+];
+
+/// Decide whether `content` may enter the memory store.
+pub fn admit(content: &str) -> Result<(), Rejection> {
+    let trimmed = content.trim();
+
+    if trimmed.is_empty() {
+        return Err(Rejection::Empty);
+    }
+    let char_count = trimmed.chars().count();
+    let min_chars = if trimmed.is_ascii() {
+        MIN_ASCII_CHARS
+    } else {
+        MIN_ANY_CHARS
+    };
+    if char_count < min_chars {
+        return Err(Rejection::TooShort);
+    }
+
+    for prefix in MACHINE_PREFIXES {
+        if trimmed.starts_with(prefix) {
+            return Err(Rejection::MachineOutput);
+        }
+    }
+    for prefix in LOOP_CONTROL_PREFIXES {
+        if trimmed.starts_with(prefix) {
+            return Err(Rejection::LoopControl);
+        }
+    }
+    // The harness's iteration warning ("[Warning: 150/200 iterations
+    // used.]") — matched on both halves so a genuine reply that merely
+    // opens with "[Warning:" (a surf advisory, say) passes.
+    if trimmed.starts_with("[Warning:") && trimmed.contains("iterations used") {
+        return Err(Rejection::LoopControl);
+    }
+    // The bare continuation nudge is exactly "Continue." — prefix-matching
+    // it would reject any reply that happens to start with that word.
+    if trimmed == "Continue." {
+        return Err(Rejection::LoopControl);
+    }
+
+    let structural_ratio = {
+        let non_ws: Vec<char> = trimmed.chars().filter(|c| !c.is_whitespace()).collect();
+        if non_ws.is_empty() {
+            0.0
+        } else {
+            let structural = non_ws
+                .iter()
+                .filter(|c| matches!(c, '{' | '}' | '[' | ']' | '"' | ':' | ',' | '\\'))
+                .count();
+            structural as f64 / non_ws.len() as f64
+        }
+    };
+
+    // Whole-content JSON: a bare object or array is serialized data, not a
+    // fact. (Prose that merely *contains* JSON still passes — only content
+    // that parses in its entirety is rejected.)
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if v.is_object() || v.is_array() {
+                return Err(Rejection::MachineOutput);
+            }
+        }
+        // Prose essentially never opens with a brace; content that does and
+        // still shows real structure (truncated dumps that fail to parse) is
+        // serialized data. `[`-led content is exempted from the tighter bound
+        // because prose legitimately starts with citations and markdown links.
+        if trimmed.starts_with('{') && structural_ratio > BRACE_LED_STRUCTURAL_RATIO {
+            return Err(Rejection::MachineOutput);
+        }
+    }
+
+    // Structure density: serialized data that doesn't parse as JSON
+    // (truncated dumps, log fragments) is still dominated by structural
+    // symbols in a way prose never is.
+    if structural_ratio > MAX_STRUCTURAL_RATIO {
+        return Err(Rejection::MachineOutput);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_ordinary_prose() {
+        assert!(admit("The Maui trip is May 24-31, two travelers, mid-range budget.").is_ok());
+        assert!(admit("User prefers briefings at 7am via Telegram.").is_ok());
+    }
+
+    #[test]
+    fn accepts_short_but_real_facts() {
+        assert!(admit("Budget: $3k").is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_and_tiny() {
+        assert_eq!(admit(""), Err(Rejection::Empty));
+        assert_eq!(admit("   \n "), Err(Rejection::Empty));
+        assert_eq!(admit("ok"), Err(Rejection::TooShort));
+        assert_eq!(admit("done"), Err(Rejection::TooShort));
+    }
+
+    #[test]
+    fn rejects_tool_dumps() {
+        assert_eq!(
+            admit("tool_call:gmail({\"action\":\"read\",\"uid\":101827})"),
+            Err(Rejection::MachineOutput)
+        );
+        assert_eq!(
+            admit("tool_result:{\"ok\":true,\"summary\":\"...\"}"),
+            Err(Rejection::MachineOutput)
+        );
+    }
+
+    #[test]
+    fn rejects_bare_json() {
+        assert_eq!(
+            admit("{\"count\":0,\"query\":\"weather\",\"results\":[]}"),
+            Err(Rejection::MachineOutput)
+        );
+        assert_eq!(
+            admit("[1, 2, 3, 4, 5, 6, 7]"),
+            Err(Rejection::MachineOutput)
+        );
+    }
+
+    #[test]
+    fn accepts_prose_containing_json() {
+        assert!(admit("The API returned {\"ok\": true} which confirms the fix worked.").is_ok());
+    }
+
+    #[test]
+    fn rejects_truncated_json_by_density() {
+        assert_eq!(
+            admit("{\"empty\":false,\"matches\":[{\"byte_offset\":12074,\"line_number\":21,"),
+            Err(Rejection::MachineOutput)
+        );
+    }
+
+    #[test]
+    fn rejects_loop_control() {
+        assert_eq!(
+            admit("Multiple consecutive tool calls have failed.\nRecent errors: ..."),
+            Err(Rejection::LoopControl)
+        );
+        assert_eq!(
+            admit("Your response was empty. Please provide a substantive answer."),
+            Err(Rejection::LoopControl)
+        );
+        assert_eq!(
+            admit("[Warning: 150/200 iterations used.]"),
+            Err(Rejection::LoopControl)
+        );
+        assert_eq!(
+            admit("Current task list (maintained via todo_write):\n[~] Email Review"),
+            Err(Rejection::LoopControl)
+        );
+    }
+
+    #[test]
+    fn harness_lookalikes_from_real_replies_are_admitted() {
+        // A genuine answer that merely opens with harness-like words must
+        // not be silently dropped from memory.
+        assert!(admit("Current task list: 1. Book Maui flights 2. Reserve the condo").is_ok());
+        assert!(admit("[Warning: high surf advisory for the north shore] Waves at 20ft.").is_ok());
+        assert!(admit("Continue. The next step is to book the flights.").is_ok());
+        // The harness's exact forms are still rejected.
+        assert_eq!(admit("Continue."), Err(Rejection::LoopControl));
+        assert_eq!(
+            admit("[Warning: 150/200 iterations used.]"),
+            Err(Rejection::LoopControl)
+        );
+    }
+
+    #[test]
+    fn short_non_ascii_facts_are_admitted() {
+        // Information-dense scripts pack a fact into a few characters.
+        assert!(admit("予算は3千ドル").is_ok());
+        assert_eq!(admit("ok"), Err(Rejection::TooShort));
+        assert_eq!(admit("done"), Err(Rejection::TooShort));
+    }
+}

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -81,11 +81,18 @@ impl HybridMemoryBackend {
     /// decisions) attached to the source memory, so a caller searching for
     /// "what does the user prefer" surfaces the structured fact, not just the
     /// raw conversational text it was lifted from.
+    /// When `session_id` is given, results are restricted to memories written
+    /// during that conversation. The filter runs inside retrieval, before
+    /// access recording. An empty scoped result falls back to a labeled
+    /// global search: facts saved via `memory_save` carry the daemon's
+    /// session id, not the conversation's, and an unlabeled empty result
+    /// would teach the model that a fact it saved earlier does not exist.
     pub async fn search(
         &self,
         query: &str,
         tags: &[String],
         limit: usize,
+        session_id: Option<Uuid>,
     ) -> rustykrab_core::Result<Value> {
         // Over-fetch when tag-filtering so the post-filter can still fill `limit`.
         let fetch = if tags.is_empty() {
@@ -93,7 +100,25 @@ impl HybridMemoryBackend {
         } else {
             (limit * 4).min(100)
         };
-        let results = self.system.recall(query, self.agent_id, fetch).await?;
+        let mut scope_note: Option<&'static str> = None;
+        let results = match session_id {
+            Some(sid) => {
+                let scoped = self
+                    .system
+                    .recall_in_session(query, self.agent_id, fetch, sid)
+                    .await?;
+                if scoped.is_empty() {
+                    scope_note = Some(
+                        "no matches within this conversation; showing global results \
+                         (explicitly saved facts are stored globally)",
+                    );
+                    self.system.recall(query, self.agent_id, fetch).await?
+                } else {
+                    scoped
+                }
+            }
+            None => self.system.recall(query, self.agent_id, fetch).await?,
+        };
 
         let mut items: Vec<Value> = Vec::with_capacity(limit);
         for r in &results {
@@ -134,10 +159,14 @@ impl HybridMemoryBackend {
             }
         }
 
-        Ok(json!({
+        let mut response = json!({
             "results": items,
             "count": items.len(),
-        }))
+        });
+        if let Some(note) = scope_note {
+            response["session_scope"] = json!(note);
+        }
+        Ok(response)
     }
 
     /// Get a specific memory by ID.
@@ -174,16 +203,29 @@ impl HybridMemoryBackend {
 
     /// Save a fact with association tags, creating a new memory.
     pub async fn save(&self, fact: &str, tags: &[String]) -> rustykrab_core::Result<Value> {
-        let memory_id = self
+        // Pre-check admission here so the tool response can carry the
+        // per-cause reason (the writer's gate only reports "refused").
+        if let Err(rejection) = crate::admission::admit(fact) {
+            return Ok(json!({
+                "status": "rejected",
+                "reason": rejection.reason(),
+            }));
+        }
+        match self
             .system
             .writer()
             .save_fact(self.agent_id, self.session_id, fact, tags)
-            .await?;
-
-        Ok(json!({
-            "id": memory_id.to_string(),
-            "status": "saved",
-        }))
+            .await?
+        {
+            Some(memory_id) => Ok(json!({
+                "id": memory_id.to_string(),
+                "status": "saved",
+            })),
+            None => Ok(json!({
+                "status": "rejected",
+                "reason": "content was refused by memory admission control",
+            })),
+        }
     }
 
     /// Delete (invalidate) a memory by ID.
@@ -280,12 +322,12 @@ mod tests {
             .unwrap();
 
         // Untagged search returns both memories.
-        let all = backend.search("preferences", &[], 10).await.unwrap();
+        let all = backend.search("preferences", &[], 10, None).await.unwrap();
         assert_eq!(all["count"], 2, "untagged search should return both");
 
         // Tag-scoped search returns only the matching memory.
         let ui = backend
-            .search("preferences", &["ui".to_string()], 10)
+            .search("preferences", &["ui".to_string()], 10, None)
             .await
             .unwrap();
         assert_eq!(ui["count"], 1, "tag filter should drop the ops memory");
@@ -293,5 +335,73 @@ mod tests {
         assert_eq!(results[0]["content"], "I prefer dark mode");
         let tags = results[0]["tags"].as_array().unwrap();
         assert!(tags.iter().any(|t| t == "ui"));
+    }
+}
+
+#[cfg(test)]
+mod session_scope_tests {
+    use super::*;
+    use crate::embedding::ZeroEmbedder;
+    use crate::storage::SqliteMemoryStorage;
+    use crate::types::{ConversationTurn, TurnMetadata};
+    use crate::{MemoryConfig, MemorySystem};
+
+    fn system() -> Arc<MemorySystem> {
+        Arc::new(MemorySystem::new(
+            MemoryConfig::default(),
+            Arc::new(SqliteMemoryStorage::open_in_memory().unwrap()),
+            Arc::new(ZeroEmbedder::new(8)),
+        ))
+    }
+
+    fn turn(session_id: Uuid, content: &str) -> ConversationTurn {
+        ConversationTurn {
+            id: Uuid::new_v4(),
+            session_id,
+            turn_number: 0,
+            speaker: "user".to_string(),
+            content: content.to_string(),
+            token_count: None,
+            metadata: TurnMetadata::default(),
+        }
+    }
+
+    /// A session-scoped search must not bump access_count or reset the decay
+    /// clock on memories belonging to other conversations — the filter runs
+    /// inside retrieval, before access recording.
+    #[tokio::test]
+    async fn scoped_search_does_not_touch_other_sessions_access_counts() {
+        let sys = system();
+        let agent = Uuid::new_v4();
+        let mine = Uuid::new_v4();
+        let theirs = Uuid::new_v4();
+
+        let a = sys
+            .retain(turn(mine, "Palermo trip departs on October 3rd."), agent)
+            .await
+            .unwrap()
+            .unwrap();
+        let b = sys
+            .retain(turn(theirs, "Maui trip departs on May 24th."), agent)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let _ = sys
+            .recall_in_session("trip departure", agent, 10, mine)
+            .await
+            .unwrap();
+
+        let other = sys.get_memory(b).await.unwrap().unwrap();
+        assert_eq!(
+            other.access_count, 0,
+            "out-of-session memory must get no phantom access bump"
+        );
+        assert!(
+            other.last_accessed_at.is_none(),
+            "out-of-session memory's decay clock must not be reset"
+        );
+        // Sanity: the in-session memory is still reachable.
+        assert!(sys.get_memory(a).await.unwrap().is_some());
     }
 }

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -51,6 +51,7 @@
 //! # }
 //! ```
 
+pub mod admission;
 pub mod backend;
 pub mod chunking;
 pub mod config;
@@ -135,7 +136,7 @@ impl MemorySystem {
         &self,
         turn: ConversationTurn,
         agent_id: Uuid,
-    ) -> rustykrab_core::Result<Uuid> {
+    ) -> rustykrab_core::Result<Option<Uuid>> {
         self.writer.retain(turn, agent_id).await
     }
 
@@ -146,7 +147,7 @@ impl MemorySystem {
         turn: ConversationTurn,
         agent_id: Uuid,
         stage: LifecycleStage,
-    ) -> rustykrab_core::Result<Uuid> {
+    ) -> rustykrab_core::Result<Option<Uuid>> {
         self.writer.retain_with_stage(turn, agent_id, stage).await
     }
 
@@ -166,6 +167,21 @@ impl MemorySystem {
         limit: usize,
     ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
         self.retriever.recall(query, agent_id, limit).await
+    }
+
+    /// [`Self::recall`] restricted to memories written during one
+    /// conversation. The filter runs inside retrieval, before access
+    /// recording, so out-of-session memories get no phantom access boost.
+    pub async fn recall_in_session(
+        &self,
+        query: &str,
+        agent_id: Uuid,
+        limit: usize,
+        session_id: Uuid,
+    ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
+        self.retriever
+            .recall_filtered(query, agent_id, limit, Some(session_id))
+            .await
     }
 
     // ── Lifecycle management ────────────────────────────────────

--- a/crates/rustykrab-memory/src/retrieval.rs
+++ b/crates/rustykrab-memory/src/retrieval.rs
@@ -51,6 +51,22 @@ impl MemoryRetriever {
         agent_id: Uuid,
         limit: usize,
     ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
+        self.recall_filtered(query, agent_id, limit, None).await
+    }
+
+    /// [`Self::recall`] with an optional session (conversation) filter.
+    ///
+    /// The filter is applied BEFORE access recording: memories excluded by
+    /// it must not receive an access bump or a decay-clock reset, otherwise
+    /// every scoped search would grant a phantom relevance boost to other
+    /// conversations' memories.
+    pub async fn recall_filtered(
+        &self,
+        query: &str,
+        agent_id: Uuid,
+        limit: usize,
+        session_id: Option<Uuid>,
+    ) -> rustykrab_core::Result<Vec<RetrievalResult>> {
         let candidates = self.config.retrieval_candidates_per_arm;
 
         // ── Stage 1: Query preprocessing ────────────────────────
@@ -116,6 +132,11 @@ impl MemoryRetriever {
 
         for (memory_id, rrf_score, sources) in &fused {
             if let Some(mem) = memories.iter().find(|m| m.id == *memory_id) {
+                if let Some(sid) = session_id {
+                    if mem.session_id != Some(sid) {
+                        continue;
+                    }
+                }
                 if !mem.is_valid || !mem.lifecycle_stage.is_retrievable() {
                     continue;
                 }

--- a/crates/rustykrab-memory/src/storage.rs
+++ b/crates/rustykrab-memory/src/storage.rs
@@ -89,6 +89,13 @@ pub trait MemoryStorage: Send + Sync {
     /// Record an access (increment access_count, update last_accessed_at).
     async fn record_access(&self, id: Uuid) -> Result<()>;
 
+    /// Record a duplicate write (increment proof_count, update
+    /// last_relevant_at). Deliberately does NOT touch access_count or
+    /// last_accessed_at: a re-save is corroboration, not evidence the
+    /// memory was useful at retrieval time, and must not reset the decay
+    /// clock or inflate the retrieval boost.
+    async fn record_duplicate(&self, id: Uuid) -> Result<()>;
+
     /// Record an access for each memory in a single round-trip.
     async fn record_access_batch(&self, ids: &[Uuid]) -> Result<()>;
 
@@ -1064,6 +1071,23 @@ impl MemoryStorage for SqliteMemoryStorage {
                 "UPDATE memories
                  SET access_count = access_count + 1,
                      last_accessed_at = ?2
+                 WHERE id = ?1",
+                params![id_str, now],
+            )
+            .map_err(storage_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn record_duplicate(&self, id: Uuid) -> Result<()> {
+        let id_str = id.to_string();
+        let now = Utc::now().to_rfc3339();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "UPDATE memories
+                 SET proof_count = proof_count + 1,
+                     last_relevant_at = ?2
                  WHERE id = ?1",
                 params![id_str, now],
             )

--- a/crates/rustykrab-memory/src/writer.rs
+++ b/crates/rustykrab-memory/src/writer.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
 use uuid::Uuid;
 
+use crate::admission;
 use crate::chunking::chunk_text;
 use crate::config::MemoryConfig;
 use crate::embedding::{cosine_similarity, Embedder};
@@ -67,7 +68,7 @@ impl MemoryWriter {
         &self,
         turn: ConversationTurn,
         agent_id: Uuid,
-    ) -> rustykrab_core::Result<Uuid> {
+    ) -> rustykrab_core::Result<Option<Uuid>> {
         self.retain_with_stage(turn, agent_id, LifecycleStage::Working)
             .await
     }
@@ -76,12 +77,22 @@ impl MemoryWriter {
     ///
     /// Used by auto-persist to write `Working` memories, and by the
     /// `memory_save` tool path which writes `Episodic` memories.
+    /// Returns `Ok(None)` when the content is refused by admission control
+    /// (machine output, agent-loop chatter — see [`crate::admission`]);
+    /// losing a memory write must never fail the caller, so a rejection is
+    /// not an error.
     pub async fn retain_with_stage(
         &self,
         turn: ConversationTurn,
         agent_id: Uuid,
         stage: LifecycleStage,
-    ) -> rustykrab_core::Result<Uuid> {
+    ) -> rustykrab_core::Result<Option<Uuid>> {
+        // ── Admission control ───────────────────────────────────
+        if let Err(rejection) = admission::admit(&turn.content) {
+            debug!(?rejection, "memory write refused by admission control");
+            return Ok(None);
+        }
+
         // ── SHA-256 dedup ───────────────────────────────────────
         let content_hash = {
             let mut hasher = Sha256::new();
@@ -94,10 +105,25 @@ impl MemoryWriter {
             .find_by_content_hash(agent_id, &content_hash)
             .await?
         {
-            debug!(memory_id = %existing.id, "exact duplicate, skipping write");
-            // Still record an access on the existing memory.
-            self.storage.record_access(existing.id).await?;
-            return Ok(existing.id);
+            if existing.session_id == Some(turn.session_id) {
+                debug!(memory_id = %existing.id, "exact duplicate, skipping write");
+                // A re-save is corroboration, not a recall: bump proof_count
+                // and leave access_count (retrieval ranking) and
+                // last_accessed_at (the decay clock) alone — otherwise
+                // repeated identical writes make a memory immortal and rank
+                // it above genuinely useful ones.
+                self.storage.record_duplicate(existing.id).await?;
+                return Ok(Some(existing.id));
+            }
+            // Identical content from a DIFFERENT conversation: corroborate
+            // the original, but still store a fresh row stamped with this
+            // conversation's session id — otherwise session-scoped recall
+            // ("earlier in this conversation…") silently loses the turn.
+            debug!(
+                original = %existing.id,
+                "duplicate content from another conversation; storing per-session copy"
+            );
+            self.storage.record_duplicate(existing.id).await?;
         }
 
         // ── Track 1: Synchronous verbatim storage ───────────────
@@ -180,6 +206,7 @@ impl MemoryWriter {
         let storage = Arc::clone(&self.storage);
         let content = turn.content;
         let dedup_threshold = self.config.dedup_auto_merge_threshold as f32;
+        let session_id = Some(turn.session_id);
         let limiter = Arc::clone(&self.dedup_limiter);
         tokio::spawn(async move {
             // Bound concurrency: heavy ingestion queues here instead of
@@ -219,6 +246,18 @@ impl MemoryWriter {
                 }
                 let sim = cosine_similarity(&new_emb, existing_emb);
                 if sim >= dedup_threshold {
+                    // Only collapse near-duplicates within the SAME
+                    // conversation: invalidating a row in favour of another
+                    // session's copy would make the turn invisible to
+                    // session-scoped recall.
+                    let same_session = match storage.get_memory(*existing_id).await {
+                        Ok(Some(existing)) => existing.session_id == session_id,
+                        _ => false,
+                    };
+                    if !same_session {
+                        let _ = storage.record_duplicate(*existing_id).await;
+                        continue;
+                    }
                     debug!(
                         new_id = %memory_id,
                         existing_id = %existing_id,
@@ -226,7 +265,7 @@ impl MemoryWriter {
                         "near-duplicate detected, invalidating new memory"
                     );
                     let _ = storage.invalidate(memory_id, Some(*existing_id)).await;
-                    let _ = storage.record_access(*existing_id).await;
+                    let _ = storage.record_duplicate(*existing_id).await;
                     return;
                 }
             }
@@ -240,7 +279,7 @@ impl MemoryWriter {
             "memory retained"
         );
 
-        Ok(memory_id)
+        Ok(Some(memory_id))
     }
 
     /// Store a simple fact with tags (backward-compatible with the old
@@ -251,7 +290,7 @@ impl MemoryWriter {
         session_id: Uuid,
         fact: &str,
         tags: &[String],
-    ) -> rustykrab_core::Result<Uuid> {
+    ) -> rustykrab_core::Result<Option<Uuid>> {
         let turn = ConversationTurn {
             id: Uuid::new_v4(),
             session_id,
@@ -279,5 +318,150 @@ impl MemoryWriter {
         self.storage.fts_index_batch(agent_id, entries).await?;
         debug!(agent_id = %agent_id, indexed = count, "FTS5 index rebuilt");
         Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embedding::ZeroEmbedder;
+    use crate::storage::SqliteMemoryStorage;
+    use crate::types::TurnMetadata;
+
+    fn test_writer() -> (MemoryWriter, Arc<dyn MemoryStorage>) {
+        let storage: Arc<dyn MemoryStorage> =
+            Arc::new(SqliteMemoryStorage::open_in_memory().unwrap());
+        let embedder = Arc::new(ZeroEmbedder::new(8));
+        let writer = MemoryWriter::new(Arc::clone(&storage), embedder, MemoryConfig::default());
+        (writer, storage)
+    }
+
+    fn turn_in(session_id: Uuid, content: &str) -> ConversationTurn {
+        ConversationTurn {
+            id: Uuid::new_v4(),
+            session_id,
+            turn_number: 0,
+            speaker: "user".to_string(),
+            content: content.to_string(),
+            token_count: None,
+            metadata: TurnMetadata::default(),
+        }
+    }
+
+    fn turn(content: &str) -> ConversationTurn {
+        turn_in(Uuid::new_v4(), content)
+    }
+
+    /// A duplicate write must corroborate (proof_count) without inflating
+    /// the retrieval signal (access_count) or resetting the decay clock
+    /// (last_accessed_at) — otherwise repeatedly re-saved content becomes
+    /// immortal and outranks genuinely useful memories.
+    #[tokio::test]
+    async fn duplicate_write_bumps_proof_count_not_access_count() {
+        let (writer, storage) = test_writer();
+        let agent = Uuid::new_v4();
+        let session = Uuid::new_v4();
+        let content = "The Maui trip is May 24-31, two travelers, mid-range budget.";
+
+        let first = writer
+            .retain(turn_in(session, content), agent)
+            .await
+            .unwrap()
+            .unwrap();
+        let second = writer
+            .retain(turn_in(session, content), agent)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first, second, "dedup should return the existing memory");
+
+        let mem = storage.get_memory(first).await.unwrap().unwrap();
+        assert_eq!(mem.proof_count, 2, "duplicate should corroborate");
+        assert_eq!(mem.access_count, 0, "duplicate must not count as an access");
+        assert!(
+            mem.last_accessed_at.is_none(),
+            "duplicate must not reset the decay clock"
+        );
+        assert!(
+            mem.last_relevant_at.is_some(),
+            "duplicate should refresh relevance"
+        );
+    }
+
+    /// Machine output must be refused at the door, not stored and ranked.
+    #[tokio::test]
+    async fn machine_output_is_refused_admission() {
+        let (writer, storage) = test_writer();
+        let agent = Uuid::new_v4();
+
+        let rejected = writer
+            .retain(turn("tool_result:{\"ok\":true,\"count\":17}"), agent)
+            .await
+            .unwrap();
+        assert!(rejected.is_none(), "tool dump should be rejected");
+
+        let accepted = writer
+            .retain(turn("User prefers morning briefings at 7am."), agent)
+            .await
+            .unwrap();
+        assert!(accepted.is_some(), "prose should be admitted");
+
+        let all = storage.list_retrievable(agent).await.unwrap();
+        assert_eq!(all.len(), 1, "only the prose row should exist");
+    }
+
+    /// Explicit `memory_save` goes through the same gate.
+    #[tokio::test]
+    async fn save_fact_is_gated_too() {
+        let (writer, _storage) = test_writer();
+        let agent = Uuid::new_v4();
+        let session = Uuid::new_v4();
+
+        let rejected = writer
+            .save_fact(agent, session, "{\"a\": [1,2,3]}", &["tag".into()])
+            .await
+            .unwrap();
+        assert!(rejected.is_none());
+
+        let accepted = writer
+            .save_fact(
+                agent,
+                session,
+                "Geoff's dog is named Rusty.",
+                &["pets".into()],
+            )
+            .await
+            .unwrap();
+        assert!(accepted.is_some());
+    }
+
+    /// Identical content from a DIFFERENT conversation gets its own row (with
+    /// the correct session id) so session-scoped recall can find it — while
+    /// still corroborating the original.
+    #[tokio::test]
+    async fn cross_session_duplicate_gets_its_own_row() {
+        let (writer, storage) = test_writer();
+        let agent = Uuid::new_v4();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+        let content = "What is our Palermo budget for the October trip?";
+
+        let a = writer
+            .retain(turn_in(session_a, content), agent)
+            .await
+            .unwrap()
+            .unwrap();
+        let b = writer
+            .retain(turn_in(session_b, content), agent)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_ne!(a, b, "each conversation should own a copy");
+        let mem_a = storage.get_memory(a).await.unwrap().unwrap();
+        let mem_b = storage.get_memory(b).await.unwrap().unwrap();
+        assert_eq!(mem_a.session_id, Some(session_a));
+        assert_eq!(mem_b.session_id, Some(session_b));
+        assert_eq!(mem_a.proof_count, 2, "original should be corroborated");
     }
 }

--- a/crates/rustykrab-providers/src/anthropic.rs
+++ b/crates/rustykrab-providers/src/anthropic.rs
@@ -93,7 +93,20 @@ impl AnthropicProvider {
             match msg.role {
                 Role::System => {
                     if let MessageContent::Text(ref text) = msg.content {
-                        system_prompt = Some(text.clone());
+                        if system_prompt.is_none() {
+                            system_prompt = Some(text.clone());
+                        } else {
+                            // A mid-conversation System message (iteration
+                            // warning, harness notice) must not REPLACE the
+                            // real system prompt — render it as an inline
+                            // user-role note instead.
+                            api_messages.push(ApiMessage {
+                                role: "user".to_string(),
+                                content: ApiContent::Blocks(vec![ContentBlock::Text {
+                                    text: format!("[System notice]\n{text}"),
+                                }]),
+                            });
+                        }
                     }
                 }
                 Role::User => match &msg.content {

--- a/crates/rustykrab-tools/src/memory_backend.rs
+++ b/crates/rustykrab-tools/src/memory_backend.rs
@@ -4,7 +4,15 @@ use serde_json::Value;
 
 #[async_trait]
 pub trait MemoryBackend: Send + Sync {
-    async fn search(&self, query: &str, tags: &[String], limit: usize) -> Result<Value>;
+    /// Search memories. `session_id` (a conversation id) restricts results to
+    /// memories recorded during that conversation.
+    async fn search(
+        &self,
+        query: &str,
+        tags: &[String],
+        limit: usize,
+        session_id: Option<&str>,
+    ) -> Result<Value>;
     async fn get(&self, memory_id: &str) -> Result<Value>;
     /// Save a fact with association tags. Returns the new memory ID.
     async fn save(&self, fact: &str, tags: &[String]) -> Result<Value>;

--- a/crates/rustykrab-tools/src/memory_search.rs
+++ b/crates/rustykrab-tools/src/memory_search.rs
@@ -24,7 +24,12 @@ impl Tool for MemorySearchTool {
     }
 
     fn description(&self) -> &str {
-        "Search long-term memory entries by tags or keywords."
+        "Search long-term memory for facts, preferences, decisions, and past \
+         conversation turns. Use this whenever the user refers to something \
+         not visible in the current context — earlier conversations, stated \
+         preferences, prior plans or decisions — or when you are uncertain \
+         about a detail you may have known before. Pass session_id to search \
+         only one conversation's history."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -46,6 +51,11 @@ impl Tool for MemorySearchTool {
                     "limit": {
                         "type": "integer",
                         "description": "Maximum number of results to return (default 10)"
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional conversation id; restricts the search to \
+                                        memories from that conversation's history"
                     }
                 },
                 "required": ["query"]
@@ -68,10 +78,11 @@ impl Tool for MemorySearchTool {
             .unwrap_or_default();
 
         let limit = args["limit"].as_u64().unwrap_or(10) as usize;
+        let session_id = args["session_id"].as_str();
 
         let results = self
             .backend
-            .search(query, &tags, limit)
+            .search(query, &tags, limit, session_id)
             .await
             .map_err(|e| rustykrab_core::Error::ToolExecution(e.to_string().into()))?;
 

--- a/crates/rustykrab-tools/src/wiki.rs
+++ b/crates/rustykrab-tools/src/wiki.rs
@@ -398,7 +398,7 @@ impl WikiTool {
         // search ignores tag filters, so non-wiki hits are mixed in and dropped.
         if let Ok(result) = self
             .memory
-            .search(query, &["wiki".to_string()], limit * 4)
+            .search(query, &["wiki".to_string()], limit * 4, None)
             .await
         {
             if let Some(items) = result.get("results").and_then(|r| r.as_array()) {
@@ -965,7 +965,13 @@ mod tests {
 
     #[async_trait]
     impl MemoryBackend for MockMemory {
-        async fn search(&self, _query: &str, _tags: &[String], _limit: usize) -> Result<Value> {
+        async fn search(
+            &self,
+            _query: &str,
+            _tags: &[String],
+            _limit: usize,
+            _session_id: Option<&str>,
+        ) -> Result<Value> {
             let results = self.search_results.lock().unwrap().clone();
             Ok(json!({ "results": results, "count": results.len() }))
         }


### PR DESCRIPTION
## Why

Auditing the live memory store turned up a corpus that had become mostly noise, and three independent mechanisms that caused it:

| Content in the live store | Rows | Share |
|---|---|---|
| `tool_call:` / `tool_result:` raw dumps | 24,269 | **91.7%** |
| Actual prose | 2,201 | 8.3% |

Of the *permanent* (semantic) tier, 86% was machine noise — and it outranked the prose:

| Kind | avg importance |
|---|---|
| `tool_result` dump | **0.627** |
| `tool_call` dump | 0.545 |
| prose | 0.479 |

`memory_search` was effectively unusable as a result: it returned tool-call JSON and empty search results, so the agent learned not to call it.

## What changed

### 1. Admission control (`crates/rustykrab-memory/src/admission.rs`, new)

Nothing decided *whether* content deserved a memory record — `retain_with_stage` wrote unconditionally and importance scoring only decided ranking. Because that heuristic rewards length and capitalization density, long JSON dumps scored higher than short factual prose (importance rises monotonically with length: 0.508 → 0.749 across length buckets), and since importance also slows decay, the noise was structurally immortal.

The gate refuses machine output and agent-loop chatter before anything is written. It is deliberately conservative:

- prose *containing* JSON still passes; only whole-content JSON is refused
- loop-control prefixes are anchored to the harness's exact wording, so a genuine reply opening `"Current task list: 1. Book Maui flights"` is **not** silently dropped
- the length floor is script-aware, so short CJK facts aren't rejected as too short

Rejection is `Ok(None)`, never an error — a refused memory write must never break a conversation in progress — and `memory_save` returns the per-cause reason so the model can correct itself.

### 2. Duplicate-write counter split (`record_duplicate`)

`record_access` was being called on the exact-duplicate **write** path — the same counter that retrieval bumps. Re-saving identical content therefore:

- inflated `access_count`, worth up to a **2x** retrieval boost via `effective_score`
- reset `last_accessed_at`, which is *the decay clock* — so re-saved content never aged out
- crossed `promote_min_access_count`, promoting it to the permanent tier

A scheduled job failing identically every morning was enough to make its own error blob permanent. In the live data, semantic-tier tool dumps averaged 30–35 "accesses" without ever being retrieved.

Duplicate writes now bump `proof_count` (a field that already existed, was persisted, and was never incremented) plus `last_relevant_at`, leaving retrieval signal and decay untouched. Cross-conversation duplicates additionally keep their own row, so scoped recall can still find them.

### 3. Scoped recall (`recall_in_session`)

`memory_search` gained an optional `session_id` for recovering one conversation's earlier history — useful once compaction has displaced it from the prompt.

The filter runs **inside retrieval, before access recording**. An over-fetch-and-post-filter design would have re-introduced precisely the distortion §2 removes: `recall` records an access on everything it returns, so filtering afterwards would hand ~40 unrelated memories a phantom access bump and decay-clock reset on every scoped search.

An empty scoped result falls back to a **labeled** global search, because facts saved via `memory_save` carry the daemon's session id rather than the conversation's — an unlabeled empty result would teach the model that a fact it saved minutes earlier doesn't exist. An unparseable `session_id` likewise degrades loudly rather than silently widening scope.

### 4. Anthropic system-prompt fix (separate commit)

`build_messages` assigned *every* `Role::System` message to the Anthropic `system` field, so the last one won. Any mid-conversation system notice — the agent loop's own iteration warning — silently replaced the real system prompt, taking identity and security policy with it for the rest of the turn. The first System message now wins; later ones render as inline `[System notice]` user text.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets`, and `cargo test --workspace` all clean — **559 tests passing**.

New regression tests cover: proof/access separation on duplicate writes, admission of prose vs machine output, `save_fact` going through the same gate, per-session duplicate rows, and absence of phantom access on out-of-session memories.

## Notes

- No schema migration — `proof_count` and `last_relevant_at` already exist and are already persisted.
- This does **not** touch compaction, which already landed on `main`; it's complementary (what goes *into* memory and how it's ranked, rather than what stays in the prompt).
- The live store was separately purged of the 24,269 noise rows (628 MB → 90 MB, backed up first). This PR is what stops it refilling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)