### PR TITLE
fix(agent): stop retrying deterministic exec failures

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -3027,6 +3027,14 @@ mod error_output_tests {
     }
 
     #[test]
+    fn timeouts_require_the_model_to_change_approach() {
+        let e = Error::ToolExecution(ToolError::timeout("command timed out"));
+        let (output, _) = tool_error_output(&e);
+        assert_eq!(output["error_kind"], "timeout");
+        assert_eq!(output["retryable"], false);
+    }
+
+    #[test]
     fn non_tool_error_variants_are_categorized() {
         assert_eq!(
             Error::Auth("x".into()).kind(),
@@ -3089,9 +3097,26 @@ async fn execute_with_watchdog(
 
 /// Retry a tool call up to `max_retries` times with exponential backoff.
 ///
-/// Auth errors (permission denied, unknown tool) are not retried since
-/// they will fail deterministically. Only transient errors (timeouts,
-/// execution failures) are retried.
+/// Invalid input, permission failures, and timeouts require the model to
+/// change its approach rather than repeating the exact same call. Preserve
+/// the existing retry behavior for other failures, which may be transient.
+fn should_retry_unchanged_tool_call(error: &Error) -> bool {
+    if matches!(error, Error::Auth(_)) {
+        return false;
+    }
+
+    !matches!(
+        error,
+        Error::ToolExecution(tool_error)
+            if matches!(
+                tool_error.kind,
+                ToolErrorKind::InvalidInput
+                    | ToolErrorKind::PermissionDenied
+                    | ToolErrorKind::Timeout
+            )
+    )
+}
+
 async fn execute_with_retries(
     call: &ToolCall,
     tools: &ToolIndex,
@@ -3105,19 +3130,8 @@ async fn execute_with_retries(
         match execute_single_tool(call, tools, sandbox, capabilities, session_id).await {
             Ok(result) => return Ok(result),
             Err(e) => {
-                // Don't retry auth errors — they'll fail the same way every time.
-                if matches!(e, Error::Auth(_)) {
+                if !should_retry_unchanged_tool_call(&e) {
                     return Err(e);
-                }
-                // Don't retry deterministic tool errors — but allow
-                // NotFound one retry since the agent may correct a typo.
-                if let Error::ToolExecution(ref te) = e {
-                    if matches!(
-                        te.kind,
-                        ToolErrorKind::InvalidInput | ToolErrorKind::PermissionDenied
-                    ) {
-                        return Err(e);
-                    }
                 }
                 tracing::warn!(
                     tool = call.name,
@@ -3137,6 +3151,34 @@ async fn execute_with_retries(
     }
     Err(last_err
         .unwrap_or_else(|| rustykrab_core::Error::ToolExecution("all retries exhausted".into())))
+}
+
+#[cfg(test)]
+mod retry_policy_tests {
+    use super::should_retry_unchanged_tool_call;
+    use rustykrab_core::{Error, ToolError};
+
+    #[test]
+    fn avoids_retries_that_require_a_changed_call() {
+        assert!(should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::transient("connection reset")
+        )));
+        assert!(should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::rate_limited("slow down")
+        )));
+        assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::timeout("command timed out")
+        )));
+        assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::invalid_input("bad command")
+        )));
+        assert!(should_retry_unchanged_tool_call(&Error::Internal(
+            "uncategorized execution failure".into()
+        )));
+        assert!(!should_retry_unchanged_tool_call(&Error::Auth(
+            "permission denied".into()
+        )));
+    }
 }
 
 /// Wrap string values in a JSON `Value` with adversarial-content markers.
@@ -3269,13 +3311,10 @@ async fn execute_single_tool(
     })
     .await
     .map_err(|_| {
-        Error::ToolExecution(
-            format!(
-                "tool '{}' exceeded sandbox timeout of {}s",
-                call.name, policy.timeout_secs
-            )
-            .into(),
-        )
+        Error::ToolExecution(rustykrab_core::ToolError::timeout(format!(
+            "tool '{}' exceeded sandbox timeout of {}s",
+            call.name, policy.timeout_secs
+        )))
     })??;
 
     // Pull any tool-attached images out before fencing — fencing rewrites

--- a/crates/rustykrab-core/src/error.rs
+++ b/crates/rustykrab-core/src/error.rs
@@ -92,14 +92,12 @@ impl ToolErrorKind {
         }
     }
 
-    /// Whether retrying the *same* call unchanged might succeed. Distinct from
-    /// the runner's retry policy: this is a hint to the model. `InvalidInput`
-    /// and `NotFound` are false because the model must change something first.
+    /// Whether retrying the *same* call unchanged might succeed. Timeouts are
+    /// false because a model must narrow the work or explicitly request a
+    /// longer tool timeout; repeating an unchanged call only burns the same
+    /// timeout again.
     pub fn retryable(&self) -> bool {
-        matches!(
-            self,
-            ToolErrorKind::Timeout | ToolErrorKind::RateLimited | ToolErrorKind::Transient
-        )
+        matches!(self, ToolErrorKind::RateLimited | ToolErrorKind::Transient)
     }
 }
 

--- a/crates/rustykrab-tools/src/exec.rs
+++ b/crates/rustykrab-tools/src/exec.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, SandboxRequirements, Tool};
+use rustykrab_core::{Result, SandboxRequirements, Tool, ToolError};
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::time::timeout;
@@ -263,13 +263,15 @@ impl Tool for ExecTool {
     }
 
     async fn execute(&self, args: Value) -> Result<Value> {
-        let command = args["command"]
-            .as_str()
-            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing command".into()))?;
+        let command = args["command"].as_str().ok_or_else(|| {
+            rustykrab_core::Error::ToolExecution(ToolError::invalid_input("missing command"))
+        })?;
 
         // Validate command against allowlist
         validate_command(command).map_err(|e| {
-            rustykrab_core::Error::ToolExecution(format!("command rejected: {e}").into())
+            rustykrab_core::Error::ToolExecution(ToolError::invalid_input(format!(
+                "command rejected: {e}"
+            )))
         })?;
 
         let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(30).min(120);
@@ -291,11 +293,13 @@ impl Tool for ExecTool {
         let output = timeout(Duration::from_secs(timeout_secs), future)
             .await
             .map_err(|_| {
-                rustykrab_core::Error::ToolExecution(
-                    format!("command timed out after {timeout_secs}s").into(),
-                )
+                rustykrab_core::Error::ToolExecution(ToolError::timeout(format!(
+                    "command timed out after {timeout_secs}s"
+                )))
             })?
-            .map_err(|e| rustykrab_core::Error::ToolExecution(e.to_string().into()))?;
+            .map_err(|e| {
+                rustykrab_core::Error::ToolExecution(ToolError::transient(e.to_string()))
+            })?;
 
         let stdout = truncate_output(String::from_utf8_lossy(&output.stdout).into_owned());
         let stderr = truncate_output(String::from_utf8_lossy(&output.stderr).into_owned());
@@ -306,5 +310,32 @@ impl Tool for ExecTool {
             "stdout": stdout,
             "stderr": stderr,
         }))
+    }
+}
+
+#[cfg(test)]
+mod error_typing_tests {
+    use super::ExecTool;
+    use rustykrab_core::{Tool, ToolErrorKind};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn invalid_commands_are_typed_as_invalid_input() {
+        let error = ExecTool::new()
+            .execute(json!({"command": "definitely-not-allowed"}))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ToolErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn command_timeouts_are_typed_as_timeout() {
+        let error = ExecTool::new()
+            .execute(json!({"command": "sleep 1", "timeout_secs": 0}))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ToolErrorKind::Timeout);
     }
 }


### PR DESCRIPTION
## Summary

- type invalid exec input as InvalidInput
- type command and runner sandbox timeouts as Timeout
- report unchanged timeouts as non-retryable to the model
- stop retrying validation, permission, and timeout failures while preserving existing retry behavior for other errors
- type process-spawn failures as transient

## Regression

Prevents a rejected or timed-out shell call from being repeated unchanged three times before the model can change approach.

## Validation

- cargo fmt --all -- --check
- cargo test -p rustykrab-tools exec --lib
- cargo test -p rustykrab-agent retry_policy_tests --lib
- cargo test -p rustykrab-agent error_output_tests --lib
- git diff --check