### PR TITLE
Dreaming P2 (1/5): the dream cycle manifest

### DIFF
--- a/crates/rustykrab-core/src/dream.rs
+++ b/crates/rustykrab-core/src/dream.rs
@@ -1,0 +1,305 @@
+//! Types for the mutating stages of the self-improvement outer loop —
+//! the Plan and Execute halves of MAPE-K (see `DREAMING.md`).
+//!
+//! Phase 1 only reads. From here on the loop can change durable state, so
+//! the governing constraint changes: every mutation must be **staged before
+//! it is live** and **reversible after it is**.
+//!
+//! The shape that provides both is a cycle. A cycle computes its whole
+//! change-set against a frozen view, records it, and touches nothing. A
+//! later promote applies the set atomically. A manifest of what it did is
+//! what makes the change reversible afterwards.
+//!
+//! Nothing here performs a mutation; these are the vocabulary and the
+//! record. The engine lives in `rustykrab-dream`.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Where a cycle is in the stage → promote → (maybe) revert progression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CycleStatus {
+    /// Change-set computed and recorded. Live state is untouched.
+    Staged,
+    /// Applied to live state.
+    Promoted,
+    /// Applied, then undone.
+    RolledBack,
+    /// Discarded before ever being applied — the ordinary outcome when a
+    /// cycle is preempted or finds nothing worth doing.
+    Aborted,
+}
+
+impl CycleStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Staged => "staged",
+            Self::Promoted => "promoted",
+            Self::RolledBack => "rolled_back",
+            Self::Aborted => "aborted",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "staged" => Some(Self::Staged),
+            "promoted" => Some(Self::Promoted),
+            "rolled_back" => Some(Self::RolledBack),
+            "aborted" => Some(Self::Aborted),
+            _ => None,
+        }
+    }
+
+    /// Whether live state currently reflects this cycle.
+    pub fn is_live(&self) -> bool {
+        matches!(self, Self::Promoted)
+    }
+}
+
+/// One proposed alteration to durable state.
+///
+/// Deliberately small and closed. A change the engine cannot describe here
+/// is a change it cannot reverse, and an irreversible mutation is exactly
+/// what this design exists to prevent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum StagedChange {
+    /// Write a new memory consolidated from existing ones.
+    CreateMemory {
+        memory_id: Uuid,
+        content: String,
+        /// Memories this one was distilled from. Recorded on the memory so
+        /// its lineage survives independently of the manifest.
+        parent_ids: Vec<Uuid>,
+    },
+    /// Retire a memory that a consolidation supersedes.
+    ///
+    /// Never a delete — retiring is a soft-delete, which is what makes the
+    /// reverse operation possible at all.
+    InvalidateMemory {
+        memory_id: Uuid,
+        superseded_by: Uuid,
+        /// Content hash observed while planning. Promote refuses the change
+        /// if the memory has moved since, so a cycle cannot silently
+        /// clobber an edit made while it was thinking.
+        expected_content_hash: String,
+    },
+}
+
+impl StagedChange {
+    /// The memory this change acts on.
+    pub fn target_id(&self) -> Uuid {
+        match self {
+            Self::CreateMemory { memory_id, .. } => *memory_id,
+            Self::InvalidateMemory { memory_id, .. } => *memory_id,
+        }
+    }
+
+    pub fn op_name(&self) -> &'static str {
+        match self {
+            Self::CreateMemory { .. } => "create_memory",
+            Self::InvalidateMemory { .. } => "invalidate_memory",
+        }
+    }
+
+    /// Whether applying this change adds retrievable content rather than
+    /// removing it. Used to keep a cycle's net effect balanced.
+    pub fn is_additive(&self) -> bool {
+        matches!(self, Self::CreateMemory { .. })
+    }
+}
+
+/// One run of the mutating loop, and what it did.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DreamCycle {
+    pub id: Uuid,
+    pub agent_id: Uuid,
+    /// What kind of work this cycle performed, e.g.
+    /// `"memory_consolidation"`.
+    pub kind: String,
+    pub status: CycleStatus,
+    pub started_at: DateTime<Utc>,
+    /// When the change-set went live. `None` until promoted.
+    pub promoted_at: Option<DateTime<Utc>>,
+    /// Human-readable account of what changed, for review.
+    pub summary: Option<String>,
+    pub rustykrab_version: Option<String>,
+}
+
+impl DreamCycle {
+    pub fn new(agent_id: Uuid, kind: impl Into<String>) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            agent_id,
+            kind: kind.into(),
+            status: CycleStatus::Staged,
+            started_at: Utc::now(),
+            promoted_at: None,
+            summary: None,
+            rustykrab_version: Some(crate::VERSION.to_string()),
+        }
+    }
+
+    pub fn with_summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+}
+
+/// How a memory came to exist.
+///
+/// Kept separate from `ImportanceSource`, which describes where a memory's
+/// *score* came from. A memory the loop wrote can still carry a
+/// user-derived importance, so conflating the two would lose one of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryOrigin {
+    /// Captured from a conversation.
+    #[default]
+    Conversation,
+    /// Written by the self-improvement outer loop.
+    Dream,
+}
+
+impl MemoryOrigin {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Conversation => "conversation",
+            Self::Dream => "dream",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "conversation" => Some(Self::Conversation),
+            "dream" => Some(Self::Dream),
+            _ => None,
+        }
+    }
+}
+
+/// Why a promoted cycle can no longer be cleanly reversed.
+///
+/// Rollback is honest about its limits rather than pretending to be a time
+/// machine: once the live system has built on a cycle's output, undoing it
+/// destroys work that came after.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RollbackBlocker {
+    /// The cycle was never applied, so there is nothing to undo.
+    NotPromoted,
+    /// A memory the cycle produced has since been retrieved into a turn,
+    /// so downstream state may depend on it.
+    OutputAccessed { memory_id: Uuid, access_count: u32 },
+    /// A memory the cycle retired has been changed since.
+    ParentModified { memory_id: Uuid },
+}
+
+impl RollbackBlocker {
+    pub fn describe(&self) -> String {
+        match self {
+            Self::NotPromoted => "cycle was never promoted".to_string(),
+            Self::OutputAccessed {
+                memory_id,
+                access_count,
+            } => format!(
+                "memory {memory_id} produced by this cycle has been retrieved {access_count} time(s) since"
+            ),
+            Self::ParentModified { memory_id } => {
+                format!("memory {memory_id} retired by this cycle has changed since")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycle_status_round_trips() {
+        for s in [
+            CycleStatus::Staged,
+            CycleStatus::Promoted,
+            CycleStatus::RolledBack,
+            CycleStatus::Aborted,
+        ] {
+            assert_eq!(CycleStatus::parse(s.as_str()), Some(s));
+        }
+        assert_eq!(CycleStatus::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn only_promoted_is_live() {
+        assert!(CycleStatus::Promoted.is_live());
+        for s in [
+            CycleStatus::Staged,
+            CycleStatus::RolledBack,
+            CycleStatus::Aborted,
+        ] {
+            assert!(!s.is_live(), "{s:?} must not read as live");
+        }
+    }
+
+    #[test]
+    fn staged_changes_round_trip_through_json() {
+        // The manifest stores these as JSON, so a change that cannot
+        // survive the round trip is a change that cannot be reversed.
+        let changes = vec![
+            StagedChange::CreateMemory {
+                memory_id: Uuid::new_v4(),
+                content: "merged fact".into(),
+                parent_ids: vec![Uuid::new_v4(), Uuid::new_v4()],
+            },
+            StagedChange::InvalidateMemory {
+                memory_id: Uuid::new_v4(),
+                superseded_by: Uuid::new_v4(),
+                expected_content_hash: "abc123".into(),
+            },
+        ];
+        for change in changes {
+            let json = serde_json::to_string(&change).unwrap();
+            let back: StagedChange = serde_json::from_str(&json).unwrap();
+            assert_eq!(change, back);
+        }
+    }
+
+    #[test]
+    fn additive_and_retiring_changes_are_distinguished() {
+        let create = StagedChange::CreateMemory {
+            memory_id: Uuid::new_v4(),
+            content: "x".into(),
+            parent_ids: vec![],
+        };
+        let retire = StagedChange::InvalidateMemory {
+            memory_id: Uuid::new_v4(),
+            superseded_by: Uuid::new_v4(),
+            expected_content_hash: "h".into(),
+        };
+        assert!(create.is_additive());
+        assert!(!retire.is_additive());
+    }
+
+    #[test]
+    fn origin_is_separate_from_importance_source() {
+        // A dream-written memory can still carry user-set importance, so
+        // origin must be its own axis.
+        assert_eq!(MemoryOrigin::default(), MemoryOrigin::Conversation);
+        assert_eq!(MemoryOrigin::parse("dream"), Some(MemoryOrigin::Dream));
+        assert_eq!(MemoryOrigin::parse("llm"), None);
+    }
+
+    #[test]
+    fn blockers_explain_themselves() {
+        let id = Uuid::new_v4();
+        let accessed = RollbackBlocker::OutputAccessed {
+            memory_id: id,
+            access_count: 3,
+        };
+        assert!(accessed.describe().contains("3 time"));
+        assert!(RollbackBlocker::NotPromoted
+            .describe()
+            .contains("never promoted"));
+    }
+}

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod activity;
 pub mod agent_def;
 pub mod capability;
 pub mod crypto;
+pub mod dream;
 pub mod error;
 pub mod model;
 pub mod orchestration;
@@ -32,6 +33,7 @@ pub use active_tools::{
 pub use activity::ActivityTracker;
 pub use agent_def::{AgentDefinition, AgentRegistry};
 pub use capability::{is_subagent_tool, Capability, CapabilitySet, SUBAGENT_TOOL_NAMES};
+pub use dream::{CycleStatus, DreamCycle, MemoryOrigin, RollbackBlocker, StagedChange};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
 pub use model::ModelProvider;
 pub use orchestration::{OrchestrationConfig, RecursiveCall, TaskComplexity, VoteResult};

--- a/crates/rustykrab-store/src/dream_cycles.rs
+++ b/crates/rustykrab-store/src/dream_cycles.rs
@@ -1,0 +1,435 @@
+//! Persistence for dream cycles and their staged changes (see
+//! `DREAMING.md`).
+//!
+//! This table *is* the safety property. A cycle records its whole
+//! change-set here before touching anything, so:
+//!
+//! - staged work is durable but inert — a crash between staging and
+//!   promoting leaves live state untouched;
+//! - a promoted cycle can be undone, because what it did was written down
+//!   rather than inferred afterwards.
+//!
+//! Changes are stored as JSON in the order they were planned, and applied
+//! in that order. Reversal walks them backwards, so a create/invalidate
+//! pair undoes in the opposite sequence to the one that applied it.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+use uuid::Uuid;
+
+use rustykrab_core::dream::{CycleStatus, DreamCycle, StagedChange};
+use rustykrab_core::Error;
+
+use crate::with_conn;
+
+/// Handle for dream-cycle persistence, backed by SQLite.
+#[derive(Clone)]
+pub struct DreamCycleStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl DreamCycleStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Record a cycle and its change-set, staged and inert.
+    ///
+    /// Written in one transaction: a cycle whose changes were only
+    /// partially recorded could be promoted into a state it cannot
+    /// describe, and therefore cannot reverse.
+    pub async fn stage(&self, cycle: &DreamCycle, changes: &[StagedChange]) -> Result<(), Error> {
+        let c = cycle.clone();
+        let changes = changes.to_vec();
+
+        with_conn(&self.conn, move |conn| {
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+
+            tx.execute(
+                "INSERT INTO dream_cycles
+                    (id, agent_id, kind, status, started_at, promoted_at, summary,
+                     rustykrab_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    c.id.to_string(),
+                    c.agent_id.to_string(),
+                    c.kind,
+                    c.status.as_str(),
+                    c.started_at.to_rfc3339(),
+                    c.promoted_at.map(|t| t.to_rfc3339()),
+                    c.summary,
+                    c.rustykrab_version,
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT INTO dream_changes (cycle_id, seq, op, target_id, payload)
+                         VALUES (?1, ?2, ?3, ?4, ?5)",
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                for (seq, change) in changes.iter().enumerate() {
+                    let payload = serde_json::to_string(change)
+                        .map_err(|e| Error::Storage(format!("cannot encode change: {e}")))?;
+                    stmt.execute(params![
+                        c.id.to_string(),
+                        seq as i64,
+                        change.op_name(),
+                        change.target_id().to_string(),
+                        payload,
+                    ])
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                }
+            }
+
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Move a cycle to a new status, stamping `promoted_at` on the way live.
+    pub async fn set_status(&self, cycle_id: Uuid, status: CycleStatus) -> Result<(), Error> {
+        let id = cycle_id.to_string();
+        let promoted_at = status.is_live().then(|| Utc::now().to_rfc3339());
+
+        with_conn(&self.conn, move |conn| {
+            let changed = conn
+                .execute(
+                    "UPDATE dream_cycles
+                     SET status = ?2,
+                         promoted_at = COALESCE(?3, promoted_at)
+                     WHERE id = ?1",
+                    params![id, status.as_str(), promoted_at],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if changed == 0 {
+                return Err(Error::NotFound(format!("dream cycle {id}")));
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    /// Attach a human-readable account of what a cycle did.
+    pub async fn set_summary(&self, cycle_id: Uuid, summary: &str) -> Result<(), Error> {
+        let id = cycle_id.to_string();
+        let summary = summary.to_string();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE dream_cycles SET summary = ?2 WHERE id = ?1",
+                params![id, summary],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn get(&self, cycle_id: Uuid) -> Result<Option<DreamCycle>, Error> {
+        let id = cycle_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, agent_id, kind, status, started_at, promoted_at, summary,
+                            rustykrab_version
+                     FROM dream_cycles WHERE id = ?1",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query_map(params![id], row_to_cycle)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            match rows.next() {
+                Some(row) => Ok(Some(row.map_err(|e| Error::Storage(e.to_string()))?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
+    /// A cycle's change-set, in the order it was planned.
+    pub async fn changes(&self, cycle_id: Uuid) -> Result<Vec<StagedChange>, Error> {
+        let id = cycle_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT payload FROM dream_changes WHERE cycle_id = ?1 ORDER BY seq ASC")
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map(params![id], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+
+            let mut out = Vec::new();
+            for row in rows {
+                let payload = row.map_err(|e| Error::Storage(e.to_string()))?;
+                let change: StagedChange = serde_json::from_str(&payload)
+                    .map_err(|e| Error::Storage(format!("cannot decode change: {e}")))?;
+                out.push(change);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// Cycles in a given status, newest first.
+    pub async fn list_by_status(
+        &self,
+        agent_id: Uuid,
+        status: CycleStatus,
+        limit: u32,
+    ) -> Result<Vec<DreamCycle>, Error> {
+        let agent = agent_id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, agent_id, kind, status, started_at, promoted_at, summary,
+                            rustykrab_version
+                     FROM dream_cycles
+                     WHERE agent_id = ?1 AND status = ?2
+                     ORDER BY started_at DESC
+                     LIMIT ?3",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map(params![agent, status.as_str(), limit], row_to_cycle)
+                .map_err(|e| Error::Storage(e.to_string()))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(rows)
+        })
+        .await
+    }
+
+    /// The most recent promoted cycle, which is the one a rollback would
+    /// target.
+    pub async fn latest_promoted(&self, agent_id: Uuid) -> Result<Option<DreamCycle>, Error> {
+        Ok(self
+            .list_by_status(agent_id, CycleStatus::Promoted, 1)
+            .await?
+            .into_iter()
+            .next())
+    }
+}
+
+fn row_to_cycle(row: &rusqlite::Row<'_>) -> rusqlite::Result<DreamCycle> {
+    let parse_uuid = |s: String| Uuid::parse_str(&s).unwrap_or_default();
+    let started_at: String = row.get("started_at")?;
+    let promoted_at: Option<String> = row.get("promoted_at")?;
+
+    Ok(DreamCycle {
+        id: parse_uuid(row.get("id")?),
+        agent_id: parse_uuid(row.get("agent_id")?),
+        kind: row.get("kind")?,
+        status: CycleStatus::parse(&row.get::<_, String>("status")?)
+            .unwrap_or(CycleStatus::Aborted),
+        started_at: DateTime::parse_from_rfc3339(&started_at)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now()),
+        promoted_at: promoted_at.and_then(|s| {
+            DateTime::parse_from_rfc3339(&s)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        }),
+        summary: row.get("summary")?,
+        rustykrab_version: row.get("rustykrab_version")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> DreamCycleStore {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        crate::Store::run_migrations(&conn).unwrap();
+        DreamCycleStore::new(Arc::new(Mutex::new(conn)))
+    }
+
+    fn consolidation(parents: &[Uuid], child: Uuid) -> Vec<StagedChange> {
+        let mut changes = vec![StagedChange::CreateMemory {
+            memory_id: child,
+            content: "merged".into(),
+            parent_ids: parents.to_vec(),
+        }];
+        for p in parents {
+            changes.push(StagedChange::InvalidateMemory {
+                memory_id: *p,
+                superseded_by: child,
+                expected_content_hash: format!("hash-{p}"),
+            });
+        }
+        changes
+    }
+
+    #[tokio::test]
+    async fn a_staged_cycle_is_recorded_but_not_live() {
+        let store = test_store();
+        let agent = Uuid::new_v4();
+        let cycle = DreamCycle::new(agent, "memory_consolidation");
+        let changes = consolidation(&[Uuid::new_v4()], Uuid::new_v4());
+
+        store.stage(&cycle, &changes).await.unwrap();
+
+        let stored = store.get(cycle.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, CycleStatus::Staged);
+        assert!(
+            !stored.status.is_live(),
+            "staging must not mark a cycle live"
+        );
+        assert!(
+            stored.promoted_at.is_none(),
+            "nothing was promoted, so there is no promotion time"
+        );
+    }
+
+    #[tokio::test]
+    async fn change_set_round_trips_in_planned_order() {
+        // Order is not cosmetic: reversal walks it backwards, so a
+        // scrambled read would undo a cycle in the wrong sequence.
+        let store = test_store();
+        let child = Uuid::new_v4();
+        let parents = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+        let cycle = DreamCycle::new(Uuid::new_v4(), "memory_consolidation");
+        let changes = consolidation(&parents, child);
+
+        store.stage(&cycle, &changes).await.unwrap();
+        let read = store.changes(cycle.id).await.unwrap();
+
+        assert_eq!(read, changes, "change-set must survive verbatim, in order");
+        assert!(read[0].is_additive(), "the create is planned first");
+    }
+
+    #[tokio::test]
+    async fn promoting_stamps_the_time_it_went_live() {
+        let store = test_store();
+        let cycle = DreamCycle::new(Uuid::new_v4(), "memory_consolidation");
+        store.stage(&cycle, &[]).await.unwrap();
+
+        store
+            .set_status(cycle.id, CycleStatus::Promoted)
+            .await
+            .unwrap();
+
+        let stored = store.get(cycle.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, CycleStatus::Promoted);
+        assert!(stored.status.is_live());
+        assert!(stored.promoted_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn rollback_preserves_when_the_cycle_had_been_live() {
+        // The promotion time is evidence about the past. Clearing it on
+        // rollback would erase the fact that live state once reflected
+        // this cycle, which is exactly what an audit needs.
+        let store = test_store();
+        let cycle = DreamCycle::new(Uuid::new_v4(), "memory_consolidation");
+        store.stage(&cycle, &[]).await.unwrap();
+        store
+            .set_status(cycle.id, CycleStatus::Promoted)
+            .await
+            .unwrap();
+        let promoted_at = store.get(cycle.id).await.unwrap().unwrap().promoted_at;
+
+        store
+            .set_status(cycle.id, CycleStatus::RolledBack)
+            .await
+            .unwrap();
+
+        let stored = store.get(cycle.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, CycleStatus::RolledBack);
+        assert!(!stored.status.is_live());
+        assert_eq!(
+            stored.promoted_at, promoted_at,
+            "a rolled-back cycle must still record that it was once live"
+        );
+    }
+
+    #[tokio::test]
+    async fn latest_promoted_ignores_staged_and_aborted_cycles() {
+        let store = test_store();
+        let agent = Uuid::new_v4();
+
+        let aborted = DreamCycle::new(agent, "memory_consolidation");
+        store.stage(&aborted, &[]).await.unwrap();
+        store
+            .set_status(aborted.id, CycleStatus::Aborted)
+            .await
+            .unwrap();
+
+        let staged = DreamCycle::new(agent, "memory_consolidation");
+        store.stage(&staged, &[]).await.unwrap();
+
+        let live = DreamCycle::new(agent, "memory_consolidation");
+        store.stage(&live, &[]).await.unwrap();
+        store
+            .set_status(live.id, CycleStatus::Promoted)
+            .await
+            .unwrap();
+
+        let found = store.latest_promoted(agent).await.unwrap().unwrap();
+        assert_eq!(
+            found.id, live.id,
+            "rollback must target the promoted cycle, not a staged or aborted one"
+        );
+    }
+
+    #[tokio::test]
+    async fn cycles_are_scoped_per_agent() {
+        let store = test_store();
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+
+        let theirs = DreamCycle::new(b, "memory_consolidation");
+        store.stage(&theirs, &[]).await.unwrap();
+        store
+            .set_status(theirs.id, CycleStatus::Promoted)
+            .await
+            .unwrap();
+
+        assert!(
+            store.latest_promoted(a).await.unwrap().is_none(),
+            "one agent's cycle must never be a rollback target for another"
+        );
+    }
+
+    #[tokio::test]
+    async fn changes_are_removed_with_their_cycle() {
+        let store = test_store();
+        let cycle = DreamCycle::new(Uuid::new_v4(), "memory_consolidation");
+        store
+            .stage(&cycle, &consolidation(&[Uuid::new_v4()], Uuid::new_v4()))
+            .await
+            .unwrap();
+        assert_eq!(store.changes(cycle.id).await.unwrap().len(), 2);
+
+        with_conn(&store.conn, move |conn| {
+            conn.execute("DELETE FROM dream_cycles", [])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            store.changes(cycle.id).await.unwrap().is_empty(),
+            "orphaned changes would describe a cycle that no longer exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn setting_status_on_an_unknown_cycle_is_an_error() {
+        // Silently succeeding here would let a promote report success
+        // while nothing was recorded as live.
+        let store = test_store();
+        let result = store
+            .set_status(Uuid::new_v4(), CycleStatus::Promoted)
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -3,6 +3,7 @@ mod conversation;
 pub mod credential_backend;
 mod credential_request;
 mod device;
+mod dream_cycles;
 mod guarded;
 mod jobs;
 pub mod keychain;
@@ -27,6 +28,7 @@ pub use credential_request::{
     CredentialRequest, CredentialRequestStore, RequestAction, RequestNotifier, RequestedField,
 };
 pub use device::{Device, DeviceStore, Principal};
+pub use dream_cycles::DreamCycleStore;
 pub use guarded::{GuardedSecrets, WriteOutcome};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
 pub use outcomes::OutcomeStore;
@@ -302,6 +304,39 @@ impl Store {
 
             CREATE INDEX IF NOT EXISTS idx_outcome_attributions_target
                 ON outcome_attributions (kind, target_id);
+
+            -- Dream cycles (see DREAMING.md). A mutating cycle records its
+            -- whole change-set here before touching anything, which is what
+            -- makes staged work inert and promoted work reversible.
+            CREATE TABLE IF NOT EXISTS dream_cycles (
+                id          TEXT PRIMARY KEY,
+                agent_id    TEXT NOT NULL,
+                kind        TEXT NOT NULL,
+                status      TEXT NOT NULL
+                    CHECK (status IN ('staged','promoted','rolled_back','aborted')),
+                started_at  TEXT NOT NULL,
+                promoted_at TEXT,
+                summary     TEXT,
+                rustykrab_version TEXT
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_dream_cycles_agent_status
+                ON dream_cycles (agent_id, status, started_at DESC);
+
+            -- The change-set itself, stored as JSON in planned order.
+            -- Applied forwards; reversed backwards.
+            CREATE TABLE IF NOT EXISTS dream_changes (
+                cycle_id  TEXT NOT NULL
+                    REFERENCES dream_cycles(id) ON DELETE CASCADE,
+                seq       INTEGER NOT NULL,
+                op        TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                payload   TEXT NOT NULL,
+                PRIMARY KEY (cycle_id, seq)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_dream_changes_target
+                ON dream_changes (target_id);
             ",
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
@@ -541,6 +576,11 @@ impl Store {
     /// Return a handle for scheduled-job operations.
     pub fn jobs(&self) -> JobStore {
         JobStore::new(Arc::clone(&self.conn))
+    }
+
+    /// Return a handle for dream-cycle persistence (see `DREAMING.md`).
+    pub fn dream_cycles(&self) -> DreamCycleStore {
+        DreamCycleStore::new(Arc::clone(&self.conn))
     }
 
     /// Return a handle for outcome-record persistence (see `DREAMING.md`).


### PR DESCRIPTION
> ### 📚 Stack — merge bottom-up
> | # | PR | Adds |
> |---|---|---|
> | **1** | **#516 ← you are here** | **manifest + core types** |
> | 2 | #517 | stage→promote→revert engine |
> | 3 | #518 | `restore()` + real-memory mutator |
> | 4 | #519 | planner + cycle orchestration |
> | 5 | #520 | invariant proof (tests only) |
>
> Base: `main`. Phases 0 and 1 are already merged. **No PR in this stack turns anything on** — the worker wiring is deliberately absent, so the whole mutation capability can be reviewed before anything can run it.

## What this adds

The vocabulary and the record for the mutating half of the outer loop. **Nothing mutates yet** — the engine follows in #517.

## The manifest *is* the safety property

Not bookkeeping around it. A cycle writes its whole change-set down before touching anything, which buys two things:

- **Staged work is durable but inert.** A crash between staging and promoting leaves live state untouched.
- **Promoted work is reversible**, because what it did was *recorded* rather than inferred afterwards.

## Design decisions worth reviewing

**`StagedChange` is deliberately small and closed.** A change the engine cannot describe is a change it cannot reverse, and an irreversible mutation is exactly what this design exists to prevent. Retiring a memory is a soft-delete for the same reason — it's what makes the reverse operation possible at all.

**`InvalidateMemory` carries the content hash observed while planning**, so promotion can refuse a change whose target moved while the cycle was thinking, rather than clobbering an edit made in the meantime. (#518 discovers something important about what "moved" can mean here.)

**Changes are stored in planned order and applied forwards; reversal walks them backwards**, so a create/invalidate pair undoes in the opposite sequence to the one that applied it. There's a test pinning the order — a scrambled read would undo a cycle wrongly.

**Rollback keeps `promoted_at`.** The fact that live state once reflected a cycle is evidence an audit needs; clearing it on revert would erase that.

**`MemoryOrigin` is separate from `ImportanceSource`.** One says where a memory came from, the other where its *score* came from — a dream-written memory can still carry user-set importance, so conflating them would lose one.

## Testing

8 store tests (staged-is-not-live, order round-trip, promotion stamping, rollback preserving history, per-agent scoping, cascade cleanup, unknown-cycle error) plus 6 core type tests. `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean under `RUSTFLAGS=-Dwarnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi