### PR TITLE
feat: add official macOS install flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,13 +285,21 @@ jobs:
               --force \
               "$APP"
 
-          codesign -vvv "$APP"
+          # Fail the release job if the bundle cannot be verified strictly.
+          # This catches malformed signatures before an artifact is published.
+          codesign --verify --deep --strict --verbose=2 "$APP"
 
       - name: Package artifact
         run: |
           mkdir -p dist
           if [ -d "target/${{ matrix.target }}/release/RustyKrab.app" ]; then
             cp -R target/${{ matrix.target }}/release/RustyKrab.app dist/
+            hdiutil create \
+              -volname RustyKrab \
+              -srcfolder dist/RustyKrab.app \
+              -ov \
+              -format UDZO \
+              "dist/rustykrab-${{ matrix.target }}.dmg"
             cd dist
             tar czf rustykrab-${{ matrix.target }}.tar.gz RustyKrab.app
           else
@@ -299,6 +307,32 @@ jobs:
             cd dist
             tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
           fi
+          shasum -a 256 dist/rustykrab-${{ matrix.target }}.* > dist/rustykrab-${{ matrix.target }}.sha256
+
+      - name: Notarize and staple macOS bundle
+        if: runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          test -n "$APPLE_ID" || { echo "APPLE_ID secret is required for macOS releases" >&2; exit 1; }
+          test -n "$APPLE_TEAM_ID" || { echo "APPLE_TEAM_ID secret is required for macOS releases" >&2; exit 1; }
+          test -n "$APPLE_APP_PASSWORD" || { echo "APPLE_APP_PASSWORD secret is required for macOS releases" >&2; exit 1; }
+          xcrun notarytool submit \
+            "dist/rustykrab-${{ matrix.target }}.dmg" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --password "$APPLE_APP_PASSWORD" \
+            --wait
+          xcrun stapler staple "dist/rustykrab-${{ matrix.target }}.dmg"
+          xcrun stapler staple target/${{ matrix.target }}/release/RustyKrab.app
+          codesign --verify --deep --strict target/${{ matrix.target }}/release/RustyKrab.app
+          rm -f "dist/rustykrab-${{ matrix.target }}.tar.gz" "dist/rustykrab-${{ matrix.target }}.sha256"
+          tar -C target/${{ matrix.target }}/release -czf \
+            "dist/rustykrab-${{ matrix.target }}.tar.gz" RustyKrab.app
+          shasum -a 256 dist/rustykrab-${{ matrix.target }}.* > \
+            "dist/rustykrab-${{ matrix.target }}.sha256"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ On macOS, `make` automatically ad-hoc codesigns the binary with the
 `keychain-access-groups` entitlement required by the Data Protection Keychain.
 You can also run `make codesign` or `make codesign-debug` separately.
 
+### macOS LaunchAgent installation
+
+For a signed release bundle, install the app and register its per-user
+LaunchAgent with:
+
+```bash
+scripts/install.sh /path/to/RustyKrab.app
+```
+
+The installer verifies the bundle signature, installs it under
+`~/Applications/RustyKrab.app`, preserves the previous bundle for rollback,
+and starts `com.gcbh.rustykrab` at login. Use `scripts/uninstall.sh` to remove
+the agent while retaining the app and data, or `scripts/uninstall.sh --purge`
+to remove the app bundle as well. `--allow-adhoc` is available only for local
+development builds; published releases should pass strict signature
+verification.
+
 ## Quick Start
 
 ### Option A: Run with Claude (recommended)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Install a signed RustyKrab.app and register it as a per-user LaunchAgent.
+#
+# Usage:
+#   scripts/install.sh [path/to/RustyKrab.app] [--allow-adhoc]
+#
+# Runtime credentials should be placed in the macOS Keychain before install.
+# Values supplied through the environment are written to the user-only plist
+# for compatibility with existing deployments; prefer the Keychain for new
+# installs.
+
+set -euo pipefail
+
+LABEL="com.gcbh.rustykrab"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+APP_DEST="$HOME/Applications/RustyKrab.app"
+LOG_DIR="$HOME/.local/share/rustykrab/logs"
+ALLOW_ADHOC=false
+APP_SRC=""
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while (($#)); do
+    case "$1" in
+        --allow-adhoc) ALLOW_ADHOC=true ;;
+        -*) die "unknown option: $1" ;;
+        *) [[ -z "$APP_SRC" ]] || die "only one app path may be supplied"; APP_SRC="$1" ;;
+    esac
+    shift
+done
+
+if [[ -z "$APP_SRC" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    APP_SRC="$SCRIPT_DIR/../RustyKrab.app"
+fi
+APP_SRC="$(cd "$APP_SRC" 2>/dev/null && pwd)" || die "app bundle not found: $APP_SRC"
+BINARY="$APP_SRC/Contents/MacOS/rustykrab-cli"
+[[ -x "$BINARY" ]] || die "app executable not found: $BINARY"
+
+if ! codesign --verify --deep --strict "$APP_SRC" 2>/dev/null; then
+    if ! $ALLOW_ADHOC; then
+        die "app signature is invalid; pass --allow-adhoc only for local development"
+    fi
+    echo "warning: installing an unverified/ad-hoc app for local development" >&2
+fi
+
+VERSION="$($BINARY --version 2>/dev/null | head -1 || true)"
+echo "Installing ${VERSION:-RustyKrab}"
+
+mkdir -p "$HOME/Applications" "$HOME/Library/LaunchAgents" "$LOG_DIR"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+
+# Keep the previous bundle available for rollback and install atomically.
+if [[ -d "$APP_DEST" ]]; then
+    BACKUP="$APP_DEST.previous-$(date -u +%Y%m%dT%H%M%SZ)"
+    mv "$APP_DEST" "$BACKUP"
+    echo "Previous app preserved at $BACKUP"
+fi
+ditto "$APP_SRC" "$APP_DEST"
+
+# PlistBuddy avoids interpolation errors from XML-sensitive configuration.
+rm -f "$PLIST"
+plutil -create xml1 "$PLIST"
+PB=(/usr/libexec/PlistBuddy -c)
+"${PB[@]}" 'Add :Label string com.gcbh.rustykrab' "$PLIST"
+"${PB[@]}" 'Add :ProgramArguments array' "$PLIST"
+"${PB[@]}" "Add :ProgramArguments:0 string $APP_DEST/Contents/MacOS/rustykrab-cli" "$PLIST"
+"${PB[@]}" 'Add :EnvironmentVariables dict' "$PLIST"
+"${PB[@]}" "Add :EnvironmentVariables:HOME string $HOME" "$PLIST"
+"${PB[@]}" 'Add :EnvironmentVariables:PATH string /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin' "$PLIST"
+
+for key in RUSTYKRAB_PROVIDER RUSTYKRAB_PORT RUSTYKRAB_WEB_UI RUST_LOG \
+    OLLAMA_BASE_URL OLLAMA_MODEL OLLAMA_NUM_CTX RUSTYKRAB_NUM_CTX \
+    TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN; do
+    if [[ -n "${!key:-}" ]]; then
+        "${PB[@]}" "Add :EnvironmentVariables:$key string ${!key}" "$PLIST"
+    fi
+done
+
+"${PB[@]}" 'Add :RunAtLoad bool true' "$PLIST"
+"${PB[@]}" 'Add :KeepAlive bool true' "$PLIST"
+"${PB[@]}" 'Add :ThrottleInterval integer 10' "$PLIST"
+"${PB[@]}" 'Add :ProcessType string Background' "$PLIST"
+"${PB[@]}" "Add :StandardOutPath string $LOG_DIR/launchagent.log" "$PLIST"
+"${PB[@]}" "Add :StandardErrorPath string $LOG_DIR/launchagent.log" "$PLIST"
+chmod 600 "$PLIST"
+plutil -lint "$PLIST"
+
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+echo "RustyKrab is installed and started."
+echo "  Status: launchctl print gui/$(id -u)/$LABEL"
+echo "  Logs:   tail -f $LOG_DIR/launchagent.log"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Remove RustyKrab's per-user LaunchAgent. Keep the app and data by default.
+
+set -euo pipefail
+
+LABEL="com.gcbh.rustykrab"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+APP_DEST="$HOME/Applications/RustyKrab.app"
+
+if launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1; then
+    launchctl bootout "gui/$(id -u)/$LABEL" || true
+fi
+rm -f "$PLIST"
+
+if [[ "${1:-}" == "--purge" ]]; then
+    rm -rf "$APP_DEST"
+    echo "Removed app bundle: $APP_DEST"
+else
+    echo "LaunchAgent removed; app retained at $APP_DEST"
+    echo "Use --purge to remove the app bundle too."
+fi


### PR DESCRIPTION
## Summary

- add a signed-release macOS installer that installs RustyKrab.app and registers a per-user LaunchAgent
- preserve the previous app bundle for rollback and add a safe uninstall path
- require strict bundle verification and publish DMG/checksum artifacts
- require notarization and staple the macOS app and DMG before release publication
- document the official LaunchAgent installation flow

## Validation

- `bash -n scripts/install.sh scripts/uninstall.sh`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `git diff --check`

The macOS release job now requires `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_PASSWORD` secrets for notarization.