### PR TITLE
feat(providers): OpenAI-compatible model provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2757,7 +2757,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4009,7 +4009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4068,7 +4068,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-imap",
  "async-trait",
@@ -4693,7 +4693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4887,7 +4887,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5386,7 +5386,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5907,7 +5907,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ export RUSTYKRAB_PROVIDER=ollama
 cargo run --release -p rustykrab-cli
 ```
 
+### Option C: Run against any OpenAI-compatible server
+
+Works with `llama-server` (llama.cpp), mistral.rs, vllm-mlx, `mlx_lm.server`,
+LM Studio's headless daemon, exo, and OpenAI-compatible hosted APIs.
+
+```bash
+llama-server -m model.gguf --jinja --cache-reuse 256 -np 1 -c 32768 --port 8080
+
+export RUSTYKRAB_PROVIDER=llama-server
+export OPENAI_BASE_URL=http://localhost:8080
+export OPENAI_MODEL=my-model
+cargo run --release -p rustykrab-cli
+```
+
+Size the context deliberately: the system prompt plus the built-in tool
+schemas is roughly 8k tokens before any conversation, and `-np N` divides the
+context between N slots. `--jinja` is required for tool calling.
+
+Point `OPENAI_BASE_URL` at another machine on the LAN or tailnet to run
+inference on separate hardware.
+
 #### Tuning the Ollama server for KV-cache reuse
 
 An agent loop re-sends the whole conversation on every iteration, so almost
@@ -159,7 +180,7 @@ All configuration is via environment variables. No plaintext config files.
 
 | Variable | Default | Description |
 |---|---|---|
-| `RUSTYKRAB_PROVIDER` | `anthropic` | Model backend: `anthropic` or `ollama` |
+| `RUSTYKRAB_PROVIDER` | `anthropic` | Model backend: `anthropic`, `ollama`, `scripted` (E2E harness), or an OpenAI-compatible alias (`openai`, `llama-server`, `llamacpp`, `mistralrs`, `lmstudio`, `mlx`, `exo`, `vllm`) |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use. The Claude 4.X family (Opus 4.7 `claude-opus-4-7`, Sonnet 4.6 `claude-sonnet-4-6`, Haiku 4.5 `claude-haiku-4-5-20251001`) is recommended for new deployments |
 | `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
@@ -174,6 +195,12 @@ All configuration is via environment variables. No plaintext config files.
 | `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say). Ollama returns a 400 for `think` against models that don't support it |
 | `OLLAMA_VISION` | `auto` | Whether the model accepts image input: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say) |
 | `OLLAMA_TIMEOUT_SECS` | `900` | HTTP request timeout for Ollama in seconds |
+| `OPENAI_MODEL` | `local-model` | Model name sent to the OpenAI-compatible server |
+| `OPENAI_BASE_URL` | `http://localhost:8080` | OpenAI-compatible server address (with or without a `/v1` suffix) |
+| `OPENAI_API_KEY` | — | Bearer token; optional, ignored by most local servers |
+| `OPENAI_TEMPERATURE` | `0.1` | Sampling temperature |
+| `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
+| `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `RUSTYKRAB_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |
@@ -182,7 +209,7 @@ All configuration is via environment variables. No plaintext config files.
 | `TELEGRAM_WEBHOOK_URL` | — | Public webhook URL (omit for long-polling mode) |
 | `TELEGRAM_WEBHOOK_SECRET` | — | Secret token for webhook validation |
 | `SIGNAL_ACCOUNT` | — | Your Signal phone number (E.164, e.g. `+1234567890`) |
-| `SIGNAL_CLI_URL` | `http://localhost:8080` | signal-cli-rest-api URL |
+| `SIGNAL_CLI_URL` | `http://localhost:8080` | signal-cli-rest-api URL (shares its default port with `OPENAI_BASE_URL` — change one if running both) |
 | `SIGNAL_ALLOWED_NUMBERS` | — | Comma-separated E.164 numbers allowed to message |
 | `SIGNAL_WEBHOOK_URL` | — | Webhook URL (omit for polling mode) |
 | `SIGNAL_WEBHOOK_SECRET` | — | Shared secret for webhook validation |

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -571,6 +571,40 @@ async fn main() -> anyhow::Result<()> {
             );
             Arc::new(p)
         }
+        // Any server exposing an OpenAI-compatible /v1/chat/completions API:
+        // llama-server, mistral.rs, vllm-mlx, mlx_lm.server, LM Studio's
+        // headless daemon, exo, or a hosted OpenAI-compatible endpoint. The
+        // aliases exist so logs and error messages name the actual backend;
+        // they behave identically otherwise.
+        "openai" | "openai-compat" | "llama-server" | "llamacpp" | "mistralrs" | "lmstudio"
+        | "mlx" | "exo" | "vllm" => {
+            let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "local-model".to_string());
+            let base_url = std::env::var("OPENAI_BASE_URL")
+                .unwrap_or_else(|_| "http://localhost:8080".to_string());
+
+            let mut config = rustykrab_providers::OpenAiConfig::default();
+            if let Some(t) = env_parse::<f32>("OPENAI_TEMPERATURE") {
+                config.temperature = t;
+            }
+            if let Some(m) = env_parse::<u32>("OPENAI_MAX_TOKENS") {
+                config.max_tokens = m;
+            }
+            // Escape hatch for servers that reject `stream_options`.
+            if let Ok(v) = std::env::var("OPENAI_INCLUDE_USAGE") {
+                config.include_usage = !matches!(v.trim(), "0" | "false" | "no");
+            }
+
+            tracing::info!(%model, %base_url, provider = %provider_name, "using OpenAI-compatible provider");
+            let mut p = rustykrab_providers::OpenAiProvider::new(model)
+                .with_base_url(base_url)
+                .with_provider_name(provider_name.clone())
+                .with_config(config);
+            // Optional — most local servers ignore it.
+            if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+                p = p.with_api_key(key);
+            }
+            Arc::new(p)
+        }
         _ => {
             let api_key = resolve_api_key(&store).await;
             let model = std::env::var("ANTHROPIC_MODEL")
@@ -2530,6 +2564,18 @@ async fn handle_pair_subcommand(data_dir: &std::path::Path) -> anyhow::Result<()
         );
     }
     Ok(())
+}
+
+/// Parse an optional env var, warning (rather than failing) on garbage.
+fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
+    let raw = std::env::var(key).ok()?;
+    match raw.trim().parse::<T>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(%key, value = %raw, "ignoring unparseable env var");
+            None
+        }
+    }
 }
 
 async fn resolve_auth_token(store: &rustykrab_store::Store) -> String {

--- a/crates/rustykrab-providers/src/lib.rs
+++ b/crates/rustykrab-providers/src/lib.rs
@@ -2,8 +2,10 @@ mod anthropic;
 mod backoff;
 mod line_buffer;
 mod ollama;
+mod openai;
 mod scripted;
 
 pub use anthropic::AnthropicProvider;
 pub use ollama::{OllamaConfig, OllamaProvider};
+pub use openai::{OpenAiConfig, OpenAiProvider};
 pub use scripted::{Scenario, Script, ScriptStep, ScriptToolCall, ScriptedProvider};

--- a/crates/rustykrab-providers/src/openai.rs
+++ b/crates/rustykrab-providers/src/openai.rs
@@ -1,0 +1,1195 @@
+use crate::backoff::retry_delay;
+use crate::line_buffer::LineBuffer;
+use async_trait::async_trait;
+use chrono::Utc;
+use rustykrab_core::error::Result;
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
+use rustykrab_core::types::{ContentBlock, Message, MessageContent, Role, ToolCall, ToolSchema};
+use rustykrab_core::Error;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Maximum number of retries for transient errors (429, 5xx).
+const MAX_RETRIES: u32 = 3;
+/// Base delay for exponential backoff (doubles each retry).
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+
+/// Configuration for OpenAI-compatible inference.
+#[derive(Debug, Clone)]
+pub struct OpenAiConfig {
+    /// Temperature for sampling (0.0 = deterministic, 0.7 = creative).
+    pub temperature: f32,
+    /// Top-p nucleus sampling threshold.
+    pub top_p: f32,
+    /// Maximum tokens to generate in the response.
+    pub max_tokens: u32,
+    /// Request token usage in the final stream chunk via `stream_options`.
+    /// Supported by llama-server, mistral.rs, LM Studio and OpenAI itself;
+    /// disable for servers that reject the field.
+    pub include_usage: bool,
+}
+
+impl Default for OpenAiConfig {
+    fn default() -> Self {
+        Self {
+            temperature: 0.1,
+            top_p: 0.9,
+            max_tokens: 8192,
+            include_usage: true,
+        }
+    }
+}
+
+impl OpenAiConfig {
+    /// Configuration optimized for tool-calling tasks (low temperature).
+    pub fn tool_calling() -> Self {
+        Self {
+            temperature: 0.0,
+            top_p: 0.9,
+            max_tokens: 4096,
+            include_usage: true,
+        }
+    }
+
+    /// Configuration for creative drafting (higher temperature).
+    pub fn creative() -> Self {
+        Self {
+            temperature: 0.7,
+            top_p: 0.95,
+            max_tokens: 16384,
+            include_usage: true,
+        }
+    }
+}
+
+/// Provider for any server exposing an OpenAI-compatible `/v1/chat/completions`
+/// endpoint.
+///
+/// This covers the local Apple Silicon serving stacks worth using in place of
+/// Ollama — `llama-server` (llama.cpp), mistral.rs, vllm-mlx, `mlx_lm.server`,
+/// LM Studio's headless daemon and exo — as well as OpenAI-compatible hosted
+/// APIs. Point [`with_base_url`](Self::with_base_url) at the server and the
+/// rest of the agent is unchanged.
+pub struct OpenAiProvider {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+    api_key: Option<String>,
+    provider_name: String,
+    config: OpenAiConfig,
+    /// Whether the target server accepts image content parts. Unlike Ollama
+    /// (which can probe `/api/show` for a model's capabilities), an arbitrary
+    /// OpenAI-compatible server gives no reliable way to detect this, so it
+    /// defaults to `false` — matching `ModelProvider::supports_vision`'s
+    /// default — and callers opt in explicitly via `with_vision`.
+    vision: bool,
+}
+
+impl OpenAiProvider {
+    pub fn new(model: impl Into<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(300))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            client,
+            // llama-server's default listen port.
+            base_url: "http://localhost:8080".to_string(),
+            model: model.into(),
+            api_key: None,
+            provider_name: "openai".to_string(),
+            config: OpenAiConfig::default(),
+            vision: false,
+        }
+    }
+
+    /// Opt in to sending image content to this server. See the `vision`
+    /// field doc for why this can't be auto-detected.
+    pub fn with_vision(mut self, vision: bool) -> Self {
+        self.vision = vision;
+        self
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    /// Bearer token. Optional — most local servers ignore it entirely.
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        let key = api_key.into();
+        self.api_key = if key.is_empty() { None } else { Some(key) };
+        self
+    }
+
+    /// Override the name reported by [`ModelProvider::name`] so logs identify
+    /// the actual backend (e.g. "llama-server", "mistralrs").
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
+    }
+
+    pub fn with_config(mut self, config: OpenAiConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.config.temperature = temperature;
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.config.max_tokens = max_tokens;
+        self
+    }
+
+    /// Get the model name.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Build the chat-completions URL, tolerating a base URL given either with
+    /// or without the `/v1` suffix — both spellings are common in the wild.
+    fn chat_url(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        if base.ends_with("/v1") {
+            format!("{base}/chat/completions")
+        } else {
+            format!("{base}/v1/chat/completions")
+        }
+    }
+
+    fn build_messages(messages: &[Message], supports_vision: bool) -> Result<Vec<OpenAiMessage>> {
+        let mut out = Vec::with_capacity(messages.len());
+        for msg in messages {
+            let role = match msg.role {
+                Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::Tool => "tool",
+            };
+
+            match &msg.content {
+                MessageContent::Text(text) => out.push(OpenAiMessage {
+                    role: role.to_string(),
+                    content: Some(OpenAiContent::Text(text.clone())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                }),
+                // Tool calls are always an assistant turn regardless of how
+                // the message was tagged.
+                MessageContent::ToolCall(call) => out.push(OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(vec![Self::wire_tool_call(call)?]),
+                    tool_call_id: None,
+                }),
+                MessageContent::MultiToolCall(calls) => out.push(OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(
+                        calls
+                            .iter()
+                            .map(Self::wire_tool_call)
+                            .collect::<Result<Vec<_>>>()?,
+                    ),
+                    tool_call_id: None,
+                }),
+                // Unlike Ollama's native API, OpenAI requires tool results
+                // to reference the originating call by id.
+                MessageContent::ToolResult(result) => {
+                    let content = match &result.output {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => serde_json::to_string(other).map_err(Error::Serialization)?,
+                    };
+                    out.push(OpenAiMessage {
+                        role: "tool".to_string(),
+                        content: Some(OpenAiContent::Text(content)),
+                        tool_calls: None,
+                        tool_call_id: Some(result.call_id.clone()),
+                    });
+                    // The OpenAI `tool` role's content is a plain string — no
+                    // image parts allowed there. Mirror Ollama's approach:
+                    // surface tool-produced images (e.g. screenshots) as a
+                    // follow-up user message, and only for vision-capable
+                    // targets so a non-vision server isn't handed a payload
+                    // it will reject or silently ignore.
+                    if supports_vision && !result.images.is_empty() {
+                        let parts = Self::image_parts(&result.images);
+                        if !parts.is_empty() {
+                            out.push(OpenAiMessage {
+                                role: "user".to_string(),
+                                content: Some(OpenAiContent::Parts(parts)),
+                                tool_calls: None,
+                                tool_call_id: None,
+                            });
+                        }
+                    }
+                }
+                MessageContent::MultiPart(blocks) => {
+                    if supports_vision {
+                        let mut parts = Vec::new();
+                        for b in blocks {
+                            match b {
+                                ContentBlock::Text { text } => {
+                                    parts.push(OpenAiContentPart::Text { text: text.clone() })
+                                }
+                                ContentBlock::Image { media_type, data } => {
+                                    parts.push(OpenAiContentPart::ImageUrl {
+                                        image_url: OpenAiImageUrl {
+                                            url: Self::data_uri(media_type, data),
+                                        },
+                                    })
+                                }
+                                // Nothing else belongs in an input message.
+                                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => {}
+                            }
+                        }
+                        out.push(OpenAiMessage {
+                            role: role.to_string(),
+                            content: Some(OpenAiContent::Parts(parts)),
+                            tool_calls: None,
+                            tool_call_id: None,
+                        });
+                    } else {
+                        // Non-vision target: drop image blocks, keep the text
+                        // so the turn still carries useful content instead of
+                        // silently vanishing from the conversation.
+                        let text = blocks
+                            .iter()
+                            .filter_map(|b| match b {
+                                ContentBlock::Text { text } => Some(text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        out.push(OpenAiMessage {
+                            role: role.to_string(),
+                            content: Some(OpenAiContent::Text(text)),
+                            tool_calls: None,
+                            tool_call_id: None,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn data_uri(media_type: &str, data: &[u8]) -> String {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        format!("data:{media_type};base64,{}", STANDARD.encode(data))
+    }
+
+    fn image_parts(blocks: &[ContentBlock]) -> Vec<OpenAiContentPart> {
+        blocks
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Image { media_type, data } => Some(OpenAiContentPart::ImageUrl {
+                    image_url: OpenAiImageUrl {
+                        url: Self::data_uri(media_type, data),
+                    },
+                }),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// OpenAI encodes tool-call arguments as a JSON *string*, not an object.
+    fn wire_tool_call(call: &ToolCall) -> Result<OpenAiToolCall> {
+        Ok(OpenAiToolCall {
+            id: call.id.clone(),
+            r#type: "function".to_string(),
+            function: OpenAiFunctionCall {
+                name: call.name.clone(),
+                arguments: serde_json::to_string(&call.arguments).map_err(Error::Serialization)?,
+            },
+        })
+    }
+
+    fn build_tools(tools: &[ToolSchema]) -> Vec<OpenAiTool> {
+        tools
+            .iter()
+            .map(|t| OpenAiTool {
+                r#type: "function".to_string(),
+                function: OpenAiToolDef {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.parameters.clone(),
+                },
+            })
+            .collect()
+    }
+
+    /// Decode tool-call arguments. Spec-compliant servers send a JSON-encoded
+    /// string; servers that send a bare object are normalized to the same form
+    /// on deserialization. An empty string is the no-argument call it
+    /// represents.
+    fn parse_arguments_str(s: &str) -> serde_json::Value {
+        if s.trim().is_empty() {
+            return serde_json::json!({});
+        }
+        serde_json::from_str(s).unwrap_or_else(|_| serde_json::Value::String(s.to_string()))
+    }
+
+    fn map_usage(usage: Option<OpenAiUsage>) -> Usage {
+        let u = usage.unwrap_or_default();
+        Usage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            // Reported by servers with prompt-cache reuse (llama-server's
+            // `--cache-reuse`, vLLM's prefix cache) — the headline metric for
+            // agent loops that re-send a growing conversation each turn.
+            cache_read_tokens: u
+                .prompt_tokens_details
+                .map(|d| d.cached_tokens)
+                .unwrap_or(0),
+            cache_creation_tokens: 0,
+        }
+    }
+
+    /// Assemble the final response from collected tool calls or text.
+    fn finish(
+        tool_calls: Vec<ToolCall>,
+        text: Option<String>,
+        finish_reason: Option<&str>,
+        usage: Usage,
+    ) -> ModelResponse {
+        if !tool_calls.is_empty() {
+            let content = if tool_calls.len() == 1 {
+                MessageContent::ToolCall(tool_calls.into_iter().next().unwrap())
+            } else {
+                MessageContent::MultiToolCall(tool_calls)
+            };
+            return ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content,
+                    created_at: Utc::now(),
+                    // Stamped by the caller that persists the message, not
+                    // known at the provider layer.
+                    agent_version: None,
+                },
+                usage,
+                stop_reason: StopReason::ToolUse,
+                // Preserve any reasoning text emitted alongside the calls.
+                text,
+            };
+        }
+
+        let stop_reason = match finish_reason {
+            Some("length") => StopReason::MaxTokens,
+            _ => StopReason::EndTurn,
+        };
+
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text.unwrap_or_default()),
+                created_at: Utc::now(),
+                agent_version: None,
+            },
+            usage,
+            stop_reason,
+            text: None,
+        }
+    }
+
+    fn parse_response(resp: OpenAiResponse) -> Result<ModelResponse> {
+        let usage = Self::map_usage(resp.usage);
+        let choice = resp.choices.into_iter().next().ok_or_else(|| {
+            Error::ModelProvider("OpenAI-compatible API returned no choices".into())
+        })?;
+
+        let msg = choice.message;
+        let text = msg.content.filter(|c| !c.is_empty());
+
+        let tool_calls: Vec<ToolCall> = msg
+            .tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(|tc| ToolCall {
+                id: if tc.id.is_empty() {
+                    Uuid::new_v4().to_string()
+                } else {
+                    tc.id
+                },
+                name: tc.function.name,
+                arguments: Self::parse_arguments_str(&tc.function.arguments),
+            })
+            .collect();
+
+        Ok(Self::finish(
+            tool_calls,
+            text,
+            choice.finish_reason.as_deref(),
+            usage,
+        ))
+    }
+
+    fn build_body(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        stream: bool,
+    ) -> Result<serde_json::Value> {
+        let api_messages = Self::build_messages(messages, self.vision)?;
+
+        if api_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call an OpenAI-compatible API with an empty message list".into(),
+            ));
+        }
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": api_messages,
+            "stream": stream,
+            "temperature": self.config.temperature,
+            "top_p": self.config.top_p,
+            "max_tokens": self.config.max_tokens,
+        });
+
+        let api_tools = Self::build_tools(tools);
+        if !api_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
+        }
+
+        if stream && self.config.include_usage {
+            body["stream_options"] = serde_json::json!({ "include_usage": true });
+        }
+
+        Ok(body)
+    }
+
+    fn request(&self, body: &serde_json::Value) -> reqwest::RequestBuilder {
+        let req = self.client.post(self.chat_url()).json(body);
+        match &self.api_key {
+            Some(key) => req.bearer_auth(key),
+            None => req,
+        }
+    }
+
+    /// Map an HTTP status code to a specific error variant.
+    fn map_status_error(&self, status: reqwest::StatusCode, body: &str) -> Error {
+        let name = &self.provider_name;
+        match status.as_u16() {
+            400 => Error::ModelBadRequest(format!("{name} API: {body}")),
+            401 | 403 => Error::ModelAuthError(format!("{name} API: {body}")),
+            429 => Error::ModelRateLimit(format!("{name} API: {body}")),
+            503 => Error::ModelOverloaded(format!("{name} API: {body}")),
+            _ => Error::ModelProvider(format!("{name} API returned {status}: {body}")),
+        }
+    }
+
+    fn connect_error(&self, e: impl std::fmt::Display) -> Error {
+        Error::ModelProvider(format!(
+            "failed to connect to {} at {}: {e}. Is the server running?",
+            self.provider_name, self.base_url
+        ))
+    }
+}
+
+#[async_trait]
+impl ModelProvider for OpenAiProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.vision
+    }
+
+    async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+        let body = self.build_body(messages, tools, false)?;
+
+        tracing::debug!(
+            model = %self.model,
+            base_url = %self.base_url,
+            "calling OpenAI-compatible chat API"
+        );
+
+        let mut last_err = None;
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
+                tracing::warn!(
+                    attempt,
+                    "retrying {} API after {delay:?}",
+                    self.provider_name
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            let resp = match self.request(&body).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(self.connect_error(e));
+                    continue;
+                }
+            };
+
+            let status = resp.status();
+            if status.is_success() {
+                let parsed: OpenAiResponse = resp.json().await.map_err(|e| {
+                    Error::ModelProvider(format!(
+                        "failed to parse {} response: {e}",
+                        self.provider_name
+                    ))
+                })?;
+                return Self::parse_response(parsed);
+            }
+
+            let error_body = resp.text().await.unwrap_or_default();
+            let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
+            last_err = Some(self.map_status_error(status, &error_body));
+
+            if !is_retryable {
+                break;
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        let body = self.build_body(messages, tools, true)?;
+
+        tracing::debug!(
+            model = %self.model,
+            base_url = %self.base_url,
+            "calling OpenAI-compatible chat API (streaming)"
+        );
+
+        let resp = self
+            .request(&body)
+            .send()
+            .await
+            .map_err(|e| self.connect_error(e))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(self.map_status_error(status, &error_body));
+        }
+
+        let mut buffer = LineBuffer::new();
+        let mut full_text = String::new();
+        let mut partials: Vec<PartialToolCall> = Vec::new();
+        let mut finish_reason: Option<String> = None;
+        let mut usage = Usage::default();
+
+        let mut response = resp;
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
+        {
+            buffer.push_chunk(&chunk);
+
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim_end();
+                let Some(data) = line.strip_prefix("data: ") else {
+                    // Blank separator lines and any `event:`/comment lines.
+                    continue;
+                };
+                let data = data.trim();
+                if data == "[DONE]" {
+                    continue;
+                }
+
+                let stream_chunk: OpenAiStreamChunk = serde_json::from_str(data).map_err(|e| {
+                    Error::ModelProvider(format!(
+                        "failed to parse {} stream chunk: {e}",
+                        self.provider_name
+                    ))
+                })?;
+
+                // The usage-only trailer chunk carries no choices.
+                if stream_chunk.usage.is_some() {
+                    usage = Self::map_usage(stream_chunk.usage);
+                }
+
+                let Some(choice) = stream_chunk.choices.into_iter().next() else {
+                    continue;
+                };
+
+                if let Some(reason) = choice.finish_reason {
+                    finish_reason = Some(reason);
+                }
+
+                if let Some(content) = choice.delta.content {
+                    if !content.is_empty() {
+                        full_text.push_str(&content);
+                        on_event(StreamEvent::TextDelta(content));
+                    }
+                }
+
+                // Tool-call arguments arrive as fragments keyed by index and
+                // must be concatenated before they parse as JSON.
+                for delta in choice.delta.tool_calls.unwrap_or_default() {
+                    let slot = Self::slot_for(&mut partials, &delta);
+                    if let Some(id) = delta.id {
+                        if !id.is_empty() {
+                            slot.id = id;
+                        }
+                    }
+                    if let Some(func) = delta.function {
+                        if let Some(name) = func.name {
+                            if !name.is_empty() {
+                                slot.name = name;
+                            }
+                        }
+                        if let Some(args) = func.arguments {
+                            slot.arguments.push_str(&args);
+                        }
+                    }
+                }
+            }
+        }
+
+        let tool_calls: Vec<ToolCall> = partials
+            .into_iter()
+            .filter(|p| !p.name.is_empty())
+            .map(|p| ToolCall {
+                id: if p.id.is_empty() {
+                    Uuid::new_v4().to_string()
+                } else {
+                    p.id
+                },
+                name: p.name,
+                arguments: Self::parse_arguments_str(&p.arguments),
+            })
+            .collect();
+
+        let text = if full_text.is_empty() {
+            None
+        } else {
+            Some(full_text)
+        };
+
+        let response = Self::finish(tool_calls, text, finish_reason.as_deref(), usage);
+
+        on_event(StreamEvent::Done(response.clone()));
+        Ok(response)
+    }
+}
+
+impl OpenAiProvider {
+    /// Resolve which accumulator a streamed tool-call delta belongs to.
+    ///
+    /// `index` is the key per the OpenAI spec. Servers that omit it all report
+    /// index 0, so a delta announcing a different call id is treated as a new
+    /// call rather than corrupting the first one.
+    fn slot_for<'a>(
+        partials: &'a mut Vec<PartialToolCall>,
+        delta: &OpenAiToolCallDelta,
+    ) -> &'a mut PartialToolCall {
+        let index = delta.index.unwrap_or(0);
+
+        if let Some(existing) = partials.get(index) {
+            let is_different_call = match (&delta.id, existing.id.is_empty()) {
+                (Some(id), false) => !id.is_empty() && id != &existing.id,
+                _ => false,
+            };
+            if is_different_call {
+                partials.push(PartialToolCall::default());
+                return partials.last_mut().unwrap();
+            }
+        }
+
+        while partials.len() <= index {
+            partials.push(PartialToolCall::default());
+        }
+        &mut partials[index]
+    }
+}
+
+/// Accumulator for a tool call assembled across streaming deltas.
+#[derive(Default)]
+struct PartialToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+// --- OpenAI API wire types (private) ---
+
+#[derive(Serialize)]
+struct OpenAiMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<OpenAiContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+/// A message's `content` field is either a plain string or an array of
+/// typed parts (text/image_url) — the OpenAI vision wire format. Untagged so
+/// a text-only message serializes exactly as before.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum OpenAiContent {
+    Text(String),
+    Parts(Vec<OpenAiContentPart>),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum OpenAiContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image_url")]
+    ImageUrl { image_url: OpenAiImageUrl },
+}
+
+#[derive(Serialize)]
+struct OpenAiImageUrl {
+    url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiToolCall {
+    #[serde(default)]
+    id: String,
+    #[serde(default, rename = "type")]
+    r#type: String,
+    function: OpenAiFunctionCall,
+}
+
+#[derive(Serialize)]
+struct OpenAiFunctionCall {
+    name: String,
+    /// Serialized as a JSON-encoded string on the wire.
+    arguments: String,
+}
+
+/// Lenient inbound form: spec says string, some servers send an object.
+impl<'de> Deserialize<'de> for OpenAiFunctionCall {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            name: String,
+            #[serde(default)]
+            arguments: serde_json::Value,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        let arguments = match raw.arguments {
+            serde_json::Value::String(s) => s,
+            serde_json::Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        Ok(OpenAiFunctionCall {
+            name: raw.name,
+            arguments,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAiTool {
+    r#type: String,
+    function: OpenAiToolDef,
+}
+
+#[derive(Serialize)]
+struct OpenAiToolDef {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    #[serde(default)]
+    choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+}
+
+#[derive(Deserialize, Default)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+    #[serde(default)]
+    prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiPromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChunk {
+    #[serde(default)]
+    choices: Vec<OpenAiStreamChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChoice {
+    #[serde(default)]
+    delta: OpenAiDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct OpenAiDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OpenAiToolCallDelta>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiToolCallDelta {
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<OpenAiFunctionDelta>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustykrab_core::types::ToolResult;
+
+    fn msg(role: Role, content: MessageContent) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role,
+            content,
+            created_at: Utc::now(),
+            agent_version: None,
+        }
+    }
+
+    fn tool_result(call_id: &str, output: serde_json::Value) -> ToolResult {
+        ToolResult {
+            call_id: call_id.to_string(),
+            output,
+            is_error: false,
+            images: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn chat_url_tolerates_both_base_url_spellings() {
+        let bare = OpenAiProvider::new("m").with_base_url("http://localhost:8080");
+        assert_eq!(bare.chat_url(), "http://localhost:8080/v1/chat/completions");
+
+        let versioned = OpenAiProvider::new("m").with_base_url("http://localhost:1234/v1");
+        assert_eq!(
+            versioned.chat_url(),
+            "http://localhost:1234/v1/chat/completions"
+        );
+
+        let trailing = OpenAiProvider::new("m").with_base_url("http://mac.tailnet:8080/");
+        assert_eq!(
+            trailing.chat_url(),
+            "http://mac.tailnet:8080/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn tool_results_carry_the_call_id() {
+        let messages = vec![
+            msg(
+                Role::Assistant,
+                MessageContent::ToolCall(ToolCall {
+                    id: "call_abc".into(),
+                    name: "read".into(),
+                    arguments: serde_json::json!({"path": "/tmp/x"}),
+                }),
+            ),
+            msg(
+                Role::Tool,
+                MessageContent::ToolResult(tool_result(
+                    "call_abc",
+                    serde_json::Value::String("contents".into()),
+                )),
+            ),
+        ];
+
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+
+        assert_eq!(built[0].role, "assistant");
+        let calls = built[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls[0].id, "call_abc");
+        // Arguments must be a JSON-encoded string, not an object.
+        assert_eq!(calls[0].function.arguments, r#"{"path":"/tmp/x"}"#);
+
+        assert_eq!(built[1].role, "tool");
+        assert_eq!(built[1].tool_call_id.as_deref(), Some("call_abc"));
+        assert!(matches!(&built[1].content, Some(OpenAiContent::Text(t)) if t == "contents"));
+    }
+
+    #[test]
+    fn multipart_becomes_text_and_image_parts_when_vision_enabled() {
+        let messages = vec![msg(
+            Role::User,
+            MessageContent::MultiPart(vec![
+                ContentBlock::Text {
+                    text: "what is this?".into(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".into(),
+                    data: vec![1, 2, 3],
+                },
+            ]),
+        )];
+
+        let built = OpenAiProvider::build_messages(&messages, true).unwrap();
+        assert_eq!(built.len(), 1);
+        let Some(OpenAiContent::Parts(parts)) = &built[0].content else {
+            panic!(
+                "expected multi-part content, got {:?}",
+                built[0].content.is_some()
+            );
+        };
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(&parts[0], OpenAiContentPart::Text { text } if text == "what is this?"));
+        assert!(matches!(
+            &parts[1],
+            OpenAiContentPart::ImageUrl { image_url }
+                if image_url.url.starts_with("data:image/png;base64,")
+        ));
+    }
+
+    #[test]
+    fn multipart_drops_images_but_keeps_text_when_vision_disabled() {
+        let messages = vec![msg(
+            Role::User,
+            MessageContent::MultiPart(vec![
+                ContentBlock::Text {
+                    text: "see attached".into(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".into(),
+                    data: vec![1, 2, 3],
+                },
+            ]),
+        )];
+
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+        assert_eq!(built.len(), 1);
+        assert!(
+            matches!(&built[0].content, Some(OpenAiContent::Text(t)) if t == "see attached"),
+            "non-vision target should keep the text rather than drop the whole message"
+        );
+    }
+
+    #[test]
+    fn tool_result_images_become_a_followup_user_message_only_when_vision_enabled() {
+        let mut result = tool_result("call_1", serde_json::json!("done"));
+        result.images.push(ContentBlock::Image {
+            media_type: "image/png".into(),
+            data: vec![9, 9, 9],
+        });
+        let messages = vec![msg(Role::Tool, MessageContent::ToolResult(result.clone()))];
+
+        // Non-vision: only the text tool-result message, image silently dropped
+        // rather than sent to a server that can't use it.
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+        assert_eq!(built.len(), 1);
+        assert_eq!(built[0].role, "tool");
+
+        // Vision-enabled: a follow-up user message carries the image.
+        let built = OpenAiProvider::build_messages(&messages, true).unwrap();
+        assert_eq!(built.len(), 2);
+        assert_eq!(built[0].role, "tool");
+        assert_eq!(built[1].role, "user");
+        let Some(OpenAiContent::Parts(parts)) = &built[1].content else {
+            panic!("expected image parts in the follow-up message");
+        };
+        assert_eq!(parts.len(), 1);
+    }
+
+    #[test]
+    fn empty_message_list_is_rejected() {
+        let provider = OpenAiProvider::new("m");
+        assert!(provider.build_body(&[], &[], false).is_err());
+    }
+
+    #[test]
+    fn parse_arguments_accepts_string_object_and_empty() {
+        // Spec-compliant: JSON-encoded string.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(r#"{"a":1}"#),
+            serde_json::json!({"a": 1})
+        );
+        // Lenient: a bare object from a non-compliant server is normalized to
+        // the string form during deserialization, then parses back cleanly.
+        let func: OpenAiFunctionCall =
+            serde_json::from_value(serde_json::json!({"name": "t", "arguments": {"a": 1}}))
+                .unwrap();
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(&func.arguments),
+            serde_json::json!({"a": 1})
+        );
+        // Zero-argument calls commonly stream as an empty string.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(""),
+            serde_json::json!({})
+        );
+        // Unparseable input is preserved rather than dropped.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str("not json"),
+            serde_json::Value::String("not json".into())
+        );
+    }
+
+    #[test]
+    fn parses_tool_calls_and_preserves_accompanying_text() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me check that.",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read", "arguments": "{\"path\":\"/tmp/x\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 8,
+                "prompt_tokens_details": {"cached_tokens": 100}
+            }
+        });
+
+        let resp = OpenAiProvider::parse_response(serde_json::from_value(body).unwrap()).unwrap();
+
+        assert_eq!(resp.stop_reason, StopReason::ToolUse);
+        assert_eq!(resp.text.as_deref(), Some("Let me check that."));
+        let calls = resp.message.content.tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read");
+        assert_eq!(calls[0].arguments, serde_json::json!({"path": "/tmp/x"}));
+        // Prompt-cache hits are surfaced for agent-loop cache tuning.
+        assert_eq!(resp.usage.cache_read_tokens, 100);
+        assert_eq!(resp.usage.prompt_tokens, 120);
+    }
+
+    #[test]
+    fn truncated_response_maps_to_max_tokens() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {"content": "partial"},
+                "finish_reason": "length"
+            }]
+        });
+        let resp = OpenAiProvider::parse_response(serde_json::from_value(body).unwrap()).unwrap();
+        assert_eq!(resp.stop_reason, StopReason::MaxTokens);
+        assert_eq!(resp.message.content.as_text(), Some("partial"));
+    }
+
+    #[test]
+    fn streaming_deltas_accumulate_by_index() {
+        let mut partials: Vec<PartialToolCall> = Vec::new();
+
+        let deltas = vec![
+            serde_json::json!({"index": 0, "id": "call_1", "function": {"name": "read", "arguments": "{\"pa"}}),
+            serde_json::json!({"index": 0, "function": {"arguments": "th\":\"/tmp/x\"}"}}),
+            serde_json::json!({"index": 1, "id": "call_2", "function": {"name": "write", "arguments": "{}"}}),
+        ];
+
+        for d in deltas {
+            let delta: OpenAiToolCallDelta = serde_json::from_value(d).unwrap();
+            let slot = OpenAiProvider::slot_for(&mut partials, &delta);
+            if let Some(id) = delta.id {
+                if !id.is_empty() {
+                    slot.id = id;
+                }
+            }
+            if let Some(func) = delta.function {
+                if let Some(name) = func.name {
+                    if !name.is_empty() {
+                        slot.name = name;
+                    }
+                }
+                if let Some(args) = func.arguments {
+                    slot.arguments.push_str(&args);
+                }
+            }
+        }
+
+        assert_eq!(partials.len(), 2);
+        assert_eq!(partials[0].name, "read");
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(&partials[0].arguments),
+            serde_json::json!({"path": "/tmp/x"})
+        );
+        assert_eq!(partials[1].id, "call_2");
+        assert_eq!(partials[1].name, "write");
+    }
+
+    #[test]
+    fn stream_options_only_sent_when_streaming_and_enabled() {
+        let messages = vec![msg(Role::User, MessageContent::Text("hi".into()))];
+
+        let provider = OpenAiProvider::new("m");
+        let streaming = provider.build_body(&messages, &[], true).unwrap();
+        assert_eq!(streaming["stream_options"]["include_usage"], true);
+
+        let blocking = provider.build_body(&messages, &[], false).unwrap();
+        assert!(blocking.get("stream_options").is_none());
+
+        let opted_out = OpenAiProvider::new("m").with_config(OpenAiConfig {
+            include_usage: false,
+            ..Default::default()
+        });
+        let body = opted_out.build_body(&messages, &[], true).unwrap();
+        assert!(body.get("stream_options").is_none());
+    }
+}

--- a/crates/rustykrab-providers/tests/openai_live.rs
+++ b/crates/rustykrab-providers/tests/openai_live.rs
@@ -1,0 +1,246 @@
+//! Live tests against a real OpenAI-compatible server.
+//!
+//! Ignored by default so CI needs no server. Run them against whatever backend
+//! you are evaluating:
+//!
+//! ```sh
+//! # Ollama's OpenAI-compatible endpoint
+//! LIVE_OPENAI_BASE_URL=http://localhost:11434/v1 LIVE_OPENAI_MODEL=qwen3:30b-a3b \
+//!   cargo test -p rustykrab-providers --test openai_live -- --ignored --nocapture
+//!
+//! # llama.cpp
+//! LIVE_OPENAI_BASE_URL=http://localhost:8080 cargo test ... -- --ignored --nocapture
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use rustykrab_core::model::{ModelProvider, StopReason, StreamEvent};
+use rustykrab_core::types::{Message, MessageContent, Role, ToolResult, ToolSchema};
+use rustykrab_providers::{OpenAiConfig, OpenAiProvider};
+use uuid::Uuid;
+
+fn provider() -> OpenAiProvider {
+    let base_url = std::env::var("LIVE_OPENAI_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:11434/v1".to_string());
+    let model = std::env::var("LIVE_OPENAI_MODEL").unwrap_or_else(|_| "qwen3:30b-a3b".to_string());
+    eprintln!("--> {base_url} model={model}");
+    OpenAiProvider::new(model)
+        .with_base_url(base_url)
+        .with_config(OpenAiConfig::tool_calling())
+}
+
+fn msg(role: Role, content: MessageContent) -> Message {
+    Message {
+        id: Uuid::new_v4(),
+        role,
+        content,
+        created_at: chrono::Utc::now(),
+        agent_version: None,
+    }
+}
+
+fn user(text: &str) -> Message {
+    msg(Role::User, MessageContent::Text(text.into()))
+}
+
+fn weather_tool() -> ToolSchema {
+    ToolSchema {
+        name: "get_weather".into(),
+        description: "Get the current weather for a city.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"}
+            },
+            "required": ["city"]
+        }),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_text_generation() {
+    let resp = provider()
+        .chat(
+            &[user("Reply with exactly the word: pong. Nothing else.")],
+            &[],
+        )
+        .await
+        .expect("chat failed");
+
+    let text = resp.message.content.as_text().unwrap_or_default();
+    eprintln!("text: {text:?}");
+    eprintln!("usage: {:?}", resp.usage);
+
+    assert!(!text.is_empty(), "model returned no text");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert!(
+        resp.usage.prompt_tokens > 0,
+        "no prompt token usage reported"
+    );
+    assert!(
+        resp.usage.completion_tokens > 0,
+        "no completion token usage reported"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_streaming_emits_incremental_deltas() {
+    let deltas = Arc::new(Mutex::new(Vec::<String>::new()));
+    let done = Arc::new(Mutex::new(0usize));
+    let (d, dn) = (deltas.clone(), done.clone());
+
+    let resp = provider()
+        .chat_stream(
+            &[user(
+                "Count from 1 to 10, separated by spaces. No other text.",
+            )],
+            &[],
+            &move |ev| match ev {
+                StreamEvent::TextDelta(t) => d.lock().unwrap().push(t),
+                StreamEvent::Done(_) => *dn.lock().unwrap() += 1,
+            },
+        )
+        .await
+        .expect("chat_stream failed");
+
+    let deltas = deltas.lock().unwrap().clone();
+    eprintln!("delta count: {}", deltas.len());
+    eprintln!("assembled: {:?}", resp.message.content.as_text());
+    eprintln!("usage: {:?}", resp.usage);
+
+    assert!(
+        deltas.len() > 1,
+        "expected incremental deltas, got {}",
+        deltas.len()
+    );
+    assert_eq!(*done.lock().unwrap(), 1, "expected exactly one Done event");
+    // The assembled text must equal the concatenated deltas.
+    assert_eq!(
+        resp.message.content.as_text().unwrap_or_default(),
+        deltas.concat()
+    );
+    assert!(
+        resp.usage.completion_tokens > 0,
+        "no usage in stream trailer"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_tool_call_is_parsed() {
+    let resp = provider()
+        .chat(
+            &[user("What is the weather in Paris? Use the tool.")],
+            &[weather_tool()],
+        )
+        .await
+        .expect("chat failed");
+
+    eprintln!("stop_reason: {:?}", resp.stop_reason);
+    eprintln!("text alongside: {:?}", resp.text);
+
+    assert_eq!(
+        resp.stop_reason,
+        StopReason::ToolUse,
+        "model did not request a tool call"
+    );
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    eprintln!("call: {} {}", calls[0].name, calls[0].arguments);
+
+    assert_eq!(calls[0].name, "get_weather");
+    assert!(!calls[0].id.is_empty(), "tool call must carry an id");
+    // Arguments must have decoded from the wire string into a real object.
+    assert!(
+        calls[0].arguments.is_object(),
+        "arguments did not decode to an object: {}",
+        calls[0].arguments
+    );
+    let city = calls[0].arguments["city"].as_str().unwrap_or_default();
+    assert!(
+        city.to_lowercase().contains("paris"),
+        "unexpected city argument: {city:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_streaming_tool_call_is_reassembled() {
+    let resp = provider()
+        .chat_stream(
+            &[user("What is the weather in Tokyo? Use the tool.")],
+            &[weather_tool()],
+            &|_| {},
+        )
+        .await
+        .expect("chat_stream failed");
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    eprintln!("streamed call: {} {}", calls[0].name, calls[0].arguments);
+
+    assert_eq!(calls[0].name, "get_weather");
+    assert!(
+        calls[0].arguments.is_object(),
+        "streamed arguments did not reassemble into an object: {}",
+        calls[0].arguments
+    );
+    let city = calls[0].arguments["city"].as_str().unwrap_or_default();
+    assert!(
+        city.to_lowercase().contains("tokyo"),
+        "unexpected city argument: {city:?}"
+    );
+}
+
+/// The full agent-loop shape: model calls a tool, we feed the result back
+/// referencing the call id, and the model answers using it. This is what
+/// breaks if `tool_call_id` correlation is wrong.
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_tool_result_round_trip() {
+    let p = provider();
+    let tools = [weather_tool()];
+
+    let mut conversation = vec![user("What is the weather in Paris? Use the tool.")];
+
+    let first = p.chat(&conversation, &tools).await.expect("turn 1 failed");
+    assert_eq!(
+        first.stop_reason,
+        StopReason::ToolUse,
+        "no tool call issued"
+    );
+    let call = first.message.content.tool_calls()[0].clone();
+    eprintln!("turn 1 -> {}({})", call.name, call.arguments);
+
+    // Echo the assistant turn back, then answer the call by id.
+    conversation.push(first.message.clone());
+    conversation.push(msg(
+        Role::Tool,
+        MessageContent::ToolResult(ToolResult {
+            call_id: call.id.clone(),
+            output: serde_json::json!({"temp_c": 3, "conditions": "freezing fog"}),
+            is_error: false,
+            images: Vec::new(),
+        }),
+    ));
+
+    let second = p.chat(&conversation, &tools).await.expect("turn 2 failed");
+    let text = second
+        .message
+        .content
+        .as_text()
+        .or(second.text.as_deref())
+        .unwrap_or_default();
+    eprintln!("turn 2 -> {text:?}");
+
+    assert!(!text.is_empty(), "model gave no final answer");
+    // The model can only know these from the tool result we supplied.
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("fog") || lower.contains("3"),
+        "final answer does not reflect the tool result: {text:?}"
+    );
+}

--- a/crates/rustykrab-providers/tests/openai_wire.rs
+++ b/crates/rustykrab-providers/tests/openai_wire.rs
@@ -1,0 +1,513 @@
+//! Wire-level tests for the OpenAI-compatible provider.
+//!
+//! These run the real provider against an in-process HTTP server so both
+//! directions are checked against actual bytes: the request we emit, and the
+//! response shapes real servers emit back (including SSE framing that splits
+//! tool-call arguments across chunks).
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rustykrab_core::model::{ModelProvider, StopReason, StreamEvent};
+use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema};
+use rustykrab_providers::OpenAiProvider;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use uuid::Uuid;
+
+/// What the mock server should send back.
+enum Reply {
+    /// A complete JSON body with Content-Length.
+    Json { status: u16, body: String },
+    /// SSE frames written incrementally and delimited by connection close,
+    /// so the provider's chunk loop sees genuinely partial reads.
+    Sse(Vec<String>),
+}
+
+/// A captured inbound request.
+#[derive(Clone)]
+struct Captured {
+    request_line: String,
+    headers: String,
+    body: serde_json::Value,
+}
+
+struct MockServer {
+    addr: SocketAddr,
+    captured: Arc<Mutex<Vec<Captured>>>,
+}
+
+impl MockServer {
+    fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    fn last(&self) -> Captured {
+        self.captured
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("mock server received no request")
+    }
+}
+
+async fn spawn_mock(reply: Reply) -> MockServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+
+    tokio::spawn(async move {
+        let reply = reply;
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                return;
+            };
+            if let Some(cap) = read_request(socket).await {
+                let (socket, cap) = cap;
+                sink.lock().unwrap().push(cap);
+                write_reply(socket, &reply).await;
+            }
+        }
+    });
+
+    MockServer { addr, captured }
+}
+
+async fn read_request(mut socket: TcpStream) -> Option<(TcpStream, Captured)> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut tmp = [0u8; 4096];
+
+    let head_end = loop {
+        let n = socket.read(&mut tmp).await.ok()?;
+        if n == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos;
+        }
+    };
+
+    let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+    let content_length = head
+        .lines()
+        .find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0);
+
+    let body_start = head_end + 4;
+    while buf.len() < body_start + content_length {
+        let n = socket.read(&mut tmp).await.ok()?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+    }
+
+    let raw_body = String::from_utf8_lossy(&buf[body_start..]).to_string();
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or_default().to_string();
+
+    Some((
+        socket,
+        Captured {
+            request_line,
+            headers: head.clone(),
+            body: serde_json::from_str(&raw_body).unwrap_or(serde_json::Value::Null),
+        },
+    ))
+}
+
+async fn write_reply(mut socket: TcpStream, reply: &Reply) {
+    match reply {
+        Reply::Json { status, body } => {
+            let head = format!(
+                "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = socket.write_all(head.as_bytes()).await;
+            let _ = socket.write_all(body.as_bytes()).await;
+        }
+        Reply::Sse(frames) => {
+            // No Content-Length: the body is delimited by connection close,
+            // which is what a streaming server does.
+            let head =
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n";
+            let _ = socket.write_all(head.as_bytes()).await;
+            for frame in frames {
+                let _ = socket.write_all(frame.as_bytes()).await;
+                let _ = socket.flush().await;
+                // Force the client to observe partial reads.
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        }
+    }
+    let _ = socket.flush().await;
+    let _ = socket.shutdown().await;
+}
+
+fn msg(role: Role, content: MessageContent) -> Message {
+    Message {
+        id: Uuid::new_v4(),
+        role,
+        content,
+        created_at: chrono::Utc::now(),
+        agent_version: None,
+    }
+}
+
+fn user(text: &str) -> Message {
+    msg(Role::User, MessageContent::Text(text.into()))
+}
+
+fn read_tool() -> ToolSchema {
+    ToolSchema {
+        name: "read".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        }),
+    }
+}
+
+// --- Request shape ---
+
+#[tokio::test]
+async fn posts_to_v1_chat_completions_with_expected_body() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2}
+        })
+        .to_string(),
+    })
+    .await;
+
+    let provider = OpenAiProvider::new("test-model").with_base_url(server.base_url());
+    let resp = provider
+        .chat(&[user("hello")], &[read_tool()])
+        .await
+        .unwrap();
+
+    assert_eq!(resp.message.content.as_text(), Some("hi"));
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert_eq!(resp.usage.prompt_tokens, 5);
+
+    let req = server.last();
+    assert_eq!(req.request_line, "POST /v1/chat/completions HTTP/1.1");
+    assert_eq!(req.body["model"], "test-model");
+    assert_eq!(req.body["stream"], false);
+    assert!(req.body.get("stream_options").is_none());
+    // Tools must be advertised in OpenAI's function-wrapper shape.
+    assert_eq!(req.body["tools"][0]["type"], "function");
+    assert_eq!(req.body["tools"][0]["function"]["name"], "read");
+    assert_eq!(
+        req.body["tools"][0]["function"]["parameters"]["properties"]["path"]["type"],
+        "string"
+    );
+}
+
+#[tokio::test]
+async fn tool_result_turn_serializes_with_tool_call_id() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({"choices": [{"message": {"content": "done"}}]}).to_string(),
+    })
+    .await;
+
+    let conversation = vec![
+        user("read /tmp/x"),
+        msg(
+            Role::Assistant,
+            MessageContent::ToolCall(ToolCall {
+                id: "call_abc".into(),
+                name: "read".into(),
+                arguments: serde_json::json!({"path": "/tmp/x"}),
+            }),
+        ),
+        msg(
+            Role::Tool,
+            MessageContent::ToolResult(ToolResult {
+                call_id: "call_abc".into(),
+                output: serde_json::Value::String("file contents".into()),
+                is_error: false,
+                images: Vec::new(),
+            }),
+        ),
+    ];
+
+    let provider = OpenAiProvider::new("m").with_base_url(server.base_url());
+    provider.chat(&conversation, &[read_tool()]).await.unwrap();
+
+    let m = &server.last().body["messages"];
+    assert_eq!(m[0]["role"], "user");
+
+    // The assistant turn carries the call with its id, arguments JSON-encoded.
+    assert_eq!(m[1]["role"], "assistant");
+    assert_eq!(m[1]["tool_calls"][0]["id"], "call_abc");
+    assert_eq!(m[1]["tool_calls"][0]["type"], "function");
+    assert_eq!(
+        m[1]["tool_calls"][0]["function"]["arguments"],
+        r#"{"path":"/tmp/x"}"#
+    );
+
+    // The result references it — required by OpenAI, absent from Ollama's API.
+    assert_eq!(m[2]["role"], "tool");
+    assert_eq!(m[2]["tool_call_id"], "call_abc");
+    assert_eq!(m[2]["content"], "file contents");
+}
+
+#[tokio::test]
+async fn api_key_is_sent_as_bearer_and_omitted_when_unset() {
+    let body = serde_json::json!({"choices": [{"message": {"content": "ok"}}]}).to_string();
+
+    let with_key = spawn_mock(Reply::Json {
+        status: 200,
+        body: body.clone(),
+    })
+    .await;
+    OpenAiProvider::new("m")
+        .with_base_url(with_key.base_url())
+        .with_api_key("sk-secret")
+        .chat(&[user("hi")], &[])
+        .await
+        .unwrap();
+    assert!(
+        with_key
+            .last()
+            .headers
+            .contains("authorization: Bearer sk-secret")
+            || with_key
+                .last()
+                .headers
+                .contains("Authorization: Bearer sk-secret")
+    );
+
+    let without = spawn_mock(Reply::Json { status: 200, body }).await;
+    OpenAiProvider::new("m")
+        .with_base_url(without.base_url())
+        .chat(&[user("hi")], &[])
+        .await
+        .unwrap();
+    assert!(!without
+        .last()
+        .headers
+        .to_lowercase()
+        .contains("authorization"));
+}
+
+// --- Response parsing ---
+
+#[tokio::test]
+async fn parses_parallel_tool_calls() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "c1", "type": "function",
+                         "function": {"name": "read", "arguments": "{\"path\":\"/a\"}"}},
+                        {"id": "c2", "type": "function",
+                         "function": {"name": "read", "arguments": "{\"path\":\"/b\"}"}}
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })
+        .to_string(),
+    })
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat(&[user("read both")], &[read_tool()])
+        .await
+        .unwrap();
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[0].arguments, serde_json::json!({"path": "/a"}));
+    assert_eq!(calls[1].arguments, serde_json::json!({"path": "/b"}));
+}
+
+#[tokio::test]
+async fn http_errors_map_to_typed_variants() {
+    for (status, expect) in [
+        (400u16, "ModelBadRequest"),
+        (401, "ModelAuthError"),
+        (403, "ModelAuthError"),
+    ] {
+        let server = spawn_mock(Reply::Json {
+            status,
+            body: serde_json::json!({"error": {"message": "nope"}}).to_string(),
+        })
+        .await;
+
+        let err = OpenAiProvider::new("m")
+            .with_base_url(server.base_url())
+            .chat(&[user("hi")], &[])
+            .await
+            .expect_err("expected an error");
+
+        let variant = format!("{err:?}");
+        assert!(
+            variant.starts_with(expect),
+            "status {status} produced {variant}, expected {expect}"
+        );
+        assert!(
+            format!("{err}").contains("nope"),
+            "error should carry the server body"
+        );
+    }
+}
+
+// --- Streaming ---
+
+#[tokio::test]
+async fn streams_text_deltas_and_emits_done() {
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo \"}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"finish_reason\":\"stop\"}]}\n\n"
+            .into(),
+        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":3,\"prompt_tokens_details\":{\"cached_tokens\":8}}}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let deltas = Arc::new(Mutex::new(Vec::new()));
+    let done = Arc::new(Mutex::new(0usize));
+    let (d, dn) = (deltas.clone(), done.clone());
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("hi")], &[], &move |ev| match ev {
+            StreamEvent::TextDelta(t) => d.lock().unwrap().push(t),
+            StreamEvent::Done(_) => *dn.lock().unwrap() += 1,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(*deltas.lock().unwrap(), vec!["Hel", "lo ", "world"]);
+    assert_eq!(*done.lock().unwrap(), 1);
+    assert_eq!(resp.message.content.as_text(), Some("Hello world"));
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    // Usage arrives in the trailer chunk after choices are exhausted.
+    assert_eq!(resp.usage.prompt_tokens, 11);
+    assert_eq!(resp.usage.cache_read_tokens, 8);
+
+    // stream_options must be requested for that trailer to exist.
+    assert_eq!(server.last().body["stream_options"]["include_usage"], true);
+    assert_eq!(server.last().body["stream"], true);
+}
+
+#[tokio::test]
+async fn reassembles_tool_call_arguments_split_across_frames() {
+    // Argument fragments are not individually valid JSON — the provider must
+    // concatenate them per index before parsing.
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"pa\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"th\\\":\\\"/tmp\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"/x.txt\\\"}\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("read it")], &[read_tool()], &|_| {})
+        .await
+        .unwrap();
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "call_1");
+    assert_eq!(calls[0].name, "read");
+    assert_eq!(
+        calls[0].arguments,
+        serde_json::json!({"path": "/tmp/x.txt"}),
+        "fragmented arguments must reassemble into the original object"
+    );
+}
+
+#[tokio::test]
+async fn streams_parallel_tool_calls_interleaved_by_index() {
+    // Real servers interleave fragments for concurrent calls.
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"c2\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"/a\\\"}\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\":\\\"/b\\\"}\"}}]}}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("read both")], &[read_tool()], &|_| {})
+        .await
+        .unwrap();
+
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[0].arguments, serde_json::json!({"path": "/a"}));
+    assert_eq!(calls[1].id, "c2");
+    assert_eq!(calls[1].arguments, serde_json::json!({"path": "/b"}));
+}
+
+#[tokio::test]
+async fn tolerates_sse_comments_and_frames_split_mid_line() {
+    // A frame deliberately split so the provider must buffer across reads.
+    let server = spawn_mock(Reply::Sse(vec![
+        ": keep-alive\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"cont".into(),
+        "ent\":\"split\"}}]}\n\n".into(),
+        "\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("hi")], &[], &|_| {})
+        .await
+        .unwrap();
+
+    assert_eq!(resp.message.content.as_text(), Some("split"));
+}
+
+#[tokio::test]
+async fn zero_argument_tool_call_yields_empty_object() {
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"now\",\"arguments\":\"\"}}]}}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("time?")], &[], &|_| {})
+        .await
+        .unwrap();
+
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].arguments, serde_json::json!({}));
+}


### PR DESCRIPTION
**Stack: 1/4** — base of a 4-PR stack (→ #pr2 bundle tooling → #pr3 node delegation → #pr4 fleet docs).

## Summary
- Adds `OpenAiProvider`, a `ModelProvider` implementing `/v1/chat/completions`, so RustyKrab can point at any OpenAI-compatible server (llama-server, mistral.rs, vllm-mlx, mlx_lm.server, LM Studio's headless daemon, exo) in addition to Anthropic and Ollama.
- Handles what Ollama's native API doesn't need but OpenAI requires: `tool_call_id` correlation on tool results, and reassembling streamed tool-call arguments sent as fragments keyed by index.
- Reuses the crate's existing `LineBuffer` (correct multi-byte UTF-8 handling across chunk boundaries) and jittered `retry_delay` rather than hand-rolling either — the first draft of this code predated both utilities and had the exact bug `LineBuffer`'s doc comment describes.
- Selected via `RUSTYKRAB_PROVIDER` (`openai`, `llama-server`, `llamacpp`, `mistralrs`, `lmstudio`, `mlx`, `exo`, `vllm` — aliases only affect logging) and configured via `OPENAI_BASE_URL` / `OPENAI_MODEL` / `OPENAI_API_KEY` / `OPENAI_TEMPERATURE` / `OPENAI_MAX_TOKENS` / `OPENAI_INCLUDE_USAGE`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo test -p rustykrab-providers -p rustykrab-cli` — 110 passed
- [x] Live-verified against Ollama's `/v1` endpoint and against `llama-server` directly, including a full tool-call round trip (model calls a tool, result fed back by `tool_call_id`, model answers using it)