### PR TITLE
chore: sync Cargo.lock with the workspace manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4279,11 +4279,10 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "aes-gcm",
  "argon2",
- "async-trait",
  "chrono",
  "croner",
  "hex",
@@ -4304,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.11"
+version = "5.1.12"
 dependencies = [
  "async-imap",
  "async-trait",


### PR DESCRIPTION
Small standalone chore, independent of the dreaming stack (#504–#511).

## The problem

`main`'s `Cargo.toml` is at **5.1.12** while its `Cargo.lock` still records **5.1.11**. Any `cargo` invocation on a fresh checkout rewrites the file, so the tree is dirty before a line of work is done — which is how I noticed it.

The lockfile also lists `async-trait` under `rustykrab-store`, which that crate's `Cargo.toml` does not depend on, so cargo drops that entry on the same regeneration.

## The fix

Regenerate the lockfile so it matches the manifests. Both corrections are lockfile-only with **no dependency resolution change** — 11 workspace version lines and one stale dependency entry:

```
11 -version = "5.1.11"
11 +version = "5.1.12"
 1 - "async-trait"
```

Same class of fix as #479 (`chore: sync Cargo.lock with workspace version 4.5.7`).

## Why standalone

I hit this while working on the dreaming stack, but folding it in would put unrelated churn in a feature PR's diff — and this affects every branch cut from `main`, not just mine.

Worth noting: `rustykrab-store` *does* gain `async-trait` in #505, so that line comes back legitimately when the stack lands. Removing it here is still correct — the lockfile should reflect the manifests as they are on `main` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi)_