### PR TITLE
Dreaming P0 (6/6): wire outcome capture into the gateway, memory, and CLI

### DIFF
--- a/DREAMING.md
+++ b/DREAMING.md
@@ -5,11 +5,12 @@ off-cycle process -- "dreaming" -- that continuously improves how the system
 executes by reviewing what has already happened and reconciling it into durable
 knowledge (memory and, eventually, skills).
 
-Status: **design / proposal.** Nothing here is implemented. The intent is to
-agree on the architecture, the safety boundaries, the *objective* being
-optimized, and the build order before writing code. The
-[Revision history](#revision-history) records how the design evolved so the
-discarded reasoning survives.
+Status: **Phase 0 implemented; Phases 1-3 proposed.** Outcome instrumentation
+and credit assignment are in the tree, opt-in behind
+`RUSTYKRAB_OUTCOME_CAPTURE` and observational only -- see
+[Phase 0 as built](#phase-0-as-built). Everything downstream of that is still
+design. The [Revision history](#revision-history) records how the design
+evolved so the discarded reasoning survives.
 
 ## Motivation
 
@@ -391,13 +392,54 @@ surface, the skill tier is theater and should be cut from scope honestly.
 
 | Phase | What | Risk | Gate to proceed |
 |---|---|---|---|
-| **0 -- Instrument outcomes (Monitor)** | Extend `ExecutionTracer` to log tool/skill invocations linked to outcome signals; add `[outcome]` to `SKILL.md`. Pure data collection. | None | Outcome data flowing for at least verifiable-signal skills. |
+| **0 -- Instrument outcomes (Monitor)** | *(implemented)* Outcome records + credit assignment; `[outcome]` in `SKILL.md`. Pure data collection, opt-in via `RUSTYKRAB_OUTCOME_CAPTURE`. | None | Outcome data flowing for at least verifiable-signal skills. |
 | **1 -- Downtime read-only analysis (Analyze)** | Trigger + queue + idle-gated worker running *report-only* jobs; abort-and-requeue on activity. | None (no writes) | Reports show real, actionable patterns. |
 | **2 -- Memory mutation (Plan+Execute)** | Consolidation that writes memory via stage-then-promote + manifest + probation-window rollback; low gain, rate-limited. | Medium | Consolidations measurably improve retrieval and are reliably reversible. |
 | **3 -- Skill improvement** | Per-skill optimization from logged outcomes; proposal-only with a review surface. | Higher | Per-skill measurable outcomes + a working review/promotion surface. |
 
 Notably **not** required, thanks to staging + soft-delete: a DB snapshot engine,
 a job-state machine for pausing, conversation versioning, or a preemption bus.
+
+## Phase 0 as built
+
+Shipped and opt-in behind `RUSTYKRAB_OUTCOME_CAPTURE` (off by default).
+
+- **`rustykrab-core::outcome`** — the shared vocabulary: `SignalClass`
+  (`Verifiable` > `Explicit` > `Implicit` > `Judge`, with `is_ground_truth()`
+  gating what may justify a costly change), `OutcomeVerdict`,
+  `Attribution`/`AttributionKind`, `ExecutionCounters`, `OutcomeRecord`,
+  `OutcomeTally`, and the `OutcomeSink` trait.
+- **`rustykrab-core::retrieval_log`** — the missing join. The retrieval path
+  knew *what was recalled* and the run-completion path knew *how the turn
+  went*, with nothing connecting them. `RetrievalLog` connects them: the
+  memory backend records the ids it actually hands to the model, and the
+  runner drains them when the run ends.
+- **`rustykrab-store::outcomes`** — `outcome_records` + `outcome_attributions`,
+  written once and never updated, pruned at 50k rows. Tallies are derived by
+  `GROUP BY` on read, with a `ground_truth_only` filter so proxy signals
+  cannot launder a verifiable failure.
+- **`SKILL.md` `[outcome]` block** — `success`, optional `checks`, and
+  `signal`. `SkillMd::is_optimizable()` implements the freeze rule; an
+  unset or unparseable `signal` degrades to `Implicit` rather than
+  something stronger, so an unclear declaration buys no authority.
+- **`AgentRunner::capture_outcome`** — the per-run tracer was hoisted from
+  `run_inner` to the `run`/`run_streaming` wrappers so capture sees the run's
+  traces regardless of which of the inner loop's ~10 exit paths fired.
+  Best-effort by construction: a failing sink is logged and swallowed.
+
+Two deliberate deviations from the plan above:
+
+1. **`harmful_count` on `Memory` is deferred to Phase 2.** `Memory` has no
+   constructor, so adding a field touches every struct literal plus four
+   hand-numbered placeholder lists in `upsert_memory`, and
+   `SqliteMemoryStorage` has no additive-migration phase to extend. Since
+   tallies are *derived* from records rather than incremented in place, the
+   column buys nothing until something mutates memory — which is Phase 2.
+2. **Verdicts are `Implicit` only.** Nothing yet checks a post-condition or
+   captures an explicit correction, so every record carries behavioural
+   evidence at low confidence and `is_actionable()` returns false for all of
+   them. That is the honest state: Phase 1 reports can be built on this,
+   Phase 2/3 promotion cannot.
 
 ## What downtime does and does not solve
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ All configuration is via environment variables. No plaintext config files.
 | `SIGNAL_WEBHOOK_SECRET` | — | Shared secret for webhook validation |
 | `RUST_LOG` | `info` | Log level (`info`, `debug`, `rustykrab_gateway=debug`) |
 | `RUSTYKRAB_LOG_STDOUT` | auto | Force stdout logging on (`1`) or off (`0`). Default: enabled only when stdout is a terminal. The rolling log file under the data directory is always written |
+| `RUSTYKRAB_OUTCOME_CAPTURE` | `0` | Record how each completed run went, and which skill, memories, and tools were in play, into the `outcome_records` table. Observational only — it changes nothing about how the agent behaves. Groundwork for the self-improvement outer loop; see `DREAMING.md` |
 
 ### Persisting credentials
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -696,8 +696,17 @@ async fn main() -> anyhow::Result<()> {
         })
     };
 
+    // Outcome instrumentation (see DREAMING.md). Observational only: the
+    // memory backend records which memories it surfaces, and a completed
+    // run credits its outcome to them. Opt-in, off by default.
+    let outcome_capture_enabled = std::env::var("RUSTYKRAB_OUTCOME_CAPTURE")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "True"))
+        .unwrap_or(false);
+    let retrieval_log = rustykrab_core::retrieval_log::RetrievalLog::new();
+
     let memory_backend: Arc<dyn MemoryBackend> = Arc::new(MemoryAdapter {
-        inner: HybridMemoryBackend::new(Arc::clone(&memory_system), agent_id, session_id),
+        inner: HybridMemoryBackend::new(Arc::clone(&memory_system), agent_id, session_id)
+            .with_retrieval_log(retrieval_log.clone()),
     });
     tracing::info!(%agent_id, "memory system initialized");
 
@@ -993,7 +1002,9 @@ async fn main() -> anyhow::Result<()> {
         .with_skill_registry(skill_registry)
         .with_memory(Arc::clone(&memory_system), agent_id)
         .with_subagents_enabled(subagents_enabled)
-        .with_computer_use_enabled(computer_use_enabled);
+        .with_computer_use_enabled(computer_use_enabled)
+        .with_retrieval_log(retrieval_log)
+        .with_outcome_capture(outcome_capture_enabled);
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -293,7 +293,19 @@ async fn prepare_agent(
     .with_config(agent_config)
     .with_active_tools(state.active_tools.clone())
     .with_recall_store(state.recall.clone())
-    .with_todo_store(state.todos.clone());
+    .with_todo_store(state.todos.clone())
+    .with_retrieval_log(state.retrieval_log.clone());
+
+    // Outcome instrumentation (see `DREAMING.md`). Observational only: the
+    // runner records how the run went and to which artifacts it should be
+    // credited. Attributing to the active skill needs its name, which the
+    // runner does not otherwise know.
+    if state.outcome_capture_enabled {
+        runner = runner.with_outcome_sink(Arc::new(state.store.outcomes()));
+        if let Some((name, _)) = options.active_skill.as_ref() {
+            runner = runner.with_active_skill(name.clone());
+        }
+    }
 
     if let Some(cb) = build_memory_callback(state, conv) {
         // The inbound user message was pushed onto conv.messages by

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -4,6 +4,7 @@ use rustykrab_core::active_tools::ActiveToolsRegistry;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
 use rustykrab_core::recall::RecallStore;
+use rustykrab_core::retrieval_log::RetrievalLog;
 use rustykrab_core::todo::TodoStore;
 use rustykrab_memory::MemorySystem;
 use rustykrab_skills::SkillRegistry;
@@ -68,6 +69,15 @@ pub struct AppState {
     /// startup; threaded through so `prepare_agent` knows whether to grant
     /// `Capability::ComputerUse`.
     pub computer_use_enabled: bool,
+    /// Records which memories were surfaced into each conversation so a
+    /// completed run's outcome can be attributed to them. Shared with the
+    /// memory backend, which writes it, and the agent runner, which drains
+    /// it. See `DREAMING.md`.
+    pub retrieval_log: RetrievalLog,
+    /// Whether completed runs report their outcome to the store. Off by
+    /// default: instrumentation is opt-in, driven by
+    /// `RUSTYKRAB_OUTCOME_CAPTURE` at startup.
+    pub outcome_capture_enabled: bool,
 }
 
 impl AppState {
@@ -106,7 +116,25 @@ impl AppState {
             todos: Arc::new(TodoStore::new()),
             subagents_enabled: false,
             computer_use_enabled: false,
+            retrieval_log: RetrievalLog::new(),
+            outcome_capture_enabled: false,
         }
+    }
+
+    /// Record how each completed run went, for later offline analysis.
+    ///
+    /// Purely observational — it changes nothing about how the agent
+    /// behaves. Driven by `RUSTYKRAB_OUTCOME_CAPTURE` in the CLI.
+    pub fn with_outcome_capture(mut self, enabled: bool) -> Self {
+        self.outcome_capture_enabled = enabled;
+        self
+    }
+
+    /// Share the retrieval log with the memory backend, which records the
+    /// memories it surfaces so runs can be credited to them.
+    pub fn with_retrieval_log(mut self, log: RetrievalLog) -> Self {
+        self.retrieval_log = log;
+        self
     }
 
     /// Enable the sub-agent / session-management tool family for every

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use rustykrab_core::active_tools::with_session_context;
+use rustykrab_core::retrieval_log::RetrievalLog;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -37,6 +39,9 @@ pub struct HybridMemoryBackend {
     agent_id: Uuid,
     session_id: Uuid,
     user_id: Option<Uuid>,
+    /// Records which memories were handed to the model, so a later outcome
+    /// can be attributed to them. See `DREAMING.md`.
+    retrieval_log: Option<RetrievalLog>,
 }
 
 impl HybridMemoryBackend {
@@ -46,12 +51,19 @@ impl HybridMemoryBackend {
             agent_id,
             session_id,
             user_id: None,
+            retrieval_log: None,
         }
     }
 
     /// Set the user ID for scoped retrieval.
     pub fn with_user_id(mut self, user_id: Uuid) -> Self {
         self.user_id = Some(user_id);
+        self
+    }
+
+    /// Record surfaced memories into a shared log for outcome attribution.
+    pub fn with_retrieval_log(mut self, log: RetrievalLog) -> Self {
+        self.retrieval_log = Some(log);
         self
     }
 
@@ -156,6 +168,24 @@ impl HybridMemoryBackend {
             items.push(item);
             if items.len() >= limit {
                 break;
+            }
+        }
+
+        // Attribution: log only what survived filtering and the limit —
+        // a memory that was recalled but never handed to the model did not
+        // contribute to whatever happens next. The conversation id comes
+        // from the enclosing runner scope; outside one there is nothing to
+        // attribute to, so recording is skipped.
+        if let Some(log) = self.retrieval_log.as_ref() {
+            let surfaced: Vec<Uuid> = items
+                .iter()
+                .filter_map(|i| i.get("id").and_then(|v| v.as_str()))
+                .filter_map(|s| Uuid::parse_str(s).ok())
+                .collect();
+            if !surfaced.is_empty() {
+                if let Some(conversation_id) = with_session_context(|ctx| ctx.conversation_id) {
+                    log.record(conversation_id, surfaced);
+                }
             }
         }
 


### PR DESCRIPTION
**Stack 6 of 6 — the last one.** Based on #507. This is the only PR in the stack that turns anything on.

1/6 #503 → 2/6 #504 → 3/6 #505 → 4/6 #506 → 5/6 #507 → `6/6 (this)`

## What this does

Connects the pieces, behind `RUSTYKRAB_OUTCOME_CAPTURE`. **Off by default**, so the shipped default behaviour is unchanged even after this merges.

## The two non-obvious bits

**Which memory ids get logged.** `HybridMemoryBackend` records ids *after* tag filtering and *after* the limit is applied — only what was actually handed to the model. A memory that was recalled but never surfaced did not contribute to whatever happens next, and crediting it would be attributing an outcome to something the model never saw.

**Where the conversation id comes from.** Not the backend's own `session_id` — that is a **process-lifetime UUID** generated once at daemon start, not a per-conversation value, so keying on it would merge every conversation's attribution into one bucket. It comes from the enclosing runner scope (`with_session_context`) instead. Outside a runner scope there is nothing to attribute to, so recording is skipped.

The gateway then shares **one** retrieval log between the backend that writes it and the runner that drains it, and passes the active skill's name, which the runner does not otherwise know (`RunOptions.active_skill` was previously consumed entirely by the prompt builder).

## Documentation

- `README.md` gains the env var row.
- `DREAMING.md` gains a **"Phase 0 as built"** section recording what actually shipped, including two deliberate deviations from the plan rather than leaving a silent gap between doc and code:
  1. **`Memory.harmful_count` deferred to Phase 2.** `Memory` has no constructor, so a new field touches every struct literal plus four hand-numbered placeholder lists in `upsert_memory`, and `SqliteMemoryStorage` has no additive-migration phase to extend. Since tallies are derived (#505), the column buys nothing until something mutates memory.
  2. **Every record is `Implicit`.** Nothing checks a post-condition or captures an explicit correction yet, so `is_actionable()` is false for all of them. That is the honest state: Phase 1 reports can be built on this; Phase 2/3 promotion cannot.

## Verification

With all six applied, the tree is **byte-identical** to the single-commit version (#502), which this stack replaces.

619 workspace tests pass. `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean under `RUSTFLAGS=-Dwarnings`.

Local builds use `--no-default-features` (this sandbox can't reach `cdn.pyke.io` for the ONNX runtime), so the `embeddings` feature path is exercised only in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi)_