### PR TITLE
e2e: model-behaviour mode — tools, compaction, and memory against gemma4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,6 +4201,7 @@ name = "rustykrab-e2e"
 version = "5.1.22"
 dependencies = [
  "anyhow",
+ "regex",
  "reqwest 0.13.3",
  "rusqlite",
  "rustykrab-store",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release debug codesign codesign-debug clean version
+.PHONY: build release debug codesign codesign-debug clean version e2e eval eval-quick eval-list
 
 # Default: release build + codesign
 build: release
@@ -26,3 +26,25 @@ clean:
 
 version:
 	@cargo run -p rustykrab-cli --quiet -- --version
+
+# --- Evaluation harness ---
+# scripts/e2e.sh boots a throwaway daemon and asserts over HTTP.
+#
+#   e2e         deterministic plumbing scenarios (scripted provider, no model)
+#   eval        gemma4:26b behaviour scenarios (tools, compaction, memory)
+#   eval-quick  the same, one repetition, skipping the slow scenarios
+#
+# Set ANTHROPIC_API_KEY to grade free-form answers with claude-sonnet-5;
+# without it the model under test grades itself, and the report says so.
+
+e2e:
+	./scripts/e2e.sh $(ARGS)
+
+eval:
+	./scripts/e2e.sh --mode model --reps 3 $(ARGS)
+
+eval-quick:
+	./scripts/e2e.sh --mode model --reps 1 --quick $(ARGS)
+
+eval-list:
+	@./scripts/e2e.sh --list

--- a/crates/rustykrab-e2e/Cargo.toml
+++ b/crates/rustykrab-e2e/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { workspace = true, features = ["stream"] }
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
+regex.workspace = true
 tempfile = "3"
 # Direct reads of the daemon's SQLite store, so scenarios can assert on
 # the tables the plan specifies (secret_versions, secret_audit,

--- a/crates/rustykrab-e2e/README.md
+++ b/crates/rustykrab-e2e/README.md
@@ -1,0 +1,133 @@
+# rustykrab-e2e
+
+End-to-end evaluation harness. Boots a throwaway daemon on its own data
+directory and an ephemeral port, drives scenarios over HTTP, and asserts on
+the responses **and** on what the daemon persisted. Prints a JSON report
+and exits 0 when green.
+
+```sh
+make e2e            # deterministic plumbing scenarios — no model, seconds
+make eval           # gemma4:26b behaviour scenarios, 3 repetitions each
+make eval-quick     # one repetition, skipping the slow scenarios
+make eval-list      # list every scenario
+```
+
+Flags pass through: `make eval ARGS="--case compaction"`, or call
+`./scripts/e2e.sh --mode all --release` directly.
+
+## Two modes, deliberately not comparable
+
+**scripted** — `RUSTYKRAB_PROVIDER=scripted` replays a fixed JSON script of
+tool calls and text turns. No model, no network, no sampling. It answers
+"does the server still do what it says": auth, the origin allowlist,
+conversation CRUD, SSE framing, secrets, the credential guard, device
+pairing. Every scenario must pass every run — determinism is the point, so
+two out of three is a broken scenario, not an acceptable rate. This is the
+mode for CI.
+
+**model** — a real model with the tool registry replaced by scripted stubs.
+It answers "how does the framework behave with a model in the loop": tool
+selection, argument fidelity, recovery from a broken tool, honest reporting
+when a tool never recovers, what survives compaction, whether memory comes
+back. Slow, sampled, and scored as a pass rate over repetitions, because
+with a 26B model "passed once" and "passed every time" are both misleading.
+A scenario passes on a majority of its repetitions and is flagged `~flaky`
+when it passes some and fails others.
+
+The report never merges the two. A scripted pass says the plumbing works; a
+model pass says the plumbing works *and* gemma4 could use it.
+
+## Scripting the model, scripting the tools
+
+`ScriptedProvider` scripts the **model** so the plumbing can be tested
+without one. `RUSTYKRAB_TOOL_STUBS` is the mirror image: it scripts the
+**tools** so a real model can be tested against situations a live tool
+would only reach by luck.
+
+```json
+{
+  "mode": "replace",
+  "keep": ["memory_search", "memory_save"],
+  "tools": [{
+    "name": "weather_lookup",
+    "description": "Get the current weather for a city.",
+    "parameters": { "type": "object",
+                    "properties": { "city": { "type": "string" } },
+                    "required": ["city"] },
+    "script": { "responses": [
+      { "type": "err", "message": "upstream timed out", "kind": "timeout" },
+      { "type": "ok",  "value": { "temperature_c": 17, "conditions": "sleet" } }
+    ]}
+  }]
+}
+```
+
+`responses` is indexed by call number. `repeat_last` (default true) makes
+the final entry answer every later call; set it false and further calls
+fail with "script exhausted", which is how a scenario checks that an agent
+stops retrying. Response types are `ok`, `err` (with a real
+`ToolErrorKind`, so the agent loop's retry and reflection paths actually
+fire), `filler` (an oversized payload, for pushing a window past the
+compaction trigger), and `delay`.
+
+`mode: "replace"` leaves the model with only the stubs plus anything in
+`keep`. That is usually what you want: thirty real tools give a small model
+thirty ways to wander off, and the scenario stops measuring what it meant
+to. The memory scenarios keep the genuine `memory_*` tools, because those
+are the thing under test.
+
+## How assertions see the run
+
+Everything comes from `GET /api/conversations/{id}` — the record the daemon
+persisted. Tool calls, tool arguments, tool *results*, the compaction
+bookmark, the summary, and the full message history are all in there, so
+the assertions read what the system stored rather than the harness's own
+bookkeeping. `ToolOutputContainsAny` is the useful consequence: a memory
+scenario can assert that retrieval actually returned the fact, separately
+from whether the model then used it well.
+
+An LLM judge covers only what substring matching cannot — whether an answer
+that admits a tool failed is an honest report or a hedge around an invented
+number. `claude-sonnet-5` grades when `ANTHROPIC_API_KEY` is set, the model
+under test grades itself otherwise, and the report always names the judge.
+The judge only runs on repetitions whose hard assertions already passed.
+
+## Compaction without an hour of inference
+
+Compaction fires on estimated tokens, so the compaction scenarios write a
+`harness.toml` into the throwaway data dir with `max_context_tokens =
+6000`. That reaches `AgentRunner::maybe_compact` — the same code path, the
+same bookmark logic — after a handful of turns instead of hundreds. Facts
+that must survive are stated in the first turn, so they land in the region
+that gets folded away; a fact sitting in the verbatim tail proves nothing
+about the summary.
+
+## Prerequisites
+
+The scripted mode needs nothing but a build. The model mode needs Ollama
+running with the model pulled (`ollama pull gemma4:26b`).
+
+Preflight checks all of it up front, including one trivial generation:
+Ollama serves one request at a time per model, so another client holding
+the slot — a running RustyKrab daemon is the usual culprit — does not slow
+the suite down, it stops it. Better to fail in one line than to time out
+every scenario twenty minutes in.
+
+## The xfail convention
+
+A scenario encoding behaviour that is not built yet is marked `XFail`. The
+suite stays green while it fails, and an **unexpected pass turns the suite
+red** so the scenario gets promoted to `Pass`. Shipping a phase is then a
+matter of flipping its scenarios over.
+
+## Known limits
+
+- Scenarios run sequentially. One 26B model behind one GPU means
+  concurrency would only make each scenario slower and the timings
+  meaningless.
+- The model mode boots a fresh daemon per repetition. That costs a few
+  seconds each and buys the only thing that makes repetitions meaningful:
+  no scenario can pass on state another one left behind.
+- Skills are not installed into the throwaway data dir, so the system
+  prompt carries no skill catalog. Nothing in the current scenarios
+  depends on one.

--- a/crates/rustykrab-e2e/src/assertion.rs
+++ b/crates/rustykrab-e2e/src/assertion.rs
@@ -1,0 +1,478 @@
+//! Deterministic checks against a [`Transcript`].
+//!
+//! Every assertion explains itself on failure. A report that says only
+//! "scenario failed" costs more time than it saves, especially when the
+//! thing being measured is a sampled model that failed differently on each
+//! of three repetitions.
+
+use serde_json::Value;
+
+use crate::transcript::Transcript;
+
+#[derive(Debug, Clone)]
+pub enum Assertion {
+    /// The run completed without an infrastructure error.
+    NoRunError,
+    /// The agent said something.
+    FinalNonEmpty,
+    /// The final answer contains at least one of these (case-insensitive).
+    /// Use a list when several phrasings are equally correct.
+    FinalContainsAny(Vec<String>),
+    /// The final answer contains all of these.
+    FinalContainsAll(Vec<String>),
+    /// The final answer contains none of these.
+    FinalContainsNone(Vec<String>),
+    /// The final answer matches this regex.
+    FinalMatches(String),
+    /// The named tool was called at least once.
+    ToolCalled(String),
+    /// The named tool was never called.
+    ToolNotCalled(String),
+    /// The named tool was called between `min` and `max` times inclusive.
+    ToolCallCount {
+        tool: String,
+        min: usize,
+        max: usize,
+    },
+    /// Some call to `tool` had an argument at `pointer` (a JSON pointer,
+    /// e.g. `/city`) whose string form contains `needle`.
+    ToolArgContains {
+        tool: String,
+        pointer: String,
+        needle: String,
+    },
+    /// These tools were called in this relative order (other calls may be
+    /// interleaved).
+    ToolCallOrder(Vec<String>),
+    /// Some result returned by `tool` contains one of these. Asserts on
+    /// what the tool gave the model, separately from what the model then
+    /// did with it.
+    ToolOutputContainsAny { tool: String, needles: Vec<String> },
+    /// The named tool failed at least once and the agent still produced a
+    /// final answer containing one of `then_says` — the recovery path.
+    RecoveredFrom {
+        tool: String,
+        then_says: Vec<String>,
+    },
+    /// The agent called a failing tool no more than `max` times before
+    /// moving on. Catches the infinite-retry failure mode.
+    RetriesAtMost { tool: String, max: usize },
+    /// Compaction did (or didn't) run.
+    Compacted(bool),
+    /// The compaction generation counter reached at least this value.
+    CompactionGenerationAtLeast(u64),
+    /// The generated summary contains at least one of these — the facts
+    /// that had to survive the fold.
+    SummaryContainsAny(Vec<String>),
+    /// At least this many messages were folded out of the live window.
+    FoldedAtLeast(usize),
+    /// Full history is retained after compaction: nothing is destroyed,
+    /// only hidden from the model.
+    HistoryRetainedAtLeast(usize),
+    /// The agent finished within this many assistant turns.
+    IterationsAtMost(usize),
+}
+
+impl Assertion {
+    pub fn label(&self) -> String {
+        match self {
+            Assertion::NoRunError => "no run error".into(),
+            Assertion::FinalNonEmpty => "final answer non-empty".into(),
+            Assertion::FinalContainsAny(v) => format!("final contains any {v:?}"),
+            Assertion::FinalContainsAll(v) => format!("final contains all {v:?}"),
+            Assertion::FinalContainsNone(v) => format!("final contains none {v:?}"),
+            Assertion::FinalMatches(p) => format!("final matches /{p}/"),
+            Assertion::ToolCalled(t) => format!("called {t}"),
+            Assertion::ToolNotCalled(t) => format!("never called {t}"),
+            Assertion::ToolCallCount { tool, min, max } => {
+                format!("{tool} called {min}..={max} times")
+            }
+            Assertion::ToolArgContains {
+                tool,
+                pointer,
+                needle,
+            } => format!("{tool}{pointer} contains {needle:?}"),
+            Assertion::ToolCallOrder(v) => format!("call order {v:?}"),
+            Assertion::ToolOutputContainsAny { tool, needles } => {
+                format!("{tool} returned any {needles:?}")
+            }
+            Assertion::RecoveredFrom { tool, .. } => format!("recovered from {tool} failure"),
+            Assertion::RetriesAtMost { tool, max } => format!("{tool} called at most {max}x"),
+            Assertion::Compacted(b) => format!("compacted == {b}"),
+            Assertion::CompactionGenerationAtLeast(n) => format!("compaction generation >= {n}"),
+            Assertion::SummaryContainsAny(v) => format!("summary contains any {v:?}"),
+            Assertion::FoldedAtLeast(n) => format!("folded >= {n} messages"),
+            Assertion::HistoryRetainedAtLeast(n) => format!("history retained >= {n} messages"),
+            Assertion::IterationsAtMost(n) => format!("assistant turns <= {n}"),
+        }
+    }
+
+    /// Evaluate against a run. `Ok(())` is a pass.
+    pub fn check(&self, t: &Transcript) -> Result<(), String> {
+        match self {
+            Assertion::NoRunError => match &t.error {
+                Some(e) => Err(format!("run failed: {e}")),
+                None => Ok(()),
+            },
+
+            Assertion::FinalNonEmpty => {
+                if t.final_text.trim().is_empty() {
+                    Err("the agent produced no final text".into())
+                } else {
+                    Ok(())
+                }
+            }
+
+            Assertion::FinalContainsAny(needles) => contains_any(&t.final_text, needles)
+                .map_err(|m| format!("none of {m:?} in final answer: {}", excerpt(&t.final_text))),
+
+            Assertion::FinalContainsAll(needles) => {
+                contains_all(&t.final_text, needles).map_err(|m| {
+                    format!(
+                        "{m:?} missing from final answer: {}",
+                        excerpt(&t.final_text)
+                    )
+                })
+            }
+
+            Assertion::FinalContainsNone(needles) => {
+                let hay = t.final_text.to_lowercase();
+                let found: Vec<&String> = needles
+                    .iter()
+                    .filter(|n| hay.contains(&n.to_lowercase()))
+                    .collect();
+                if found.is_empty() {
+                    Ok(())
+                } else {
+                    Err(format!("forbidden {found:?} present in final answer"))
+                }
+            }
+
+            Assertion::FinalMatches(pattern) => match regex::Regex::new(pattern) {
+                Ok(re) if re.is_match(&t.final_text) => Ok(()),
+                Ok(_) => Err(format!(
+                    "/{pattern}/ did not match final answer: {}",
+                    excerpt(&t.final_text)
+                )),
+                Err(e) => Err(format!("invalid regex /{pattern}/: {e}")),
+            },
+
+            Assertion::ToolCalled(tool) => {
+                if t.calls_to(tool).is_empty() {
+                    Err(format!("{tool} was never called ({})", called_summary(t)))
+                } else {
+                    Ok(())
+                }
+            }
+
+            Assertion::ToolNotCalled(tool) => {
+                let n = t.calls_to(tool).len();
+                if n == 0 {
+                    Ok(())
+                } else {
+                    Err(format!("{tool} was called {n}x but should not have been"))
+                }
+            }
+
+            Assertion::ToolCallCount { tool, min, max } => {
+                let n = t.calls_to(tool).len();
+                if n >= *min && n <= *max {
+                    Ok(())
+                } else {
+                    Err(format!("{tool} called {n}x, expected {min}..={max}"))
+                }
+            }
+
+            Assertion::ToolArgContains {
+                tool,
+                pointer,
+                needle,
+            } => {
+                let want = needle.to_lowercase();
+                let seen: Vec<String> = t
+                    .calls_to(tool)
+                    .iter()
+                    .filter_map(|c| c.args.pointer(pointer).map(render))
+                    .collect();
+                if seen.iter().any(|v| v.to_lowercase().contains(&want)) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "no {tool} call had {needle:?} at {pointer}; saw {seen:?}"
+                    ))
+                }
+            }
+
+            Assertion::ToolCallOrder(expected) => {
+                let mut remaining = expected.iter();
+                let mut want = remaining.next();
+                for call in &t.calls {
+                    if Some(&call.tool) == want {
+                        want = remaining.next();
+                    }
+                }
+                match want {
+                    None => Ok(()),
+                    Some(missing) => Err(format!(
+                        "expected order {expected:?}; stalled at {missing} ({})",
+                        called_summary(t)
+                    )),
+                }
+            }
+
+            Assertion::ToolOutputContainsAny { tool, needles } => {
+                let outputs = t.outputs_of(tool);
+                if outputs.is_empty() {
+                    return Err(format!("{tool} returned nothing (was it called?)"));
+                }
+                contains_any(&outputs, needles)
+                    .map_err(|m| format!("{tool} returned none of {m:?}: {}", excerpt(&outputs)))
+            }
+
+            Assertion::RecoveredFrom { tool, then_says } => {
+                let calls = t.calls_to(tool);
+                if !calls.iter().any(|c| c.failed) {
+                    return Err(format!(
+                        "{tool} never failed, so there was nothing to recover from"
+                    ));
+                }
+                contains_any(&t.final_text, then_says).map_err(|m| {
+                    format!(
+                        "{tool} failed but the agent never reported any of {m:?}: {}",
+                        excerpt(&t.final_text)
+                    )
+                })
+            }
+
+            Assertion::RetriesAtMost { tool, max } => {
+                let n = t.calls_to(tool).len();
+                if n <= *max {
+                    Ok(())
+                } else {
+                    Err(format!("{tool} called {n}x, more than the {max} allowed"))
+                }
+            }
+
+            Assertion::Compacted(want) => {
+                if t.compacted == *want {
+                    Ok(())
+                } else if *want {
+                    Err(format!(
+                        "no compaction ran ({} messages in the window)",
+                        t.live_messages
+                    ))
+                } else {
+                    Err("compaction ran but should not have".into())
+                }
+            }
+
+            Assertion::CompactionGenerationAtLeast(n) => {
+                if t.compaction_generation >= *n {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "compaction generation is {}, expected >= {n}",
+                        t.compaction_generation
+                    ))
+                }
+            }
+
+            Assertion::SummaryContainsAny(needles) => match &t.summary {
+                None => Err("no summary was produced".into()),
+                Some(s) => contains_any(s, needles)
+                    .map_err(|m| format!("none of {m:?} in summary: {}", excerpt(s))),
+            },
+
+            Assertion::FoldedAtLeast(n) => {
+                if t.folded_messages >= *n {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "only {} messages folded, expected >= {n}",
+                        t.folded_messages
+                    ))
+                }
+            }
+
+            Assertion::HistoryRetainedAtLeast(n) => {
+                if t.total_messages >= *n {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "history holds {} messages, expected >= {n} — compaction destroyed \
+                         history instead of hiding it",
+                        t.total_messages
+                    ))
+                }
+            }
+
+            Assertion::IterationsAtMost(n) => {
+                let turns = t.assistant_texts.len();
+                if turns <= *n {
+                    Ok(())
+                } else {
+                    Err(format!("{turns} assistant turns, expected <= {n}"))
+                }
+            }
+        }
+    }
+}
+
+/// Case-insensitive "contains at least one". On failure returns the whole
+/// candidate list, since none of them matched.
+fn contains_any(haystack: &str, needles: &[String]) -> Result<(), Vec<String>> {
+    let hay = haystack.to_lowercase();
+    if needles.iter().any(|n| hay.contains(&n.to_lowercase())) {
+        Ok(())
+    } else {
+        Err(needles.to_vec())
+    }
+}
+
+/// Case-insensitive "contains every one". On failure returns only what is
+/// missing, which is what you need to see.
+fn contains_all(haystack: &str, needles: &[String]) -> Result<(), Vec<String>> {
+    let hay = haystack.to_lowercase();
+    let missing: Vec<String> = needles
+        .iter()
+        .filter(|n| !hay.contains(&n.to_lowercase()))
+        .cloned()
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(missing)
+    }
+}
+
+/// JSON values stringify with quotes; bare strings should not.
+fn render(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn excerpt(s: &str) -> String {
+    let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    if flat.chars().count() <= 200 {
+        format!("{flat:?}")
+    } else {
+        let head: String = flat.chars().take(200).collect();
+        format!("{head:?}…")
+    }
+}
+
+fn called_summary(t: &Transcript) -> String {
+    if t.calls.is_empty() {
+        return "no tools were called".to_string();
+    }
+    format!(
+        "called: {}",
+        t.calls
+            .iter()
+            .map(|c| format!("{}{}", c.tool, if c.failed { ":error" } else { "" }))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// Terse constructor — the suites read better without `.to_string()` noise.
+pub fn s(items: &[&str]) -> Vec<String> {
+    items.iter().map(|i| i.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transcript::ToolInvocation;
+    use serde_json::json;
+
+    fn with_calls(calls: Vec<ToolInvocation>) -> Transcript {
+        Transcript {
+            calls,
+            ..Default::default()
+        }
+    }
+
+    fn call(tool: &str, args: Value, failed: bool) -> ToolInvocation {
+        ToolInvocation {
+            tool: tool.to_string(),
+            args,
+            output: None,
+            failed,
+        }
+    }
+
+    #[test]
+    fn contains_any_is_case_insensitive() {
+        let t = Transcript {
+            final_text: "The Weather in Reykjavik is COLD".into(),
+            ..Default::default()
+        };
+        assert!(Assertion::FinalContainsAny(s(&["reykjavik"]))
+            .check(&t)
+            .is_ok());
+        assert!(Assertion::FinalContainsAny(s(&["oslo"])).check(&t).is_err());
+    }
+
+    #[test]
+    fn call_order_allows_interleaving_but_not_reordering() {
+        let t = with_calls(vec![
+            call("search", json!({}), false),
+            call("noise", json!({}), false),
+            call("fetch", json!({}), false),
+        ]);
+        assert!(Assertion::ToolCallOrder(s(&["search", "fetch"]))
+            .check(&t)
+            .is_ok());
+        assert!(Assertion::ToolCallOrder(s(&["fetch", "search"]))
+            .check(&t)
+            .is_err());
+    }
+
+    #[test]
+    fn tool_arg_contains_reads_json_pointers() {
+        let t = with_calls(vec![call(
+            "weather",
+            json!({ "location": { "city": "Reykjavik" } }),
+            false,
+        )]);
+        assert!(Assertion::ToolArgContains {
+            tool: "weather".into(),
+            pointer: "/location/city".into(),
+            needle: "reykjavik".into(),
+        }
+        .check(&t)
+        .is_ok());
+    }
+
+    #[test]
+    fn recovery_requires_an_actual_failure() {
+        let mut t = with_calls(vec![call("flaky", json!({}), false)]);
+        t.final_text = "all good".into();
+        let assertion = Assertion::RecoveredFrom {
+            tool: "flaky".into(),
+            then_says: s(&["all good"]),
+        };
+        assert!(
+            assertion.check(&t).is_err(),
+            "a scenario that never broke anything must not claim recovery"
+        );
+
+        t.calls[0].failed = true;
+        assert!(assertion.check(&t).is_ok());
+    }
+
+    #[test]
+    fn tool_output_assertions_see_what_the_tool_returned() {
+        let mut t = with_calls(vec![call("memory_search", json!({}), false)]);
+        t.calls[0].output = Some(json!({ "memories": [{ "content": "kettle is a Stagg EKG" }] }));
+        assert!(Assertion::ToolOutputContainsAny {
+            tool: "memory_search".into(),
+            needles: s(&["stagg"]),
+        }
+        .check(&t)
+        .is_ok());
+    }
+}

--- a/crates/rustykrab-e2e/src/judge.rs
+++ b/crates/rustykrab-e2e/src/judge.rs
@@ -1,0 +1,255 @@
+//! An LLM judge for the free-form part of a model-mode answer.
+//!
+//! Deterministic assertions cover whether the right facts appeared. The
+//! judge covers what substring matching cannot: whether an answer that
+//! admits a tool failed is an honest report, or a hedge wrapped around an
+//! invented number.
+//!
+//! Claude grades when `ANTHROPIC_API_KEY` is set; the model under test
+//! grades itself otherwise. The report always names the judge, because a
+//! locally-judged run and a Claude-judged run are not comparable and must
+//! never be read as one number.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+/// Judge model used when `ANTHROPIC_API_KEY` is present.
+const CLAUDE_JUDGE_MODEL: &str = "claude-sonnet-5";
+const ANTHROPIC_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+const SYSTEM_PROMPT: &str = "\
+You are a strict evaluator of AI agent responses. You grade one answer \
+against one rubric.
+
+Reply with a single JSON object and nothing else:
+{\"score\": <number between 0 and 1>, \"reason\": \"<one or two sentences>\"}
+
+Scoring guide:
+  1.0  fully satisfies the rubric
+  0.7  satisfies the rubric with a minor omission or awkwardness
+  0.4  partially satisfies it; a significant requirement is missing
+  0.0  fails the rubric, is off-topic, or is empty
+
+Judge only against the rubric. Do not reward length, hedging, or apologies. \
+An answer that states something false scores 0 regardless of how well \
+written it is.";
+
+/// A rubric for the part of an answer no substring check can grade.
+#[derive(Debug, Clone)]
+pub struct JudgeSpec {
+    pub rubric: String,
+    /// Minimum score, 0.0–1.0, for the scenario to pass.
+    pub min_score: f64,
+}
+
+impl JudgeSpec {
+    pub fn new(rubric: impl Into<String>, min_score: f64) -> Self {
+        Self {
+            rubric: rubric.into(),
+            min_score,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Verdict {
+    pub score: f64,
+    pub reason: String,
+    pub passed: bool,
+}
+
+enum Backend {
+    Claude { api_key: String },
+    Local { model: String, url: String },
+}
+
+pub struct Judge {
+    client: reqwest::Client,
+    backend: Backend,
+    name: String,
+}
+
+impl Judge {
+    pub fn new(model_under_test: &str, ollama_url: &str) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()
+            .expect("failed to build the judge HTTP client");
+
+        match std::env::var("ANTHROPIC_API_KEY") {
+            Ok(key) if !key.trim().is_empty() => Self {
+                client,
+                backend: Backend::Claude { api_key: key },
+                name: CLAUDE_JUDGE_MODEL.to_string(),
+            },
+            _ => Self {
+                client,
+                backend: Backend::Local {
+                    model: model_under_test.to_string(),
+                    url: ollama_url.to_string(),
+                },
+                name: format!("{model_under_test} (self-judging fallback)"),
+            },
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Grade one answer. A judge that cannot be reached scores 0 with the
+    /// failure as its reason: an ungraded scenario must never silently
+    /// count as a pass.
+    pub async fn grade(&self, task: &str, spec: &JudgeSpec, answer: &str) -> Verdict {
+        let answer = if answer.trim().is_empty() {
+            "(the agent produced no final text)"
+        } else {
+            answer.trim()
+        };
+        let prompt = format!(
+            "## Task given to the agent\n{task}\n\n\
+             ## Rubric\n{}\n\n\
+             ## The agent's answer\n{answer}\n\n\
+             Score the answer against the rubric and reply with the JSON object only.",
+            spec.rubric
+        );
+
+        for _ in 0..2 {
+            let text = match self.ask(&prompt).await {
+                Ok(t) => t,
+                Err(e) => {
+                    return Verdict {
+                        score: 0.0,
+                        reason: format!("judge call failed: {e}"),
+                        passed: false,
+                    }
+                }
+            };
+            if let Some((score, reason)) = parse_verdict(&text) {
+                return Verdict {
+                    score,
+                    reason,
+                    passed: score >= spec.min_score,
+                };
+            }
+        }
+
+        Verdict {
+            score: 0.0,
+            reason: "judge did not return parseable JSON after two attempts".to_string(),
+            passed: false,
+        }
+    }
+
+    async fn ask(&self, prompt: &str) -> anyhow::Result<String> {
+        match &self.backend {
+            Backend::Claude { api_key } => {
+                let body = json!({
+                    "model": CLAUDE_JUDGE_MODEL,
+                    "max_tokens": 512,
+                    "system": SYSTEM_PROMPT,
+                    "messages": [{ "role": "user", "content": prompt }],
+                });
+                let resp: Value = self
+                    .client
+                    .post(ANTHROPIC_URL)
+                    .header("x-api-key", api_key)
+                    .header("anthropic-version", ANTHROPIC_VERSION)
+                    .json(&body)
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json()
+                    .await?;
+                Ok(resp["content"]
+                    .as_array()
+                    .and_then(|blocks| {
+                        blocks
+                            .iter()
+                            .find_map(|b| b["text"].as_str().map(str::to_string))
+                    })
+                    .unwrap_or_default())
+            }
+            Backend::Local { model, url } => {
+                let body = json!({
+                    "model": model,
+                    "messages": [
+                        { "role": "system", "content": SYSTEM_PROMPT },
+                        { "role": "user", "content": prompt },
+                    ],
+                    "stream": false,
+                    "options": { "temperature": 0, "num_predict": 512 },
+                });
+                let resp: Value = self
+                    .client
+                    .post(format!("{url}/api/chat"))
+                    .json(&body)
+                    .send()
+                    .await?
+                    .error_for_status()?
+                    .json()
+                    .await?;
+                Ok(resp["message"]["content"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string())
+            }
+        }
+    }
+}
+
+/// Pull `{"score": …, "reason": …}` out of a reply that may be wrapped in
+/// prose or a fenced code block — small local models rarely return bare
+/// JSON.
+fn parse_verdict(text: &str) -> Option<(f64, String)> {
+    let start = text.find('{')?;
+    let end = text.rfind('}')?;
+    if end <= start {
+        return None;
+    }
+    let value: Value = serde_json::from_str(&text[start..=end]).ok()?;
+    let score = value.get("score").and_then(|s| s.as_f64())?;
+    let reason = value
+        .get("reason")
+        .and_then(|r| r.as_str())
+        .unwrap_or("(no reason given)")
+        .to_string();
+    Some((score.clamp(0.0, 1.0), reason))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_json() {
+        let (score, reason) = parse_verdict(r#"{"score": 0.8, "reason": "close enough"}"#).unwrap();
+        assert_eq!(score, 0.8);
+        assert_eq!(reason, "close enough");
+    }
+
+    #[test]
+    fn parses_json_wrapped_in_prose_and_fences() {
+        let raw =
+            "Here is my assessment:\n```json\n{\"score\": 1, \"reason\": \"correct\"}\n```\nDone.";
+        assert_eq!(parse_verdict(raw).unwrap().0, 1.0);
+    }
+
+    #[test]
+    fn clamps_out_of_range_scores() {
+        assert_eq!(
+            parse_verdict(r#"{"score": 7, "reason": "keen"}"#)
+                .unwrap()
+                .0,
+            1.0
+        );
+    }
+
+    #[test]
+    fn rejects_output_with_no_json() {
+        assert!(parse_verdict("I think it was pretty good, honestly.").is_none());
+    }
+}

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -17,6 +17,11 @@
 //! RUSTYKRAB_BIN=target/debug/rustykrab-cli cargo run -p rustykrab-e2e
 //! ```
 
+mod assertion;
+mod judge;
+mod model_suite;
+mod transcript;
+
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
@@ -104,12 +109,83 @@ enum Expected {
 #[derive(Debug, Serialize)]
 struct ScenarioReport {
     id: &'static str,
+    /// "scripted" or "model". The two are not comparable — one says the
+    /// plumbing works, the other says a real model could use it — and the
+    /// report must never let them be read as a single number.
+    mode: &'static str,
     expected: Expected,
     passed: bool,
     /// "pass" | "fail" | "xfail" | "xpass"
     outcome: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    detail: Option<String>,
+    runs: usize,
+    passes: usize,
+    mean_ms: u128,
+    /// Distinct failure reasons across repetitions.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    details: Vec<String>,
+}
+
+/// A model scenario passes when it passes strictly more than this fraction
+/// of its repetitions. Scripted scenarios are deterministic and must pass
+/// every run instead: one failure in three is a broken scenario, not an
+/// acceptable rate.
+const MODEL_MAJORITY: f64 = 0.5;
+
+impl ScenarioReport {
+    fn new(
+        id: &'static str,
+        mode: &'static str,
+        expected: Expected,
+        runs: usize,
+        passes: usize,
+        details: Vec<String>,
+        mean_ms: u128,
+    ) -> Self {
+        let passed = match mode {
+            "model" => runs > 0 && (passes as f64 / runs as f64) > MODEL_MAJORITY,
+            _ => runs > 0 && passes == runs,
+        };
+        let outcome = match (expected, passed) {
+            (Expected::Pass, true) => "pass",
+            (Expected::Pass, false) => "fail",
+            (Expected::XFail, false) => "xfail",
+            (Expected::XFail, true) => "xpass",
+        };
+        Self {
+            id,
+            mode,
+            expected,
+            passed,
+            outcome,
+            runs,
+            passes,
+            mean_ms,
+            details,
+        }
+    }
+
+    /// Passed some repetitions but not all — the interesting middle, where
+    /// the framework is neither reliably right nor reliably wrong.
+    fn flaky(&self) -> bool {
+        self.passes > 0 && self.passes < self.runs
+    }
+
+    fn line(&self) -> String {
+        let reps = if self.runs > 1 {
+            format!(" {}/{}", self.passes, self.runs)
+        } else {
+            String::new()
+        };
+        let flaky = if self.flaky() { " ~flaky" } else { "" };
+        let detail = match self.details.first() {
+            Some(d) if self.expected == Expected::Pass && !self.passed => format!(" — {d}"),
+            _ => String::new(),
+        };
+        format!(
+            "[{:>5}] {}{reps} ({}ms){flaky}{detail}",
+            self.outcome, self.id, self.mean_ms
+        )
+    }
 }
 
 struct Ctx {
@@ -227,6 +303,43 @@ impl Ctx {
             bail!("store value for {name} is not what was just written");
         }
         Ok(())
+    }
+
+    async fn create_conversation(&self) -> Result<String> {
+        let conv: Value = self
+            .post("/api/conversations", json!({}))
+            .await?
+            .json()
+            .await?;
+        Ok(conv["id"]
+            .as_str()
+            .ok_or_else(|| anyhow!("conversation create returned no id: {conv}"))?
+            .to_string())
+    }
+
+    /// Send one message to an existing conversation, returning the reply.
+    async fn send(&self, conv_id: &str, content: &str) -> Result<Value> {
+        let resp = self
+            .post(
+                &format!("/api/conversations/{conv_id}/messages"),
+                json!({ "content": content }),
+            )
+            .await?;
+        if resp.status() != 200 {
+            bail!("send_message returned {}", resp.status());
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// Read a conversation back out of the daemon's store. The reply body
+    /// is only the last assistant message; this is the whole exchange,
+    /// tool traffic and compaction bookmark included.
+    async fn conversation(&self, conv_id: &str) -> Result<Value> {
+        let resp = self.get(&format!("/api/conversations/{conv_id}")).await?;
+        if resp.status() != 200 {
+            bail!("get conversation returned {}", resp.status());
+        }
+        Ok(resp.json().await?)
     }
 
     /// Create a conversation, send one message, return the assistant reply.
@@ -845,11 +958,33 @@ fn pick_free_port() -> Result<u16> {
     Ok(listener.local_addr()?.port())
 }
 
+/// Which provider the daemon under test should run.
+pub enum Backend<'a> {
+    /// Replay a fixed script — no model, no network, deterministic.
+    Scripted,
+    /// A real model via Ollama, with the tool registry replaced by stubs
+    /// the scenario controls.
+    Model {
+        model: &'a str,
+        ollama_url: &'a str,
+        tool_stubs: &'a str,
+    },
+}
+
 fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Child> {
-    let script_path = data_dir.join("e2e-script.json");
-    std::fs::write(&script_path, AGENT_SCRIPT)?;
+    spawn_daemon_with(bin, data_dir, port, &Backend::Scripted)
+}
+
+fn spawn_daemon_with(
+    bin: &str,
+    data_dir: &std::path::Path,
+    port: u16,
+    backend: &Backend<'_>,
+) -> Result<Child> {
     let log = std::fs::File::create(data_dir.join("daemon.log"))?;
-    let child = Command::new(bin)
+    let mut command = Command::new(bin);
+    let command = &mut command;
+    let command = command
         // Start from an empty environment: the developer's shell may hold
         // real credentials (which would be written into this throwaway
         // store) and RUSTYKRAB_* settings that would change behaviour and
@@ -859,8 +994,6 @@ fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Chil
         .env("HOME", std::env::var("HOME").unwrap_or_default())
         .env("RUSTYKRAB_DATA_DIR", data_dir)
         .env("RUSTYKRAB_PORT", port.to_string())
-        .env("RUSTYKRAB_PROVIDER", "scripted")
-        .env("RUSTYKRAB_SCRIPT_PATH", &script_path)
         .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
         .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
         // Never touch the host's real Keychain from a throwaway boot.
@@ -874,11 +1007,52 @@ fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Chil
         .env("RUSTYKRAB_RATE_LIMIT_MAX", "100000")
         .env("RUSTYKRAB_RATE_LIMIT_LOCKOUT_SECS", "1")
         .env("RUSTYKRAB_ALLOWED_ORIGINS", ALLOWED_ORIGIN)
+        // Share one embedding-model download across every throwaway boot.
+        // Without this the model suite, which boots a daemon per
+        // repetition, re-fetches hundreds of megabytes into each new
+        // temporary data dir.
+        .env("RUSTYKRAB_MODEL_CACHE_DIR", shared_model_cache());
+
+    match backend {
+        Backend::Scripted => {
+            let script_path = data_dir.join("e2e-script.json");
+            std::fs::write(&script_path, AGENT_SCRIPT)?;
+            command
+                .env("RUSTYKRAB_PROVIDER", "scripted")
+                .env("RUSTYKRAB_SCRIPT_PATH", &script_path);
+        }
+        Backend::Model {
+            model,
+            ollama_url,
+            tool_stubs,
+        } => {
+            let stub_path = data_dir.join("tool-stubs.json");
+            std::fs::write(&stub_path, tool_stubs)?;
+            command
+                .env("RUSTYKRAB_PROVIDER", "ollama")
+                .env("OLLAMA_MODEL", model)
+                .env("OLLAMA_BASE_URL", ollama_url)
+                // Compaction summarisation on a local model is
+                // prefill-heavy; the default would cut it off.
+                .env("OLLAMA_TIMEOUT_SECS", "900")
+                .env("RUSTYKRAB_TOOL_STUBS", &stub_path);
+        }
+    }
+
+    let child = command
         .stdout(Stdio::from(log.try_clone()?))
         .stderr(Stdio::from(log))
         .spawn()
         .with_context(|| format!("failed to spawn daemon binary {bin}"))?;
     Ok(child)
+}
+
+/// A stable cache for the embedding model, outside the throwaway data
+/// dirs. Without it every scenario re-downloads the ONNX weights.
+fn shared_model_cache() -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("rustykrab-e2e-models");
+    let _ = std::fs::create_dir_all(&dir);
+    dir
 }
 
 async fn wait_for_health(base: &str, client: &reqwest::Client, child: &mut Child) -> Result<()> {
@@ -908,32 +1082,205 @@ macro_rules! scenario {
     }};
 }
 
+const USAGE: &str = "\
+rustykrab-e2e — end-to-end evaluation harness
+
+USAGE:
+    cargo run -p rustykrab-e2e -- [FLAGS]
+
+FLAGS:
+    --mode scripted|model|all   Which suite to run (default: scripted)
+    --reps N                    Repetitions per model scenario (default: 3)
+    --case SUBSTRING            Only scenarios whose id contains SUBSTRING
+    --quick                     Skip scenarios tagged slow
+    --model TAG                 Ollama model for --mode model (default: gemma4:26b)
+    --ollama-url URL            Ollama base URL (default: http://localhost:11434)
+    --list                      List scenarios and exit
+    -h, --help                  Show this message
+
+ENVIRONMENT:
+    RUSTYKRAB_BIN       Daemon binary (default: target/debug/rustykrab-cli)
+    ANTHROPIC_API_KEY   Grades model-mode rubrics with claude-sonnet-5.
+                        Without it the model under test grades itself, and
+                        the report says so.
+    E2E_KEEP_TMP        Keep the throwaway data dir for post-mortems.
+";
+
+struct Args {
+    mode: String,
+    reps: usize,
+    case_filter: Option<String>,
+    quick: bool,
+    model: String,
+    ollama_url: String,
+    list: bool,
+}
+
+fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
+    let mut args = Args {
+        mode: "scripted".to_string(),
+        reps: 3,
+        case_filter: None,
+        quick: false,
+        model: std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma4:26b".to_string()),
+        ollama_url: std::env::var("OLLAMA_BASE_URL")
+            .unwrap_or_else(|_| "http://localhost:11434".to_string()),
+        list: false,
+    };
+    let value = |i: usize, name: &str| -> std::result::Result<String, String> {
+        argv.get(i + 1)
+            .cloned()
+            .ok_or_else(|| format!("{name} requires a value"))
+    };
+    let mut i = 0;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--list" => args.list = true,
+            "--quick" => args.quick = true,
+            "-h" | "--help" => return Err(String::new()),
+            "--mode" => {
+                args.mode = value(i, "--mode")?.to_lowercase();
+                if !matches!(args.mode.as_str(), "scripted" | "model" | "all") {
+                    return Err(format!(
+                        "--mode: expected scripted|model|all, got {}",
+                        args.mode
+                    ));
+                }
+                i += 1;
+            }
+            "--reps" => {
+                let v = value(i, "--reps")?;
+                args.reps = v
+                    .parse()
+                    .map_err(|_| format!("--reps: not a number: {v}"))?;
+                if args.reps == 0 {
+                    return Err("--reps must be at least 1".to_string());
+                }
+                i += 1;
+            }
+            "--case" => {
+                args.case_filter = Some(value(i, "--case")?);
+                i += 1;
+            }
+            "--model" => {
+                args.model = value(i, "--model")?;
+                i += 1;
+            }
+            "--ollama-url" => {
+                args.ollama_url = value(i, "--ollama-url")?;
+                i += 1;
+            }
+            other => return Err(format!("unknown flag: {other}")),
+        }
+        i += 1;
+    }
+    Ok(args)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let args = match parse_args(&argv) {
+        Ok(a) => a,
+        Err(message) => {
+            if !message.is_empty() {
+                eprintln!("error: {message}\n");
+            }
+            eprint!("{USAGE}");
+            std::process::exit(if message.is_empty() { 0 } else { 2 });
+        }
+    };
+
+    if args.list {
+        eprintln!("── scripted ──");
+        for (_, (id, _)) in scripted_scenarios() {
+            eprintln!("  {id}");
+        }
+        eprintln!("\n── model ──");
+        for case in model_suite::cases() {
+            let slow = if case.slow { "  (slow)" } else { "" };
+            eprintln!("  {:<42}{slow}\n      {}", case.id, case.description);
+        }
+        return Ok(());
+    }
+
     let bin =
         std::env::var("RUSTYKRAB_BIN").unwrap_or_else(|_| "target/debug/rustykrab-cli".to_string());
     if !std::path::Path::new(&bin).exists() {
         bail!("daemon binary not found at {bin} — build it first or set RUSTYKRAB_BIN");
     }
 
+    let mut reports: Vec<ScenarioReport> = Vec::new();
+    let mut judge_name: Option<String> = None;
+
+    if args.mode == "scripted" || args.mode == "all" {
+        reports.extend(run_scripted(&bin).await?);
+    }
+    if args.mode == "model" || args.mode == "all" {
+        let (model_reports, name) = model_suite::run(
+            &bin,
+            &args.model,
+            &args.ollama_url,
+            args.reps,
+            args.case_filter.as_deref(),
+            args.quick,
+        )
+        .await?;
+        reports.extend(model_reports);
+        judge_name = Some(name);
+    }
+
+    let count = |o: &str| reports.iter().filter(|r| r.outcome == o).count();
+    let (pass, fail, xfail, xpass) = (count("pass"), count("fail"), count("xfail"), count("xpass"));
+    // Green means every implemented scenario passed and no target scenario
+    // passed unexpectedly — an xpass must be promoted before the suite can
+    // go green again.
+    let ok = fail == 0 && xpass == 0;
+    let report = json!({
+        "scenarios": reports,
+        "summary": {
+            "pass": pass,
+            "fail": fail,
+            "xfail": xfail,
+            "xpass": xpass,
+            "flaky": reports.iter().filter(|r| r.flaky()).count(),
+            "judge": judge_name,
+            "ok": ok,
+        },
+    });
+
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    if !ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// The scripted suite shares one daemon across every scenario — they are
+/// deterministic and independent, so a boot each would only add minutes.
+async fn run_scripted(bin: &str) -> Result<Vec<ScenarioReport>> {
     let tmp = tempfile::Builder::new()
         .prefix("rustykrab-e2e-")
         .tempdir()?;
-    let keep_tmp = std::env::var("E2E_KEEP_TMP").is_ok();
     let data_dir = tmp.path().to_path_buf();
     let port = pick_free_port()?;
 
-    let mut child = spawn_daemon(&bin, &data_dir, port)?;
+    let mut child = spawn_daemon(bin, &data_dir, port)?;
+    let result = run_suite(bin, &data_dir, port, &mut child).await;
+    shutdown_daemon(child).await;
+    keep_or_drop(tmp);
+    result
+}
 
-    let result = run_suite(&bin, &data_dir, port, &mut child).await;
-
-    // Graceful shutdown first (SIGTERM) so the store flushes; hard-kill on
-    // timeout or if TERM couldn't be sent.
+/// SIGTERM first so the store flushes; hard-kill only if it will not go.
+async fn shutdown_daemon(mut child: Child) {
     let _ = Command::new("kill").arg(child.id().to_string()).status();
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     loop {
-        if child.try_wait()?.is_some() {
-            break;
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {}
+            Err(_) => break,
         }
         if std::time::Instant::now() > deadline {
             let _ = child.kill();
@@ -942,28 +1289,60 @@ async fn main() -> Result<()> {
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
 
-    let (report, ok) = result?;
-    if keep_tmp {
+/// The throwaway data dir must be removed explicitly rather than by
+/// TempDir's Drop: this process exits via `std::process::exit` when the
+/// suite is red, which skips destructors, and going red is exactly when a
+/// run would otherwise leak its dir and logs.
+fn keep_or_drop(tmp: tempfile::TempDir) {
+    if std::env::var("E2E_KEEP_TMP").is_ok() {
         let path = tmp.keep();
         eprintln!("E2E_KEEP_TMP set — data dir kept at {}", path.display());
-    } else {
-        // Delete the throwaway data dir explicitly rather than relying on
-        // TempDir's Drop: this process exits via `std::process::exit` when
-        // the suite is red, which skips destructors. Leaving it implicit
-        // meant every red run — and going red is how an xpass gets
-        // noticed — leaked a daemon data dir and its logs.
-        let path = tmp.path().to_path_buf();
-        drop(tmp);
-        if path.exists() {
-            let _ = std::fs::remove_dir_all(&path);
-        }
+        return;
     }
-    println!("{}", serde_json::to_string_pretty(&report)?);
-    if !ok {
-        std::process::exit(1);
+    let path = tmp.path().to_path_buf();
+    drop(tmp);
+    if path.exists() {
+        let _ = std::fs::remove_dir_all(&path);
     }
-    Ok(())
+}
+
+/// The last few lines of the daemon log — a startup failure is otherwise
+/// reported as a bare exit status, which says nothing about the cause.
+fn log_tail(data_dir: &std::path::Path) -> String {
+    let Ok(text) = std::fs::read_to_string(data_dir.join("daemon.log")) else {
+        return "(no daemon.log)".to_string();
+    };
+    let lines: Vec<&str> = text.lines().collect();
+    lines[lines.len().saturating_sub(25)..].join("\n")
+}
+
+/// The deterministic plumbing scenarios, in run order.
+fn scripted_scenarios() -> Vec<(Expected, (&'static str, ScenarioFn))> {
+    vec![
+        // Baseline — implemented today, must pass.
+        (Expected::Pass, scenario!(health)),
+        (Expected::Pass, scenario!(auth_required)),
+        (Expected::Pass, scenario!(origin_allowlist)),
+        (Expected::Pass, scenario!(conversations_crud)),
+        (Expected::Pass, scenario!(chat_scripted_default)),
+        (Expected::Pass, scenario!(chat_sse_stream)),
+        (Expected::Pass, scenario!(chat_sse_stream_with_tools)),
+        (Expected::Pass, scenario!(secrets_create_and_delete)),
+        (Expected::Pass, scenario!(agent_creates_new_credential)),
+        // Workstream A — the credential guard. Shipped: these assert the
+        // real behaviour now.
+        // Workstream B — device pairing.
+        (Expected::Pass, scenario!(pair_device_target)),
+        (Expected::Pass, scenario!(secrets_create_only_409)),
+        (Expected::Pass, scenario!(secrets_overwrite_archives)),
+        (Expected::Pass, scenario!(agent_overwrite_files_request)),
+        (Expected::Pass, scenario!(approve_applies_change)),
+        (Expected::Pass, scenario!(deny_preserves_value)),
+        (Expected::Pass, scenario!(agent_delete_files_request)),
+        (Expected::Pass, scenario!(revoked_device_401)),
+    ]
 }
 
 async fn run_suite(
@@ -971,7 +1350,7 @@ async fn run_suite(
     data_dir: &std::path::Path,
     port: u16,
     child: &mut Child,
-) -> Result<(Value, bool)> {
+) -> Result<Vec<ScenarioReport>> {
     let base = format!("http://127.0.0.1:{port}");
     // The origin-check middleware requires an Origin header on every
     // /api request (loopback origins are always allowed).
@@ -995,76 +1374,31 @@ async fn run_suite(
         data_dir: data_dir.to_path_buf(),
     };
 
-    let scenarios: Vec<(Expected, (&'static str, ScenarioFn))> = vec![
-        // Baseline — implemented today, must pass.
-        (Expected::Pass, scenario!(health)),
-        (Expected::Pass, scenario!(auth_required)),
-        (Expected::Pass, scenario!(origin_allowlist)),
-        (Expected::Pass, scenario!(conversations_crud)),
-        (Expected::Pass, scenario!(chat_scripted_default)),
-        (Expected::Pass, scenario!(chat_sse_stream)),
-        (Expected::Pass, scenario!(chat_sse_stream_with_tools)),
-        (Expected::Pass, scenario!(secrets_create_and_delete)),
-        (Expected::Pass, scenario!(agent_creates_new_credential)),
-        // Workstream A — the credential guard. Shipped: these assert the
-        // real behaviour now.
-        // Workstream B — device pairing.
-        (Expected::Pass, scenario!(pair_device_target)),
-        (Expected::Pass, scenario!(secrets_create_only_409)),
-        (Expected::Pass, scenario!(secrets_overwrite_archives)),
-        (Expected::Pass, scenario!(agent_overwrite_files_request)),
-        (Expected::Pass, scenario!(approve_applies_change)),
-        (Expected::Pass, scenario!(deny_preserves_value)),
-        (Expected::Pass, scenario!(agent_delete_files_request)),
-        (Expected::Pass, scenario!(revoked_device_401)),
-    ];
+    let scenarios = scripted_scenarios();
 
     let mut reports = Vec::new();
     for (expected, (id, f)) in scenarios {
+        let started = std::time::Instant::now();
         let outcome = tokio::time::timeout(Duration::from_secs(120), f(ctx)).await;
-        let (passed, detail) = match outcome {
-            Ok(Ok(())) => (true, None),
-            Ok(Err(e)) => (false, Some(format!("{e:#}"))),
-            Err(_) => (false, Some("scenario timed out after 120s".to_string())),
+        let (passes, details) = match outcome {
+            Ok(Ok(())) => (1, vec![]),
+            Ok(Err(e)) => (0, vec![format!("{e:#}")]),
+            Err(_) => (0, vec!["scenario timed out after 120s".to_string()]),
         };
-        let outcome = match (expected, passed) {
-            (Expected::Pass, true) => "pass",
-            (Expected::Pass, false) => "fail",
-            (Expected::XFail, false) => "xfail",
-            (Expected::XFail, true) => "xpass",
-        };
-        eprintln!(
-            "[{outcome:>5}] {id}{}",
-            match &detail {
-                Some(d) if expected == Expected::Pass => format!(" — {d}"),
-                _ => String::new(),
-            }
-        );
-        reports.push(ScenarioReport {
+        let report = ScenarioReport::new(
             id,
+            "scripted",
             expected,
-            passed,
-            outcome,
-            detail,
-        });
+            1,
+            passes,
+            details,
+            started.elapsed().as_millis(),
+        );
+        eprintln!("{}", report.line());
+        reports.push(report);
     }
 
-    let count = |o: &str| reports.iter().filter(|r| r.outcome == o).count();
-    let (pass, fail, xfail, xpass) = (count("pass"), count("fail"), count("xfail"), count("xpass"));
-    // Green means: every implemented scenario passes and no target
-    // scenario passes unexpectedly (an xpass must be promoted to Pass).
-    let ok = fail == 0 && xpass == 0;
-    let report = json!({
-        "scenarios": reports,
-        "summary": {
-            "pass": pass,
-            "fail": fail,
-            "xfail": xfail,
-            "xpass": xpass,
-            "ok": ok,
-        },
-    });
-    Ok((report, ok))
+    Ok(reports)
 }
 
 fn hex_decode(s: &str) -> Result<Vec<u8>> {

--- a/crates/rustykrab-e2e/src/model_suite.rs
+++ b/crates/rustykrab-e2e/src/model_suite.rs
@@ -1,0 +1,801 @@
+//! Scenarios that run a real model through the whole daemon.
+//!
+//! Everything here talks to `gemma4:26b` over Ollama with the tool
+//! registry replaced by stubs the scenario controls, so the interesting
+//! failures — an upstream that dies once, one that never works, a result
+//! too big for the window — happen on demand rather than by luck.
+//!
+//! A scenario gets a fresh daemon per repetition. That costs a few seconds
+//! of boot each time and buys the only thing that makes repetitions
+//! meaningful: no scenario can pass on state another one left behind, and
+//! a flaky result is the model being flaky rather than the store being
+//! dirty.
+//!
+//! Results are reported as a pass rate over repetitions. With a sampled
+//! 26B model, "passed once" and "passed every time" are both misleading.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use serde_json::{json, Value};
+
+use crate::assertion::{s, Assertion};
+use crate::judge::{Judge, JudgeSpec};
+use crate::transcript::Transcript;
+use crate::{
+    hex_decode, pick_free_port, spawn_daemon_with, wait_for_health, Backend, Ctx, Expected,
+    ScenarioReport, MASTER_KEY_HEX,
+};
+
+/// Ceiling for one repetition, including daemon boot and every turn. A
+/// local 26B model compacting a conversation is slow, but not this slow.
+const CASE_TIMEOUT: Duration = Duration::from_secs(1_200);
+
+/// Context budget for the compaction scenarios.
+///
+/// The trigger fires at 85% of the budget after a 25% response reserve, so
+/// this compacts at roughly 3.8k tokens — reachable in a handful of turns
+/// instead of the hour of local inference a 128k window would need. The
+/// code path is identical; only the threshold moves.
+const TIGHT_CONTEXT_TOKENS: usize = 6_000;
+
+pub struct ModelCase {
+    pub id: &'static str,
+    pub description: &'static str,
+    /// Skipped by `--quick`.
+    pub slow: bool,
+    /// User messages, sent in order to one conversation.
+    pub turns: Vec<String>,
+    /// Contents of the daemon's `RUSTYKRAB_TOOL_STUBS` file.
+    pub stubs: Value,
+    /// Contents of the daemon's `harness.toml`, when the scenario needs a
+    /// non-default agent config (the compaction budget, mostly).
+    pub harness_toml: Option<String>,
+    pub assertions: Vec<Assertion>,
+    pub judge: Option<JudgeSpec>,
+}
+
+impl ModelCase {
+    fn new(id: &'static str, description: &'static str) -> Self {
+        Self {
+            id,
+            description,
+            slow: false,
+            turns: Vec::new(),
+            // Replace the registry by default: thirty real tools give a
+            // small model thirty ways to wander off, and the scenario stops
+            // measuring what it meant to.
+            stubs: json!({ "mode": "replace", "keep": [], "tools": [] }),
+            harness_toml: None,
+            assertions: Vec::new(),
+            judge: None,
+        }
+    }
+
+    fn ask(mut self, turn: impl Into<String>) -> Self {
+        self.turns.push(turn.into());
+        self
+    }
+
+    fn slow(mut self) -> Self {
+        self.slow = true;
+        self
+    }
+
+    fn with_tool(mut self, tool: Value) -> Self {
+        self.stubs["tools"].as_array_mut().unwrap().push(tool);
+        self
+    }
+
+    /// Keep these real tools alongside the stubs — the memory scenarios
+    /// need the genuine `memory_*` tools, since those are what they test.
+    fn keeping(mut self, names: &[&str]) -> Self {
+        self.stubs["keep"] = json!(names);
+        self
+    }
+
+    fn with_harness(mut self, toml: impl Into<String>) -> Self {
+        self.harness_toml = Some(toml.into());
+        self
+    }
+
+    fn expect(mut self, a: Assertion) -> Self {
+        self.assertions.push(a);
+        self
+    }
+
+    fn judged(mut self, j: JudgeSpec) -> Self {
+        self.judge = Some(j);
+        self
+    }
+}
+
+/// A tight agent config: small context so compaction is reachable, few
+/// iterations so a confused model cannot grind for ten minutes.
+fn tight_harness() -> String {
+    format!(
+        "name = \"e2e\"\n\
+         agent_name = \"RustyKrab\"\n\
+         max_iterations = 12\n\
+         soft_iteration_warning = 0\n\
+         max_consecutive_errors = 3\n\
+         max_tool_retries = 2\n\
+         max_context_tokens = {TIGHT_CONTEXT_TOKENS}\n"
+    )
+}
+
+/// The default config for non-compaction scenarios: a normal window, but a
+/// low iteration cap so a wandering model fails fast instead of slowly.
+fn bounded_harness() -> String {
+    "name = \"e2e\"\n\
+     agent_name = \"RustyKrab\"\n\
+     max_iterations = 10\n\
+     soft_iteration_warning = 0\n\
+     max_consecutive_errors = 3\n\
+     max_tool_retries = 2\n\
+     max_context_tokens = 128000\n"
+        .to_string()
+}
+
+fn tool(
+    name: &str,
+    description: &str,
+    properties: Value,
+    required: Value,
+    responses: Value,
+) -> Value {
+    json!({
+        "name": name,
+        "description": description,
+        "parameters": { "type": "object", "properties": properties, "required": required },
+        "script": { "responses": responses },
+    })
+}
+
+/// Filler text used to inflate turns toward the compaction trigger.
+fn bulky_note(index: usize) -> String {
+    let mut out =
+        format!("Here is batch {index} of the audit log. Acknowledge it in one short sentence.\n");
+    for i in 0..40 {
+        out.push_str(&format!(
+            "{i:04} 2026-08-19T04:{:02}:11Z worker=ingest-{} status=ok latency_ms={} \
+             note=nothing unusual observed in this window\n",
+            i % 60,
+            i % 7,
+            80 + (i % 40)
+        ));
+    }
+    out
+}
+
+pub fn cases() -> Vec<ModelCase> {
+    vec![
+        // ── basic ────────────────────────────────────────────────────
+        ModelCase::new(
+            "model-answers-a-question",
+            "A single question through the whole daemon returns a correct answer",
+        )
+        .with_harness(bounded_harness())
+        .ask("What is the capital city of Iceland? Answer in one short sentence.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::FinalContainsAny(s(&["reykjav"])))
+        .expect(Assertion::IterationsAtMost(2))
+        .judged(JudgeSpec::new(
+            "The answer states that Reykjavik is the capital of Iceland, in roughly one \
+             sentence. Extra trivia is fine; a wrong city, a refusal, or a wall of text is not.",
+            0.7,
+        )),
+        ModelCase::new(
+            "model-keeps-multi-turn-context",
+            "A fact from the first turn is still available three turns later",
+        )
+        .with_harness(bounded_harness())
+        .ask("My deployment is codenamed Vireo. Just acknowledge that briefly.")
+        .ask("I also run a nightly backup at 02:30. Acknowledge briefly.")
+        .ask("What is my deployment codenamed?")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::FinalContainsAny(s(&["vireo"]))),
+        ModelCase::new(
+            "model-admits-ignorance",
+            "The agent declines to invent facts it cannot have",
+        )
+        .with_harness(bounded_harness())
+        .ask(
+            "What was the exact closing share price of the company Vantablack Logistics \
+             on 14 March 2031?",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::FinalNonEmpty)
+        .judged(JudgeSpec::new(
+            "The answer makes clear it cannot know this — the date is in the future, or the \
+             company is unknown to it, or it has no market data. Any answer that states or \
+             estimates a specific share price scores 0.",
+            0.7,
+        )),
+        ModelCase::new(
+            "model-honours-a-tight-output-format",
+            "A strict output-format instruction is followed exactly",
+        )
+        .with_harness(bounded_harness())
+        .ask(
+            "Reply with exactly three words separated by single commas and nothing else: \
+             the three primary additive colours, lowercase.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::FinalContainsAll(s(&["red", "green", "blue"])))
+        .expect(Assertion::FinalMatches(
+            r"(?i)^\s*red\s*,\s*green\s*,\s*blue\s*\.?\s*$".to_string(),
+        )),
+        // ── tools ────────────────────────────────────────────────────
+        ModelCase::new(
+            "model-calls-one-tool",
+            "The agent picks the right tool, fills its schema, and reports the result",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "weather_lookup",
+            "Get the current weather for a city. Returns temperature in Celsius and conditions.",
+            json!({ "city": { "type": "string", "description": "Name of the city" } }),
+            json!(["city"]),
+            // Odd values so a matching answer cannot be a lucky guess.
+            json!([{ "type": "ok",
+                     "value": { "city": "Reykjavik", "temperature_c": 17,
+                                "conditions": "sleet" } }]),
+        ))
+        .ask("What is the weather in Reykjavik right now? Use the tool, then tell me.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("weather_lookup".into()))
+        .expect(Assertion::ToolArgContains {
+            tool: "weather_lookup".into(),
+            pointer: "/city".into(),
+            needle: "reykjavik".into(),
+        })
+        .expect(Assertion::FinalContainsAll(s(&["17", "sleet"]))),
+        ModelCase::new(
+            "model-fills-a-multi-argument-schema",
+            "Every required field of a three-argument schema is filled correctly",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "book_room",
+            "Reserve a meeting room. All three arguments are required.",
+            json!({
+                "room": { "type": "string", "description": "Room name" },
+                "date": { "type": "string", "description": "ISO-8601 date, e.g. 2026-09-01" },
+                "start_time": { "type": "string", "description": "24-hour time, e.g. 14:00" },
+            }),
+            json!(["room", "date", "start_time"]),
+            json!([{ "type": "ok", "value": { "booked": true, "confirmation": "KRB-8842" } }]),
+        ))
+        .ask(
+            "Book the Kelvin room for 9 September 2026 starting at 15:30, then give me the \
+             confirmation code.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolArgContains {
+            tool: "book_room".into(),
+            pointer: "/room".into(),
+            needle: "kelvin".into(),
+        })
+        .expect(Assertion::ToolArgContains {
+            tool: "book_room".into(),
+            pointer: "/date".into(),
+            needle: "2026-09-09".into(),
+        })
+        .expect(Assertion::ToolArgContains {
+            tool: "book_room".into(),
+            pointer: "/start_time".into(),
+            needle: "15:30".into(),
+        })
+        .expect(Assertion::FinalContainsAny(s(&["KRB-8842"]))),
+        ModelCase::new(
+            "model-leaves-irrelevant-tools-alone",
+            "A present but irrelevant tool is not called",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "send_invoice",
+            "Email an invoice to a customer. Only use when explicitly asked to bill someone.",
+            json!({
+                "customer": { "type": "string", "description": "Customer name" },
+                "amount": { "type": "string", "description": "Amount in USD" },
+            }),
+            json!(["customer", "amount"]),
+            json!([{ "type": "ok", "value": { "sent": true } }]),
+        ))
+        .ask("How many millilitres are in a litre? Just answer.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolNotCalled("send_invoice".into()))
+        .expect(Assertion::FinalContainsNone(s(&["invoice"])))
+        .expect(Assertion::FinalContainsAny(s(&[
+            "1000",
+            "1,000",
+            "one thousand",
+        ]))),
+        ModelCase::new(
+            "model-recovers-from-a-transient-tool-error",
+            "A tool that fails once and then succeeds still produces a correct answer",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "weather_lookup",
+            "Get the current weather for a city. Returns temperature in Celsius and conditions.",
+            json!({ "city": { "type": "string", "description": "Name of the city" } }),
+            json!(["city"]),
+            json!([
+                { "type": "err", "message": "upstream weather service timed out after 30s",
+                  "kind": "transient" },
+                { "type": "ok", "value": { "city": "Reykjavik", "temperature_c": 17,
+                                           "conditions": "sleet" } }
+            ]),
+        ))
+        .ask("What is the weather in Reykjavik? Use the tool. Retry once if it errors.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCallCount {
+            tool: "weather_lookup".into(),
+            min: 2,
+            max: 5,
+        })
+        .expect(Assertion::RecoveredFrom {
+            tool: "weather_lookup".into(),
+            then_says: s(&["17", "sleet"]),
+        }),
+        ModelCase::new(
+            "model-reports-a-permanent-tool-failure",
+            "A tool that always fails is reported honestly, without fabrication or looping",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "stock_quote",
+            "Get the latest share price for a ticker symbol.",
+            json!({ "ticker": { "type": "string", "description": "Ticker symbol" } }),
+            json!(["ticker"]),
+            json!([{ "type": "err", "message": "quote provider returned 503: service unavailable",
+                     "kind": "transient" }]),
+        ))
+        .ask("What is the current share price of NVDA? Use the tool.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("stock_quote".into()))
+        .expect(Assertion::RetriesAtMost {
+            tool: "stock_quote".into(),
+            max: 8,
+        })
+        .expect(Assertion::FinalNonEmpty)
+        .judged(JudgeSpec::new(
+            "The answer says the price could not be retrieved because the tool or provider \
+             failed. It must NOT state, guess, estimate, or recall any specific share price \
+             for NVDA — doing so scores 0, however well hedged.",
+            0.7,
+        )),
+        ModelCase::new(
+            "model-distinguishes-empty-from-failed",
+            "An empty-but-successful result is reported as empty, not as an error",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "search_orders",
+            "Search customer orders. Returns a list, which may be empty.",
+            json!({ "query": { "type": "string", "description": "Search terms" } }),
+            json!(["query"]),
+            json!([{ "type": "ok", "value": { "results": [], "count": 0 } }]),
+        ))
+        .ask("Find my orders for a titanium kettle. Use the tool and tell me what you find.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("search_orders".into()))
+        .expect(Assertion::RetriesAtMost {
+            tool: "search_orders".into(),
+            max: 3,
+        })
+        .judged(JudgeSpec::new(
+            "The answer says no matching orders were found. It must not claim an error or \
+             failure occurred, and must not invent any order.",
+            0.7,
+        )),
+        ModelCase::new(
+            "model-chains-dependent-tool-calls",
+            "One tool's output becomes the next tool's input",
+        )
+        .with_harness(bounded_harness())
+        .with_tool(tool(
+            "find_order",
+            "Look up an order id from a customer name.",
+            json!({ "customer": { "type": "string", "description": "Customer full name" } }),
+            json!(["customer"]),
+            json!([{ "type": "ok", "value": { "order_id": "ORD-51993" } }]),
+        ))
+        .with_tool(tool(
+            "order_status",
+            "Get the delivery status of an order by its order id.",
+            json!({ "order_id": { "type": "string", "description": "Order id" } }),
+            json!(["order_id"]),
+            json!([{ "type": "ok", "value": { "status": "held at customs", "eta_days": 6 } }]),
+        ))
+        .ask(
+            "Find the order for Wren Okonkwo and tell me its delivery status. \
+             You will need both tools.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCallOrder(s(&["find_order", "order_status"])))
+        .expect(Assertion::ToolArgContains {
+            tool: "order_status".into(),
+            pointer: "/order_id".into(),
+            needle: "ORD-51993".into(),
+        })
+        .expect(Assertion::FinalContainsAny(s(&["customs"]))),
+        // ── compaction ───────────────────────────────────────────────
+        ModelCase::new(
+            "compaction-does-not-fire-early",
+            "A short conversation under budget is never compacted",
+        )
+        .with_harness(bounded_harness())
+        .ask("We are planning a small migration next week. Acknowledge briefly.")
+        .ask("In one sentence, what did I say I was planning?")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::Compacted(false))
+        .expect(Assertion::FinalContainsAny(s(&["migration"]))),
+        ModelCase::new(
+            "compaction-triggers-and-keeps-history",
+            "An over-budget conversation compacts, and no message is destroyed by it",
+        )
+        .slow()
+        .with_harness(tight_harness())
+        .ask("We are auditing the ingest pipeline. Acknowledge in one sentence.")
+        .ask(bulky_note(1))
+        .ask(bulky_note(2))
+        .ask(bulky_note(3))
+        .ask(bulky_note(4))
+        .ask(bulky_note(5))
+        .ask("Summarise where we are in one sentence.")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::Compacted(true))
+        .expect(Assertion::CompactionGenerationAtLeast(1))
+        .expect(Assertion::FoldedAtLeast(4))
+        // Seven user turns plus their replies: compaction must hide
+        // history, never delete it.
+        .expect(Assertion::HistoryRetainedAtLeast(12))
+        .expect(Assertion::FinalNonEmpty),
+        ModelCase::new(
+            "compaction-preserves-an-early-fact",
+            "A fact stated before the bookmark survives the fold and stays answerable",
+        )
+        .slow()
+        .with_harness(tight_harness())
+        .ask(
+            "Before we start: the staging cluster is named borealis and the incident owner \
+             is Priya Raman. Acknowledge in one sentence.",
+        )
+        .ask(bulky_note(1))
+        .ask(bulky_note(2))
+        .ask(bulky_note(3))
+        .ask(bulky_note(4))
+        .ask(bulky_note(5))
+        .ask("What is the staging cluster called, and who owns incidents for this service?")
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::Compacted(true))
+        // The summary is what the model will see from here on, so the fact
+        // has to be in there — answering correctly from a tail that happened
+        // not to be folded yet would prove nothing.
+        .expect(Assertion::SummaryContainsAny(s(&["borealis"])))
+        .expect(Assertion::FinalContainsAny(s(&["borealis"])))
+        .judged(JudgeSpec::new(
+            "The answer names the staging cluster as `borealis` AND names Priya Raman as the \
+             incident owner. Both are required; either one missing or wrong scores below 0.5.",
+            0.7,
+        )),
+        ModelCase::new(
+            "compaction-keeps-the-newest-turn-verbatim",
+            "The most recent instruction survives compaction word-for-word",
+        )
+        .slow()
+        .with_harness(tight_harness())
+        .ask("We are auditing the ingest pipeline. Acknowledge in one sentence.")
+        .ask(bulky_note(1))
+        .ask(bulky_note(2))
+        .ask(bulky_note(3))
+        .ask(bulky_note(4))
+        .ask(bulky_note(5))
+        .ask(
+            "Forget the audit for a moment. My postgres replica is called selkie-2. \
+             Repeat its name back to me exactly.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::Compacted(true))
+        .expect(Assertion::FinalContainsAny(s(&["selkie-2"]))),
+        // ── memory ───────────────────────────────────────────────────
+        // These keep the real memory tools: the whole point is whether
+        // hybrid retrieval finds the fact, so stubbing it would test
+        // nothing.
+        ModelCase::new(
+            "memory-saves-when-asked",
+            "An explicit request to remember something reaches the memory store",
+        )
+        .with_harness(bounded_harness())
+        .keeping(&["memory_save", "memory_search", "memory_get"])
+        .ask(
+            "Please remember this for later: my postgres replica is called selkie-2. \
+             Save it to memory, then confirm you have.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("memory_save".into())),
+        ModelCase::new(
+            "memory-round-trip",
+            "A fact saved in one turn is retrievable through memory in a later turn",
+        )
+        .slow()
+        .with_harness(bounded_harness())
+        .keeping(&["memory_save", "memory_search", "memory_get"])
+        .ask("Remember that my kettle is a Stagg EKG Pro. Save that to memory.")
+        .ask(
+            "Search your memory: what model is my kettle? If it is not in memory, say so — \
+             do not guess.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("memory_save".into()))
+        .expect(Assertion::ToolCalled("memory_search".into()))
+        // Asserts retrieval actually returned the fact, separately from
+        // whether the model then used it well.
+        .expect(Assertion::ToolOutputContainsAny {
+            tool: "memory_search".into(),
+            needles: s(&["stagg"]),
+        })
+        .expect(Assertion::FinalContainsAny(s(&["stagg"]))),
+        ModelCase::new(
+            "memory-does-not-fabricate-on-a-miss",
+            "A query with no matching memory produces an honest miss, not an invention",
+        )
+        .with_harness(bounded_harness())
+        .keeping(&["memory_save", "memory_search", "memory_get"])
+        .ask(
+            "Search your memory for my bicycle's serial number and tell me what it is. \
+             If it is not there, say so plainly.",
+        )
+        .expect(Assertion::NoRunError)
+        .expect(Assertion::ToolCalled("memory_search".into()))
+        .expect(Assertion::FinalNonEmpty)
+        .judged(JudgeSpec::new(
+            "The answer says no bicycle serial number is stored in memory. Any answer that \
+             supplies a serial number, or claims to have found one, scores 0.",
+            0.7,
+        )),
+    ]
+}
+
+/// Run the model suite. Returns the reports and the judge that graded.
+pub async fn run(
+    bin: &str,
+    model: &str,
+    ollama_url: &str,
+    reps: usize,
+    case_filter: Option<&str>,
+    quick: bool,
+) -> Result<(Vec<ScenarioReport>, String)> {
+    preflight(model, ollama_url).await?;
+
+    let judge = Judge::new(model, ollama_url);
+    eprintln!("model suite: {model}, judged by {}", judge.name());
+
+    let selected: Vec<ModelCase> = cases()
+        .into_iter()
+        .filter(|c| case_filter.is_none_or(|needle| c.id.contains(needle)))
+        .filter(|c| !(quick && c.slow))
+        .collect();
+
+    let mut reports = Vec::new();
+    for case in &selected {
+        let started = Instant::now();
+        let mut passes = 0;
+        let mut details: Vec<String> = Vec::new();
+
+        for _ in 0..reps {
+            let transcript =
+                match tokio::time::timeout(CASE_TIMEOUT, run_once(bin, model, ollama_url, case))
+                    .await
+                {
+                    Ok(Ok(t)) => t,
+                    Ok(Err(e)) => Transcript::failed(format!("{e:#}"), 0),
+                    Err(_) => Transcript::failed(
+                        format!("timed out after {}s", CASE_TIMEOUT.as_secs()),
+                        0,
+                    ),
+                };
+
+            let failures: Vec<String> = case
+                .assertions
+                .iter()
+                .filter_map(|a| {
+                    a.check(&transcript)
+                        .err()
+                        .map(|why| format!("{}: {why}", a.label()))
+                })
+                .collect();
+
+            // Only grade a run whose hard assertions already passed:
+            // judging an answer that failed a substring check wastes a
+            // judge call and clutters the report.
+            let verdict = match (&case.judge, failures.is_empty()) {
+                (Some(spec), true) => Some(
+                    judge
+                        .grade(&case.turns.join("\n"), spec, &transcript.final_text)
+                        .await,
+                ),
+                _ => None,
+            };
+
+            let passed = failures.is_empty() && verdict.as_ref().is_none_or(|v| v.passed);
+            if passed {
+                passes += 1;
+            }
+            for f in failures {
+                if !details.contains(&f) {
+                    details.push(f);
+                }
+            }
+            if let Some(v) = verdict.filter(|v| !v.passed) {
+                let line = format!("judge {:.2}: {}", v.score, v.reason);
+                if !details.contains(&line) {
+                    details.push(line);
+                }
+            }
+        }
+
+        let r = ScenarioReport::new(
+            case.id,
+            "model",
+            Expected::Pass,
+            reps,
+            passes,
+            details,
+            started.elapsed().as_millis() / reps as u128,
+        );
+        eprintln!("{}", r.line());
+        reports.push(r);
+    }
+
+    Ok((reports, judge.name().to_string()))
+}
+
+/// One repetition: a fresh daemon, every turn, then the persisted
+/// conversation read back.
+async fn run_once(
+    bin: &str,
+    model: &str,
+    ollama_url: &str,
+    case: &ModelCase,
+) -> Result<Transcript> {
+    let tmp = tempfile::Builder::new()
+        .prefix("rustykrab-e2e-model-")
+        .tempdir()?;
+    let data_dir = tmp.path().to_path_buf();
+    if let Some(toml) = &case.harness_toml {
+        std::fs::write(data_dir.join("harness.toml"), toml)?;
+    }
+
+    let port = pick_free_port()?;
+    let stubs = serde_json::to_string_pretty(&case.stubs)?;
+    let backend = Backend::Model {
+        model,
+        ollama_url,
+        tool_stubs: &stubs,
+    };
+    let mut child = spawn_daemon_with(bin, &data_dir, port, &backend)?;
+
+    let result = async {
+        let base = format!("http://127.0.0.1:{port}");
+        // The origin-check middleware requires an Origin header on every
+        // /api request (loopback origins are always allowed).
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::ORIGIN, base.parse()?);
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            // A local 26B model answering a compacted conversation can take
+            // minutes; the per-repetition timeout is the real bound.
+            .timeout(Duration::from_secs(900))
+            .build()?;
+        wait_for_health(&base, &client, &mut child).await?;
+
+        // Opened after the daemon is healthy — it owns the database and
+        // its migrations; this is a read handle for assertions.
+        let store = rustykrab_store::Store::open(data_dir.join("db"), hex_decode(MASTER_KEY_HEX)?)?;
+        let ctx = Ctx {
+            base,
+            client,
+            secrets: store.secrets(),
+            db_path: data_dir.join("db").join("store.db"),
+            bin: bin.to_string(),
+            data_dir: data_dir.clone(),
+        };
+
+        let started = Instant::now();
+        let conv_id = ctx.create_conversation().await?;
+        for turn in &case.turns {
+            ctx.send(&conv_id, turn).await?;
+        }
+        let conv = ctx.conversation(&conv_id).await?;
+        let mut transcript = Transcript::parse(&conv);
+        transcript.duration_ms = started.elapsed().as_millis();
+        Ok::<_, anyhow::Error>(transcript)
+    }
+    .await;
+
+    if result.is_err() {
+        eprintln!("--- daemon.log tail ---\n{}", crate::log_tail(&data_dir));
+    }
+    crate::shutdown_daemon(child).await;
+    crate::keep_or_drop(tmp);
+    result
+}
+
+/// Fail in one line if the machine cannot run the suite, rather than once
+/// per scenario twenty minutes in.
+async fn preflight(model: &str, ollama_url: &str) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()?;
+
+    let tags: Value = client
+        .get(format!("{ollama_url}/api/tags"))
+        .send()
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Ollama is not reachable at {ollama_url}: {e}\nStart it with `ollama serve`."
+            )
+        })?
+        .json()
+        .await?;
+
+    let available: Vec<String> = tags["models"]
+        .as_array()
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|m| m["name"].as_str())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if !available.iter().any(|m| m == model) {
+        anyhow::bail!(
+            "model {model} is not pulled. Available: {}\nPull it with `ollama pull {model}`.",
+            if available.is_empty() {
+                "(none)".into()
+            } else {
+                available.join(", ")
+            }
+        );
+    }
+
+    // Ollama serves one request at a time per model, so a busy client — a
+    // running RustyKrab daemon is the usual one — does not slow the suite
+    // down, it stops it. Better to say so now than to time out every case.
+    let started = Instant::now();
+    let probe = client
+        .post(format!("{ollama_url}/api/chat"))
+        .timeout(Duration::from_secs(120))
+        .json(&json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": "Reply with the single word: ready" }],
+            "stream": false,
+            "options": { "num_predict": 4, "temperature": 0 },
+        }))
+        .send()
+        .await;
+    match probe {
+        Ok(r) if r.status().is_success() => {
+            eprintln!(
+                "warm-up: {model} responded in {:.1}s",
+                started.elapsed().as_secs_f64()
+            );
+            Ok(())
+        }
+        Ok(r) => anyhow::bail!("Ollama returned HTTP {} for a trivial request", r.status()),
+        Err(e) if e.is_timeout() => anyhow::bail!(
+            "Ollama accepted the connection but produced nothing in 120s.\n\n\
+             It serves one request at a time per model, so this usually means another client \
+             holds the slot — a running RustyKrab daemon is the common culprit. Check \
+             `ollama ps` and `ps aux | grep rustykrab`, or point the suite elsewhere with \
+             --ollama-url."
+        ),
+        Err(e) => anyhow::bail!("the warm-up request failed: {e}"),
+    }
+}

--- a/crates/rustykrab-e2e/src/transcript.rs
+++ b/crates/rustykrab-e2e/src/transcript.rs
@@ -1,0 +1,259 @@
+//! What a scenario actually produced, read back out of the daemon.
+//!
+//! Everything here comes from `GET /api/conversations/{id}` — the same
+//! record the daemon persisted. That is deliberate: an in-process harness
+//! can watch tool calls through a side channel, but then it is asserting
+//! on its own bookkeeping rather than on what the system stored. Tool
+//! calls, tool results, the compaction bookmark, and the summary are all
+//! in the persisted conversation, so the assertions read the real thing.
+
+use serde_json::Value;
+
+/// One tool call, paired with the result that came back for it.
+#[derive(Debug, Clone)]
+pub struct ToolInvocation {
+    pub tool: String,
+    pub args: Value,
+    /// The tool's output, matched by call id. `None` when the run ended
+    /// before a result arrived.
+    pub output: Option<Value>,
+    pub failed: bool,
+}
+
+/// A conversation, parsed into the shape assertions need.
+#[derive(Debug, Clone, Default)]
+pub struct Transcript {
+    /// The last assistant text turn — what a user would actually read.
+    pub final_text: String,
+    /// Every assistant text turn, oldest first.
+    pub assistant_texts: Vec<String>,
+    pub calls: Vec<ToolInvocation>,
+    /// True once `compacted_through` is set.
+    pub compacted: bool,
+    pub compaction_generation: u64,
+    /// The summary standing in for the folded-away history.
+    pub summary: Option<String>,
+    /// Messages retained in history but no longer sent to the model.
+    pub folded_messages: usize,
+    /// Messages still sent verbatim.
+    pub live_messages: usize,
+    pub total_messages: usize,
+    pub duration_ms: u128,
+    /// Set when the run itself failed rather than merely scoring badly.
+    pub error: Option<String>,
+}
+
+impl Transcript {
+    /// Parse a conversation as returned by the REST API.
+    pub fn parse(conv: &Value) -> Self {
+        let empty = Vec::new();
+        let messages = conv["messages"].as_array().unwrap_or(&empty);
+
+        let mut assistant_texts = Vec::new();
+        let mut calls: Vec<ToolInvocation> = Vec::new();
+        // call id -> index into `calls`, so a result can find its call even
+        // when several tools ran in parallel and returned out of order.
+        let mut by_call_id: Vec<(String, usize)> = Vec::new();
+
+        for message in messages {
+            let role = message["role"].as_str().unwrap_or_default();
+            let kind = message["content"]["type"].as_str().unwrap_or_default();
+            let data = &message["content"]["data"];
+
+            match (role, kind) {
+                ("assistant", "text") => {
+                    if let Some(text) = data.as_str() {
+                        let text = text.trim();
+                        if !text.is_empty() {
+                            assistant_texts.push(text.to_string());
+                        }
+                    }
+                }
+                (_, "tool_call") => push_call(&mut calls, &mut by_call_id, data),
+                (_, "multi_tool_call") => {
+                    for call in data.as_array().unwrap_or(&empty) {
+                        push_call(&mut calls, &mut by_call_id, call);
+                    }
+                }
+                (_, "tool_result") => {
+                    let call_id = data["call_id"].as_str().unwrap_or_default();
+                    if let Some((_, idx)) = by_call_id.iter().find(|(id, _)| id == call_id) {
+                        let invocation = &mut calls[*idx];
+                        invocation.output = Some(data["output"].clone());
+                        // A tool can also fail by returning an `error` key
+                        // without the runner flagging it, which is how the
+                        // agent loop itself decides a call went wrong.
+                        invocation.failed = data["is_error"].as_bool().unwrap_or(false)
+                            || data["output"].get("error").is_some();
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let folded_messages = match conv["compacted_through"].as_str() {
+            Some(bookmark) => messages
+                .iter()
+                .position(|m| m["id"].as_str() == Some(bookmark))
+                .map(|i| i + 1)
+                .unwrap_or(0),
+            None => 0,
+        };
+
+        Self {
+            final_text: assistant_texts.last().cloned().unwrap_or_default(),
+            assistant_texts,
+            calls,
+            compacted: !conv["compacted_through"].is_null(),
+            compaction_generation: conv["compaction_generation"].as_u64().unwrap_or(0),
+            summary: conv["summary"].as_str().map(str::to_string),
+            folded_messages,
+            live_messages: messages.len().saturating_sub(folded_messages),
+            total_messages: messages.len(),
+            duration_ms: 0,
+            error: None,
+        }
+    }
+
+    /// A run that never got off the ground. Every assertion fails against
+    /// it, which is the honest outcome — an infrastructure failure is not
+    /// a pass.
+    pub fn failed(error: impl Into<String>, duration_ms: u128) -> Self {
+        Self {
+            error: Some(error.into()),
+            duration_ms,
+            ..Default::default()
+        }
+    }
+
+    pub fn calls_to(&self, tool: &str) -> Vec<&ToolInvocation> {
+        self.calls.iter().filter(|c| c.tool == tool).collect()
+    }
+
+    /// Every tool result for `tool`, rendered as text. Used to assert on
+    /// what a tool actually returned to the model — memory recall, most
+    /// importantly, where the question is whether retrieval found the fact
+    /// at all, separately from whether the model then used it.
+    pub fn outputs_of(&self, tool: &str) -> String {
+        self.calls_to(tool)
+            .iter()
+            .filter_map(|c| c.output.as_ref())
+            .map(|o| o.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+fn push_call(calls: &mut Vec<ToolInvocation>, by_call_id: &mut Vec<(String, usize)>, data: &Value) {
+    if let Some(id) = data["id"].as_str() {
+        by_call_id.push((id.to_string(), calls.len()));
+    }
+    calls.push(ToolInvocation {
+        tool: data["name"].as_str().unwrap_or_default().to_string(),
+        args: data["arguments"].clone(),
+        output: None,
+        failed: false,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn conv(messages: Value, extra: Value) -> Value {
+        let mut c = json!({
+            "id": "c1",
+            "messages": messages,
+            "summary": null,
+            "compacted_through": null,
+            "compaction_generation": 0,
+        });
+        for (k, v) in extra.as_object().unwrap() {
+            c[k] = v.clone();
+        }
+        c
+    }
+
+    #[test]
+    fn pairs_tool_results_with_their_calls_by_id() {
+        let t = Transcript::parse(&conv(
+            json!([
+                { "id": "m1", "role": "assistant",
+                  "content": { "type": "tool_call",
+                               "data": { "id": "call-1", "name": "weather",
+                                         "arguments": { "city": "Oslo" } } } },
+                { "id": "m2", "role": "tool",
+                  "content": { "type": "tool_result",
+                               "data": { "call_id": "call-1",
+                                         "output": { "temperature_c": 3 },
+                                         "is_error": false } } },
+                { "id": "m3", "role": "assistant",
+                  "content": { "type": "text", "data": "It is 3 degrees in Oslo." } }
+            ]),
+            json!({}),
+        ));
+
+        assert_eq!(t.calls.len(), 1);
+        assert_eq!(t.calls[0].tool, "weather");
+        assert_eq!(t.calls[0].args["city"], "Oslo");
+        assert!(!t.calls[0].failed);
+        assert!(t.outputs_of("weather").contains("temperature_c"));
+        assert_eq!(t.final_text, "It is 3 degrees in Oslo.");
+    }
+
+    #[test]
+    fn a_result_carrying_an_error_key_counts_as_a_failure() {
+        // The agent loop treats an `error` key in the output as a failed
+        // call even without is_error, so the transcript must agree — or a
+        // recovery scenario would think nothing ever went wrong.
+        let t = Transcript::parse(&conv(
+            json!([
+                { "id": "m1", "role": "assistant",
+                  "content": { "type": "tool_call",
+                               "data": { "id": "c", "name": "flaky", "arguments": {} } } },
+                { "id": "m2", "role": "tool",
+                  "content": { "type": "tool_result",
+                               "data": { "call_id": "c", "output": { "error": "boom" } } } }
+            ]),
+            json!({}),
+        ));
+        assert!(t.calls[0].failed);
+    }
+
+    #[test]
+    fn splits_parallel_tool_calls_into_separate_invocations() {
+        let t = Transcript::parse(&conv(
+            json!([
+                { "id": "m1", "role": "assistant",
+                  "content": { "type": "multi_tool_call",
+                               "data": [
+                                   { "id": "a", "name": "one", "arguments": {} },
+                                   { "id": "b", "name": "two", "arguments": {} }
+                               ] } }
+            ]),
+            json!({}),
+        ));
+        assert_eq!(t.calls.len(), 2);
+        assert_eq!(t.calls[1].tool, "two");
+    }
+
+    #[test]
+    fn reads_the_compaction_bookmark() {
+        let t = Transcript::parse(&conv(
+            json!([
+                { "id": "m1", "role": "user", "content": { "type": "text", "data": "old" } },
+                { "id": "m2", "role": "assistant", "content": { "type": "text", "data": "older" } },
+                { "id": "m3", "role": "user", "content": { "type": "text", "data": "new" } }
+            ]),
+            json!({ "compacted_through": "m2", "summary": "earlier chat",
+                    "compaction_generation": 2 }),
+        ));
+        assert!(t.compacted);
+        assert_eq!(t.folded_messages, 2);
+        assert_eq!(t.live_messages, 1);
+        assert_eq!(t.compaction_generation, 2);
+        // History is hidden, never destroyed.
+        assert_eq!(t.total_messages, 3);
+    }
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,16 +7,26 @@
 # scripted agent. Prints a JSON report; exit code 0 means green
 # (implemented scenarios pass, Phase 2 target scenarios are xfail).
 #
-# Usage: scripts/e2e.sh [--release]
+# Usage:
+#   scripts/e2e.sh                      # scripted plumbing suite (fast, CI)
+#   scripts/e2e.sh --mode model         # gemma4 behaviour suite (slow)
+#   scripts/e2e.sh --mode all --release
+#
+# Any flag other than --release is passed through to the runner.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 PROFILE=debug
 CARGO_FLAGS=()
-if [[ "${1:-}" == "--release" ]]; then
-  PROFILE=release
-  CARGO_FLAGS+=(--release)
-fi
+RUNNER_ARGS=()
+for arg in "$@"; do
+  if [[ "$arg" == "--release" ]]; then
+    PROFILE=release
+    CARGO_FLAGS+=(--release)
+  else
+    RUNNER_ARGS+=("$arg")
+  fi
+done
 
 echo "building daemon (--no-default-features)..." >&2
 cargo build -p rustykrab-cli --no-default-features "${CARGO_FLAGS[@]+"${CARGO_FLAGS[@]}"}"
@@ -27,6 +37,6 @@ cargo build -p rustykrab-e2e "${CARGO_FLAGS[@]+"${CARGO_FLAGS[@]}"}"
 # artifact); the exit code is the runner's.
 set +e
 RUSTYKRAB_BIN="target/$PROFILE/rustykrab-cli" "target/$PROFILE/rustykrab-e2e" \
-  | tee e2e-report.json
+  "${RUNNER_ARGS[@]+"${RUNNER_ARGS[@]}"}" | tee e2e-report.json
 status=${PIPESTATUS[0]}
 exit "$status"


### PR DESCRIPTION
Second of two. Stacked on #522 — review that first; this diff is against it.

### Why

The scripted suite answers *"does the server still do what it says"*. It
cannot answer *"how does the framework behave with a model in the loop"*,
and `scripted.rs` says so itself about the hardest case:

> **Known limitation:** because the step index is derived from the
> transcript rather than held as state, anything that *rewrites* history
> desynchronises the replay — notably compaction.

So compaction, the retry paths, and memory recall are exactly the things
the existing harness structurally cannot reach.

### What

A second mode alongside the first. Same daemon, same boot path, but
`RUSTYKRAB_PROVIDER=ollama` with the tool registry replaced by the stubs
from #522. **18 scenarios** over four areas:

| area | what it pins down |
|---|---|
| basics | single-turn answer, multi-turn state, strict output format, declining to invent facts |
| tools | right tool chosen, three-argument schema filled, irrelevant tool left alone, chained calls, recovery from a transient error, honest reporting of a permanent one, empty-vs-failed |
| compaction | does not fire early, fires when over budget, history retained not destroyed, an early fact survives into the summary, the newest turn stays verbatim |
| memory | saves when asked, round-trips through retrieval, does not fabricate on a miss |

### Three things worth review attention

**Assertions read what the daemon persisted.** Everything comes from
`GET /api/conversations/{id}` — tool calls, arguments, *results*, the
compaction bookmark, the summary. A scenario asserts on the stored record
rather than on harness bookkeeping. That is what makes
`ToolOutputContainsAny` possible: a memory scenario checks that retrieval
returned the fact, separately from whether the model then used it well.

**Compaction without an hour of inference.** The compaction scenarios write
`harness.toml` into the throwaway data dir with `max_context_tokens =
6000` — the daemon's own config path, the same `maybe_compact` code, a
handful of turns instead of hundreds. Facts that must survive are stated in
the first turn so they land in the folded region; a fact sitting in the
verbatim tail proves nothing about the summary.

**Results are a pass rate, not a verdict.** With a sampled 26B model
"passed once" and "passed every time" both mislead. A model scenario passes
on a **majority** of repetitions and is flagged `~flaky` when it splits.
Scripted scenarios still must pass **every** run — determinism is their
whole point. The report keeps the modes separate and names the judge,
because a locally-judged run and a Claude-judged one are not comparable.

### Judging

`claude-sonnet-5` grades the free-form rubrics when `ANTHROPIC_API_KEY` is
set, the model under test grades itself otherwise, and the report says
which. The judge only runs on repetitions whose hard assertions already
passed — grading an answer that already failed a substring check wastes a
call and clutters the report.

### Verification status — please read

- **The 17 existing scripted scenarios still pass, verified** (`fail: 0,
  pass: 17, ok: true`). No regression.
- 13 unit tests over transcript parsing, the assertion vocabulary, and
  judge-output parsing. `fmt` and `clippy --all-targets` clean.
- **The 18 model scenarios have not been executed end-to-end.** The machine
  had a long-running eval holding Ollama's single inference slot for the
  duration of this work. They compile and their assertions are unit-tested,
  but I am not claiming they pass. That is why this is a draft.

### Also here

- `spawn_daemon` gains a `Backend` parameter (scripted vs model) rather
  than hardcoding the scripted provider.
- `RUSTYKRAB_MODEL_CACHE_DIR` so throwaway daemons share one embedding-model
  download instead of re-fetching hundreds of megabytes per boot.
- `scripts/e2e.sh` passes flags through; `make e2e` / `eval` / `eval-quick`
  / `eval-list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)