### PR TITLE
build: app-bundle signing for Data Protection Keychain access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ e2e-report.json
 # Eval run artefacts (the harness and its scenarios are versioned; results are not)
 /e2e-report.json
 /e2e-credential-trials.jsonl
+/e2e-ablation.json
+/e2e-ablation.md
+/sweep.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.35] - 2026-08-26
+
+- feat: default to a 128k context window, with the ablation that justifies it (#547)
+
 ## [5.1.34] - 2026-08-26
 
 - fix(ci): correct shasum paths in Package artifact step (#546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.36] - 2026-08-27
+
+- feat(providers): OpenAI-compatible model provider (#526)
+
 ## [5.1.35] - 2026-08-26
 
 - feat: default to a 128k context window, with the ablation that justifies it (#547)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2757,7 +2757,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4009,7 +4009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4068,7 +4068,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4693,7 +4693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4887,7 +4887,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5386,7 +5386,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5907,7 +5907,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.28"
+version = "5.1.34"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.1.34"
+version = "5.1.35"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.1.35"
+version = "5.1.36"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release debug codesign codesign-debug clean version e2e eval eval-quick eval-cred eval-list e2e eval eval-quick eval-list
+.PHONY: build release debug codesign codesign-debug bundle bundle-debug clean version e2e eval eval-quick eval-cred eval-list e2e eval eval-quick eval-list
 
 # Default: release build + codesign
 build: release
@@ -20,6 +20,17 @@ codesign:
 
 codesign-debug:
 	./scripts/codesign.sh
+
+# Bundle + sign into a .app. Required for Data Protection Keychain access:
+# a bare signed binary falls back to the legacy keychain and prompts on every
+# credential read. Use these for any build you intend to run.
+bundle:
+	cargo build --release -p rustykrab-cli
+	./scripts/bundle.sh --release
+
+bundle-debug:
+	cargo build -p rustykrab-cli
+	./scripts/bundle.sh --debug
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ export RUSTYKRAB_PROVIDER=ollama
 cargo run --release -p rustykrab-cli
 ```
 
+### Option C: Run against any OpenAI-compatible server
+
+Works with `llama-server` (llama.cpp), mistral.rs, vllm-mlx, `mlx_lm.server`,
+LM Studio's headless daemon, exo, and OpenAI-compatible hosted APIs.
+
+```bash
+llama-server -m model.gguf --jinja --cache-reuse 256 -np 1 -c 32768 --port 8080
+
+export RUSTYKRAB_PROVIDER=llama-server
+export OPENAI_BASE_URL=http://localhost:8080
+export OPENAI_MODEL=my-model
+cargo run --release -p rustykrab-cli
+```
+
+Size the context deliberately: the system prompt plus the built-in tool
+schemas is roughly 8k tokens before any conversation, and `-np N` divides the
+context between N slots. `--jinja` is required for tool calling.
+
+Point `OPENAI_BASE_URL` at another machine on the LAN or tailnet to run
+inference on separate hardware.
+
 #### Tuning the Ollama server for KV-cache reuse
 
 An agent loop re-sends the whole conversation on every iteration, so almost
@@ -159,7 +180,7 @@ All configuration is via environment variables. No plaintext config files.
 
 | Variable | Default | Description |
 |---|---|---|
-| `RUSTYKRAB_PROVIDER` | `anthropic` | Model backend: `anthropic` or `ollama` |
+| `RUSTYKRAB_PROVIDER` | `anthropic` | Model backend: `anthropic`, `ollama`, `scripted` (E2E harness), or an OpenAI-compatible alias (`openai`, `llama-server`, `llamacpp`, `mistralrs`, `lmstudio`, `mlx`, `exo`, `vllm`) |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (required for Claude) |
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use. The Claude 4.X family (Opus 4.7 `claude-opus-4-7`, Sonnet 4.6 `claude-sonnet-4-6`, Haiku 4.5 `claude-haiku-4-5-20251001`) is recommended for new deployments |
 | `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
@@ -174,6 +195,12 @@ All configuration is via environment variables. No plaintext config files.
 | `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say). Ollama returns a 400 for `think` against models that don't support it |
 | `OLLAMA_VISION` | `auto` | Whether the model accepts image input: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say) |
 | `OLLAMA_TIMEOUT_SECS` | `900` | HTTP request timeout for Ollama in seconds |
+| `OPENAI_MODEL` | `local-model` | Model name sent to the OpenAI-compatible server |
+| `OPENAI_BASE_URL` | `http://localhost:8080` | OpenAI-compatible server address (with or without a `/v1` suffix) |
+| `OPENAI_API_KEY` | — | Bearer token; optional, ignored by most local servers |
+| `OPENAI_TEMPERATURE` | `0.1` | Sampling temperature |
+| `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
+| `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `RUSTYKRAB_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |
@@ -182,7 +209,7 @@ All configuration is via environment variables. No plaintext config files.
 | `TELEGRAM_WEBHOOK_URL` | — | Public webhook URL (omit for long-polling mode) |
 | `TELEGRAM_WEBHOOK_SECRET` | — | Secret token for webhook validation |
 | `SIGNAL_ACCOUNT` | — | Your Signal phone number (E.164, e.g. `+1234567890`) |
-| `SIGNAL_CLI_URL` | `http://localhost:8080` | signal-cli-rest-api URL |
+| `SIGNAL_CLI_URL` | `http://localhost:8080` | signal-cli-rest-api URL (shares its default port with `OPENAI_BASE_URL` — change one if running both) |
 | `SIGNAL_ALLOWED_NUMBERS` | — | Comma-separated E.164 numbers allowed to message |
 | `SIGNAL_WEBHOOK_URL` | — | Webhook URL (omit for polling mode) |
 | `SIGNAL_WEBHOOK_SECRET` | — | Shared secret for webhook validation |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ much:
 
 ```bash
 # Must be >= RUSTYKRAB_NUM_CTX, or the server silently truncates prompts.
-export OLLAMA_CONTEXT_LENGTH=65536
+export OLLAMA_CONTEXT_LENGTH=131072
 
 # One slot keeps a single conversation pinned to a single warm cache.
 # Raising this splits KV memory across slots and round-robins requests, so
@@ -164,11 +164,11 @@ All configuration is via environment variables. No plaintext config files.
 | `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | Claude model to use. The Claude 4.X family (Opus 4.7 `claude-opus-4-7`, Sonnet 4.6 `claude-sonnet-4-6`, Haiku 4.5 `claude-haiku-4-5-20251001`) is recommended for new deployments |
 | `ANTHROPIC_CONTEXT_LENGTH` | `200000` | Context window in tokens for the selected Claude model. Anthropic doesn't expose a discovery endpoint, so set this when enabling a non-default window (e.g. the 1M-token beta) so compaction thresholds stay in sync |
 | `RUSTYKRAB_MAX_CONTEXT_TOKENS` | `128000` (cloud) / `32000` (ollama) | Context budget used to compute the compaction threshold. Default is provider-aware: 128k for cloud providers (Anthropic) and 32k for local Ollama, where prompt evaluation on consumer GPUs times out long before a 128k window fills. Set to override the default for either provider |
-| `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` | `65536` | Hard upper bound on the context window used to compute the compaction threshold. Keeps compaction firing at a sane size even when the backing model advertises a much larger window |
+| `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` | `131072` | Hard upper bound on the context window used to compute the compaction threshold. Keeps compaction firing at a sane size even when the backing model advertises a much larger window |
 | `RUSTYKRAB_COMPACTION_SUMMARY_MAX_TOKENS` | `8192` | Env-configurable upper bound on the final compaction summary. The effective cap is further bounded by `RUSTYKRAB_MAX_CONTEXT_TOKENS / 4`, so on a 32k local-Ollama deployment the summary stays under 8k regardless of this value. If the summarizer returns a summary larger than the effective cap, it is re-summarized (up to 3 passes) and eventually truncated |
 | `OLLAMA_MODEL` | `gemma4:26b` | Ollama model name |
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server address |
-| `RUSTYKRAB_NUM_CTX` | `65536` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. The whole window is allocated as KV cache when the model loads, so lower this (or enable KV quantization, below) if the model won't fit in VRAM. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
+| `RUSTYKRAB_NUM_CTX` | `131072` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. The whole window is allocated as KV cache when the model loads, so lower this (or enable KV quantization, below) if the model won't fit in VRAM. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
 | `OLLAMA_NUM_CTX` | — | Legacy alias for `RUSTYKRAB_NUM_CTX`. Used only when `RUSTYKRAB_NUM_CTX` is unset |
 | `OLLAMA_KEEP_ALIVE` | `30m` | How long Ollama keeps the model and its KV cache resident after a request (Ollama duration syntax; `-1` for forever). Ollama's own default is 5 minutes, short enough that a sporadically-used gateway reloads the model on most messages. Set to `server` to omit the field |
 | `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say). Ollama returns a 400 for `think` against models that don't support it |

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -142,11 +142,21 @@ const PLANNING_ONLY_RETRY_LIMIT: usize = 2;
 const TASK_COMPLETE_RETRY_LIMIT: usize = 3;
 
 /// Default upper bound on the effective context window used when computing
-/// the compaction threshold. Keeps compaction aggressive even when the
-/// backing model advertises a much larger window (e.g. a 128k-ctx Ollama
-/// deployment whose GPU can't actually evaluate that much in reasonable
-/// time). Override with the `RUSTYKRAB_COMPACTION_CONTEXT_CEILING` env var.
-const DEFAULT_COMPACTION_CONTEXT_CEILING: usize = 65_536;
+/// the compaction threshold. Guards against a model that *advertises* a
+/// window its GPU cannot evaluate in reasonable time — the budget would
+/// otherwise be derived from a number nothing can serve.
+///
+/// It must track `DEFAULT_NUM_CTX` in the Ollama provider. When the ceiling
+/// sits below the served window the symptom is silent: compaction keeps
+/// triggering at the old threshold, the extra context goes unused, and
+/// "I raised RUSTYKRAB_NUM_CTX and nothing changed" is the only visible
+/// effect. `effective_context_limit` warns once when that happens.
+///
+/// Raised to 128k alongside the provider default on measured evidence:
+/// across 4k→128k on gemma4:26b, generation throughput held at ~51 t/s and
+/// the whole KV cache grew by 1.2 GB. Override with
+/// `RUSTYKRAB_COMPACTION_CONTEXT_CEILING`.
+const DEFAULT_COMPACTION_CONTEXT_CEILING: usize = 131_072;
 
 /// Return the compaction context ceiling, reading the env var once.
 fn compaction_context_ceiling() -> usize {
@@ -157,6 +167,40 @@ fn compaction_context_ceiling() -> usize {
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&v| v > 0)
             .unwrap_or(DEFAULT_COMPACTION_CONTEXT_CEILING)
+    })
+}
+
+/// Parse `RUSTYKRAB_COMPACTION_EXPAND_CTX`. A positive integer expands
+/// every summarization call to that context window; anything else (unset,
+/// `off`, `0`, garbage) leaves compaction at the everyday window.
+fn parse_expand_ctx(raw: Option<&str>) -> Option<u32> {
+    raw?.trim().parse::<u32>().ok().filter(|&v| v > 0)
+}
+
+/// The expanded context window for compaction calls, read once.
+///
+/// Compaction is the one moment the agent genuinely wants a bigger window
+/// than it runs its turns at: the summarizer's input budget derives from
+/// the window, and a small window forces the history into chunks — one
+/// model call each. Ollama resizes its KV cache in about three seconds, so
+/// paying that twice around a summarization that would otherwise chunk is
+/// usually a large win. Off by default; a provider that cannot resize
+/// ignores the hint via the `chat_with_ctx` default.
+fn compaction_expand_ctx() -> Option<u32> {
+    static EXPAND: OnceLock<Option<u32>> = OnceLock::new();
+    *EXPAND.get_or_init(|| {
+        let v = parse_expand_ctx(
+            std::env::var("RUSTYKRAB_COMPACTION_EXPAND_CTX")
+                .ok()
+                .as_deref(),
+        );
+        if let Some(ctx) = v {
+            tracing::info!(
+                ctx,
+                "compaction will expand the context window per summarization call"
+            );
+        }
+        v
     })
 }
 
@@ -2678,8 +2722,28 @@ impl AgentRunner {
                 agent_version: Message::version_stamp(),
             },
         ];
-        let response = self.provider.chat(&messages, &[]).await?;
-        Ok(response.message.content.as_text().unwrap_or("").to_string())
+        let started = std::time::Instant::now();
+        let expand = compaction_expand_ctx();
+        let response = match expand {
+            Some(ctx) => self.provider.chat_with_ctx(&messages, &[], ctx).await?,
+            None => self.provider.chat(&messages, &[]).await?,
+        };
+        let text = response.message.content.as_text().unwrap_or("").to_string();
+        // One line per summarizer call, so a slow compaction can be
+        // attributed rather than guessed at: how many calls, how big each
+        // prompt was, and how much of the time went to generation. Local
+        // thinking models vary enormously call to call, and without this
+        // the only visible symptom is a long silence.
+        tracing::info!(
+            expanded_ctx = ?expand,
+            input_chars = input.len(),
+            prompt_tokens = response.usage.prompt_tokens,
+            completion_tokens = response.usage.completion_tokens,
+            output_chars = text.len(),
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "compaction: summarizer call"
+        );
+        Ok(text)
     }
 
     /// Summarize a set of text fragments, recursively reducing until a
@@ -2867,7 +2931,13 @@ impl AgentRunner {
         // tokens can exceed the provider HTTP timeout even though a regular
         // request of the same size would not (regular requests intersperse
         // tool turns, so individual prompt sizes are smaller in practice).
-        let ceiling = self.effective_context_limit();
+        // With expansion on, the summarizer runs at its own, larger window,
+        // so the input budget derives from that instead of the everyday
+        // limit — which is the entire point: more history per call, fewer
+        // or no chunks.
+        let ceiling = compaction_expand_ctx()
+            .map(|c| c as usize)
+            .unwrap_or_else(|| self.effective_context_limit());
         let ratio = compaction_input_budget_ratio();
         let ratioed = (ceiling as f64 * ratio) as usize;
         // The response reserve is a fixed 4096, which is larger than the
@@ -2922,7 +2992,15 @@ impl AgentRunner {
             // it back off — this avoids deep-cloning the entire history at
             // the exact moment it is at its largest.
             conv.messages.push(compaction_prompt);
-            let response = self.provider.chat(&conv.messages, &[]).await;
+            // Must follow the expanded window when one is set: the expanded
+            // input budget is what routed this history to the fast path, and
+            // a plain chat() would trim it back to the everyday window — the
+            // model would summarize a truncated fragment while this code
+            // believes it saw everything.
+            let response = match compaction_expand_ctx() {
+                Some(ctx) => self.provider.chat_with_ctx(&conv.messages, &[], ctx).await,
+                None => self.provider.chat(&conv.messages, &[]).await,
+            };
             conv.messages.pop();
             let response = response?;
             response.message.content.as_text().unwrap_or("").to_string()
@@ -5707,6 +5785,24 @@ mod outcome_capture_tests {
 #[cfg(test)]
 mod compaction_budget_tests {
     use super::*;
+
+    #[test]
+    fn expand_ctx_parses_positive_integers_and_nothing_else() {
+        assert_eq!(parse_expand_ctx(Some("65536")), Some(65536));
+        assert_eq!(parse_expand_ctx(Some(" 131072 ")), Some(131072));
+        assert_eq!(
+            parse_expand_ctx(Some("0")),
+            None,
+            "zero is off, not a window"
+        );
+        assert_eq!(parse_expand_ctx(Some("off")), None);
+        assert_eq!(
+            parse_expand_ctx(Some("max")),
+            None,
+            "no magic words — a number or nothing"
+        );
+        assert_eq!(parse_expand_ctx(None), None);
+    }
 
     /// The budget a compaction call gets, for a given effective context
     /// limit — mirrors the arithmetic in `compact_history`.

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -571,6 +571,40 @@ async fn main() -> anyhow::Result<()> {
             );
             Arc::new(p)
         }
+        // Any server exposing an OpenAI-compatible /v1/chat/completions API:
+        // llama-server, mistral.rs, vllm-mlx, mlx_lm.server, LM Studio's
+        // headless daemon, exo, or a hosted OpenAI-compatible endpoint. The
+        // aliases exist so logs and error messages name the actual backend;
+        // they behave identically otherwise.
+        "openai" | "openai-compat" | "llama-server" | "llamacpp" | "mistralrs" | "lmstudio"
+        | "mlx" | "exo" | "vllm" => {
+            let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| "local-model".to_string());
+            let base_url = std::env::var("OPENAI_BASE_URL")
+                .unwrap_or_else(|_| "http://localhost:8080".to_string());
+
+            let mut config = rustykrab_providers::OpenAiConfig::default();
+            if let Some(t) = env_parse::<f32>("OPENAI_TEMPERATURE") {
+                config.temperature = t;
+            }
+            if let Some(m) = env_parse::<u32>("OPENAI_MAX_TOKENS") {
+                config.max_tokens = m;
+            }
+            // Escape hatch for servers that reject `stream_options`.
+            if let Ok(v) = std::env::var("OPENAI_INCLUDE_USAGE") {
+                config.include_usage = !matches!(v.trim(), "0" | "false" | "no");
+            }
+
+            tracing::info!(%model, %base_url, provider = %provider_name, "using OpenAI-compatible provider");
+            let mut p = rustykrab_providers::OpenAiProvider::new(model)
+                .with_base_url(base_url)
+                .with_provider_name(provider_name.clone())
+                .with_config(config);
+            // Optional — most local servers ignore it.
+            if let Ok(key) = std::env::var("OPENAI_API_KEY") {
+                p = p.with_api_key(key);
+            }
+            Arc::new(p)
+        }
         _ => {
             let api_key = resolve_api_key(&store).await;
             let model = std::env::var("ANTHROPIC_MODEL")
@@ -2530,6 +2564,18 @@ async fn handle_pair_subcommand(data_dir: &std::path::Path) -> anyhow::Result<()
         );
     }
     Ok(())
+}
+
+/// Parse an optional env var, warning (rather than failing) on garbage.
+fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
+    let raw = std::env::var(key).ok()?;
+    match raw.trim().parse::<T>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(%key, value = %raw, "ignoring unparseable env var");
+            None
+        }
+    }
 }
 
 async fn resolve_auth_token(store: &rustykrab_store::Store) -> String {

--- a/crates/rustykrab-core/src/model.rs
+++ b/crates/rustykrab-core/src/model.rs
@@ -94,6 +94,25 @@ pub trait ModelProvider: Send + Sync {
     /// Send a conversation to the model and get back the next message.
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse>;
 
+    /// Like [`Self::chat`], but asking the provider to serve this one call
+    /// with at least `num_ctx` tokens of context, where it can.
+    ///
+    /// Exists for compaction: a summarization call wants to see far more
+    /// history than a normal turn, and a provider that can resize its
+    /// window per request (Ollama rebuilds the KV cache in ~3s) can honour
+    /// that without changing the window every other call runs at.
+    ///
+    /// The default ignores the hint — cloud providers have one fixed
+    /// window and it is already large.
+    async fn chat_with_ctx(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        _num_ctx: u32,
+    ) -> Result<ModelResponse> {
+        self.chat(messages, tools).await
+    }
+
     /// Send a conversation to the model with an explicit tool-choice constraint.
     ///
     /// Default implementation ignores the constraint and calls [`chat`].

--- a/crates/rustykrab-e2e/README.md
+++ b/crates/rustykrab-e2e/README.md
@@ -13,6 +13,74 @@ make eval-list      # list every scenario
 Flags pass through: `make eval ARGS="--case compaction"`, or call
 `./scripts/e2e.sh --mode all --release`.
 
+## The system, as the harness sees it
+
+```mermaid
+flowchart TB
+    subgraph HARNESS["rustykrab-e2e (one binary, one report, one exit code)"]
+        MODES["--mode scripted | model | credential | ablation"]
+        JUDGE["LLM judge<br/>claude-sonnet-5, or the model<br/>under test (report says which)"]
+        ASSERT["assertions + transcript<br/>read from the daemon's SQLite,<br/>not the REST API"]
+        ABL["ablation driver<br/>speed probes · suite per window ·<br/>compaction cost A/B"]
+    end
+
+    subgraph DAEMON["throwaway daemon per scenario (rustykrab-cli)"]
+        GW["gateway (axum)<br/>bearer auth · origin allowlist · rate limit"]
+        ROUTER["HarnessRouter<br/>keyword preset, minus the fields<br/>harness.toml named; =off pins all"]
+        RUNNER["AgentRunner loop"]
+        ACTIVE["ActiveToolsRegistry<br/>lazy activation + seed<br/>(stubs / RUSTYKRAB_ACTIVE_TOOLS)"]
+        TOOLS["tools: stubbed (scripted responses)<br/>or real · task_complete protocol"]
+        COMPACT["compact_history<br/>fast path or chunked ·<br/>optional expanded window"]
+    end
+
+    subgraph PROVIDER["OllamaProvider"]
+        CTX["window resolution<br/>RUSTYKRAB_NUM_CTX → 65536 default"]
+        BUDGET["context_limit = window − reserves<br/>(floor: window/4) · num_predict clamp"]
+        TRIM["trim_to_budget (per request)"]
+    end
+
+    subgraph STORES["state"]
+        SQL["SQLite: conversations · messages ·<br/>credential_requests · recall_archive"]
+        MEM["memory system<br/>hybrid retrieval, memory_* tools"]
+    end
+
+    OLLAMA["Ollama · gemma4:26b Q4_K_M<br/>model max 262,144 ctx · ~3s KV resize,<br/>~28s cold load"]
+
+    MODES -->|"HTTP + webhooks<br/>(capture server for telegram/signal)"| GW
+    GW --> ROUTER --> RUNNER
+    RUNNER --> ACTIVE --> TOOLS
+    RUNNER --> COMPACT
+    RUNNER --> CTX
+    COMPACT -->|"chat_with_ctx(expanded)"| CTX
+    CTX --> BUDGET --> TRIM --> OLLAMA
+    RUNNER --> SQL
+    COMPACT -->|"displaced history"| SQL
+    TOOLS --> MEM
+    ASSERT --> SQL
+    ABL -->|"probes bypass the daemon"| OLLAMA
+    MODES --> JUDGE
+```
+
+### Where a token budget actually comes from
+
+```mermaid
+flowchart LR
+    W["num_ctx (serving window)"] --> R["− num_predict (clamped to ≤ window/2)<br/>− tool block − framing"]
+    R --> IB["input budget<br/>(floor: window/4)"]
+    IB --> T75["trim: cut history to 75%<br/>of budget, per request"]
+    IB --> CEIL["min(budget, compaction ceiling 65,536)"]
+    CEIL --> TRIG["compaction trigger:<br/>85% of effective limit"]
+    TRIG --> CH["compact_history input budget:<br/>½ effective − summarizer reserve<br/>(reserve capped at half, floor 512)"]
+    EX["RUSTYKRAB_COMPACTION_EXPAND_CTX"] -.->|"summarization calls only,<br/>~3s KV resize each way"| CH
+```
+
+The load-bearing facts: the trigger must sit **below** what the trim
+destroys, or history silently vanishes instead of being summarized (the
+`context_limit` floor exists for exactly this); the ceiling means windows
+above 65,536 change nothing about compaction; and the expansion switch is
+what lets everyday turns run small and hot while summarization sees far
+more history per call.
+
 ## Three modes, and why they are not one number
 
 | mode | provider | scored by | gates CI |

--- a/crates/rustykrab-e2e/src/ablation.rs
+++ b/crates/rustykrab-e2e/src/ablation.rs
@@ -1,0 +1,578 @@
+//! Context-window ablation: sweep `num_ctx` and measure what each window
+//! costs and what it buys.
+//!
+//! Three instruments per window:
+//!
+//! - **Speed probes**, straight against Ollama: the cost of switching to
+//!   the window (KV realloc), resident memory, generation throughput, and
+//!   prompt-processing throughput at a fixed size (cross-window
+//!   comparability) and at a size scaled to the window (what big prompts
+//!   actually cost there).
+//! - **The full model suite** at that window, for accuracy. Compaction
+//!   scenarios whose standard seed cannot reach the trigger at a given
+//!   window are annotated rather than counted as failures — a scenario
+//!   that cannot fire is not a scenario that failed.
+//! - **A compaction cost probe**: history seeded past that window's
+//!   trigger, run twice — expansion off, expansion on
+//!   (`RUSTYKRAB_COMPACTION_EXPAND_CTX`) — on otherwise-identical input.
+//!   This is the direct measurement behind "should compaction expand the
+//!   window".
+//!
+//! The whole mode is a measurement, not a gate: it always exits 0 and
+//! writes its findings to `e2e-ablation.json` / `e2e-ablation.md`.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::assertion::{s, Assertion};
+use crate::model_suite::{self, ModelCase};
+
+/// Mirrors the provider's fixed reserves: default `num_predict` (4096),
+/// the assumed tool block (2048), framing (512). Approximate on purpose —
+/// the exact figure depends on the measured tool block, and this only
+/// steers seeding and annotation, never scoring.
+const APPROX_RESERVES: usize = 4_096 + 2_048 + 512;
+/// The runner's compaction ceiling default.
+const COMPACTION_CEILING: usize = 65_536;
+const TRIGGER_RATIO: f64 = 0.85;
+/// Roughly what one `bulky_note` costs in tokens.
+const NOTE_TOKENS: usize = 1_300;
+/// What the three firing-compaction scenarios seed, roughly, in tokens.
+const STANDARD_SEED_TOKENS: usize = 2_900;
+/// Expansion target for the A/B probe. Twice the ceiling: big enough that
+/// every history the ceiling permits fits in one summarizer call.
+const EXPAND_TARGET: u32 = 131_072;
+
+fn approx_input_budget(w: u32) -> usize {
+    let w = w as usize;
+    if w > APPROX_RESERVES {
+        w - APPROX_RESERVES
+    } else {
+        (w / 4).max(512)
+    }
+}
+
+/// Where the runner's compaction trigger sits at this window.
+fn approx_threshold(w: u32) -> usize {
+    (approx_input_budget(w).min(COMPACTION_CEILING) as f64 * TRIGGER_RATIO) as usize
+}
+
+/// Can the standard compaction scenarios (fixed two-note seed) reach the
+/// trigger at this window?
+fn standard_seed_fires(w: u32) -> bool {
+    approx_threshold(w) <= STANDARD_SEED_TOKENS
+}
+
+const FIRING_COMPACTION_SCENARIOS: &[&str] = &[
+    "compaction-triggers-and-keeps-history",
+    "compaction-preserves-an-early-fact",
+    "compaction-keeps-the-newest-turn-verbatim",
+];
+
+#[derive(Debug, Clone, Serialize)]
+struct SpeedProbe {
+    window: u32,
+    /// KV realloc / model load for this window, seconds.
+    load_secs: f64,
+    /// Resident size after load, bytes, from /api/ps.
+    size_bytes: u64,
+    size_vram_bytes: u64,
+    /// The context length Ollama reports actually serving. Makes the row
+    /// self-validating: a request for a window the server quietly declines
+    /// would otherwise be reported as a measurement of that window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    served_ctx: Option<u64>,
+    /// Generation throughput, tokens/second.
+    gen_tps: f64,
+    /// Prompt-processing throughput on a fixed ~8k-token prompt.
+    prompt_tps_fixed: f64,
+    /// Prompt-processing throughput on a prompt scaled to ~60% of the
+    /// window (capped at ~48k tokens), where that exceeds the fixed size.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_tps_scaled: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scaled_prompt_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+async fn ollama_chat(
+    client: &reqwest::Client,
+    url: &str,
+    model: &str,
+    content: &str,
+    num_ctx: u32,
+    num_predict: i32,
+    timeout: Duration,
+) -> Result<Value> {
+    let response = client
+        .post(format!("{url}/api/chat"))
+        .timeout(timeout)
+        .json(&json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": content }],
+            "stream": false,
+            "options": { "num_ctx": num_ctx, "num_predict": num_predict, "temperature": 0 },
+        }))
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(response.json().await?)
+}
+
+fn tps(count: &Value, duration_ns: &Value) -> f64 {
+    let c = count.as_f64().unwrap_or(0.0);
+    let d = duration_ns.as_f64().unwrap_or(0.0) / 1e9;
+    if d > 0.0 {
+        c / d
+    } else {
+        0.0
+    }
+}
+
+/// A prompt of roughly `tokens` tokens with a unique prefix so Ollama's
+/// prefix cache cannot answer for the measurement.
+fn probe_prompt(tag: &str, tokens: usize) -> String {
+    let filler = "Reference material to ignore. ";
+    let chars = tokens * 7 / 2; // the provider's own ~3.5 chars/token
+    let mut out = format!("Probe {tag}: read the following and reply with the word ok.\n");
+    while out.len() < chars {
+        out.push_str(filler);
+    }
+    out
+}
+
+async fn speed_probe(client: &reqwest::Client, url: &str, model: &str, w: u32) -> SpeedProbe {
+    let mut probe = SpeedProbe {
+        window: w,
+        load_secs: 0.0,
+        size_bytes: 0,
+        size_vram_bytes: 0,
+        served_ctx: None,
+        gen_tps: 0.0,
+        prompt_tps_fixed: 0.0,
+        prompt_tps_scaled: None,
+        scaled_prompt_tokens: None,
+        error: None,
+    };
+
+    // Switch/load. Generous timeout: a 256k KV allocation is the slowest
+    // thing this mode does.
+    match ollama_chat(client, url, model, "hi", w, 2, Duration::from_secs(900)).await {
+        Ok(r) => probe.load_secs = r["load_duration"].as_f64().unwrap_or(0.0) / 1e9,
+        Err(e) => {
+            probe.error = Some(format!(
+                "load failed: {e:#} — a timeout here usually means another client holds \
+                 Ollama's inference slot, not that the window cannot be served"
+            ));
+            return probe;
+        }
+    }
+
+    // Let the runner settle before reading /api/ps: querying the instant
+    // the request returns can catch the previous runner's numbers, which
+    // is how a 262144 row once reported less resident memory than 131072.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    if let Ok(ps) = client.get(format!("{url}/api/ps")).send().await {
+        if let Ok(v) = ps.json::<Value>().await {
+            if let Some(m) = v["models"].as_array().and_then(|a| a.first()) {
+                probe.size_bytes = m["size"].as_u64().unwrap_or(0);
+                probe.size_vram_bytes = m["size_vram"].as_u64().unwrap_or(0);
+                probe.served_ctx = m["context_length"]
+                    .as_u64()
+                    .or_else(|| m["details"]["context_length"].as_u64());
+            }
+        }
+    }
+    if let Some(served) = probe.served_ctx {
+        if served != w as u64 {
+            probe.error = Some(format!(
+                "requested num_ctx {w} but Ollama is serving {served}; this row measures \
+                 the served window, not the requested one"
+            ));
+        }
+    }
+
+    match ollama_chat(
+        client,
+        url,
+        model,
+        &format!("Probe {w} gen: write a long paragraph about the ocean."),
+        w,
+        256,
+        Duration::from_secs(300),
+    )
+    .await
+    {
+        Ok(r) => probe.gen_tps = tps(&r["eval_count"], &r["eval_duration"]),
+        Err(e) => probe.error = Some(format!("gen probe failed: {e:#}")),
+    }
+
+    match ollama_chat(
+        client,
+        url,
+        model,
+        &probe_prompt(&format!("{w}-fixed"), 6_000.min(w as usize * 3 / 5)),
+        w,
+        4,
+        Duration::from_secs(600),
+    )
+    .await
+    {
+        Ok(r) => probe.prompt_tps_fixed = tps(&r["prompt_eval_count"], &r["prompt_eval_duration"]),
+        Err(e) => probe.error = Some(format!("fixed prompt probe failed: {e:#}")),
+    }
+
+    let scaled = (w as usize * 3 / 5).min(48_000);
+    if scaled > 9_000 {
+        match ollama_chat(
+            client,
+            url,
+            model,
+            &probe_prompt(&format!("{w}-scaled"), scaled),
+            w,
+            4,
+            Duration::from_secs(1_800),
+        )
+        .await
+        {
+            Ok(r) => {
+                probe.prompt_tps_scaled =
+                    Some(tps(&r["prompt_eval_count"], &r["prompt_eval_duration"]));
+                probe.scaled_prompt_tokens =
+                    Some(r["prompt_eval_count"].as_u64().unwrap_or(0) as usize);
+            }
+            Err(e) => probe.error = Some(format!("scaled prompt probe failed: {e:#}")),
+        }
+    }
+
+    probe
+}
+
+/// The A/B compaction cost probe at one window: identical seeded history,
+/// summarized with expansion off and then on.
+fn compaction_probe_cases(w: u32) -> Vec<ModelCase> {
+    // Overshoot the trigger. An earlier version seeded 95% of it, which
+    // is below it by construction — the 32768 and 65536 cells duly
+    // reported "no compaction ran" after half an hour of seeding each.
+    // 130% leaves room for the estimator disagreeing with itself about
+    // exactly where the threshold sits.
+    let notes = ((approx_threshold(w) * 130 / 100) / NOTE_TOKENS).clamp(1, 45);
+    let mut variants = Vec::new();
+    for (mode, env) in [
+        ("baseline", Vec::new()),
+        (
+            "expanded",
+            vec![(
+                "RUSTYKRAB_COMPACTION_EXPAND_CTX".to_string(),
+                EXPAND_TARGET.to_string(),
+            )],
+        ),
+    ] {
+        // Ids are per-window and per-arm; leaked because ModelCase ids are
+        // &'static str. A handful per run, bounded by the window list.
+        let id: &'static str =
+            Box::leak(format!("ablation-compaction-{w}-{mode}").into_boxed_str());
+        let mut case = ModelCase::new(
+            id,
+            "Scaled compaction cost probe: history sized to this window's trigger",
+        )
+        .with_harness(model_suite::bounded_harness())
+        .with_num_ctx(w)
+        .ask(
+            "Before we start: the staging cluster is named borealis. \
+             Acknowledge in one sentence.",
+        );
+        for i in 0..notes {
+            case = case.ask(model_suite::bulky_note(i + 1));
+        }
+        case = case
+            .ask("What is the staging cluster called? Answer in one short sentence.")
+            .expect(Assertion::NoRunError)
+            .expect(Assertion::Compacted(true))
+            .expect(Assertion::FinalContainsAny(s(&["borealis"])));
+        case.extra_env = env;
+        variants.push(case);
+    }
+    variants
+}
+
+pub async fn run(
+    bin: &str,
+    model: &str,
+    ollama_url: &str,
+    ctx_list: &[u32],
+    reps: usize,
+    case_filter: Option<&str>,
+    quick: bool,
+) -> Result<Value> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(1_800))
+        .build()?;
+
+    // The model's own maximum, for the report.
+    let model_max: Option<u64> = match client
+        .post(format!("{ollama_url}/api/show"))
+        .json(&json!({ "model": model }))
+        .send()
+        .await
+    {
+        Ok(r) => r.json::<Value>().await.ok().and_then(|v| {
+            v["model_info"]
+                .as_object()?
+                .iter()
+                .find(|(k, _)| k.ends_with(".context_length"))
+                .and_then(|(_, v)| v.as_u64())
+        }),
+        Err(_) => None,
+    };
+
+    let mut windows: Vec<Value> = Vec::new();
+
+    for &w in ctx_list {
+        eprintln!("── window {w} ──");
+        let probe = speed_probe(&client, ollama_url, model, w).await;
+        eprintln!(
+            "  load {:.1}s  gen {:.0} t/s  prompt {:.0} t/s  resident {:.1} GB",
+            probe.load_secs,
+            probe.gen_tps,
+            probe.prompt_tps_fixed,
+            probe.size_bytes as f64 / 1e9
+        );
+        if probe.error.is_some() && probe.gen_tps == 0.0 {
+            // The window does not serve at all; record and move on.
+            windows.push(json!({ "window": w, "speed": probe, "suite": null }));
+            continue;
+        }
+
+        let selected: Vec<ModelCase> = model_suite::cases()
+            .into_iter()
+            .filter(|c| case_filter.is_none_or(|needle| c.id.contains(needle)))
+            .filter(|c| !(quick && c.slow))
+            .collect();
+        let (mut suite, judge) =
+            model_suite::run_cases(bin, model, ollama_url, reps, selected, Some(w)).await?;
+
+        // Annotate compaction scenarios whose trigger the standard seed
+        // cannot reach at this window. Their "failure" is geometry, not
+        // behaviour, and counting it as accuracy would say the model got
+        // worse at large windows when nothing of the kind happened.
+        let unreachable = !standard_seed_fires(w);
+        let mut annotated: Vec<Value> = Vec::new();
+        for r in suite.drain(..) {
+            let na = unreachable && FIRING_COMPACTION_SCENARIOS.contains(&r.id.as_str());
+            let mut v = serde_json::to_value(&r)?;
+            if na {
+                v["not_applicable"] = json!("standard seed below this window's compaction trigger");
+            }
+            annotated.push(v);
+        }
+
+        // The compaction cost A/B, where the ceiling still lets the
+        // trigger move with the window. Above the ceiling the threshold
+        // stops growing, so re-measuring it would repeat the 65536 cell.
+        let cost_probe = if (w as usize) <= COMPACTION_CEILING {
+            let (reports, _) =
+                // Same repetition count as the suite: with a thinking model
+                // the summarizer's cost varies enormously call to call, and a
+                // single sample of each arm cannot separate arm from noise.
+                model_suite::run_cases(
+                    bin,
+                    model,
+                    ollama_url,
+                    reps,
+                    compaction_probe_cases(w),
+                    None,
+                )
+                .await?;
+            Some(
+                reports
+                    .iter()
+                    .map(serde_json::to_value)
+                    .collect::<std::result::Result<Vec<_>, _>>()?,
+            )
+        } else {
+            None
+        };
+
+        windows.push(json!({
+            "window": w,
+            "speed": probe,
+            "judge": judge,
+            "suite": annotated,
+            "compaction_cost": cost_probe,
+        }));
+    }
+
+    Ok(json!({
+        "model": model,
+        "model_max_context": model_max,
+        "expand_target": EXPAND_TARGET,
+        "compaction_ceiling": COMPACTION_CEILING,
+        "windows": windows,
+    }))
+}
+
+/// Render the report as a markdown summary.
+pub fn render_markdown(report: &Value) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Context-window ablation — {}\n\nmodel max context: {} · compaction ceiling: {} · expansion target: {}\n\n",
+        report["model"].as_str().unwrap_or("?"),
+        report["model_max_context"].as_u64().map(|v| v.to_string()).unwrap_or("unknown".into()),
+        report["compaction_ceiling"],
+        report["expand_target"],
+    ));
+
+    out.push_str("## Speed\n\n| window | served | load s | resident GB | gen t/s | prompt t/s (fixed) | prompt t/s (scaled) |\n|---|---|---|---|---|---|---|\n");
+    for win in report["windows"].as_array().unwrap_or(&Vec::new()) {
+        let sp = &win["speed"];
+        // A probe that failed must say so, not render as a measured zero —
+        // a busy inference slot and an unservable window both land here,
+        // and "0 t/s" reads as data.
+        if let Some(err) = sp["error"].as_str() {
+            out.push_str(&format!(
+                "| {} | probe failed: {err} ||||||\n",
+                win["window"]
+            ));
+            continue;
+        }
+        out.push_str(&format!(
+            "| {} | {} | {:.1} | {:.1} | {:.0} | {:.0} | {} |\n",
+            win["window"],
+            sp["served_ctx"]
+                .as_u64()
+                .map(|v| v.to_string())
+                .unwrap_or("?".into()),
+            sp["load_secs"].as_f64().unwrap_or(0.0),
+            sp["size_bytes"].as_u64().unwrap_or(0) as f64 / 1e9,
+            sp["gen_tps"].as_f64().unwrap_or(0.0),
+            sp["prompt_tps_fixed"].as_f64().unwrap_or(0.0),
+            sp["prompt_tps_scaled"]
+                .as_f64()
+                .map(|v| format!("{v:.0}"))
+                .unwrap_or("—".into()),
+        ));
+    }
+
+    out.push_str("\n## Accuracy (suite pass / applicable)\n\n| window | pass | fail | n/a by design | mean scenario ms |\n|---|---|---|---|---|\n");
+    for win in report["windows"].as_array().unwrap_or(&Vec::new()) {
+        let Some(suite) = win["suite"].as_array() else {
+            out.push_str(&format!(
+                "| {} | — window did not serve — ||||\n",
+                win["window"]
+            ));
+            continue;
+        };
+        let na = suite
+            .iter()
+            .filter(|r| r.get("not_applicable").is_some())
+            .count();
+        let pass = suite
+            .iter()
+            .filter(|r| r["outcome"] == "pass" && r.get("not_applicable").is_none())
+            .count();
+        let fail = suite
+            .iter()
+            .filter(|r| r["outcome"] == "fail" && r.get("not_applicable").is_none())
+            .count();
+        let mean: u64 = {
+            let ms: Vec<u64> = suite.iter().filter_map(|r| r["mean_ms"].as_u64()).collect();
+            if ms.is_empty() {
+                0
+            } else {
+                ms.iter().sum::<u64>() / ms.len() as u64
+            }
+        };
+        out.push_str(&format!(
+            "| {} | {pass} | {fail} | {na} | {mean} |\n",
+            win["window"]
+        ));
+    }
+
+    out.push_str("\n## Compaction cost (identical history; expansion off vs on)\n\n| window | baseline ms | baseline | expanded ms | expanded |\n|---|---|---|---|---|\n");
+    for win in report["windows"].as_array().unwrap_or(&Vec::new()) {
+        let Some(probe) = win["compaction_cost"].as_array() else {
+            continue;
+        };
+        let cell = |mode: &str, field: &str| -> String {
+            probe
+                .iter()
+                .find(|r| r["id"].as_str().is_some_and(|i| i.ends_with(mode)))
+                .map(|r| match field {
+                    "ms" => r["mean_ms"].to_string(),
+                    // pass/fail alone hides a split verdict; show the rate.
+                    _ => format!(
+                        "{} {}/{}",
+                        r["outcome"].as_str().unwrap_or("?"),
+                        r["passes"],
+                        r["runs"]
+                    ),
+                })
+                .unwrap_or("—".into())
+        };
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            win["window"],
+            cell("baseline", "ms"),
+            cell("baseline", "outcome"),
+            cell("expanded", "ms"),
+            cell("expanded", "outcome"),
+        ));
+    }
+    out
+}
+
+// Quiet re-export check: the driver needs these from model_suite.
+#[allow(unused_imports)]
+use crate::model_suite::cases as _cases_visible;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thresholds_follow_the_window_until_the_ceiling() {
+        // Small windows floor at a quarter; mid windows grow linearly;
+        // beyond the ceiling the trigger stops moving — which is why the
+        // cost probe does not re-run above it.
+        assert_eq!(approx_threshold(4_096), 870);
+        assert_eq!(approx_threshold(8_192), 1_305);
+        assert!(approx_threshold(16_384) > 8_000);
+        assert_eq!(approx_threshold(131_072), approx_threshold(262_144));
+    }
+
+    #[test]
+    fn standard_seed_reachability_matches_the_thresholds() {
+        assert!(standard_seed_fires(4_096));
+        assert!(standard_seed_fires(8_192));
+        assert!(
+            !standard_seed_fires(16_384),
+            "2.9k of seed cannot reach an 8.3k trigger"
+        );
+        assert!(!standard_seed_fires(65_536));
+    }
+
+    #[test]
+    fn the_cost_probe_scales_its_seed_and_caps_it() {
+        let small = compaction_probe_cases(8_192);
+        let large = compaction_probe_cases(65_536);
+        assert!(small[0].turns.len() < large[0].turns.len());
+        assert!(large[0].turns.len() <= 47, "seed is capped");
+        // The seed must exceed the trigger, not approach it: sizing to 95%
+        // of the threshold meant compaction never fired at 32k and 64k.
+        let seeded_tokens = (large[0].turns.len() - 2) * NOTE_TOKENS;
+        assert!(
+            seeded_tokens > approx_threshold(65_536),
+            "seed {seeded_tokens} must exceed the {} trigger",
+            approx_threshold(65_536)
+        );
+        // The two arms differ only in environment.
+        assert_eq!(large[0].turns, large[1].turns);
+        assert!(large[0].extra_env.is_empty());
+        assert_eq!(large[1].extra_env[0].0, "RUSTYKRAB_COMPACTION_EXPAND_CTX");
+    }
+}

--- a/crates/rustykrab-e2e/src/credential_suite.rs
+++ b/crates/rustykrab-e2e/src/credential_suite.rs
@@ -572,6 +572,7 @@ async fn run_trial_inner(
         // identical to one that found it and declined to ask.
         active_tools: CREDENTIAL_TOOLS,
         tool_stubs: "",
+        extra_env: &[],
         channel: Some((surface, &capture_base)),
     };
     let mut child = spawn_daemon_with(bin, &data_dir, port, &backend)?;

--- a/crates/rustykrab-e2e/src/login_suite.rs
+++ b/crates/rustykrab-e2e/src/login_suite.rs
@@ -346,6 +346,7 @@ async fn run_trial_inner(
         active_tools: LOGIN_TOOLS,
         tool_stubs: "",
         channel: None,
+        extra_env: &[],
     };
     let mut child = spawn_daemon_with(bin, &data_dir, port, &backend)?;
 

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -17,6 +17,7 @@
 //! RUSTYKRAB_BIN=target/debug/rustykrab-cli cargo run -p rustykrab-e2e
 //! ```
 
+mod ablation;
 mod assertion;
 mod classify;
 mod credential_suite;
@@ -1018,6 +1019,9 @@ pub enum Backend<'a> {
         /// default; the compaction scenarios lower it, because that is
         /// what `effective_context_limit()` actually reads.
         num_ctx: Option<u32>,
+        /// Extra environment for this daemon, applied last so a case can
+        /// override anything the harness sets by default.
+        extra_env: &'a [(String, String)],
         /// Tools to seed into the active set. Registering a tool is not
         /// enough for the model to see it — schemas are only sent for
         /// active tools — so a scenario has to name what it is testing or
@@ -1120,6 +1124,7 @@ fn spawn_daemon_with(
             active_tools,
             tool_stubs,
             channel,
+            extra_env,
         } => {
             command
                 .env("RUSTYKRAB_PROVIDER", "ollama")
@@ -1194,6 +1199,11 @@ fn spawn_daemon_with(
             if let Some((surface, capture_base)) = channel {
                 crate::surface::configure_channel(command, *surface, capture_base);
             }
+
+            // Last, so a case can override any default above.
+            for (key, value) in *extra_env {
+                command.env(key, value);
+            }
         }
     }
 
@@ -1261,11 +1271,13 @@ USAGE:
     cargo run -p rustykrab-e2e -- [FLAGS]
 
 FLAGS:
-    --mode SUITE                scripted | model | credential | login | all
-                                (default: scripted). `login` reaches the
-                                real internet with real credentials and is
-                                never included in `all`; it skips unless
-                                RK_LOGIN_URL/USER/PASS are set.
+    --mode SUITE                scripted | model | credential | login |
+                                ablation | all (default: scripted). `login`
+                                reaches the real internet with real
+                                credentials and is never included in `all`;
+                                it skips unless RK_LOGIN_URL/USER/PASS are set.
+    --ctx-list A,B,C            Windows for --mode ablation (default:
+                                4096,8192,16384,32768,65536,131072,262144)
     --surfaces LIST             Surfaces for --mode credential
                                 (default: gateway,telegram; signal has no
                                 agent loop reading it and will error)
@@ -1298,6 +1310,7 @@ struct Args {
     quick: bool,
     model: String,
     ollama_url: String,
+    ctx_list: Vec<u32>,
     list: bool,
 }
 
@@ -1316,6 +1329,7 @@ fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
         model: std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma4:26b".to_string()),
         ollama_url: std::env::var("OLLAMA_BASE_URL")
             .unwrap_or_else(|_| "http://localhost:11434".to_string()),
+        ctx_list: vec![4_096, 8_192, 16_384, 32_768, 65_536, 131_072, 262_144],
         list: false,
     };
     let value = |i: usize, name: &str| -> std::result::Result<String, String> {
@@ -1334,10 +1348,10 @@ fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
                 args.mode = value(i, "--mode")?.to_lowercase();
                 if !matches!(
                     args.mode.as_str(),
-                    "scripted" | "model" | "credential" | "login" | "all"
+                    "scripted" | "model" | "credential" | "login" | "ablation" | "all"
                 ) {
                     return Err(format!(
-                        "--mode: expected scripted|model|credential|login|all, got {}",
+                        "--mode: expected scripted|model|credential|login|ablation|all, got {}",
                         args.mode
                     ));
                 }
@@ -1382,6 +1396,18 @@ fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
             }
             "--ollama-url" => {
                 args.ollama_url = value(i, "--ollama-url")?;
+                i += 1;
+            }
+            "--ctx-list" => {
+                let v = value(i, "--ctx-list")?;
+                args.ctx_list = v
+                    .split(',')
+                    .map(|n| n.trim().parse::<u32>())
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(|_| format!("--ctx-list: not a number list: {v}"))?;
+                if args.ctx_list.is_empty() {
+                    return Err("--ctx-list needs at least one window".to_string());
+                }
                 i += 1;
             }
             other => return Err(format!("unknown flag: {other}")),
@@ -1430,6 +1456,26 @@ async fn main() -> Result<()> {
         std::env::var("RUSTYKRAB_BIN").unwrap_or_else(|_| "target/debug/rustykrab-cli".to_string());
     if !std::path::Path::new(&bin).exists() {
         bail!("daemon binary not found at {bin} — build it first or set RUSTYKRAB_BIN");
+    }
+
+    if args.mode == "ablation" {
+        let report = ablation::run(
+            &bin,
+            &args.model,
+            &args.ollama_url,
+            &args.ctx_list,
+            args.reps,
+            args.case_filter.as_deref(),
+            args.quick,
+        )
+        .await?;
+        let md = ablation::render_markdown(&report);
+        std::fs::write("e2e-ablation.json", serde_json::to_string_pretty(&report)?)?;
+        std::fs::write("e2e-ablation.md", &md)?;
+        eprintln!("{md}");
+        eprintln!("written: e2e-ablation.json, e2e-ablation.md");
+        // A measurement, not a gate.
+        return Ok(());
     }
 
     let mut reports: Vec<ScenarioReport> = Vec::new();

--- a/crates/rustykrab-e2e/src/model_suite.rs
+++ b/crates/rustykrab-e2e/src/model_suite.rs
@@ -81,12 +81,16 @@ pub struct ModelCase {
     /// to the profile's `max_context_tokens` when the provider reports
     /// nothing. Ollama always reports, so the profile value never applied.
     pub num_ctx: Option<u32>,
+    /// Extra environment for the daemon this case boots. The ablation
+    /// driver uses it to A/B `RUSTYKRAB_COMPACTION_EXPAND_CTX` on
+    /// otherwise-identical scenarios.
+    pub extra_env: Vec<(String, String)>,
     pub assertions: Vec<Assertion>,
     pub judge: Option<JudgeSpec>,
 }
 
 impl ModelCase {
-    fn new(id: &'static str, description: &'static str) -> Self {
+    pub(crate) fn new(id: &'static str, description: &'static str) -> Self {
         Self {
             id,
             description,
@@ -99,54 +103,55 @@ impl ModelCase {
             harness_toml: None,
             split_conversation: false,
             num_ctx: None,
+            extra_env: Vec::new(),
             assertions: Vec::new(),
             judge: None,
         }
     }
 
-    fn ask(mut self, turn: impl Into<String>) -> Self {
+    pub(crate) fn ask(mut self, turn: impl Into<String>) -> Self {
         self.turns.push(turn.into());
         self
     }
 
-    fn slow(mut self) -> Self {
+    pub(crate) fn slow(mut self) -> Self {
         self.slow = true;
         self
     }
 
-    fn with_tool(mut self, tool: Value) -> Self {
+    pub(crate) fn with_tool(mut self, tool: Value) -> Self {
         self.stubs["tools"].as_array_mut().unwrap().push(tool);
         self
     }
 
     /// Keep these real tools alongside the stubs — the memory scenarios
     /// need the genuine `memory_*` tools, since those are what they test.
-    fn keeping(mut self, names: &[&str]) -> Self {
+    pub(crate) fn keeping(mut self, names: &[&str]) -> Self {
         self.stubs["keep"] = json!(names);
         self
     }
 
-    fn with_harness(mut self, toml: impl Into<String>) -> Self {
+    pub(crate) fn with_harness(mut self, toml: impl Into<String>) -> Self {
         self.harness_toml = Some(toml.into());
         self
     }
 
-    fn across_conversations(mut self) -> Self {
+    pub(crate) fn across_conversations(mut self) -> Self {
         self.split_conversation = true;
         self
     }
 
-    fn with_num_ctx(mut self, tokens: u32) -> Self {
+    pub(crate) fn with_num_ctx(mut self, tokens: u32) -> Self {
         self.num_ctx = Some(tokens);
         self
     }
 
-    fn expect(mut self, a: Assertion) -> Self {
+    pub(crate) fn expect(mut self, a: Assertion) -> Self {
         self.assertions.push(a);
         self
     }
 
-    fn judged(mut self, j: JudgeSpec) -> Self {
+    pub(crate) fn judged(mut self, j: JudgeSpec) -> Self {
         self.judge = Some(j);
         self
     }
@@ -168,7 +173,7 @@ fn tight_harness() -> String {
 
 /// The default config for non-compaction scenarios: a normal window, but a
 /// low iteration cap so a wandering model fails fast instead of slowly.
-fn bounded_harness() -> String {
+pub(crate) fn bounded_harness() -> String {
     "name = \"e2e\"\n\
      agent_name = \"RustyKrab\"\n\
      max_iterations = 10\n\
@@ -195,7 +200,7 @@ fn tool(
 }
 
 /// Filler text used to inflate turns toward the compaction trigger.
-fn bulky_note(index: usize) -> String {
+pub(crate) fn bulky_note(index: usize) -> String {
     let mut out =
         format!("Here is batch {index} of the audit log. Acknowledge it in one short sentence.\n");
     for i in 0..40 {
@@ -677,16 +682,29 @@ pub async fn run(
     case_filter: Option<&str>,
     quick: bool,
 ) -> Result<(Vec<ScenarioReport>, String)> {
-    preflight(model, ollama_url).await?;
-
-    let judge = Judge::new(model, ollama_url);
-    eprintln!("model suite: {model}, judged by {}", judge.name());
-
     let selected: Vec<ModelCase> = cases()
         .into_iter()
         .filter(|c| case_filter.is_none_or(|needle| c.id.contains(needle)))
         .filter(|c| !(quick && c.slow))
         .collect();
+    run_cases(bin, model, ollama_url, reps, selected, None).await
+}
+
+/// Run an explicit case list, optionally forcing every case onto one
+/// context window. The ablation driver sweeps windows by calling this once
+/// per window with the same cases.
+pub async fn run_cases(
+    bin: &str,
+    model: &str,
+    ollama_url: &str,
+    reps: usize,
+    selected: Vec<ModelCase>,
+    ctx_override: Option<u32>,
+) -> Result<(Vec<ScenarioReport>, String)> {
+    preflight(model, ollama_url).await?;
+
+    let judge = Judge::new(model, ollama_url);
+    eprintln!("model suite: {model}, judged by {}", judge.name());
 
     let mut reports = Vec::new();
     for case in &selected {
@@ -695,17 +713,18 @@ pub async fn run(
         let mut details: Vec<String> = Vec::new();
 
         for _ in 0..reps {
-            let transcript =
-                match tokio::time::timeout(CASE_TIMEOUT, run_once(bin, model, ollama_url, case))
-                    .await
-                {
-                    Ok(Ok(t)) => t,
-                    Ok(Err(e)) => Transcript::failed(format!("{e:#}"), 0),
-                    Err(_) => Transcript::failed(
-                        format!("timed out after {}s", CASE_TIMEOUT.as_secs()),
-                        0,
-                    ),
-                };
+            let transcript = match tokio::time::timeout(
+                CASE_TIMEOUT,
+                run_once(bin, model, ollama_url, case, ctx_override),
+            )
+            .await
+            {
+                Ok(Ok(t)) => t,
+                Ok(Err(e)) => Transcript::failed(format!("{e:#}"), 0),
+                Err(_) => {
+                    Transcript::failed(format!("timed out after {}s", CASE_TIMEOUT.as_secs()), 0)
+                }
+            };
 
             let failures: Vec<String> = case
                 .assertions
@@ -769,6 +788,7 @@ async fn run_once(
     model: &str,
     ollama_url: &str,
     case: &ModelCase,
+    ctx_override: Option<u32>,
 ) -> Result<Transcript> {
     let tmp = tempfile::Builder::new()
         .prefix("rustykrab-e2e-model-")
@@ -783,13 +803,14 @@ async fn run_once(
     let backend = Backend::Model {
         model,
         ollama_url,
-        num_ctx: case.num_ctx,
+        num_ctx: ctx_override.or(case.num_ctx),
         // The model suite names its tools through the stub file.
         active_tools: &[],
         tool_stubs: &stubs,
         // These scenarios drive the gateway directly; the credential
         // suite is the one that varies the surface.
         channel: None,
+        extra_env: &case.extra_env,
     };
     let mut child = spawn_daemon_with(bin, &data_dir, port, &backend)?;
 

--- a/crates/rustykrab-providers/src/lib.rs
+++ b/crates/rustykrab-providers/src/lib.rs
@@ -2,8 +2,10 @@ mod anthropic;
 mod backoff;
 mod line_buffer;
 mod ollama;
+mod openai;
 mod scripted;
 
 pub use anthropic::AnthropicProvider;
 pub use ollama::{OllamaConfig, OllamaProvider};
+pub use openai::{OpenAiConfig, OpenAiProvider};
 pub use scripted::{Scenario, Script, ScriptStep, ScriptToolCall, ScriptedProvider};

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -29,15 +29,29 @@ const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
 /// prompt that overshoots gets silently truncated server-side — which moves
 /// the truncation point every turn and defeats prefix caching completely.
 ///
-/// 64k matches `DEFAULT_COMPACTION_CONTEXT_CEILING` in the agent runner, so
+/// 128k matches `DEFAULT_COMPACTION_CONTEXT_CEILING` in the agent runner, so
 /// the provider's window and the compaction budget agree instead of one
 /// silently capping the other. It is clamped down to the model's own native
 /// length at startup, so a smaller model still gets a sane value.
 ///
-/// This costs VRAM: the KV cache is allocated for the whole window when the
-/// runner loads. Lower it with `RUSTYKRAB_NUM_CTX` if the model won't fit, or
-/// halve the cache with `OLLAMA_KV_CACHE_TYPE=q8_0` (see README).
-const DEFAULT_NUM_CTX: u32 = 65_536;
+/// This costs VRAM — but far less than the linear intuition suggests, at
+/// least for the architectures we target. Measured on gemma4:26b (Q4_K_M,
+/// M1 Max), resident size against window:
+///
+/// ```text
+///   4k → 17.38 GB     32k → 17.66 GB     128k → 18.57 GB
+///   8k → 17.61 GB     64k → 18.30 GB
+/// ```
+///
+/// 32× the context for 1.2 GB, because Gemma interleaves local and global
+/// attention and only the global layers hold a full-length cache. Generation
+/// throughput was flat at ~51 t/s across that whole range; the only cost that
+/// grows is prompt processing on proportionally larger prompts (~517 → ~413
+/// tokens/s). A dense-attention model will not be this cheap.
+///
+/// Lower it with `RUSTYKRAB_NUM_CTX` if the model won't fit, or halve the
+/// cache with `OLLAMA_KV_CACHE_TYPE=q8_0` (see README).
+const DEFAULT_NUM_CTX: u32 = 131_072;
 
 /// Default `keep_alive` sent with every request: how long Ollama keeps the
 /// model (and its KV cache) resident after the request finishes. Ollama's own
@@ -289,6 +303,184 @@ impl OllamaProvider {
     /// Effective context window used for client-side prompt trimming.
     /// Prefers the user's explicit `num_ctx`, then the value detected from
     /// the model via `/api/show`, else `None` (no trimming).
+    /// The real chat implementation. `window_override` serves this one
+    /// call at a different context window: both the client-side trim and
+    /// the `num_ctx` sent to the server use it, so an expanded
+    /// summarization call is not quietly trimmed back to the everyday
+    /// window before the model ever sees it.
+    async fn chat_at(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        window_override: Option<u32>,
+    ) -> Result<ModelResponse> {
+        let window = window_override.or(self.effective_ctx());
+        let ollama_messages = Self::build_messages(messages, self.supports_vision())?;
+        // Fix #200: validate non-empty messages.
+        if ollama_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call Ollama API with an empty message list".into(),
+            ));
+        }
+
+        let ollama_tools = Self::build_tools(tools);
+        let tool_tokens = estimate_tool_tokens(&ollama_tools);
+        self.note_tool_block(&ollama_tools, tool_tokens);
+
+        let num_predict = clamp_num_predict(window, self.config.num_predict);
+        let ollama_messages =
+            Self::trim_to_budget(ollama_messages, window, num_predict, tool_tokens);
+
+        let mut options = serde_json::json!({
+            "temperature": self.config.temperature,
+            "top_p": self.config.top_p,
+            "num_predict": num_predict,
+        });
+        // Only override the server's context length when the user has asked
+        // for it explicitly — otherwise leave `num_ctx` out so `OLLAMA_CONTEXT_LENGTH`
+        // (or the model default) wins.
+        if let Some(num_ctx) = window_override.or(self.config.num_ctx) {
+            options["num_ctx"] = serde_json::json!(num_ctx);
+        }
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": ollama_messages,
+            "stream": false,
+            "options": options,
+        });
+        // `think` is rejected outright by models that don't support it, so
+        // it is only sent when the model (or an explicit override) says yes.
+        if self.resolved_think() {
+            body["think"] = serde_json::json!(true);
+        }
+        // Keep the model — and with it the KV cache built from this prompt —
+        // resident between turns. Without this Ollama evicts after five idle
+        // minutes and the next message pays a reload plus a cold prompt eval.
+        if let Some(keep_alive) = &self.config.keep_alive {
+            body["keep_alive"] = serde_json::json!(keep_alive);
+        }
+
+        if !ollama_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&ollama_tools).map_err(Error::Serialization)?;
+        }
+
+        tracing::debug!(
+            model = %self.model,
+            base_url = %self.base_url,
+            num_messages = ollama_messages.len(),
+            num_ctx = ?self.config.num_ctx,
+            num_tools = ollama_tools.len(),
+            tool_tokens,
+            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
+            "calling Ollama chat API"
+        );
+        rustykrab_core::prompt_trace::record_prompt(
+            self.name(),
+            &self.model,
+            false,
+            messages,
+            tools,
+        );
+
+        let url = format!("{}/api/chat", self.base_url);
+
+        let request_start = std::time::Instant::now();
+        let mut last_err = None;
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
+                tracing::warn!(attempt, "retrying Ollama API after {delay:?}");
+                tokio::time::sleep(delay).await;
+            }
+
+            let resp = match self.client.post(&url).json(&body).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    // Don't retry timeouts: retrying the same 99K-token prompt
+                    // would just burn another 15-minute budget for the same
+                    // failure.  The caller (agent loop) needs to reduce context
+                    // or abort before re-trying.
+                    if e.is_timeout() {
+                        tracing::warn!(
+                            model = %self.model,
+                            num_messages = ollama_messages.len(),
+                            num_ctx = ?self.config.num_ctx,
+                            "Ollama request timed out — not retrying (reduce context or raise OLLAMA_TIMEOUT_SECS)"
+                        );
+                        return Err(Error::ModelProvider(format!(
+                            "Ollama request timed out after the configured HTTP timeout. \
+                             Reduce prompt size or raise OLLAMA_TIMEOUT_SECS: {e}"
+                        )));
+                    }
+                    last_err = Some(Error::ModelProvider(format!(
+                        "failed to connect to Ollama at {}: {e}. Is Ollama running?",
+                        self.base_url
+                    )));
+                    continue;
+                }
+            };
+
+            let status = resp.status();
+            if status.is_success() {
+                let raw_body = resp.text().await.map_err(|e| {
+                    Error::ModelProvider(format!("failed to read Ollama response body: {e}"))
+                })?;
+                let ollama_resp: OllamaResponse = serde_json::from_str(&raw_body).map_err(|e| {
+                    Error::ModelProvider(format!("failed to parse Ollama response: {e}"))
+                })?;
+                let response = Self::parse_response(&self.model, ollama_resp)?;
+
+                // Debug: dump raw response when message text is empty
+                // despite having completion tokens.
+                if response.usage.completion_tokens > 0
+                    && !response.message.content.has_tool_calls()
+                    && response
+                        .message
+                        .content
+                        .as_text()
+                        .is_none_or(|t| t.is_empty())
+                {
+                    tracing::warn!(
+                        completion_tokens = response.usage.completion_tokens,
+                        ?response.stop_reason,
+                        "empty message text with completion tokens — dumping raw response"
+                    );
+                    tracing::warn!(raw_body = %raw_body, "raw Ollama API response");
+                }
+
+                rustykrab_core::prompt_trace::record_response(
+                    self.name(),
+                    &self.model,
+                    false,
+                    &response.message,
+                    &response.usage,
+                    &response.stop_reason,
+                    request_start.elapsed().as_millis() as u64,
+                );
+                return Ok(response);
+            }
+
+            let error_body = resp.text().await.unwrap_or_default();
+            tracing::warn!(
+                status = %status,
+                num_ctx = ?self.config.num_ctx,
+                num_messages = ollama_messages.len(),
+                error_body = %error_body,
+                "Ollama API error"
+            );
+            let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
+            // Fix #186: map status codes to specific error variants.
+            last_err = Some(Self::map_status_error(status, &error_body));
+
+            if !is_retryable {
+                break;
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    }
+
     pub fn effective_ctx(&self) -> Option<u32> {
         self.config.num_ctx.or(self.detected_ctx)
     }
@@ -928,174 +1120,16 @@ impl ModelProvider for OllamaProvider {
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
-        let ollama_messages = Self::build_messages(messages, self.supports_vision())?;
+        self.chat_at(messages, tools, None).await
+    }
 
-        // Fix #200: validate non-empty messages.
-        if ollama_messages.is_empty() {
-            return Err(Error::ModelBadRequest(
-                "cannot call Ollama API with an empty message list".into(),
-            ));
-        }
-
-        let ollama_tools = Self::build_tools(tools);
-        let tool_tokens = estimate_tool_tokens(&ollama_tools);
-        self.note_tool_block(&ollama_tools, tool_tokens);
-
-        let ollama_messages = Self::trim_to_budget(
-            ollama_messages,
-            self.effective_ctx(),
-            self.config.num_predict,
-            tool_tokens,
-        );
-
-        let mut options = serde_json::json!({
-            "temperature": self.config.temperature,
-            "top_p": self.config.top_p,
-            "num_predict": self.config.num_predict,
-        });
-        // Only override the server's context length when the user has asked
-        // for it explicitly — otherwise leave `num_ctx` out so `OLLAMA_CONTEXT_LENGTH`
-        // (or the model default) wins.
-        if let Some(num_ctx) = self.config.num_ctx {
-            options["num_ctx"] = serde_json::json!(num_ctx);
-        }
-
-        let mut body = serde_json::json!({
-            "model": self.model,
-            "messages": ollama_messages,
-            "stream": false,
-            "options": options,
-        });
-        // `think` is rejected outright by models that don't support it, so
-        // it is only sent when the model (or an explicit override) says yes.
-        if self.resolved_think() {
-            body["think"] = serde_json::json!(true);
-        }
-        // Keep the model — and with it the KV cache built from this prompt —
-        // resident between turns. Without this Ollama evicts after five idle
-        // minutes and the next message pays a reload plus a cold prompt eval.
-        if let Some(keep_alive) = &self.config.keep_alive {
-            body["keep_alive"] = serde_json::json!(keep_alive);
-        }
-
-        if !ollama_tools.is_empty() {
-            body["tools"] = serde_json::to_value(&ollama_tools).map_err(Error::Serialization)?;
-        }
-
-        tracing::debug!(
-            model = %self.model,
-            base_url = %self.base_url,
-            num_messages = ollama_messages.len(),
-            num_ctx = ?self.config.num_ctx,
-            num_tools = ollama_tools.len(),
-            tool_tokens,
-            trace_id = ?rustykrab_core::prompt_trace::current_trace_id(),
-            "calling Ollama chat API"
-        );
-        rustykrab_core::prompt_trace::record_prompt(
-            self.name(),
-            &self.model,
-            false,
-            messages,
-            tools,
-        );
-
-        let url = format!("{}/api/chat", self.base_url);
-
-        let request_start = std::time::Instant::now();
-        let mut last_err = None;
-        for attempt in 0..=MAX_RETRIES {
-            if attempt > 0 {
-                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
-                tracing::warn!(attempt, "retrying Ollama API after {delay:?}");
-                tokio::time::sleep(delay).await;
-            }
-
-            let resp = match self.client.post(&url).json(&body).send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    // Don't retry timeouts: retrying the same 99K-token prompt
-                    // would just burn another 15-minute budget for the same
-                    // failure.  The caller (agent loop) needs to reduce context
-                    // or abort before re-trying.
-                    if e.is_timeout() {
-                        tracing::warn!(
-                            model = %self.model,
-                            num_messages = ollama_messages.len(),
-                            num_ctx = ?self.config.num_ctx,
-                            "Ollama request timed out — not retrying (reduce context or raise OLLAMA_TIMEOUT_SECS)"
-                        );
-                        return Err(Error::ModelProvider(format!(
-                            "Ollama request timed out after the configured HTTP timeout. \
-                             Reduce prompt size or raise OLLAMA_TIMEOUT_SECS: {e}"
-                        )));
-                    }
-                    last_err = Some(Error::ModelProvider(format!(
-                        "failed to connect to Ollama at {}: {e}. Is Ollama running?",
-                        self.base_url
-                    )));
-                    continue;
-                }
-            };
-
-            let status = resp.status();
-            if status.is_success() {
-                let raw_body = resp.text().await.map_err(|e| {
-                    Error::ModelProvider(format!("failed to read Ollama response body: {e}"))
-                })?;
-                let ollama_resp: OllamaResponse = serde_json::from_str(&raw_body).map_err(|e| {
-                    Error::ModelProvider(format!("failed to parse Ollama response: {e}"))
-                })?;
-                let response = Self::parse_response(&self.model, ollama_resp)?;
-
-                // Debug: dump raw response when message text is empty
-                // despite having completion tokens.
-                if response.usage.completion_tokens > 0
-                    && !response.message.content.has_tool_calls()
-                    && response
-                        .message
-                        .content
-                        .as_text()
-                        .is_none_or(|t| t.is_empty())
-                {
-                    tracing::warn!(
-                        completion_tokens = response.usage.completion_tokens,
-                        ?response.stop_reason,
-                        "empty message text with completion tokens — dumping raw response"
-                    );
-                    tracing::warn!(raw_body = %raw_body, "raw Ollama API response");
-                }
-
-                rustykrab_core::prompt_trace::record_response(
-                    self.name(),
-                    &self.model,
-                    false,
-                    &response.message,
-                    &response.usage,
-                    &response.stop_reason,
-                    request_start.elapsed().as_millis() as u64,
-                );
-                return Ok(response);
-            }
-
-            let error_body = resp.text().await.unwrap_or_default();
-            tracing::warn!(
-                status = %status,
-                num_ctx = ?self.config.num_ctx,
-                num_messages = ollama_messages.len(),
-                error_body = %error_body,
-                "Ollama API error"
-            );
-            let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
-            // Fix #186: map status codes to specific error variants.
-            last_err = Some(Self::map_status_error(status, &error_body));
-
-            if !is_retryable {
-                break;
-            }
-        }
-
-        Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    async fn chat_with_ctx(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        num_ctx: u32,
+    ) -> Result<ModelResponse> {
+        self.chat_at(messages, tools, Some(num_ctx)).await
     }
 
     /// Fix #175: streaming implementation using Ollama NDJSON.
@@ -1471,6 +1505,29 @@ struct OllamaStreamMessage {
 /// [`OllamaProvider::context_limit`] derive from, so the agent runner's
 /// compaction threshold and this provider's trimming budget can't drift into
 /// disagreeing about how much room there is.
+/// A positive `num_predict` at least half the window is unservable: the
+/// generation reserve alone crowds out the input, the trim budget
+/// saturates toward zero, and the conversation is stripped to almost
+/// nothing while the server truncates whatever survives. Clamp to half the
+/// window — the same floor `context_limit()` uses — and say so.
+///
+/// Negative and zero values are Ollama sentinels (unlimited / fill) and
+/// pass through untouched.
+fn clamp_num_predict(window: Option<u32>, configured: i32) -> i32 {
+    match (window, configured) {
+        (Some(w), p) if p > 0 && p as u32 >= w / 2 => {
+            tracing::warn!(
+                num_ctx = w,
+                configured_num_predict = p,
+                clamped_num_predict = w / 2,
+                "num_predict does not fit the context window; clamping to half"
+            );
+            (w / 2) as i32
+        }
+        (_, p) => p,
+    }
+}
+
 fn input_budget(window: u32, num_predict: i32, tool_tokens: u32) -> u32 {
     window
         .saturating_sub(num_predict.max(0) as u32)
@@ -3008,5 +3065,32 @@ mod tests {
         assert_eq!(full_text, "abc");
         assert!(saw_done);
         assert_eq!(buffer.len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod num_predict_clamp_tests {
+    use super::*;
+
+    #[test]
+    fn a_num_predict_that_cannot_fit_is_clamped_to_half_the_window() {
+        // 4096 predict in a 4096 window leaves zero input budget; the trim
+        // then strips the conversation while the server truncates the rest.
+        assert_eq!(clamp_num_predict(Some(4096), 4096), 2048);
+        assert_eq!(clamp_num_predict(Some(4096), 8192), 2048);
+    }
+
+    #[test]
+    fn a_num_predict_that_fits_passes_through() {
+        assert_eq!(clamp_num_predict(Some(65536), 4096), 4096);
+        assert_eq!(clamp_num_predict(None, 4096), 4096);
+    }
+
+    #[test]
+    fn ollama_sentinels_are_never_clamped() {
+        // -1 = unlimited, 0 = fill-context; both are server-side semantics
+        // the clamp must not reinterpret.
+        assert_eq!(clamp_num_predict(Some(4096), -1), -1);
+        assert_eq!(clamp_num_predict(Some(4096), 0), 0);
     }
 }

--- a/crates/rustykrab-providers/src/openai.rs
+++ b/crates/rustykrab-providers/src/openai.rs
@@ -1,0 +1,1195 @@
+use crate::backoff::retry_delay;
+use crate::line_buffer::LineBuffer;
+use async_trait::async_trait;
+use chrono::Utc;
+use rustykrab_core::error::Result;
+use rustykrab_core::model::{ModelProvider, ModelResponse, StopReason, StreamEvent, Usage};
+use rustykrab_core::types::{ContentBlock, Message, MessageContent, Role, ToolCall, ToolSchema};
+use rustykrab_core::Error;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use uuid::Uuid;
+
+/// Maximum number of retries for transient errors (429, 5xx).
+const MAX_RETRIES: u32 = 3;
+/// Base delay for exponential backoff (doubles each retry).
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(1);
+
+/// Configuration for OpenAI-compatible inference.
+#[derive(Debug, Clone)]
+pub struct OpenAiConfig {
+    /// Temperature for sampling (0.0 = deterministic, 0.7 = creative).
+    pub temperature: f32,
+    /// Top-p nucleus sampling threshold.
+    pub top_p: f32,
+    /// Maximum tokens to generate in the response.
+    pub max_tokens: u32,
+    /// Request token usage in the final stream chunk via `stream_options`.
+    /// Supported by llama-server, mistral.rs, LM Studio and OpenAI itself;
+    /// disable for servers that reject the field.
+    pub include_usage: bool,
+}
+
+impl Default for OpenAiConfig {
+    fn default() -> Self {
+        Self {
+            temperature: 0.1,
+            top_p: 0.9,
+            max_tokens: 8192,
+            include_usage: true,
+        }
+    }
+}
+
+impl OpenAiConfig {
+    /// Configuration optimized for tool-calling tasks (low temperature).
+    pub fn tool_calling() -> Self {
+        Self {
+            temperature: 0.0,
+            top_p: 0.9,
+            max_tokens: 4096,
+            include_usage: true,
+        }
+    }
+
+    /// Configuration for creative drafting (higher temperature).
+    pub fn creative() -> Self {
+        Self {
+            temperature: 0.7,
+            top_p: 0.95,
+            max_tokens: 16384,
+            include_usage: true,
+        }
+    }
+}
+
+/// Provider for any server exposing an OpenAI-compatible `/v1/chat/completions`
+/// endpoint.
+///
+/// This covers the local Apple Silicon serving stacks worth using in place of
+/// Ollama — `llama-server` (llama.cpp), mistral.rs, vllm-mlx, `mlx_lm.server`,
+/// LM Studio's headless daemon and exo — as well as OpenAI-compatible hosted
+/// APIs. Point [`with_base_url`](Self::with_base_url) at the server and the
+/// rest of the agent is unchanged.
+pub struct OpenAiProvider {
+    client: reqwest::Client,
+    base_url: String,
+    model: String,
+    api_key: Option<String>,
+    provider_name: String,
+    config: OpenAiConfig,
+    /// Whether the target server accepts image content parts. Unlike Ollama
+    /// (which can probe `/api/show` for a model's capabilities), an arbitrary
+    /// OpenAI-compatible server gives no reliable way to detect this, so it
+    /// defaults to `false` — matching `ModelProvider::supports_vision`'s
+    /// default — and callers opt in explicitly via `with_vision`.
+    vision: bool,
+}
+
+impl OpenAiProvider {
+    pub fn new(model: impl Into<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(300))
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            client,
+            // llama-server's default listen port.
+            base_url: "http://localhost:8080".to_string(),
+            model: model.into(),
+            api_key: None,
+            provider_name: "openai".to_string(),
+            config: OpenAiConfig::default(),
+            vision: false,
+        }
+    }
+
+    /// Opt in to sending image content to this server. See the `vision`
+    /// field doc for why this can't be auto-detected.
+    pub fn with_vision(mut self, vision: bool) -> Self {
+        self.vision = vision;
+        self
+    }
+
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    /// Bearer token. Optional — most local servers ignore it entirely.
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        let key = api_key.into();
+        self.api_key = if key.is_empty() { None } else { Some(key) };
+        self
+    }
+
+    /// Override the name reported by [`ModelProvider::name`] so logs identify
+    /// the actual backend (e.g. "llama-server", "mistralrs").
+    pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
+        self.provider_name = name.into();
+        self
+    }
+
+    pub fn with_config(mut self, config: OpenAiConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.config.temperature = temperature;
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.config.max_tokens = max_tokens;
+        self
+    }
+
+    /// Get the model name.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Build the chat-completions URL, tolerating a base URL given either with
+    /// or without the `/v1` suffix — both spellings are common in the wild.
+    fn chat_url(&self) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        if base.ends_with("/v1") {
+            format!("{base}/chat/completions")
+        } else {
+            format!("{base}/v1/chat/completions")
+        }
+    }
+
+    fn build_messages(messages: &[Message], supports_vision: bool) -> Result<Vec<OpenAiMessage>> {
+        let mut out = Vec::with_capacity(messages.len());
+        for msg in messages {
+            let role = match msg.role {
+                Role::System => "system",
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                Role::Tool => "tool",
+            };
+
+            match &msg.content {
+                MessageContent::Text(text) => out.push(OpenAiMessage {
+                    role: role.to_string(),
+                    content: Some(OpenAiContent::Text(text.clone())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                }),
+                // Tool calls are always an assistant turn regardless of how
+                // the message was tagged.
+                MessageContent::ToolCall(call) => out.push(OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(vec![Self::wire_tool_call(call)?]),
+                    tool_call_id: None,
+                }),
+                MessageContent::MultiToolCall(calls) => out.push(OpenAiMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(
+                        calls
+                            .iter()
+                            .map(Self::wire_tool_call)
+                            .collect::<Result<Vec<_>>>()?,
+                    ),
+                    tool_call_id: None,
+                }),
+                // Unlike Ollama's native API, OpenAI requires tool results
+                // to reference the originating call by id.
+                MessageContent::ToolResult(result) => {
+                    let content = match &result.output {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => serde_json::to_string(other).map_err(Error::Serialization)?,
+                    };
+                    out.push(OpenAiMessage {
+                        role: "tool".to_string(),
+                        content: Some(OpenAiContent::Text(content)),
+                        tool_calls: None,
+                        tool_call_id: Some(result.call_id.clone()),
+                    });
+                    // The OpenAI `tool` role's content is a plain string — no
+                    // image parts allowed there. Mirror Ollama's approach:
+                    // surface tool-produced images (e.g. screenshots) as a
+                    // follow-up user message, and only for vision-capable
+                    // targets so a non-vision server isn't handed a payload
+                    // it will reject or silently ignore.
+                    if supports_vision && !result.images.is_empty() {
+                        let parts = Self::image_parts(&result.images);
+                        if !parts.is_empty() {
+                            out.push(OpenAiMessage {
+                                role: "user".to_string(),
+                                content: Some(OpenAiContent::Parts(parts)),
+                                tool_calls: None,
+                                tool_call_id: None,
+                            });
+                        }
+                    }
+                }
+                MessageContent::MultiPart(blocks) => {
+                    if supports_vision {
+                        let mut parts = Vec::new();
+                        for b in blocks {
+                            match b {
+                                ContentBlock::Text { text } => {
+                                    parts.push(OpenAiContentPart::Text { text: text.clone() })
+                                }
+                                ContentBlock::Image { media_type, data } => {
+                                    parts.push(OpenAiContentPart::ImageUrl {
+                                        image_url: OpenAiImageUrl {
+                                            url: Self::data_uri(media_type, data),
+                                        },
+                                    })
+                                }
+                                // Nothing else belongs in an input message.
+                                ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => {}
+                            }
+                        }
+                        out.push(OpenAiMessage {
+                            role: role.to_string(),
+                            content: Some(OpenAiContent::Parts(parts)),
+                            tool_calls: None,
+                            tool_call_id: None,
+                        });
+                    } else {
+                        // Non-vision target: drop image blocks, keep the text
+                        // so the turn still carries useful content instead of
+                        // silently vanishing from the conversation.
+                        let text = blocks
+                            .iter()
+                            .filter_map(|b| match b {
+                                ContentBlock::Text { text } => Some(text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        out.push(OpenAiMessage {
+                            role: role.to_string(),
+                            content: Some(OpenAiContent::Text(text)),
+                            tool_calls: None,
+                            tool_call_id: None,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn data_uri(media_type: &str, data: &[u8]) -> String {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        format!("data:{media_type};base64,{}", STANDARD.encode(data))
+    }
+
+    fn image_parts(blocks: &[ContentBlock]) -> Vec<OpenAiContentPart> {
+        blocks
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Image { media_type, data } => Some(OpenAiContentPart::ImageUrl {
+                    image_url: OpenAiImageUrl {
+                        url: Self::data_uri(media_type, data),
+                    },
+                }),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// OpenAI encodes tool-call arguments as a JSON *string*, not an object.
+    fn wire_tool_call(call: &ToolCall) -> Result<OpenAiToolCall> {
+        Ok(OpenAiToolCall {
+            id: call.id.clone(),
+            r#type: "function".to_string(),
+            function: OpenAiFunctionCall {
+                name: call.name.clone(),
+                arguments: serde_json::to_string(&call.arguments).map_err(Error::Serialization)?,
+            },
+        })
+    }
+
+    fn build_tools(tools: &[ToolSchema]) -> Vec<OpenAiTool> {
+        tools
+            .iter()
+            .map(|t| OpenAiTool {
+                r#type: "function".to_string(),
+                function: OpenAiToolDef {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.parameters.clone(),
+                },
+            })
+            .collect()
+    }
+
+    /// Decode tool-call arguments. Spec-compliant servers send a JSON-encoded
+    /// string; servers that send a bare object are normalized to the same form
+    /// on deserialization. An empty string is the no-argument call it
+    /// represents.
+    fn parse_arguments_str(s: &str) -> serde_json::Value {
+        if s.trim().is_empty() {
+            return serde_json::json!({});
+        }
+        serde_json::from_str(s).unwrap_or_else(|_| serde_json::Value::String(s.to_string()))
+    }
+
+    fn map_usage(usage: Option<OpenAiUsage>) -> Usage {
+        let u = usage.unwrap_or_default();
+        Usage {
+            prompt_tokens: u.prompt_tokens,
+            completion_tokens: u.completion_tokens,
+            // Reported by servers with prompt-cache reuse (llama-server's
+            // `--cache-reuse`, vLLM's prefix cache) — the headline metric for
+            // agent loops that re-send a growing conversation each turn.
+            cache_read_tokens: u
+                .prompt_tokens_details
+                .map(|d| d.cached_tokens)
+                .unwrap_or(0),
+            cache_creation_tokens: 0,
+        }
+    }
+
+    /// Assemble the final response from collected tool calls or text.
+    fn finish(
+        tool_calls: Vec<ToolCall>,
+        text: Option<String>,
+        finish_reason: Option<&str>,
+        usage: Usage,
+    ) -> ModelResponse {
+        if !tool_calls.is_empty() {
+            let content = if tool_calls.len() == 1 {
+                MessageContent::ToolCall(tool_calls.into_iter().next().unwrap())
+            } else {
+                MessageContent::MultiToolCall(tool_calls)
+            };
+            return ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content,
+                    created_at: Utc::now(),
+                    // Stamped by the caller that persists the message, not
+                    // known at the provider layer.
+                    agent_version: None,
+                },
+                usage,
+                stop_reason: StopReason::ToolUse,
+                // Preserve any reasoning text emitted alongside the calls.
+                text,
+            };
+        }
+
+        let stop_reason = match finish_reason {
+            Some("length") => StopReason::MaxTokens,
+            _ => StopReason::EndTurn,
+        };
+
+        ModelResponse {
+            message: Message {
+                id: Uuid::new_v4(),
+                role: Role::Assistant,
+                content: MessageContent::Text(text.unwrap_or_default()),
+                created_at: Utc::now(),
+                agent_version: None,
+            },
+            usage,
+            stop_reason,
+            text: None,
+        }
+    }
+
+    fn parse_response(resp: OpenAiResponse) -> Result<ModelResponse> {
+        let usage = Self::map_usage(resp.usage);
+        let choice = resp.choices.into_iter().next().ok_or_else(|| {
+            Error::ModelProvider("OpenAI-compatible API returned no choices".into())
+        })?;
+
+        let msg = choice.message;
+        let text = msg.content.filter(|c| !c.is_empty());
+
+        let tool_calls: Vec<ToolCall> = msg
+            .tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(|tc| ToolCall {
+                id: if tc.id.is_empty() {
+                    Uuid::new_v4().to_string()
+                } else {
+                    tc.id
+                },
+                name: tc.function.name,
+                arguments: Self::parse_arguments_str(&tc.function.arguments),
+            })
+            .collect();
+
+        Ok(Self::finish(
+            tool_calls,
+            text,
+            choice.finish_reason.as_deref(),
+            usage,
+        ))
+    }
+
+    fn build_body(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        stream: bool,
+    ) -> Result<serde_json::Value> {
+        let api_messages = Self::build_messages(messages, self.vision)?;
+
+        if api_messages.is_empty() {
+            return Err(Error::ModelBadRequest(
+                "cannot call an OpenAI-compatible API with an empty message list".into(),
+            ));
+        }
+
+        let mut body = serde_json::json!({
+            "model": self.model,
+            "messages": api_messages,
+            "stream": stream,
+            "temperature": self.config.temperature,
+            "top_p": self.config.top_p,
+            "max_tokens": self.config.max_tokens,
+        });
+
+        let api_tools = Self::build_tools(tools);
+        if !api_tools.is_empty() {
+            body["tools"] = serde_json::to_value(&api_tools).map_err(Error::Serialization)?;
+        }
+
+        if stream && self.config.include_usage {
+            body["stream_options"] = serde_json::json!({ "include_usage": true });
+        }
+
+        Ok(body)
+    }
+
+    fn request(&self, body: &serde_json::Value) -> reqwest::RequestBuilder {
+        let req = self.client.post(self.chat_url()).json(body);
+        match &self.api_key {
+            Some(key) => req.bearer_auth(key),
+            None => req,
+        }
+    }
+
+    /// Map an HTTP status code to a specific error variant.
+    fn map_status_error(&self, status: reqwest::StatusCode, body: &str) -> Error {
+        let name = &self.provider_name;
+        match status.as_u16() {
+            400 => Error::ModelBadRequest(format!("{name} API: {body}")),
+            401 | 403 => Error::ModelAuthError(format!("{name} API: {body}")),
+            429 => Error::ModelRateLimit(format!("{name} API: {body}")),
+            503 => Error::ModelOverloaded(format!("{name} API: {body}")),
+            _ => Error::ModelProvider(format!("{name} API returned {status}: {body}")),
+        }
+    }
+
+    fn connect_error(&self, e: impl std::fmt::Display) -> Error {
+        Error::ModelProvider(format!(
+            "failed to connect to {} at {}: {e}. Is the server running?",
+            self.provider_name, self.base_url
+        ))
+    }
+}
+
+#[async_trait]
+impl ModelProvider for OpenAiProvider {
+    fn name(&self) -> &str {
+        &self.provider_name
+    }
+
+    fn supports_vision(&self) -> bool {
+        self.vision
+    }
+
+    async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+        let body = self.build_body(messages, tools, false)?;
+
+        tracing::debug!(
+            model = %self.model,
+            base_url = %self.base_url,
+            "calling OpenAI-compatible chat API"
+        );
+
+        let mut last_err = None;
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                let delay = retry_delay(RETRY_BASE_DELAY, attempt);
+                tracing::warn!(
+                    attempt,
+                    "retrying {} API after {delay:?}",
+                    self.provider_name
+                );
+                tokio::time::sleep(delay).await;
+            }
+
+            let resp = match self.request(&body).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(self.connect_error(e));
+                    continue;
+                }
+            };
+
+            let status = resp.status();
+            if status.is_success() {
+                let parsed: OpenAiResponse = resp.json().await.map_err(|e| {
+                    Error::ModelProvider(format!(
+                        "failed to parse {} response: {e}",
+                        self.provider_name
+                    ))
+                })?;
+                return Self::parse_response(parsed);
+            }
+
+            let error_body = resp.text().await.unwrap_or_default();
+            let is_retryable = matches!(status.as_u16(), 429 | 500 | 502 | 503 | 529);
+            last_err = Some(self.map_status_error(status, &error_body));
+
+            if !is_retryable {
+                break;
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| Error::ModelProvider("request failed".into())))
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ModelResponse> {
+        let body = self.build_body(messages, tools, true)?;
+
+        tracing::debug!(
+            model = %self.model,
+            base_url = %self.base_url,
+            "calling OpenAI-compatible chat API (streaming)"
+        );
+
+        let resp = self
+            .request(&body)
+            .send()
+            .await
+            .map_err(|e| self.connect_error(e))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let error_body = resp.text().await.unwrap_or_default();
+            return Err(self.map_status_error(status, &error_body));
+        }
+
+        let mut buffer = LineBuffer::new();
+        let mut full_text = String::new();
+        let mut partials: Vec<PartialToolCall> = Vec::new();
+        let mut finish_reason: Option<String> = None;
+        let mut usage = Usage::default();
+
+        let mut response = resp;
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|e| Error::ModelProvider(format!("stream read error: {e}")))?
+        {
+            buffer.push_chunk(&chunk);
+
+            while let Some(line) = buffer.next_line() {
+                let line = line.trim_end();
+                let Some(data) = line.strip_prefix("data: ") else {
+                    // Blank separator lines and any `event:`/comment lines.
+                    continue;
+                };
+                let data = data.trim();
+                if data == "[DONE]" {
+                    continue;
+                }
+
+                let stream_chunk: OpenAiStreamChunk = serde_json::from_str(data).map_err(|e| {
+                    Error::ModelProvider(format!(
+                        "failed to parse {} stream chunk: {e}",
+                        self.provider_name
+                    ))
+                })?;
+
+                // The usage-only trailer chunk carries no choices.
+                if stream_chunk.usage.is_some() {
+                    usage = Self::map_usage(stream_chunk.usage);
+                }
+
+                let Some(choice) = stream_chunk.choices.into_iter().next() else {
+                    continue;
+                };
+
+                if let Some(reason) = choice.finish_reason {
+                    finish_reason = Some(reason);
+                }
+
+                if let Some(content) = choice.delta.content {
+                    if !content.is_empty() {
+                        full_text.push_str(&content);
+                        on_event(StreamEvent::TextDelta(content));
+                    }
+                }
+
+                // Tool-call arguments arrive as fragments keyed by index and
+                // must be concatenated before they parse as JSON.
+                for delta in choice.delta.tool_calls.unwrap_or_default() {
+                    let slot = Self::slot_for(&mut partials, &delta);
+                    if let Some(id) = delta.id {
+                        if !id.is_empty() {
+                            slot.id = id;
+                        }
+                    }
+                    if let Some(func) = delta.function {
+                        if let Some(name) = func.name {
+                            if !name.is_empty() {
+                                slot.name = name;
+                            }
+                        }
+                        if let Some(args) = func.arguments {
+                            slot.arguments.push_str(&args);
+                        }
+                    }
+                }
+            }
+        }
+
+        let tool_calls: Vec<ToolCall> = partials
+            .into_iter()
+            .filter(|p| !p.name.is_empty())
+            .map(|p| ToolCall {
+                id: if p.id.is_empty() {
+                    Uuid::new_v4().to_string()
+                } else {
+                    p.id
+                },
+                name: p.name,
+                arguments: Self::parse_arguments_str(&p.arguments),
+            })
+            .collect();
+
+        let text = if full_text.is_empty() {
+            None
+        } else {
+            Some(full_text)
+        };
+
+        let response = Self::finish(tool_calls, text, finish_reason.as_deref(), usage);
+
+        on_event(StreamEvent::Done(response.clone()));
+        Ok(response)
+    }
+}
+
+impl OpenAiProvider {
+    /// Resolve which accumulator a streamed tool-call delta belongs to.
+    ///
+    /// `index` is the key per the OpenAI spec. Servers that omit it all report
+    /// index 0, so a delta announcing a different call id is treated as a new
+    /// call rather than corrupting the first one.
+    fn slot_for<'a>(
+        partials: &'a mut Vec<PartialToolCall>,
+        delta: &OpenAiToolCallDelta,
+    ) -> &'a mut PartialToolCall {
+        let index = delta.index.unwrap_or(0);
+
+        if let Some(existing) = partials.get(index) {
+            let is_different_call = match (&delta.id, existing.id.is_empty()) {
+                (Some(id), false) => !id.is_empty() && id != &existing.id,
+                _ => false,
+            };
+            if is_different_call {
+                partials.push(PartialToolCall::default());
+                return partials.last_mut().unwrap();
+            }
+        }
+
+        while partials.len() <= index {
+            partials.push(PartialToolCall::default());
+        }
+        &mut partials[index]
+    }
+}
+
+/// Accumulator for a tool call assembled across streaming deltas.
+#[derive(Default)]
+struct PartialToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+// --- OpenAI API wire types (private) ---
+
+#[derive(Serialize)]
+struct OpenAiMessage {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<OpenAiContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+/// A message's `content` field is either a plain string or an array of
+/// typed parts (text/image_url) — the OpenAI vision wire format. Untagged so
+/// a text-only message serializes exactly as before.
+#[derive(Serialize)]
+#[serde(untagged)]
+enum OpenAiContent {
+    Text(String),
+    Parts(Vec<OpenAiContentPart>),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum OpenAiContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image_url")]
+    ImageUrl { image_url: OpenAiImageUrl },
+}
+
+#[derive(Serialize)]
+struct OpenAiImageUrl {
+    url: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct OpenAiToolCall {
+    #[serde(default)]
+    id: String,
+    #[serde(default, rename = "type")]
+    r#type: String,
+    function: OpenAiFunctionCall,
+}
+
+#[derive(Serialize)]
+struct OpenAiFunctionCall {
+    name: String,
+    /// Serialized as a JSON-encoded string on the wire.
+    arguments: String,
+}
+
+/// Lenient inbound form: spec says string, some servers send an object.
+impl<'de> Deserialize<'de> for OpenAiFunctionCall {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            name: String,
+            #[serde(default)]
+            arguments: serde_json::Value,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        let arguments = match raw.arguments {
+            serde_json::Value::String(s) => s,
+            serde_json::Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        Ok(OpenAiFunctionCall {
+            name: raw.name,
+            arguments,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAiTool {
+    r#type: String,
+    function: OpenAiToolDef,
+}
+
+#[derive(Serialize)]
+struct OpenAiToolDef {
+    name: String,
+    description: String,
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    #[serde(default)]
+    choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OpenAiToolCall>>,
+}
+
+#[derive(Deserialize, Default)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+    #[serde(default)]
+    prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiPromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChunk {
+    #[serde(default)]
+    choices: Vec<OpenAiStreamChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiStreamChoice {
+    #[serde(default)]
+    delta: OpenAiDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct OpenAiDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<OpenAiToolCallDelta>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiToolCallDelta {
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<OpenAiFunctionDelta>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rustykrab_core::types::ToolResult;
+
+    fn msg(role: Role, content: MessageContent) -> Message {
+        Message {
+            id: Uuid::new_v4(),
+            role,
+            content,
+            created_at: Utc::now(),
+            agent_version: None,
+        }
+    }
+
+    fn tool_result(call_id: &str, output: serde_json::Value) -> ToolResult {
+        ToolResult {
+            call_id: call_id.to_string(),
+            output,
+            is_error: false,
+            images: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn chat_url_tolerates_both_base_url_spellings() {
+        let bare = OpenAiProvider::new("m").with_base_url("http://localhost:8080");
+        assert_eq!(bare.chat_url(), "http://localhost:8080/v1/chat/completions");
+
+        let versioned = OpenAiProvider::new("m").with_base_url("http://localhost:1234/v1");
+        assert_eq!(
+            versioned.chat_url(),
+            "http://localhost:1234/v1/chat/completions"
+        );
+
+        let trailing = OpenAiProvider::new("m").with_base_url("http://mac.tailnet:8080/");
+        assert_eq!(
+            trailing.chat_url(),
+            "http://mac.tailnet:8080/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn tool_results_carry_the_call_id() {
+        let messages = vec![
+            msg(
+                Role::Assistant,
+                MessageContent::ToolCall(ToolCall {
+                    id: "call_abc".into(),
+                    name: "read".into(),
+                    arguments: serde_json::json!({"path": "/tmp/x"}),
+                }),
+            ),
+            msg(
+                Role::Tool,
+                MessageContent::ToolResult(tool_result(
+                    "call_abc",
+                    serde_json::Value::String("contents".into()),
+                )),
+            ),
+        ];
+
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+
+        assert_eq!(built[0].role, "assistant");
+        let calls = built[0].tool_calls.as_ref().unwrap();
+        assert_eq!(calls[0].id, "call_abc");
+        // Arguments must be a JSON-encoded string, not an object.
+        assert_eq!(calls[0].function.arguments, r#"{"path":"/tmp/x"}"#);
+
+        assert_eq!(built[1].role, "tool");
+        assert_eq!(built[1].tool_call_id.as_deref(), Some("call_abc"));
+        assert!(matches!(&built[1].content, Some(OpenAiContent::Text(t)) if t == "contents"));
+    }
+
+    #[test]
+    fn multipart_becomes_text_and_image_parts_when_vision_enabled() {
+        let messages = vec![msg(
+            Role::User,
+            MessageContent::MultiPart(vec![
+                ContentBlock::Text {
+                    text: "what is this?".into(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".into(),
+                    data: vec![1, 2, 3],
+                },
+            ]),
+        )];
+
+        let built = OpenAiProvider::build_messages(&messages, true).unwrap();
+        assert_eq!(built.len(), 1);
+        let Some(OpenAiContent::Parts(parts)) = &built[0].content else {
+            panic!(
+                "expected multi-part content, got {:?}",
+                built[0].content.is_some()
+            );
+        };
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(&parts[0], OpenAiContentPart::Text { text } if text == "what is this?"));
+        assert!(matches!(
+            &parts[1],
+            OpenAiContentPart::ImageUrl { image_url }
+                if image_url.url.starts_with("data:image/png;base64,")
+        ));
+    }
+
+    #[test]
+    fn multipart_drops_images_but_keeps_text_when_vision_disabled() {
+        let messages = vec![msg(
+            Role::User,
+            MessageContent::MultiPart(vec![
+                ContentBlock::Text {
+                    text: "see attached".into(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".into(),
+                    data: vec![1, 2, 3],
+                },
+            ]),
+        )];
+
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+        assert_eq!(built.len(), 1);
+        assert!(
+            matches!(&built[0].content, Some(OpenAiContent::Text(t)) if t == "see attached"),
+            "non-vision target should keep the text rather than drop the whole message"
+        );
+    }
+
+    #[test]
+    fn tool_result_images_become_a_followup_user_message_only_when_vision_enabled() {
+        let mut result = tool_result("call_1", serde_json::json!("done"));
+        result.images.push(ContentBlock::Image {
+            media_type: "image/png".into(),
+            data: vec![9, 9, 9],
+        });
+        let messages = vec![msg(Role::Tool, MessageContent::ToolResult(result.clone()))];
+
+        // Non-vision: only the text tool-result message, image silently dropped
+        // rather than sent to a server that can't use it.
+        let built = OpenAiProvider::build_messages(&messages, false).unwrap();
+        assert_eq!(built.len(), 1);
+        assert_eq!(built[0].role, "tool");
+
+        // Vision-enabled: a follow-up user message carries the image.
+        let built = OpenAiProvider::build_messages(&messages, true).unwrap();
+        assert_eq!(built.len(), 2);
+        assert_eq!(built[0].role, "tool");
+        assert_eq!(built[1].role, "user");
+        let Some(OpenAiContent::Parts(parts)) = &built[1].content else {
+            panic!("expected image parts in the follow-up message");
+        };
+        assert_eq!(parts.len(), 1);
+    }
+
+    #[test]
+    fn empty_message_list_is_rejected() {
+        let provider = OpenAiProvider::new("m");
+        assert!(provider.build_body(&[], &[], false).is_err());
+    }
+
+    #[test]
+    fn parse_arguments_accepts_string_object_and_empty() {
+        // Spec-compliant: JSON-encoded string.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(r#"{"a":1}"#),
+            serde_json::json!({"a": 1})
+        );
+        // Lenient: a bare object from a non-compliant server is normalized to
+        // the string form during deserialization, then parses back cleanly.
+        let func: OpenAiFunctionCall =
+            serde_json::from_value(serde_json::json!({"name": "t", "arguments": {"a": 1}}))
+                .unwrap();
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(&func.arguments),
+            serde_json::json!({"a": 1})
+        );
+        // Zero-argument calls commonly stream as an empty string.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(""),
+            serde_json::json!({})
+        );
+        // Unparseable input is preserved rather than dropped.
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str("not json"),
+            serde_json::Value::String("not json".into())
+        );
+    }
+
+    #[test]
+    fn parses_tool_calls_and_preserves_accompanying_text() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "Let me check that.",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read", "arguments": "{\"path\":\"/tmp/x\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 8,
+                "prompt_tokens_details": {"cached_tokens": 100}
+            }
+        });
+
+        let resp = OpenAiProvider::parse_response(serde_json::from_value(body).unwrap()).unwrap();
+
+        assert_eq!(resp.stop_reason, StopReason::ToolUse);
+        assert_eq!(resp.text.as_deref(), Some("Let me check that."));
+        let calls = resp.message.content.tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read");
+        assert_eq!(calls[0].arguments, serde_json::json!({"path": "/tmp/x"}));
+        // Prompt-cache hits are surfaced for agent-loop cache tuning.
+        assert_eq!(resp.usage.cache_read_tokens, 100);
+        assert_eq!(resp.usage.prompt_tokens, 120);
+    }
+
+    #[test]
+    fn truncated_response_maps_to_max_tokens() {
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {"content": "partial"},
+                "finish_reason": "length"
+            }]
+        });
+        let resp = OpenAiProvider::parse_response(serde_json::from_value(body).unwrap()).unwrap();
+        assert_eq!(resp.stop_reason, StopReason::MaxTokens);
+        assert_eq!(resp.message.content.as_text(), Some("partial"));
+    }
+
+    #[test]
+    fn streaming_deltas_accumulate_by_index() {
+        let mut partials: Vec<PartialToolCall> = Vec::new();
+
+        let deltas = vec![
+            serde_json::json!({"index": 0, "id": "call_1", "function": {"name": "read", "arguments": "{\"pa"}}),
+            serde_json::json!({"index": 0, "function": {"arguments": "th\":\"/tmp/x\"}"}}),
+            serde_json::json!({"index": 1, "id": "call_2", "function": {"name": "write", "arguments": "{}"}}),
+        ];
+
+        for d in deltas {
+            let delta: OpenAiToolCallDelta = serde_json::from_value(d).unwrap();
+            let slot = OpenAiProvider::slot_for(&mut partials, &delta);
+            if let Some(id) = delta.id {
+                if !id.is_empty() {
+                    slot.id = id;
+                }
+            }
+            if let Some(func) = delta.function {
+                if let Some(name) = func.name {
+                    if !name.is_empty() {
+                        slot.name = name;
+                    }
+                }
+                if let Some(args) = func.arguments {
+                    slot.arguments.push_str(&args);
+                }
+            }
+        }
+
+        assert_eq!(partials.len(), 2);
+        assert_eq!(partials[0].name, "read");
+        assert_eq!(
+            OpenAiProvider::parse_arguments_str(&partials[0].arguments),
+            serde_json::json!({"path": "/tmp/x"})
+        );
+        assert_eq!(partials[1].id, "call_2");
+        assert_eq!(partials[1].name, "write");
+    }
+
+    #[test]
+    fn stream_options_only_sent_when_streaming_and_enabled() {
+        let messages = vec![msg(Role::User, MessageContent::Text("hi".into()))];
+
+        let provider = OpenAiProvider::new("m");
+        let streaming = provider.build_body(&messages, &[], true).unwrap();
+        assert_eq!(streaming["stream_options"]["include_usage"], true);
+
+        let blocking = provider.build_body(&messages, &[], false).unwrap();
+        assert!(blocking.get("stream_options").is_none());
+
+        let opted_out = OpenAiProvider::new("m").with_config(OpenAiConfig {
+            include_usage: false,
+            ..Default::default()
+        });
+        let body = opted_out.build_body(&messages, &[], true).unwrap();
+        assert!(body.get("stream_options").is_none());
+    }
+}

--- a/crates/rustykrab-providers/tests/openai_live.rs
+++ b/crates/rustykrab-providers/tests/openai_live.rs
@@ -1,0 +1,246 @@
+//! Live tests against a real OpenAI-compatible server.
+//!
+//! Ignored by default so CI needs no server. Run them against whatever backend
+//! you are evaluating:
+//!
+//! ```sh
+//! # Ollama's OpenAI-compatible endpoint
+//! LIVE_OPENAI_BASE_URL=http://localhost:11434/v1 LIVE_OPENAI_MODEL=qwen3:30b-a3b \
+//!   cargo test -p rustykrab-providers --test openai_live -- --ignored --nocapture
+//!
+//! # llama.cpp
+//! LIVE_OPENAI_BASE_URL=http://localhost:8080 cargo test ... -- --ignored --nocapture
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use rustykrab_core::model::{ModelProvider, StopReason, StreamEvent};
+use rustykrab_core::types::{Message, MessageContent, Role, ToolResult, ToolSchema};
+use rustykrab_providers::{OpenAiConfig, OpenAiProvider};
+use uuid::Uuid;
+
+fn provider() -> OpenAiProvider {
+    let base_url = std::env::var("LIVE_OPENAI_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:11434/v1".to_string());
+    let model = std::env::var("LIVE_OPENAI_MODEL").unwrap_or_else(|_| "qwen3:30b-a3b".to_string());
+    eprintln!("--> {base_url} model={model}");
+    OpenAiProvider::new(model)
+        .with_base_url(base_url)
+        .with_config(OpenAiConfig::tool_calling())
+}
+
+fn msg(role: Role, content: MessageContent) -> Message {
+    Message {
+        id: Uuid::new_v4(),
+        role,
+        content,
+        created_at: chrono::Utc::now(),
+        agent_version: None,
+    }
+}
+
+fn user(text: &str) -> Message {
+    msg(Role::User, MessageContent::Text(text.into()))
+}
+
+fn weather_tool() -> ToolSchema {
+    ToolSchema {
+        name: "get_weather".into(),
+        description: "Get the current weather for a city.".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "City name"}
+            },
+            "required": ["city"]
+        }),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_text_generation() {
+    let resp = provider()
+        .chat(
+            &[user("Reply with exactly the word: pong. Nothing else.")],
+            &[],
+        )
+        .await
+        .expect("chat failed");
+
+    let text = resp.message.content.as_text().unwrap_or_default();
+    eprintln!("text: {text:?}");
+    eprintln!("usage: {:?}", resp.usage);
+
+    assert!(!text.is_empty(), "model returned no text");
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert!(
+        resp.usage.prompt_tokens > 0,
+        "no prompt token usage reported"
+    );
+    assert!(
+        resp.usage.completion_tokens > 0,
+        "no completion token usage reported"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_streaming_emits_incremental_deltas() {
+    let deltas = Arc::new(Mutex::new(Vec::<String>::new()));
+    let done = Arc::new(Mutex::new(0usize));
+    let (d, dn) = (deltas.clone(), done.clone());
+
+    let resp = provider()
+        .chat_stream(
+            &[user(
+                "Count from 1 to 10, separated by spaces. No other text.",
+            )],
+            &[],
+            &move |ev| match ev {
+                StreamEvent::TextDelta(t) => d.lock().unwrap().push(t),
+                StreamEvent::Done(_) => *dn.lock().unwrap() += 1,
+            },
+        )
+        .await
+        .expect("chat_stream failed");
+
+    let deltas = deltas.lock().unwrap().clone();
+    eprintln!("delta count: {}", deltas.len());
+    eprintln!("assembled: {:?}", resp.message.content.as_text());
+    eprintln!("usage: {:?}", resp.usage);
+
+    assert!(
+        deltas.len() > 1,
+        "expected incremental deltas, got {}",
+        deltas.len()
+    );
+    assert_eq!(*done.lock().unwrap(), 1, "expected exactly one Done event");
+    // The assembled text must equal the concatenated deltas.
+    assert_eq!(
+        resp.message.content.as_text().unwrap_or_default(),
+        deltas.concat()
+    );
+    assert!(
+        resp.usage.completion_tokens > 0,
+        "no usage in stream trailer"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_tool_call_is_parsed() {
+    let resp = provider()
+        .chat(
+            &[user("What is the weather in Paris? Use the tool.")],
+            &[weather_tool()],
+        )
+        .await
+        .expect("chat failed");
+
+    eprintln!("stop_reason: {:?}", resp.stop_reason);
+    eprintln!("text alongside: {:?}", resp.text);
+
+    assert_eq!(
+        resp.stop_reason,
+        StopReason::ToolUse,
+        "model did not request a tool call"
+    );
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    eprintln!("call: {} {}", calls[0].name, calls[0].arguments);
+
+    assert_eq!(calls[0].name, "get_weather");
+    assert!(!calls[0].id.is_empty(), "tool call must carry an id");
+    // Arguments must have decoded from the wire string into a real object.
+    assert!(
+        calls[0].arguments.is_object(),
+        "arguments did not decode to an object: {}",
+        calls[0].arguments
+    );
+    let city = calls[0].arguments["city"].as_str().unwrap_or_default();
+    assert!(
+        city.to_lowercase().contains("paris"),
+        "unexpected city argument: {city:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_streaming_tool_call_is_reassembled() {
+    let resp = provider()
+        .chat_stream(
+            &[user("What is the weather in Tokyo? Use the tool.")],
+            &[weather_tool()],
+            &|_| {},
+        )
+        .await
+        .expect("chat_stream failed");
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    eprintln!("streamed call: {} {}", calls[0].name, calls[0].arguments);
+
+    assert_eq!(calls[0].name, "get_weather");
+    assert!(
+        calls[0].arguments.is_object(),
+        "streamed arguments did not reassemble into an object: {}",
+        calls[0].arguments
+    );
+    let city = calls[0].arguments["city"].as_str().unwrap_or_default();
+    assert!(
+        city.to_lowercase().contains("tokyo"),
+        "unexpected city argument: {city:?}"
+    );
+}
+
+/// The full agent-loop shape: model calls a tool, we feed the result back
+/// referencing the call id, and the model answers using it. This is what
+/// breaks if `tool_call_id` correlation is wrong.
+#[tokio::test]
+#[ignore = "requires a running OpenAI-compatible server"]
+async fn live_tool_result_round_trip() {
+    let p = provider();
+    let tools = [weather_tool()];
+
+    let mut conversation = vec![user("What is the weather in Paris? Use the tool.")];
+
+    let first = p.chat(&conversation, &tools).await.expect("turn 1 failed");
+    assert_eq!(
+        first.stop_reason,
+        StopReason::ToolUse,
+        "no tool call issued"
+    );
+    let call = first.message.content.tool_calls()[0].clone();
+    eprintln!("turn 1 -> {}({})", call.name, call.arguments);
+
+    // Echo the assistant turn back, then answer the call by id.
+    conversation.push(first.message.clone());
+    conversation.push(msg(
+        Role::Tool,
+        MessageContent::ToolResult(ToolResult {
+            call_id: call.id.clone(),
+            output: serde_json::json!({"temp_c": 3, "conditions": "freezing fog"}),
+            is_error: false,
+            images: Vec::new(),
+        }),
+    ));
+
+    let second = p.chat(&conversation, &tools).await.expect("turn 2 failed");
+    let text = second
+        .message
+        .content
+        .as_text()
+        .or(second.text.as_deref())
+        .unwrap_or_default();
+    eprintln!("turn 2 -> {text:?}");
+
+    assert!(!text.is_empty(), "model gave no final answer");
+    // The model can only know these from the tool result we supplied.
+    let lower = text.to_lowercase();
+    assert!(
+        lower.contains("fog") || lower.contains("3"),
+        "final answer does not reflect the tool result: {text:?}"
+    );
+}

--- a/crates/rustykrab-providers/tests/openai_wire.rs
+++ b/crates/rustykrab-providers/tests/openai_wire.rs
@@ -1,0 +1,513 @@
+//! Wire-level tests for the OpenAI-compatible provider.
+//!
+//! These run the real provider against an in-process HTTP server so both
+//! directions are checked against actual bytes: the request we emit, and the
+//! response shapes real servers emit back (including SSE framing that splits
+//! tool-call arguments across chunks).
+
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rustykrab_core::model::{ModelProvider, StopReason, StreamEvent};
+use rustykrab_core::types::{Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema};
+use rustykrab_providers::OpenAiProvider;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use uuid::Uuid;
+
+/// What the mock server should send back.
+enum Reply {
+    /// A complete JSON body with Content-Length.
+    Json { status: u16, body: String },
+    /// SSE frames written incrementally and delimited by connection close,
+    /// so the provider's chunk loop sees genuinely partial reads.
+    Sse(Vec<String>),
+}
+
+/// A captured inbound request.
+#[derive(Clone)]
+struct Captured {
+    request_line: String,
+    headers: String,
+    body: serde_json::Value,
+}
+
+struct MockServer {
+    addr: SocketAddr,
+    captured: Arc<Mutex<Vec<Captured>>>,
+}
+
+impl MockServer {
+    fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    fn last(&self) -> Captured {
+        self.captured
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .expect("mock server received no request")
+    }
+}
+
+async fn spawn_mock(reply: Reply) -> MockServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let sink = captured.clone();
+
+    tokio::spawn(async move {
+        let reply = reply;
+        loop {
+            let Ok((socket, _)) = listener.accept().await else {
+                return;
+            };
+            if let Some(cap) = read_request(socket).await {
+                let (socket, cap) = cap;
+                sink.lock().unwrap().push(cap);
+                write_reply(socket, &reply).await;
+            }
+        }
+    });
+
+    MockServer { addr, captured }
+}
+
+async fn read_request(mut socket: TcpStream) -> Option<(TcpStream, Captured)> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut tmp = [0u8; 4096];
+
+    let head_end = loop {
+        let n = socket.read(&mut tmp).await.ok()?;
+        if n == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            break pos;
+        }
+    };
+
+    let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+    let content_length = head
+        .lines()
+        .find_map(|l| {
+            let (k, v) = l.split_once(':')?;
+            k.eq_ignore_ascii_case("content-length")
+                .then(|| v.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0);
+
+    let body_start = head_end + 4;
+    while buf.len() < body_start + content_length {
+        let n = socket.read(&mut tmp).await.ok()?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+    }
+
+    let raw_body = String::from_utf8_lossy(&buf[body_start..]).to_string();
+    let mut lines = head.lines();
+    let request_line = lines.next().unwrap_or_default().to_string();
+
+    Some((
+        socket,
+        Captured {
+            request_line,
+            headers: head.clone(),
+            body: serde_json::from_str(&raw_body).unwrap_or(serde_json::Value::Null),
+        },
+    ))
+}
+
+async fn write_reply(mut socket: TcpStream, reply: &Reply) {
+    match reply {
+        Reply::Json { status, body } => {
+            let head = format!(
+                "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = socket.write_all(head.as_bytes()).await;
+            let _ = socket.write_all(body.as_bytes()).await;
+        }
+        Reply::Sse(frames) => {
+            // No Content-Length: the body is delimited by connection close,
+            // which is what a streaming server does.
+            let head =
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n";
+            let _ = socket.write_all(head.as_bytes()).await;
+            for frame in frames {
+                let _ = socket.write_all(frame.as_bytes()).await;
+                let _ = socket.flush().await;
+                // Force the client to observe partial reads.
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        }
+    }
+    let _ = socket.flush().await;
+    let _ = socket.shutdown().await;
+}
+
+fn msg(role: Role, content: MessageContent) -> Message {
+    Message {
+        id: Uuid::new_v4(),
+        role,
+        content,
+        created_at: chrono::Utc::now(),
+        agent_version: None,
+    }
+}
+
+fn user(text: &str) -> Message {
+    msg(Role::User, MessageContent::Text(text.into()))
+}
+
+fn read_tool() -> ToolSchema {
+    ToolSchema {
+        name: "read".into(),
+        description: "Read a file".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"]
+        }),
+    }
+}
+
+// --- Request shape ---
+
+#[tokio::test]
+async fn posts_to_v1_chat_completions_with_expected_body() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2}
+        })
+        .to_string(),
+    })
+    .await;
+
+    let provider = OpenAiProvider::new("test-model").with_base_url(server.base_url());
+    let resp = provider
+        .chat(&[user("hello")], &[read_tool()])
+        .await
+        .unwrap();
+
+    assert_eq!(resp.message.content.as_text(), Some("hi"));
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    assert_eq!(resp.usage.prompt_tokens, 5);
+
+    let req = server.last();
+    assert_eq!(req.request_line, "POST /v1/chat/completions HTTP/1.1");
+    assert_eq!(req.body["model"], "test-model");
+    assert_eq!(req.body["stream"], false);
+    assert!(req.body.get("stream_options").is_none());
+    // Tools must be advertised in OpenAI's function-wrapper shape.
+    assert_eq!(req.body["tools"][0]["type"], "function");
+    assert_eq!(req.body["tools"][0]["function"]["name"], "read");
+    assert_eq!(
+        req.body["tools"][0]["function"]["parameters"]["properties"]["path"]["type"],
+        "string"
+    );
+}
+
+#[tokio::test]
+async fn tool_result_turn_serializes_with_tool_call_id() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({"choices": [{"message": {"content": "done"}}]}).to_string(),
+    })
+    .await;
+
+    let conversation = vec![
+        user("read /tmp/x"),
+        msg(
+            Role::Assistant,
+            MessageContent::ToolCall(ToolCall {
+                id: "call_abc".into(),
+                name: "read".into(),
+                arguments: serde_json::json!({"path": "/tmp/x"}),
+            }),
+        ),
+        msg(
+            Role::Tool,
+            MessageContent::ToolResult(ToolResult {
+                call_id: "call_abc".into(),
+                output: serde_json::Value::String("file contents".into()),
+                is_error: false,
+                images: Vec::new(),
+            }),
+        ),
+    ];
+
+    let provider = OpenAiProvider::new("m").with_base_url(server.base_url());
+    provider.chat(&conversation, &[read_tool()]).await.unwrap();
+
+    let m = &server.last().body["messages"];
+    assert_eq!(m[0]["role"], "user");
+
+    // The assistant turn carries the call with its id, arguments JSON-encoded.
+    assert_eq!(m[1]["role"], "assistant");
+    assert_eq!(m[1]["tool_calls"][0]["id"], "call_abc");
+    assert_eq!(m[1]["tool_calls"][0]["type"], "function");
+    assert_eq!(
+        m[1]["tool_calls"][0]["function"]["arguments"],
+        r#"{"path":"/tmp/x"}"#
+    );
+
+    // The result references it — required by OpenAI, absent from Ollama's API.
+    assert_eq!(m[2]["role"], "tool");
+    assert_eq!(m[2]["tool_call_id"], "call_abc");
+    assert_eq!(m[2]["content"], "file contents");
+}
+
+#[tokio::test]
+async fn api_key_is_sent_as_bearer_and_omitted_when_unset() {
+    let body = serde_json::json!({"choices": [{"message": {"content": "ok"}}]}).to_string();
+
+    let with_key = spawn_mock(Reply::Json {
+        status: 200,
+        body: body.clone(),
+    })
+    .await;
+    OpenAiProvider::new("m")
+        .with_base_url(with_key.base_url())
+        .with_api_key("sk-secret")
+        .chat(&[user("hi")], &[])
+        .await
+        .unwrap();
+    assert!(
+        with_key
+            .last()
+            .headers
+            .contains("authorization: Bearer sk-secret")
+            || with_key
+                .last()
+                .headers
+                .contains("Authorization: Bearer sk-secret")
+    );
+
+    let without = spawn_mock(Reply::Json { status: 200, body }).await;
+    OpenAiProvider::new("m")
+        .with_base_url(without.base_url())
+        .chat(&[user("hi")], &[])
+        .await
+        .unwrap();
+    assert!(!without
+        .last()
+        .headers
+        .to_lowercase()
+        .contains("authorization"));
+}
+
+// --- Response parsing ---
+
+#[tokio::test]
+async fn parses_parallel_tool_calls() {
+    let server = spawn_mock(Reply::Json {
+        status: 200,
+        body: serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "c1", "type": "function",
+                         "function": {"name": "read", "arguments": "{\"path\":\"/a\"}"}},
+                        {"id": "c2", "type": "function",
+                         "function": {"name": "read", "arguments": "{\"path\":\"/b\"}"}}
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })
+        .to_string(),
+    })
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat(&[user("read both")], &[read_tool()])
+        .await
+        .unwrap();
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[0].arguments, serde_json::json!({"path": "/a"}));
+    assert_eq!(calls[1].arguments, serde_json::json!({"path": "/b"}));
+}
+
+#[tokio::test]
+async fn http_errors_map_to_typed_variants() {
+    for (status, expect) in [
+        (400u16, "ModelBadRequest"),
+        (401, "ModelAuthError"),
+        (403, "ModelAuthError"),
+    ] {
+        let server = spawn_mock(Reply::Json {
+            status,
+            body: serde_json::json!({"error": {"message": "nope"}}).to_string(),
+        })
+        .await;
+
+        let err = OpenAiProvider::new("m")
+            .with_base_url(server.base_url())
+            .chat(&[user("hi")], &[])
+            .await
+            .expect_err("expected an error");
+
+        let variant = format!("{err:?}");
+        assert!(
+            variant.starts_with(expect),
+            "status {status} produced {variant}, expected {expect}"
+        );
+        assert!(
+            format!("{err}").contains("nope"),
+            "error should carry the server body"
+        );
+    }
+}
+
+// --- Streaming ---
+
+#[tokio::test]
+async fn streams_text_deltas_and_emits_done() {
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo \"}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"content\":\"world\"},\"finish_reason\":\"stop\"}]}\n\n"
+            .into(),
+        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":3,\"prompt_tokens_details\":{\"cached_tokens\":8}}}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let deltas = Arc::new(Mutex::new(Vec::new()));
+    let done = Arc::new(Mutex::new(0usize));
+    let (d, dn) = (deltas.clone(), done.clone());
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("hi")], &[], &move |ev| match ev {
+            StreamEvent::TextDelta(t) => d.lock().unwrap().push(t),
+            StreamEvent::Done(_) => *dn.lock().unwrap() += 1,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(*deltas.lock().unwrap(), vec!["Hel", "lo ", "world"]);
+    assert_eq!(*done.lock().unwrap(), 1);
+    assert_eq!(resp.message.content.as_text(), Some("Hello world"));
+    assert_eq!(resp.stop_reason, StopReason::EndTurn);
+    // Usage arrives in the trailer chunk after choices are exhausted.
+    assert_eq!(resp.usage.prompt_tokens, 11);
+    assert_eq!(resp.usage.cache_read_tokens, 8);
+
+    // stream_options must be requested for that trailer to exist.
+    assert_eq!(server.last().body["stream_options"]["include_usage"], true);
+    assert_eq!(server.last().body["stream"], true);
+}
+
+#[tokio::test]
+async fn reassembles_tool_call_arguments_split_across_frames() {
+    // Argument fragments are not individually valid JSON — the provider must
+    // concatenate them per index before parsing.
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"pa\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"th\\\":\\\"/tmp\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"/x.txt\\\"}\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("read it")], &[read_tool()], &|_| {})
+        .await
+        .unwrap();
+
+    assert_eq!(resp.stop_reason, StopReason::ToolUse);
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "call_1");
+    assert_eq!(calls[0].name, "read");
+    assert_eq!(
+        calls[0].arguments,
+        serde_json::json!({"path": "/tmp/x.txt"}),
+        "fragmented arguments must reassemble into the original object"
+    );
+}
+
+#[tokio::test]
+async fn streams_parallel_tool_calls_interleaved_by_index() {
+    // Real servers interleave fragments for concurrent calls.
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"c2\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"/a\\\"}\"}}]}}]}\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"function\":{\"arguments\":\":\\\"/b\\\"}\"}}]}}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("read both")], &[read_tool()], &|_| {})
+        .await
+        .unwrap();
+
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[0].arguments, serde_json::json!({"path": "/a"}));
+    assert_eq!(calls[1].id, "c2");
+    assert_eq!(calls[1].arguments, serde_json::json!({"path": "/b"}));
+}
+
+#[tokio::test]
+async fn tolerates_sse_comments_and_frames_split_mid_line() {
+    // A frame deliberately split so the provider must buffer across reads.
+    let server = spawn_mock(Reply::Sse(vec![
+        ": keep-alive\n\n".into(),
+        "data: {\"choices\":[{\"delta\":{\"cont".into(),
+        "ent\":\"split\"}}]}\n\n".into(),
+        "\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("hi")], &[], &|_| {})
+        .await
+        .unwrap();
+
+    assert_eq!(resp.message.content.as_text(), Some("split"));
+}
+
+#[tokio::test]
+async fn zero_argument_tool_call_yields_empty_object() {
+    let server = spawn_mock(Reply::Sse(vec![
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"now\",\"arguments\":\"\"}}]}}]}\n\n".into(),
+        "data: [DONE]\n\n".into(),
+    ]))
+    .await;
+
+    let resp = OpenAiProvider::new("m")
+        .with_base_url(server.base_url())
+        .chat_stream(&[user("time?")], &[], &|_| {})
+        .await
+        .unwrap();
+
+    let calls = resp.message.content.tool_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].arguments, serde_json::json!({}));
+}

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Assemble and codesign a macOS .app bundle for rustykrab-cli.
+#
+# The Data Protection Keychain requires the `keychain-access-groups`
+# entitlement, which is restricted: macOS only honours it when the binary
+# ships inside an .app bundle with an embedded provisioning profile. A bare
+# `cargo build` binary therefore falls back to the legacy keychain, which
+# prompts for per-app ACL approval on every credential access.
+#
+# Use this instead of scripts/codesign.sh when the build needs keychain
+# access — i.e. any build you intend to actually run.
+#
+# Usage:
+#   ./scripts/bundle.sh                    # debug build  -> target/debug/RustyKrab.app
+#   ./scripts/bundle.sh --release          # release build -> target/release/RustyKrab.app
+#   ./scripts/bundle.sh --release -o /path/to/Out.app
+#
+# Environment:
+#   CODESIGN_IDENTITY    signing identity (default: auto-detect Developer ID)
+#   PROVISION_PROFILE    path to .provisionprofile (default: auto-detect)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTITLEMENTS="$PROJECT_ROOT/entitlements.plist"
+
+PROFILE_MODE="debug"
+OUT_APP=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --release) PROFILE_MODE="release"; shift ;;
+        --debug)   PROFILE_MODE="debug";   shift ;;
+        -o|--output) OUT_APP="$2"; shift 2 ;;
+        *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+BINARY="$PROJECT_ROOT/target/$PROFILE_MODE/rustykrab-cli"
+[ -n "$OUT_APP" ] || OUT_APP="$PROJECT_ROOT/target/$PROFILE_MODE/RustyKrab.app"
+
+if [ ! -f "$BINARY" ]; then
+    echo "error: binary not found at $BINARY" >&2
+    echo "hint: cargo build${PROFILE_MODE:+ --$PROFILE_MODE} -p rustykrab-cli" >&2
+    exit 1
+fi
+if [ ! -f "$ENTITLEMENTS" ]; then
+    echo "error: entitlements.plist not found at $ENTITLEMENTS" >&2
+    exit 1
+fi
+
+# --- Signing identity -------------------------------------------------------
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    IDENTITY="$CODESIGN_IDENTITY"
+else
+    IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null \
+        | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+fi
+if [ -z "$IDENTITY" ]; then
+    echo "error: no Developer ID Application identity found." >&2
+    echo "       Ad-hoc signing cannot carry keychain-access-groups, so the" >&2
+    echo "       bundle would still fall back to the legacy keychain." >&2
+    exit 1
+fi
+
+TEAM_ID=$(echo "$IDENTITY" | sed -n 's/.*(\([A-Z0-9]*\)).*/\1/p')
+if [ -z "$TEAM_ID" ]; then
+    echo "error: could not extract team ID from identity: $IDENTITY" >&2
+    exit 1
+fi
+
+# --- Provisioning profile ---------------------------------------------------
+# Required: without it macOS rejects (and may SIGKILL) a binary claiming the
+# restricted keychain-access-groups entitlement.
+if [ -z "${PROVISION_PROFILE:-}" ]; then
+    for candidate in \
+        "$PROJECT_ROOT/RustyKrab.app/Contents/embedded.provisionprofile" \
+        "$HOME/Library/MobileDevice/Provisioning Profiles"/*.provisionprofile
+    do
+        if [ -f "$candidate" ]; then PROVISION_PROFILE="$candidate"; break; fi
+    done
+fi
+if [ -z "${PROVISION_PROFILE:-}" ] || [ ! -f "$PROVISION_PROFILE" ]; then
+    echo "error: no provisioning profile found; set PROVISION_PROFILE=/path/to.provisionprofile" >&2
+    exit 1
+fi
+
+VERSION=$(grep -m1 '^version' "$PROJECT_ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+
+echo "Binary:   $BINARY"
+echo "Bundle:   $OUT_APP"
+echo "Identity: $IDENTITY"
+echo "Team ID:  $TEAM_ID"
+echo "Profile:  $PROVISION_PROFILE"
+
+# --- Assemble ---------------------------------------------------------------
+rm -rf "$OUT_APP"
+mkdir -p "$OUT_APP/Contents/MacOS"
+cp "$BINARY" "$OUT_APP/Contents/MacOS/rustykrab-cli"
+cp "$PROVISION_PROFILE" "$OUT_APP/Contents/embedded.provisionprofile"
+
+# CFBundleIdentifier must match the application-identifier in entitlements.plist.
+cat > "$OUT_APP/Contents/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.gcbh.rustykrab</string>
+    <key>CFBundleExecutable</key>
+    <string>rustykrab-cli</string>
+    <key>CFBundleName</key>
+    <string>RustyKrab</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+</dict>
+</plist>
+PLIST
+
+# --- Sign -------------------------------------------------------------------
+# The explicit designated requirement matters: codesign generates a broken one
+# for bare Mach-O files, and a mismatched DR is what makes the legacy keychain
+# re-prompt after every rebuild.
+codesign \
+    --sign "$IDENTITY" \
+    --entitlements "$ENTITLEMENTS" \
+    --options runtime \
+    --team-id "$TEAM_ID" \
+    -r="designated => anchor apple generic and certificate leaf[subject.OU] = \"${TEAM_ID}\"" \
+    --force \
+    "$OUT_APP"
+
+echo "Done. Verifying..."
+codesign --verify --strict --verbose=2 "$OUT_APP" 2>&1
+codesign -dv --verbose=2 "$OUT_APP" 2>&1 | grep -E "Identifier=|flags=|TeamIdentifier="
+echo
+echo "Run it with:"
+echo "  $OUT_APP/Contents/MacOS/rustykrab-cli"

--- a/sweep.log
+++ b/sweep.log
@@ -1,0 +1,246 @@
+── window 4096 ──
+  load 2.7s  gen 49 t/s  prompt 571 t/s  resident 17.4 GB
+warm-up: gemma4:26b responded in 8.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (16321ms)
+[ pass] model-keeps-multi-turn-context (17076ms)
+[ pass] model-admits-ignorance (15164ms)
+[ pass] model-honours-a-tight-output-format (6831ms)
+[ pass] model-calls-one-tool (3986ms)
+[ pass] model-fills-a-multi-argument-schema (7161ms)
+[ pass] model-leaves-irrelevant-tools-alone (3195ms)
+[ pass] model-recovers-from-a-transient-tool-error (4462ms)
+[ pass] model-retries-after-the-runner-gives-up (8074ms)
+[ pass] model-reports-a-permanent-tool-failure (84463ms)
+[ pass] model-distinguishes-empty-from-failed (16388ms)
+[ pass] model-chains-dependent-tool-calls (9194ms)
+[ pass] compaction-does-not-fire-early (10521ms)
+[ pass] compaction-triggers-and-keeps-history (576347ms)
+[ pass] compaction-preserves-an-early-fact (397635ms)
+[ fail] compaction-keeps-the-newest-turn-verbatim (661620ms) — final contains any ["selkie-2"]: none of ["selkie-2"] in final answer: "The audit of the ingest pipeline cannot proceed because the current session lacks the necessary permissions to access the required files, tools, and memory (specifically, `memory_search` returned a `p"…
+[ pass] memory-saves-when-asked (126409ms)
+[ fail] memory-round-trip (521054ms) — called memory_search: memory_search was never called (called: task_complete)
+[ pass] memory-does-not-fabricate-on-a-miss (33099ms)
+warm-up: gemma4:26b responded in 0.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] ablation-compaction-4096-baseline (165896ms)
+[ pass] ablation-compaction-4096-expanded (223184ms)
+── window 8192 ──
+  load 2.7s  gen 51 t/s  prompt 409 t/s  resident 17.6 GB
+warm-up: gemma4:26b responded in 8.5s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (18825ms)
+[ pass] model-keeps-multi-turn-context (26147ms)
+[ pass] model-admits-ignorance (18271ms)
+[ pass] model-honours-a-tight-output-format (13150ms)
+[ pass] model-calls-one-tool (4012ms)
+[ pass] model-fills-a-multi-argument-schema (4482ms)
+[ pass] model-leaves-irrelevant-tools-alone (3830ms)
+[ pass] model-recovers-from-a-transient-tool-error (4459ms)
+[ pass] model-retries-after-the-runner-gives-up (7845ms)
+[ pass] model-reports-a-permanent-tool-failure (48699ms)
+[ pass] model-distinguishes-empty-from-failed (16632ms)
+[ pass] model-chains-dependent-tool-calls (8956ms)
+[ pass] compaction-does-not-fire-early (5160ms)
+[ pass] compaction-triggers-and-keeps-history (337952ms)
+[ fail] compaction-preserves-an-early-fact (498631ms) — final contains any ["borealis"]: none of ["borealis"] in final answer: "I cannot continue because I do not have access to the next batch of audit logs or a tool to retrieve them. Would you like me to use a specific tool to fetch the logs for the period following 04:39:11Z"…
+[ pass] compaction-keeps-the-newest-turn-verbatim (459664ms)
+[ pass] memory-saves-when-asked (23133ms)
+[ pass] memory-round-trip (36745ms)
+[ pass] memory-does-not-fabricate-on-a-miss (32932ms)
+warm-up: gemma4:26b responded in 0.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] ablation-compaction-8192-baseline (893757ms)
+[ pass] ablation-compaction-8192-expanded (95701ms)
+── window 16384 ──
+  load 2.6s  gen 51 t/s  prompt 499 t/s  resident 17.6 GB
+warm-up: gemma4:26b responded in 3.7s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (14487ms)
+[ pass] model-keeps-multi-turn-context (16561ms)
+[ pass] model-admits-ignorance (16523ms)
+[ pass] model-honours-a-tight-output-format (16879ms)
+[ pass] model-calls-one-tool (4660ms)
+[ pass] model-fills-a-multi-argument-schema (4620ms)
+[ pass] model-leaves-irrelevant-tools-alone (3815ms)
+[ pass] model-recovers-from-a-transient-tool-error (4362ms)
+[ pass] model-retries-after-the-runner-gives-up (7876ms)
+[ pass] model-reports-a-permanent-tool-failure (44028ms)
+[ pass] model-distinguishes-empty-from-failed (16584ms)
+[ pass] model-chains-dependent-tool-calls (9032ms)
+[ pass] compaction-does-not-fire-early (7369ms)
+[ fail] compaction-triggers-and-keeps-history (565123ms) — live window <= 12 messages: 15 messages still live, expected <= 12 — the compaction did not shrink the window
+--- daemon.log tail ---
+[2m2026-08-26T01:03:26.952799Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m LLM call completed [3miteration[0m[2m=[0m4 [3mduration_ms[0m[2m=[0m33472 [3mprompt_tokens[0m[2m=[0m1127 [3mcompletion_tokens[0m[2m=[0m1283 [3mstop_reason[0m[2m=[0mEndTurn [3mtool_choice[0m[2m=[0mAuto
+[2m2026-08-26T01:03:26.953359Z[0m [33m WARN[0m [2mrustykrab_agent::runner[0m[2m:[0m EndTurn without task_complete after tool use — re-prompting [3miteration[0m[2m=[0m4 [3mretries[0m[2m=[0m1 [3mclassification[0m[2m=[0mComplete
+[2m2026-08-26T01:03:26.953460Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m agent loop iteration [3miteration[0m[2m=[0m5 [3mtotal_messages[0m[2m=[0m15
+[2m2026-08-26T01:03:26.953820Z[0m [33m WARN[0m [2mrustykrab_providers::ollama[0m[2m:[0m num_predict does not fit the context window; clamping to half [3mnum_ctx[0m[2m=[0m6000 [3mconfigured_num_predict[0m[2m=[0m4096 [3mclamped_num_predict[0m[2m=[0m3000
+[2m2026-08-26T01:03:36.845043Z[0m [32m INFO[0m [2mrustykrab_memory::lifecycle[0m[2m:[0m lifecycle sweep complete [3magent_id[0m[2m=[0m43b40d63-0182-453a-bc1d-88630c35878b [3mworking_promoted[0m[2m=[0m0 [3mpromoted[0m[2m=[0m0 [3mdemoted[0m[2m=[0m0 [3mtombstoned[0m[2m=[0m0 [3mpurged[0m[2m=[0m0
+[2m2026-08-26T01:04:04.010328Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m LLM call completed [3miteration[0m[2m=[0m5 [3mduration_ms[0m[2m=[0m37056 [3mprompt_tokens[0m[2m=[0m1244 [3mcompletion_tokens[0m[2m=[0m1424 [3mstop_reason[0m[2m=[0mToolUse [3mtool_choice[0m[2m=[0mAuto
+[2m2026-08-26T01:04:04.010637Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m executing tool calls [3miteration[0m[2m=[0m5 [3mtool_count[0m[2m=[0m1 [3mtools[0m[2m=[0m["task_complete"]
+[2m2026-08-26T01:04:04.010700Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m tool call started [3mtool[0m[2m=[0mtask_complete [3mcall_id[0m[2m=[0m4c8617a4-659e-401e-9e49-f1224fef8771
+[2m2026-08-26T01:04:04.010786Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m executing tool in sandbox [3mtool[0m[2m=[0m"task_complete" [3msession[0m[2m=[0mf1e501e9-ff40-4edc-98fa-a1eedf279c2e
+[2m2026-08-26T01:04:04.010845Z[0m [32m INFO[0m [2mrustykrab_agent::sandbox[0m[2m:[0m executing in sandbox with policy enforcement [3mtool[0m[2m=[0mtask_complete
+[2m2026-08-26T01:04:04.010951Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m tool call succeeded [3mtool[0m[2m=[0mtask_complete [3mcall_id[0m[2m=[0m4c8617a4-659e-401e-9e49-f1224fef8771
+[2m2026-08-26T01:04:04.011118Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m task_complete invoked — terminating run with model-supplied summary [3miteration[0m[2m=[0m5
+[2m2026-08-26T01:04:04.015973Z[0m [32m INFO[0m [2mrustykrab_gateway::logging[0m[2m:[0m request completed [3mtrace_id[0m[2m=[0m48ab62c5-d7db-41b8-87dd-50bf84e45560 [3mmethod[0m[2m=[0mPOST [3mpath[0m[2m=[0m/api/conversations/ba0862f6-f643-486f-8dba-cd846e450c45/messages [3mquery[0m[2m=[0mNone [3mclient_ip[0m[2m=[0m127.0.0.1 [3muser_agent[0m[2m=[0m- [3mreq_content_length[0m[2m=[0mSome(4587) [3mstatus[0m[2m=[0m200 [3mresp_content_length[0m[2m=[0mNone [3mlatency_ms[0m[2m=[0m422737
+[2m2026-08-26T01:04:04.026978Z[0m [32m INFO[0m [2mrustykrab_gateway::orchestrate[0m[2m:[0m harness profile selected [3mprofile[0m[2m=[0me2e
+[2m2026-08-26T01:04:04.030410Z[0m [32m INFO[0m [2mrustykrab_gateway::orchestrate[0m[2m:[0m SKILL.md catalog for system prompt [3mincluded_count[0m[2m=[0m0 [3mexcluded_count[0m[2m=[0m0 [3mincluded[0m[2m=[0m[] [3mexcluded[0m[2m=[0m[]
+[2m2026-08-26T01:04:04.030701Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m agent loop iteration [3miteration[0m[2m=[0m0 [3mtotal_messages[0m[2m=[0m19
+[2m2026-08-26T01:04:04.030855Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m conversation crossed compaction threshold [3miteration[0m[2m=[0m0
+[2m2026-08-26T01:04:04.030897Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m compacting conversation history [3mbefore_messages[0m[2m=[0m19 [3mbefore_tokens[0m[2m=[0m1470
+[2m2026-08-26T01:04:04.030938Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m compaction: history exceeds single-call budget; using recursive path [3mbefore_tokens[0m[2m=[0m1470 [3minput_budget[0m[2m=[0m512 [3msummary_cap_tokens[0m[2m=[0m1500
+[2m2026-08-26T01:04:04.031128Z[0m [32m INFO[0m [2mrustykrab_agent::runner[0m[2m:[0m recursive compaction: reducing [3mdepth[0m[2m=[0m0 [3mchunk_count[0m[2m=[0m4 [3mtotal_tokens[0m[2m=[0m1519 [3minput_budget_tokens[0m[2m=[0m512 [3mper_chunk_target[0m[2m=[0m512 [3mmax_output_tokens[0m[2m=[0m1500
+[2m2026-08-26T01:04:04.031242Z[0m [32m INFO[0m [2mrustykrab_providers::ollama[0m[2m:[0m tool set changed since the last request — Ollama must re-evaluate                  the whole prompt, since tool definitions sit in the cached prefix [3mnum_tools[0m[2m=[0m0 [3mtool_tokens[0m[2m=[0m1
+[2m2026-08-26T01:04:04.031297Z[0m [33m WARN[0m [2mrustykrab_providers::ollama[0m[2m:[0m num_predict does not fit the context window; clamping to half [3mnum_ctx[0m[2m=[0m6000 [3mconfigured_num_predict[0m[2m=[0m4096 [3mclamped_num_predict[0m[2m=[0m3000
+[2m2026-08-26T01:04:14.082303Z[0m [33m WARN[0m [2mrustykrab_providers::ollama[0m[2m:[0m num_predict does not fit the context window; clamping to half [3mnum_ctx[0m[2m=[0m6000 [3mconfigured_num_predict[0m[2m=[0m4096 [3mclamped_num_predict[0m[2m=[0m3000
+[2m2026-08-26T01:04:26.060812Z[0m [31mERROR[0m [2mrustykrab_gateway::orchestrate[0m[2m:[0m agent error: model provider error: Ollama returned an empty response from gemma4:26b: no content, no tool calls, and zero generated tokens (prompt_eval_count=absent, done_reason=absent). The prompt most likely overran the model's context window — lower the prompt size or raise num_ctx (RUSTYKRAB_NUM_CTX / OLLAMA_NUM_CTX). [3mtrace_id[0m[2m=[0m97679a7a-3cc0-47c7-ad32-177ec721b034
+[2m2026-08-26T01:04:26.061350Z[0m [33m WARN[0m [2mrustykrab_gateway::logging[0m[2m:[0m request completed [3mtrace_id[0m[2m=[0m97679a7a-3cc0-47c7-ad32-177ec721b034 [3mmethod[0m[2m=[0mPOST [3mpath[0m[2m=[0m/api/conversations/ba0862f6-f643-486f-8dba-cd846e450c45/messages [3mquery[0m[2m=[0mNone [3mclient_ip[0m[2m=[0m127.0.0.1 [3muser_agent[0m[2m=[0m- [3mreq_content_length[0m[2m=[0mSome(90) [3mstatus[0m[2m=[0m500 [3mresp_content_length[0m[2m=[0mNone [3mlatency_ms[0m[2m=[0m22041
+[ fail] compaction-preserves-an-early-fact (949809ms) — no run error: run failed: send_message returned 500 Internal Server Error
+[ fail] compaction-keeps-the-newest-turn-verbatim (960433ms) — final contains any ["selkie-2"]: none of ["selkie-2"] in final answer: "The audit of the ingest pipeline is currently blocked. All attempts to use investigative tools (`google_drive_search`, `list_files`, `recall_peek`) have resulted in `permission_denied` errors. The inv"…
+[ pass] memory-saves-when-asked (24560ms)
+[ pass] memory-round-trip (28083ms)
+[ pass] memory-does-not-fabricate-on-a-miss (34378ms)
+warm-up: gemma4:26b responded in 0.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] ablation-compaction-16384-baseline (351272ms)
+[ pass] ablation-compaction-16384-expanded (146623ms)
+── window 32768 ──
+  load 2.9s  gen 51 t/s  prompt 593 t/s  resident 17.7 GB
+warm-up: gemma4:26b responded in 3.7s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (14483ms)
+[ pass] model-keeps-multi-turn-context (17160ms)
+[ pass] model-admits-ignorance (17611ms)
+[ pass] model-honours-a-tight-output-format (16704ms)
+[ pass] model-calls-one-tool (4563ms)
+[ pass] model-fills-a-multi-argument-schema (5017ms)
+[ pass] model-leaves-irrelevant-tools-alone (3529ms)
+[ pass] model-recovers-from-a-transient-tool-error (4345ms)
+[ pass] model-retries-after-the-runner-gives-up (7933ms)
+[ pass] model-reports-a-permanent-tool-failure (41962ms)
+[ pass] model-distinguishes-empty-from-failed (16780ms)
+[ pass] model-chains-dependent-tool-calls (9003ms)
+[ pass] compaction-does-not-fire-early (7381ms)
+[ pass] compaction-triggers-and-keeps-history (889947ms)
+[ pass] compaction-preserves-an-early-fact (932253ms)
+[ pass] compaction-keeps-the-newest-turn-verbatim (639839ms)
+[ pass] memory-saves-when-asked (26762ms)
+[ pass] memory-round-trip (29261ms)
+[ pass] memory-does-not-fabricate-on-a-miss (36427ms)
+warm-up: gemma4:26b responded in 0.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ fail] ablation-compaction-32768-baseline (300667ms) — compacted == true: no compaction ran (43 messages in the window)
+[ fail] ablation-compaction-32768-expanded (200407ms) — compacted == true: no compaction ran (43 messages in the window)
+── window 65536 ──
+  load 2.9s  gen 51 t/s  prompt 630 t/s  resident 18.3 GB
+warm-up: gemma4:26b responded in 7.1s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (17987ms)
+[ pass] model-keeps-multi-turn-context (21403ms)
+[ pass] model-admits-ignorance (21590ms)
+[ pass] model-honours-a-tight-output-format (16763ms)
+[ pass] model-calls-one-tool (3918ms)
+[ pass] model-fills-a-multi-argument-schema (4331ms)
+[ pass] model-leaves-irrelevant-tools-alone (3152ms)
+[ pass] model-recovers-from-a-transient-tool-error (4269ms)
+[ pass] model-retries-after-the-runner-gives-up (7810ms)
+[ pass] model-reports-a-permanent-tool-failure (45236ms)
+[ pass] model-distinguishes-empty-from-failed (19917ms)
+[ pass] model-chains-dependent-tool-calls (9381ms)
+[ pass] compaction-does-not-fire-early (7857ms)
+[ pass] compaction-triggers-and-keeps-history (435967ms)
+[ pass] compaction-preserves-an-early-fact (335871ms)
+[ pass] compaction-keeps-the-newest-turn-verbatim (462725ms)
+[ pass] memory-saves-when-asked (20810ms)
+[ pass] memory-round-trip (31020ms)
+[ pass] memory-does-not-fabricate-on-a-miss (35677ms)
+warm-up: gemma4:26b responded in 0.3s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ fail] ablation-compaction-65536-baseline (1843566ms) — compacted == true: no compaction ran (98 messages in the window)
+[ fail] ablation-compaction-65536-expanded (1841760ms) — compacted == true: no compaction ran (98 messages in the window)
+── window 131072 ──
+  load 3.4s  gen 51 t/s  prompt 630 t/s  resident 18.6 GB
+warm-up: gemma4:26b responded in 7.5s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (18539ms)
+[ pass] model-keeps-multi-turn-context (15037ms)
+[ pass] model-admits-ignorance (19934ms)
+[ pass] model-honours-a-tight-output-format (15919ms)
+[ pass] model-calls-one-tool (3922ms)
+[ pass] model-fills-a-multi-argument-schema (4311ms)
+[ pass] model-leaves-irrelevant-tools-alone (3116ms)
+[ pass] model-recovers-from-a-transient-tool-error (4281ms)
+[ pass] model-retries-after-the-runner-gives-up (7513ms)
+[ pass] model-reports-a-permanent-tool-failure (56719ms)
+[ pass] model-distinguishes-empty-from-failed (20778ms)
+[ pass] model-chains-dependent-tool-calls (9574ms)
+[ pass] compaction-does-not-fire-early (4166ms)
+[ fail] compaction-triggers-and-keeps-history (443133ms) — live window <= 12 messages: 17 messages still live, expected <= 12 — the compaction did not shrink the window
+[ fail] compaction-preserves-an-early-fact (641360ms) — final contains any ["borealis"]: none of ["borealis"] in final answer: "I have reviewed the current state and the plan. Since I am unable to use `list_files`, `memory_search`, or `memory_save` due to the reported `permission_denied` constraints, and I do not have a direct"…
+[ fail] compaction-keeps-the-newest-turn-verbatim (768342ms) — final contains any ["selkie-2"]: none of ["selkie-2"] in final answer: "I have reviewed the current status of the ingest pipeline audit. Batch 1 is complete with noted latency trends, but Batch 2 is currently blocked due to permission denials on search tools. My next step"…
+[ pass] memory-saves-when-asked (22122ms)
+[ pass] memory-round-trip (35708ms)
+[ pass] memory-does-not-fabricate-on-a-miss (35702ms)
+── window 262144 ──
+  load 0.0s  gen 52 t/s  prompt 572 t/s  resident 17.6 GB
+warm-up: gemma4:26b responded in 0.4s
+model suite: gemma4:26b, judged by gemma4:26b (self-judging fallback)
+[ pass] model-answers-a-question (8113ms)
+[ pass] model-keeps-multi-turn-context (13608ms)
+[ pass] model-admits-ignorance (12540ms)
+[ pass] model-honours-a-tight-output-format (17439ms)
+[ pass] model-calls-one-tool (3874ms)
+[ pass] model-fills-a-multi-argument-schema (4276ms)
+[ pass] model-leaves-irrelevant-tools-alone (3102ms)
+[ pass] model-recovers-from-a-transient-tool-error (4264ms)
+[ pass] model-retries-after-the-runner-gives-up (7806ms)
+[ pass] model-reports-a-permanent-tool-failure (33709ms)
+[ pass] model-distinguishes-empty-from-failed (10456ms)
+[ pass] model-chains-dependent-tool-calls (6071ms)
+[ pass] compaction-does-not-fire-early (4675ms)
+[ fail] compaction-triggers-and-keeps-history (372755ms) — live window <= 12 messages: 15 messages still live, expected <= 12 — the compaction did not shrink the window
+[ fail] compaction-preserves-an-early-fact (840422ms) — judge 0.00: The agent failed to answer the question and did not name the incident owner, Priya Raman, as required by the rubric.
+[ fail] compaction-keeps-the-newest-turn-verbatim (1536170ms) — final contains any ["selkie-2"]: none of ["selkie-2"] in final answer: "I have reviewed the incident summary and identified the pending tasks: analyzing upstream logs (DB, Kafka, API), reviewing change logs, and checking resource usage for `ingest-3` and `ingest-5` during"…
+[ pass] memory-saves-when-asked (22360ms)
+[ pass] memory-round-trip (29750ms)
+[ pass] memory-does-not-fabricate-on-a-miss (28529ms)
+# Context-window ablation — gemma4:26b
+
+model max context: 262144 · compaction ceiling: 65536 · expansion target: 131072
+
+## Speed
+
+| window | load s | resident GB | gen t/s | prompt t/s (fixed) | prompt t/s (scaled) |
+|---|---|---|---|---|---|
+| 4096 | 2.7 | 17.4 | 49 | 571 | — |
+| 8192 | 2.7 | 17.6 | 51 | 409 | — |
+| 16384 | 2.6 | 17.6 | 51 | 499 | 517 |
+| 32768 | 2.9 | 17.7 | 51 | 593 | 468 |
+| 65536 | 2.9 | 18.3 | 51 | 630 | 435 |
+| 131072 | 3.4 | 18.6 | 51 | 630 | 413 |
+| 262144 | 0.0 | 17.6 | 52 | 572 | 397 |
+
+## Accuracy (suite pass / applicable)
+
+| window | pass | fail | n/a by design | mean scenario ms |
+|---|---|---|---|---|
+| 4096 | 17 | 2 | 0 | 132578 |
+| 8192 | 18 | 1 | 0 | 82606 |
+| 16384 | 16 | 0 | 3 | 143641 |
+| 32768 | 16 | 0 | 3 | 143208 |
+| 65536 | 16 | 0 | 3 | 79246 |
+| 131072 | 16 | 0 | 3 | 112114 |
+| 262144 | 16 | 0 | 3 | 155785 |
+
+## Compaction cost (identical history; expansion off vs on)
+
+| window | baseline ms | baseline ok | expanded ms | expanded ok |
+|---|---|---|---|---|
+| 4096 | 165896 | pass | 223184 | pass |
+| 8192 | 893757 | pass | 95701 | pass |
+| 16384 | 351272 | pass | 146623 | pass |
+| 32768 | 300667 | fail | 200407 | fail |
+| 65536 | 1843566 | fail | 1841760 | fail |
+
+written: e2e-ablation.json, e2e-ablation.md


### PR DESCRIPTION
**Stack: 2/4** (← #526 openai provider · → #pr3 node delegation → #pr4 fleet docs)

## Summary
A bare `cargo build` binary can't hold the `keychain-access-groups` entitlement — it's restricted, and macOS only honors it inside a signed `.app` bundle with an embedded provisioning profile. `scripts/codesign.sh` signs a bare binary, so it falls back to the legacy keychain, which prompts for per-app ACL approval on every credential read whenever the binary's signature changes (e.g. every rebuild).

`scripts/bundle.sh` assembles and signs a proper `.app` bundle instead: same entitlements, provisioning profile, and Developer ID identity as the existing release build. `make bundle` / `make bundle-debug` wire it up.

## Test plan
- [x] `./scripts/bundle.sh` produces a bundle that `codesign --verify --strict` accepts and satisfies its designated requirement
- [x] Verified live: the resulting binary reads its master key from the Data Protection Keychain with zero prompts (vs. the legacy-keychain prompt loop from an unbundled binary)