### PR TITLE
Dreaming P2 (4/5): plan and run a consolidation cycle

### DIFF
--- a/crates/rustykrab-dream/src/cluster_source.rs
+++ b/crates/rustykrab-dream/src/cluster_source.rs
@@ -1,0 +1,137 @@
+//! Finding duplicate clusters in the real memory system.
+//!
+//! Builds on the `SemanticSimilar` links that `LifecycleManager::
+//! detect_near_duplicates` already writes, so this stage consumes work the
+//! memory system was doing and discarding rather than re-deriving it.
+//!
+//! Clusters are connected components over those links, capped in size. An
+//! unbounded component is a warning sign rather than an opportunity: if
+//! forty memories are all "similar", the similarity threshold is doing
+//! something other than finding duplicates, and consolidating them would
+//! destroy distinctions the threshold failed to see.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use rustykrab_core::Result;
+use rustykrab_memory::types::LinkType;
+use rustykrab_memory::MemorySystem;
+use uuid::Uuid;
+
+use crate::planner::{ConsolidationSource, MemoryCandidate};
+
+/// Largest component that will be treated as a duplicate cluster.
+///
+/// Beyond this, "similar" has stopped meaning "the same", and merging
+/// would collapse distinctions rather than remove redundancy.
+pub const MAX_CLUSTER_SIZE: usize = 6;
+
+/// Minimum link weight to treat two memories as saying the same thing.
+///
+/// Higher than the threshold that creates the links: being related enough
+/// to help retrieval is a much weaker claim than being redundant.
+pub const MIN_DUPLICATE_WEIGHT: f64 = 0.92;
+
+/// Reads duplicate clusters out of the memory graph.
+pub struct MemoryClusterSource {
+    system: Arc<MemorySystem>,
+}
+
+impl MemoryClusterSource {
+    pub fn new(system: Arc<MemorySystem>) -> Self {
+        Self { system }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConsolidationSource for MemoryClusterSource {
+    async fn duplicate_clusters(&self, agent_id: Uuid) -> Result<Vec<Vec<MemoryCandidate>>> {
+        let memories = self.system.storage().list_retrievable(agent_id).await?;
+        if memories.len() < 2 {
+            return Ok(Vec::new());
+        }
+
+        let by_id: HashMap<Uuid, &rustykrab_memory::types::Memory> =
+            memories.iter().map(|m| (m.id, m)).collect();
+        let ids: Vec<Uuid> = memories.iter().map(|m| m.id).collect();
+
+        // Adjacency over strong similarity links only, and only between
+        // memories that are both still retrievable.
+        let links = self.system.storage().get_links_from_many(&ids).await?;
+        let mut adjacency: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+        for link in links {
+            if link.link_type != LinkType::SemanticSimilar
+                || link.weight < MIN_DUPLICATE_WEIGHT
+                || !by_id.contains_key(&link.target_id)
+                || link.source_id == link.target_id
+            {
+                continue;
+            }
+            adjacency
+                .entry(link.source_id)
+                .or_default()
+                .push(link.target_id);
+            adjacency
+                .entry(link.target_id)
+                .or_default()
+                .push(link.source_id);
+        }
+
+        let mut seen: HashSet<Uuid> = HashSet::new();
+        let mut clusters = Vec::new();
+
+        for id in &ids {
+            if seen.contains(id) || !adjacency.contains_key(id) {
+                continue;
+            }
+
+            // Breadth-first over the component, stopping at the cap.
+            let mut component = Vec::new();
+            let mut queue = VecDeque::from([*id]);
+            seen.insert(*id);
+            let mut overflowed = false;
+
+            while let Some(current) = queue.pop_front() {
+                component.push(current);
+                if component.len() >= MAX_CLUSTER_SIZE {
+                    overflowed = !queue.is_empty();
+                    break;
+                }
+                for neighbour in adjacency.get(&current).into_iter().flatten() {
+                    if seen.insert(*neighbour) {
+                        queue.push_back(*neighbour);
+                    }
+                }
+            }
+
+            if overflowed {
+                // Leave it alone and say so. A component this large means
+                // the similarity threshold is mis-tuned, and consolidating
+                // on that basis would destroy real distinctions.
+                tracing::debug!(
+                    root = %id,
+                    "skipping oversized similarity component; threshold may be mis-tuned"
+                );
+                continue;
+            }
+
+            if component.len() >= 2 {
+                clusters.push(
+                    component
+                        .into_iter()
+                        .filter_map(|cid| by_id.get(&cid))
+                        .map(|m| MemoryCandidate {
+                            id: m.id,
+                            content_hash: m.content_hash.clone(),
+                            importance: m.importance,
+                            access_count: m.access_count,
+                            proof_count: m.proof_count,
+                        })
+                        .collect(),
+                );
+            }
+        }
+
+        Ok(clusters)
+    }
+}

--- a/crates/rustykrab-dream/src/consolidation.rs
+++ b/crates/rustykrab-dream/src/consolidation.rs
@@ -1,0 +1,492 @@
+//! One consolidation cycle, start to finish (see `DREAMING.md`).
+//!
+//! Sequences the pieces in the order the safety argument requires:
+//!
+//! 1. **Analyze** — is the evidence good enough to act on at all?
+//! 2. **Plan** — what would change, computed against current state?
+//! 3. **Stage** — write the change-set down, still inert.
+//! 4. **Promote** — apply it, re-checking preconditions first.
+//!
+//! Every exit before step 4 leaves live state untouched, and step 4 leaves
+//! behind a manifest that makes what it did reversible. A cycle that finds
+//! nothing to do is recorded as aborted rather than skipped silently, so
+//! "the loop ran and declined" is distinguishable from "the loop never
+//! ran".
+
+use std::sync::Arc;
+
+use rustykrab_core::dream::{CycleStatus, DreamCycle};
+use rustykrab_core::Result;
+use rustykrab_store::DreamCycleStore;
+use uuid::Uuid;
+
+use crate::engine::{promote, CyclePolicy, PromotionRefusal};
+use crate::mutation::MemoryMutator;
+use crate::planner::{plan_consolidation, ConsolidationSource};
+use crate::report::Readiness;
+
+/// What a cycle did, for logging and for the caller to assert on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CycleOutcome {
+    /// The evidence could not justify changing anything.
+    Refused { reason: String },
+    /// The cycle ran and found nothing worth doing.
+    NothingToDo { clusters_considered: usize },
+    /// A change-set was applied.
+    Promoted {
+        cycle_id: Uuid,
+        applied: usize,
+        skipped_stale: usize,
+    },
+}
+
+impl CycleOutcome {
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Refused { reason } => format!("consolidation refused: {reason}"),
+            Self::NothingToDo {
+                clusters_considered,
+            } => {
+                format!("consolidation found nothing to do across {clusters_considered} cluster(s)")
+            }
+            Self::Promoted {
+                applied,
+                skipped_stale,
+                ..
+            } => {
+                let mut s = format!("consolidation promoted {applied} change(s)");
+                if *skipped_stale > 0 {
+                    s.push_str(&format!(", {skipped_stale} skipped as stale"));
+                }
+                s
+            }
+        }
+    }
+}
+
+/// Run one consolidation cycle.
+///
+/// The `readiness` argument comes from the Analyze stage and is checked
+/// before anything is planned: computing a change-set the loop is not
+/// permitted to apply wastes the connection it is competing for.
+pub async fn run_consolidation_cycle(
+    cycles: &DreamCycleStore,
+    source: &dyn ConsolidationSource,
+    mutator: &dyn MemoryMutator,
+    agent_id: Uuid,
+    readiness: Readiness,
+    policy: &CyclePolicy,
+) -> Result<CycleOutcome> {
+    if !readiness.permits_mutation() {
+        return Ok(CycleOutcome::Refused {
+            reason: format!(
+                "evidence is {} and cannot justify changing memory",
+                readiness.as_str()
+            ),
+        });
+    }
+
+    let plan = plan_consolidation(source, agent_id, policy).await?;
+    let cycle = DreamCycle::new(agent_id, "memory_consolidation").with_summary(plan.summary());
+
+    if plan.is_empty() {
+        // Recorded, not skipped: a cycle that declined is evidence the
+        // loop is running and finding the system already tidy.
+        cycles.stage(&cycle, &[]).await?;
+        cycles.set_status(cycle.id, CycleStatus::Aborted).await?;
+        return Ok(CycleOutcome::NothingToDo {
+            clusters_considered: plan.clusters_considered,
+        });
+    }
+
+    // Written down before anything is applied. A crash here leaves a
+    // staged, inert cycle rather than a half-changed memory set.
+    cycles.stage(&cycle, &plan.changes).await?;
+
+    let promotion = promote(
+        mutator,
+        CycleStatus::Staged,
+        readiness,
+        &plan.changes,
+        policy,
+    )
+    .await?;
+
+    match promotion {
+        Ok(applied) => {
+            cycles.set_status(cycle.id, CycleStatus::Promoted).await?;
+            let summary = format!(
+                "{} | applied {}, skipped {} stale",
+                plan.summary(),
+                applied.applied.len(),
+                applied.skipped_stale.len()
+            );
+            cycles.set_summary(cycle.id, &summary).await?;
+            Ok(CycleOutcome::Promoted {
+                cycle_id: cycle.id,
+                applied: applied.applied.len(),
+                skipped_stale: applied.skipped_stale.len(),
+            })
+        }
+        Err(refusal) => {
+            cycles.set_status(cycle.id, CycleStatus::Aborted).await?;
+            Ok(CycleOutcome::Refused {
+                reason: refusal.describe(),
+            })
+        }
+    }
+}
+
+/// Convenience wiring for the daemon: cluster source and mutator over the
+/// same memory system.
+pub struct ConsolidationContext {
+    pub cycles: DreamCycleStore,
+    pub system: Arc<rustykrab_memory::MemorySystem>,
+    pub agent_id: Uuid,
+    pub policy: CyclePolicy,
+}
+
+impl ConsolidationContext {
+    /// Run a cycle, constructing a fresh cycle id for provenance.
+    pub async fn run(&self, readiness: Readiness) -> Result<CycleOutcome> {
+        let cycle_id = Uuid::new_v4();
+        let source = crate::cluster_source::MemoryClusterSource::new(Arc::clone(&self.system));
+        let mutator = crate::memory_mutator::MemorySystemMutator::new(
+            Arc::clone(&self.system),
+            self.agent_id,
+            cycle_id,
+        );
+        run_consolidation_cycle(
+            &self.cycles,
+            &source,
+            &mutator,
+            self.agent_id,
+            readiness,
+            &self.policy,
+        )
+        .await
+    }
+}
+
+/// Refusal rendered for a log line.
+pub fn refusal_line(refusal: &PromotionRefusal) -> String {
+    format!("consolidation refused: {}", refusal.describe())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_mutator::MemorySystemMutator;
+    use crate::planner::MemoryCandidate;
+    use rustykrab_core::dream::StagedChange;
+    use rustykrab_memory::embedding::HashEmbedder;
+    use rustykrab_memory::storage::SqliteMemoryStorage;
+    use rustykrab_memory::types::{ImportanceSource, LifecycleStage, Memory, MemoryScope};
+    use rustykrab_memory::{MemoryConfig, MemorySystem};
+
+    fn store() -> rustykrab_store::Store {
+        // A temp directory the test owns for the lifetime of the process;
+        // the store needs a real path for its master key handling.
+        let dir = std::env::temp_dir().join(format!("rk-dream-{}", Uuid::new_v4()));
+        rustykrab_store::Store::open(&dir, vec![7u8; 32]).expect("store opens")
+    }
+
+    fn live_system() -> Arc<MemorySystem> {
+        let storage = Arc::new(SqliteMemoryStorage::open_in_memory().unwrap());
+        Arc::new(MemorySystem::new(
+            MemoryConfig::default(),
+            storage,
+            Arc::new(HashEmbedder::new(64)),
+        ))
+    }
+
+    async fn seed(system: &MemorySystem, agent: Uuid, content: &str, accesses: u32) -> Memory {
+        let m = Memory {
+            id: Uuid::new_v4(),
+            agent_id: agent,
+            content: content.to_string(),
+            content_hash: rustykrab_memory::hash_content(content),
+            scope: MemoryScope::User,
+            session_id: None,
+            user_id: None,
+            lifecycle_stage: LifecycleStage::Episodic,
+            importance: 0.6,
+            importance_source: ImportanceSource::Heuristic,
+            decay_rate: 1.0,
+            confidence: 1.0,
+            access_count: accesses,
+            last_accessed_at: None,
+            last_relevant_at: None,
+            created_at: chrono::Utc::now(),
+            parent_memory_ids: Vec::new(),
+            consolidation_generation: 0,
+            proof_count: 1,
+            occurred_start: None,
+            occurred_end: None,
+            is_valid: true,
+            invalidated_by: None,
+            invalidated_at: None,
+            tags: Vec::new(),
+            metadata: serde_json::json!({}),
+        };
+        system.storage().upsert_memory(&m).await.unwrap();
+        m
+    }
+
+    /// Feeds the planner a fixed cluster so a cycle can be driven without
+    /// depending on embedding similarity.
+    struct FixedClusters(Vec<Vec<MemoryCandidate>>);
+
+    #[async_trait::async_trait]
+    impl ConsolidationSource for FixedClusters {
+        async fn duplicate_clusters(&self, _: Uuid) -> Result<Vec<Vec<MemoryCandidate>>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn candidates(memories: &[&Memory]) -> Vec<MemoryCandidate> {
+        memories
+            .iter()
+            .map(|m| MemoryCandidate {
+                id: m.id,
+                content_hash: m.content_hash.clone(),
+                importance: m.importance,
+                access_count: m.access_count,
+                proof_count: m.proof_count,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_full_cycle_removes_duplicates_and_records_what_it_did() {
+        let store = store();
+        let cycles = store.dream_cycles();
+        let system = live_system();
+        let agent = Uuid::new_v4();
+
+        let keeper = seed(&system, agent, "user prefers aisle seats", 9).await;
+        let dup = seed(&system, agent, "user prefers aisle seats", 0).await;
+
+        let source = FixedClusters(vec![candidates(&[&keeper, &dup])]);
+        let mutator = MemorySystemMutator::new(Arc::clone(&system), agent, Uuid::new_v4());
+
+        let outcome = run_consolidation_cycle(
+            &cycles,
+            &source,
+            &mutator,
+            agent,
+            Readiness::Ready,
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        let cycle_id = match outcome {
+            CycleOutcome::Promoted {
+                cycle_id, applied, ..
+            } => {
+                assert_eq!(applied, 1, "one duplicate retired");
+                cycle_id
+            }
+            other => panic!("expected a promotion, got {other:?}"),
+        };
+
+        // Live state: the used memory survived, the duplicate did not.
+        let keeper_after = system
+            .storage()
+            .get_memory(keeper.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let dup_after = system.storage().get_memory(dup.id).await.unwrap().unwrap();
+        assert!(keeper_after.is_valid, "the used memory survives");
+        assert!(!dup_after.is_valid, "the duplicate is retired");
+        assert_eq!(dup_after.invalidated_by, Some(keeper.id));
+
+        // The manifest describes it, which is what makes it reversible.
+        let recorded = cycles.get(cycle_id).await.unwrap().unwrap();
+        assert_eq!(recorded.status, CycleStatus::Promoted);
+        assert!(recorded.promoted_at.is_some());
+        assert!(recorded.summary.unwrap().contains("applied 1"));
+
+        let changes = cycles.changes(cycle_id).await.unwrap();
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(changes[0], StagedChange::InvalidateMemory { .. }));
+    }
+
+    #[tokio::test]
+    async fn a_promoted_cycle_can_be_undone_from_its_manifest_alone() {
+        // The manifest is the whole input to reversal — nothing else about
+        // the cycle needs to still be in memory.
+        let store = store();
+        let cycles = store.dream_cycles();
+        let system = live_system();
+        let agent = Uuid::new_v4();
+
+        let keeper = seed(&system, agent, "duplicated fact", 4).await;
+        let dup = seed(&system, agent, "duplicated fact", 0).await;
+        let source = FixedClusters(vec![candidates(&[&keeper, &dup])]);
+        let mutator = MemorySystemMutator::new(Arc::clone(&system), agent, Uuid::new_v4());
+
+        let CycleOutcome::Promoted { cycle_id, .. } = run_consolidation_cycle(
+            &cycles,
+            &source,
+            &mutator,
+            agent,
+            Readiness::Ready,
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap() else {
+            panic!("expected a promotion");
+        };
+
+        assert!(
+            !system
+                .storage()
+                .get_memory(dup.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_valid
+        );
+
+        // Read the change-set back and reverse it.
+        let recorded = cycles.get(cycle_id).await.unwrap().unwrap();
+        let changes = cycles.changes(cycle_id).await.unwrap();
+        let reverted =
+            crate::engine::rollback(&mutator, recorded.status, &changes, &CyclePolicy::default())
+                .await
+                .unwrap()
+                .expect("nothing has depended on it");
+        cycles
+            .set_status(cycle_id, CycleStatus::RolledBack)
+            .await
+            .unwrap();
+
+        assert_eq!(reverted, 1);
+        let dup_after = system.storage().get_memory(dup.id).await.unwrap().unwrap();
+        assert!(dup_after.is_valid, "the retired duplicate came back");
+        assert!(dup_after.lifecycle_stage.is_retrievable());
+        assert_eq!(
+            cycles.get(cycle_id).await.unwrap().unwrap().status,
+            CycleStatus::RolledBack
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_only_evidence_stops_the_cycle_before_it_plans() {
+        // The gate must bite before any work is done, not after.
+        let store = store();
+        let cycles = store.dream_cycles();
+        let system = live_system();
+        let agent = Uuid::new_v4();
+        let a = seed(&system, agent, "dup", 1).await;
+        let b = seed(&system, agent, "dup", 0).await;
+
+        let source = FixedClusters(vec![candidates(&[&a, &b])]);
+        let mutator = MemorySystemMutator::new(Arc::clone(&system), agent, Uuid::new_v4());
+
+        let outcome = run_consolidation_cycle(
+            &cycles,
+            &source,
+            &mutator,
+            agent,
+            Readiness::ProxyOnly,
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(outcome, CycleOutcome::Refused { .. }));
+        assert!(
+            system
+                .storage()
+                .get_memory(b.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_valid,
+            "nothing may be retired on proxy evidence"
+        );
+        assert!(
+            cycles
+                .list_by_status(agent, CycleStatus::Staged, 10)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a refused cycle must not even stage a change-set"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cycle_that_finds_nothing_is_recorded_as_having_run() {
+        // 'The loop ran and declined' must be distinguishable from 'the
+        // loop never ran'.
+        let store = store();
+        let cycles = store.dream_cycles();
+        let system = live_system();
+        let agent = Uuid::new_v4();
+
+        let outcome = run_consolidation_cycle(
+            &cycles,
+            &FixedClusters(vec![]),
+            &MemorySystemMutator::new(Arc::clone(&system), agent, Uuid::new_v4()),
+            agent,
+            Readiness::Ready,
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(outcome, CycleOutcome::NothingToDo { .. }));
+        let aborted = cycles
+            .list_by_status(agent, CycleStatus::Aborted, 10)
+            .await
+            .unwrap();
+        assert_eq!(aborted.len(), 1, "the declined cycle is on the record");
+        assert!(aborted[0]
+            .summary
+            .as_ref()
+            .unwrap()
+            .contains("nothing worth changing"));
+    }
+
+    #[tokio::test]
+    async fn a_cycle_never_retires_every_copy_of_a_fact() {
+        // The property that matters most: consolidation must reduce
+        // redundancy without losing the information itself.
+        let store = store();
+        let cycles = store.dream_cycles();
+        let system = live_system();
+        let agent = Uuid::new_v4();
+
+        let a = seed(&system, agent, "the one fact", 3).await;
+        let b = seed(&system, agent, "the one fact", 1).await;
+        let c = seed(&system, agent, "the one fact", 0).await;
+
+        run_consolidation_cycle(
+            &cycles,
+            &FixedClusters(vec![candidates(&[&a, &b, &c])]),
+            &MemorySystemMutator::new(Arc::clone(&system), agent, Uuid::new_v4()),
+            agent,
+            Readiness::Ready,
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        let survivors = system.storage().list_retrievable(agent).await.unwrap();
+        assert_eq!(
+            survivors.len(),
+            1,
+            "exactly one copy must remain, got {}",
+            survivors.len()
+        );
+        assert_eq!(survivors[0].id, a.id, "the most-used copy is the survivor");
+        assert_eq!(
+            survivors[0].content, "the one fact",
+            "the information itself survives"
+        );
+    }
+}

--- a/crates/rustykrab-dream/src/lib.rs
+++ b/crates/rustykrab-dream/src/lib.rs
@@ -13,16 +13,22 @@
 //! the **Analyze** stage only: deterministic, read-only reporting over
 //! recorded outcomes. Nothing here calls a model or changes any artifact.
 
+pub mod cluster_source;
+pub mod consolidation;
 pub mod engine;
 pub mod memory_mutator;
 pub mod mutation;
+pub mod planner;
 pub mod report;
 pub mod store_source;
 pub mod worker;
 
+pub use cluster_source::MemoryClusterSource;
+pub use consolidation::{run_consolidation_cycle, ConsolidationContext, CycleOutcome};
 pub use engine::{promote, rollback, rollback_blockers, CyclePolicy, Promotion, PromotionRefusal};
 pub use memory_mutator::MemorySystemMutator;
 pub use mutation::{MemoryFacts, MemoryMutator};
+pub use planner::{plan_consolidation, ConsolidationPlan, ConsolidationSource, MemoryCandidate};
 pub use report::{
     analyze, AnalysisReport, ArtifactFinding, FindingVerdict, OutcomeSource, Readiness,
     SignalQuality, MIN_OBSERVATIONS, UNDERPERFORMING_BELOW,

--- a/crates/rustykrab-dream/src/planner.rs
+++ b/crates/rustykrab-dream/src/planner.rs
@@ -1,0 +1,343 @@
+//! Deciding what a consolidation cycle should change (see `DREAMING.md`).
+//!
+//! This is the Plan stage, and it is deliberately **deterministic**. The
+//! design reserves model-driven synthesis for later; the first thing worth
+//! doing to a set of near-identical memories is not to rewrite them but to
+//! stop keeping several copies.
+//!
+//! So a plan here keeps the best member of a duplicate cluster and retires
+//! the rest against it. That preserves the survivor's access history and
+//! decay state, which minting a fresh "merged" memory would throw away —
+//! and for byte-similar content there is nothing to merge anyway.
+//!
+//! The change vocabulary already supports creating a synthesized memory;
+//! no planner emits one yet.
+
+use rustykrab_core::dream::StagedChange;
+use rustykrab_core::Result;
+use uuid::Uuid;
+
+use crate::engine::CyclePolicy;
+
+/// What the planner needs to know about a candidate memory.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoryCandidate {
+    pub id: Uuid,
+    pub content_hash: String,
+    pub importance: f64,
+    pub access_count: u32,
+    /// How many observations back this memory.
+    pub proof_count: u32,
+}
+
+/// Supplies clusters of memories that say the same thing.
+#[async_trait::async_trait]
+pub trait ConsolidationSource: Send + Sync {
+    /// Groups of near-identical memories. Each group has at least two
+    /// members; a group of one is not a duplicate.
+    async fn duplicate_clusters(&self, agent_id: Uuid) -> Result<Vec<Vec<MemoryCandidate>>>;
+}
+
+/// A proposed change-set, with enough context to explain itself.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConsolidationPlan {
+    pub changes: Vec<StagedChange>,
+    pub clusters_considered: usize,
+    pub clusters_planned: usize,
+    /// Clusters left for a later cycle because this one hit its change
+    /// limit. Reported rather than dropped silently, so a persistently
+    /// large backlog is visible.
+    pub clusters_deferred: usize,
+}
+
+impl ConsolidationPlan {
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    pub fn summary(&self) -> String {
+        if self.is_empty() {
+            return format!(
+                "consolidation: {} cluster(s) considered, nothing worth changing",
+                self.clusters_considered
+            );
+        }
+        let mut s = format!(
+            "consolidation: {} of {} cluster(s) planned, {} memories retired",
+            self.clusters_planned,
+            self.clusters_considered,
+            self.changes.len()
+        );
+        if self.clusters_deferred > 0 {
+            s.push_str(&format!(
+                ", {} deferred to a later cycle",
+                self.clusters_deferred
+            ));
+        }
+        s
+    }
+}
+
+/// Pick the member of a cluster worth keeping.
+///
+/// Most-used first, then best-evidenced, then most important, with the id
+/// as a final tie-break so the choice is stable across runs. Access count
+/// leads because a memory the system actually retrieves has demonstrated
+/// its worth, where importance is only ever an estimate of it.
+fn representative(cluster: &[MemoryCandidate]) -> &MemoryCandidate {
+    cluster
+        .iter()
+        .max_by(|a, b| {
+            a.access_count
+                .cmp(&b.access_count)
+                .then(a.proof_count.cmp(&b.proof_count))
+                .then(
+                    a.importance
+                        .partial_cmp(&b.importance)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                )
+                .then(a.id.cmp(&b.id))
+        })
+        .expect("clusters are never empty")
+}
+
+/// Plan a consolidation cycle for one agent.
+///
+/// Stops at the policy's change limit and reports what it left behind,
+/// rather than proposing an unbounded change-set that promotion would
+/// simply refuse.
+pub async fn plan_consolidation(
+    source: &dyn ConsolidationSource,
+    agent_id: Uuid,
+    policy: &CyclePolicy,
+) -> Result<ConsolidationPlan> {
+    let clusters = source.duplicate_clusters(agent_id).await?;
+    let clusters_considered = clusters.len();
+
+    let mut changes = Vec::new();
+    let mut clusters_planned = 0usize;
+    let mut clusters_deferred = 0usize;
+
+    for cluster in clusters {
+        // A cluster of one is not a duplicate.
+        if cluster.len() < 2 {
+            continue;
+        }
+
+        let keep = representative(&cluster).clone();
+        let retire: Vec<&MemoryCandidate> = cluster.iter().filter(|m| m.id != keep.id).collect();
+
+        // Take the cluster whole or not at all. Half-pruning a cluster
+        // leaves duplicates behind and spends the budget achieving nothing.
+        if changes.len() + retire.len() > policy.max_changes_per_cycle {
+            clusters_deferred += 1;
+            continue;
+        }
+
+        for member in retire {
+            changes.push(StagedChange::InvalidateMemory {
+                memory_id: member.id,
+                superseded_by: keep.id,
+                expected_content_hash: member.content_hash.clone(),
+            });
+        }
+        clusters_planned += 1;
+    }
+
+    Ok(ConsolidationPlan {
+        changes,
+        clusters_considered,
+        clusters_planned,
+        clusters_deferred,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeSource(Vec<Vec<MemoryCandidate>>);
+
+    #[async_trait::async_trait]
+    impl ConsolidationSource for FakeSource {
+        async fn duplicate_clusters(&self, _: Uuid) -> Result<Vec<Vec<MemoryCandidate>>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn candidate(importance: f64, accesses: u32, proofs: u32) -> MemoryCandidate {
+        MemoryCandidate {
+            id: Uuid::new_v4(),
+            content_hash: "h".into(),
+            importance,
+            access_count: accesses,
+            proof_count: proofs,
+        }
+    }
+
+    fn retired_ids(plan: &ConsolidationPlan) -> Vec<Uuid> {
+        plan.changes.iter().map(|c| c.target_id()).collect()
+    }
+
+    #[tokio::test]
+    async fn nothing_to_do_produces_no_changes() {
+        let plan = plan_consolidation(&FakeSource(vec![]), Uuid::new_v4(), &CyclePolicy::default())
+            .await
+            .unwrap();
+        assert!(plan.is_empty());
+        assert!(plan.summary().contains("nothing worth changing"));
+    }
+
+    #[tokio::test]
+    async fn a_cluster_of_one_is_not_a_duplicate() {
+        let plan = plan_consolidation(
+            &FakeSource(vec![vec![candidate(0.9, 5, 3)]]),
+            Uuid::new_v4(),
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+        assert!(plan.is_empty(), "a lone memory must never be retired");
+    }
+
+    #[tokio::test]
+    async fn the_most_used_member_survives() {
+        // A memory the system actually retrieves has demonstrated its
+        // worth; importance is only an estimate of it.
+        let used = candidate(0.4, 12, 1);
+        let important_but_unused = candidate(0.99, 0, 9);
+        let plan = plan_consolidation(
+            &FakeSource(vec![vec![important_but_unused.clone(), used.clone()]]),
+            Uuid::new_v4(),
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(retired_ids(&plan), vec![important_but_unused.id]);
+        match &plan.changes[0] {
+            StagedChange::InvalidateMemory { superseded_by, .. } => {
+                assert_eq!(*superseded_by, used.id, "the used memory survives")
+            }
+            other => panic!("expected a retirement, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn selection_is_stable_across_runs() {
+        // Identical candidates must not produce a different survivor each
+        // cycle, or consolidation would churn forever.
+        let mut a = candidate(0.5, 3, 2);
+        let mut b = candidate(0.5, 3, 2);
+        a.id = Uuid::from_u128(1);
+        b.id = Uuid::from_u128(2);
+
+        for _ in 0..5 {
+            let plan = plan_consolidation(
+                &FakeSource(vec![vec![a.clone(), b.clone()]]),
+                Uuid::new_v4(),
+                &CyclePolicy::default(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(retired_ids(&plan), vec![a.id], "survivor must be stable");
+        }
+    }
+
+    #[tokio::test]
+    async fn every_duplicate_in_a_cluster_is_retired_against_one_survivor() {
+        let keep = candidate(0.5, 10, 1);
+        let dup1 = candidate(0.5, 1, 1);
+        let dup2 = candidate(0.5, 0, 1);
+        let plan = plan_consolidation(
+            &FakeSource(vec![vec![keep.clone(), dup1.clone(), dup2.clone()]]),
+            Uuid::new_v4(),
+            &CyclePolicy::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.changes.len(), 2);
+        for change in &plan.changes {
+            match change {
+                StagedChange::InvalidateMemory { superseded_by, .. } => {
+                    assert_eq!(*superseded_by, keep.id)
+                }
+                other => panic!("expected a retirement, got {other:?}"),
+            }
+        }
+        assert!(
+            !retired_ids(&plan).contains(&keep.id),
+            "the survivor must never retire itself"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cluster_is_taken_whole_or_deferred() {
+        // Half-pruning leaves duplicates behind and spends the budget
+        // achieving nothing.
+        let big: Vec<MemoryCandidate> = (0..6).map(|i| candidate(0.5, i, 1)).collect();
+        let plan = plan_consolidation(
+            &FakeSource(vec![big]),
+            Uuid::new_v4(),
+            &CyclePolicy {
+                max_changes_per_cycle: 3,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            plan.is_empty(),
+            "the cluster needed 5 changes, budget was 3"
+        );
+        assert_eq!(plan.clusters_deferred, 1);
+        assert!(plan.summary().contains("nothing worth changing"));
+    }
+
+    #[tokio::test]
+    async fn deferred_clusters_are_reported_not_dropped() {
+        // A persistently large backlog should be visible, not silent.
+        let small = vec![candidate(0.5, 1, 1), candidate(0.5, 0, 1)];
+        let large: Vec<MemoryCandidate> = (0..8).map(|i| candidate(0.5, i, 1)).collect();
+        let plan = plan_consolidation(
+            &FakeSource(vec![small, large]),
+            Uuid::new_v4(),
+            &CyclePolicy {
+                max_changes_per_cycle: 3,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.clusters_planned, 1);
+        assert_eq!(plan.clusters_deferred, 1);
+        assert!(plan.summary().contains("deferred"));
+    }
+
+    #[tokio::test]
+    async fn a_plan_never_exceeds_the_change_budget() {
+        // Whatever the input, promotion must not be handed a change-set it
+        // is obliged to refuse.
+        let policy = CyclePolicy {
+            max_changes_per_cycle: 5,
+            ..Default::default()
+        };
+        let clusters: Vec<Vec<MemoryCandidate>> = (0..10)
+            .map(|_| vec![candidate(0.5, 2, 1), candidate(0.5, 1, 1)])
+            .collect();
+
+        let plan = plan_consolidation(&FakeSource(clusters), Uuid::new_v4(), &policy)
+            .await
+            .unwrap();
+
+        assert!(
+            plan.changes.len() <= policy.max_changes_per_cycle,
+            "planned {} changes against a limit of {}",
+            plan.changes.len(),
+            policy.max_changes_per_cycle
+        );
+    }
+}


### PR DESCRIPTION
> ### 📚 Stack — merge bottom-up
> | # | PR | Adds |
> |---|---|---|
> | 1 | #516 | manifest + core types |
> | 2 | #517 | stage→promote→revert engine |
> | 3 | #518 | `restore()` + real-memory mutator |
> | **4** | **#519 ← you are here** | **planner + cycle orchestration** |
> | 5 | #520 | invariant proof (tests only) |
>
> Base: #518. Completes the loop, but **still schedules nothing** — the worker wiring is deliberately left out so this can be merged without turning anything on.

## What this adds

Completes the mutating loop: **plan → stage → promote**, with the manifest as the record.

## The planner is deliberately deterministic

No model is called. `DREAMING.md` reserves model-driven synthesis for later, and the first thing worth doing to a set of near-identical memories is not to rewrite them but to **stop keeping several copies**.

So a plan keeps the best member of a cluster and retires the rest against it. That preserves the survivor's access history and decay state — minting a fresh "merged" memory would throw those away, and for near-identical content there's nothing to merge anyway. The `CreateMemory` variant exists in the vocabulary; no planner emits one yet.

## How the survivor is chosen

Most-used, then best-evidenced, then most important, with the id as a final tie-break.

**Access count leads deliberately**: a memory the system actually retrieves has *demonstrated* its worth, where importance is only ever an estimate of it. The tie-break exists so identical candidates don't produce a different survivor each cycle — without it, consolidation would churn forever. There's a test running the same input five times and asserting a stable choice.

## A cluster is taken whole or deferred

Half-pruning leaves duplicates behind and spends the budget achieving nothing. Deferred clusters are **counted and reported**, not dropped, so a persistent backlog stays visible.

## Where clusters come from

The `SemanticSimilar` links `LifecycleManager::detect_near_duplicates` already writes and discards — so this consumes work the memory system was doing for nothing.

Two guards: a **higher weight threshold** than the one that creates the links (being related enough to help retrieval is a much weaker claim than being redundant), and **oversized components are skipped entirely**. If six memories are all "similar", the threshold is doing something other than finding duplicates, and merging them would collapse distinctions rather than remove redundancy.

## Recording a decline

A cycle that finds nothing is recorded as `Aborted`, not skipped — so *"the loop ran and declined"* is distinguishable from *"the loop never ran"*.

## Testing

8 planner tests plus 5 end-to-end cycle tests **against real SQLite**, including the property that matters most: a cycle reduces redundancy without ever retiring every copy of a fact. Also: undoing a promoted cycle **from its manifest alone**, and the gate biting before any planning work is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmcUdEmFcKUdkSa7EDozMi