### PR TITLE
feat(tools): real peer delegation for the nodes tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,9 +316,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
-          test -n "$APPLE_ID" || { echo "APPLE_ID secret is required for macOS releases" >&2; exit 1; }
-          test -n "$APPLE_TEAM_ID" || { echo "APPLE_TEAM_ID secret is required for macOS releases" >&2; exit 1; }
-          test -n "$APPLE_APP_PASSWORD" || { echo "APPLE_APP_PASSWORD secret is required for macOS releases" >&2; exit 1; }
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_TEAM_ID" ] || [ -z "$APPLE_APP_PASSWORD" ]; then
+            echo "::notice::Apple notarization secrets are not set; publishing the Developer ID-signed bundle without a notarization ticket."
+            echo "The signed tarball from the Package step is published as-is. Notarization is only"
+            echo "needed for bundles downloaded through a browser, which get a Gatekeeper quarantine"
+            echo "attribute. Set APPLE_ID, APPLE_TEAM_ID and APPLE_APP_PASSWORD to enable it."
+            exit 0
+          fi
           xcrun notarytool submit \
             "dist/rustykrab-${{ matrix.target }}.dmg" \
             --apple-id "$APPLE_ID" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.37] - 2026-08-27
+
+- build: app-bundle signing for Data Protection Keychain access (#549)
+
 ## [5.1.36] - 2026-08-27
 
 - feat(providers): OpenAI-compatible model provider (#526)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.38] - 2026-08-27
+
+- fix(ci): skip notarization when Apple secrets are absent (#550)
+
 ## [5.1.37] - 2026-08-27
 
 - build: app-bundle signing for Data Protection Keychain access (#549)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.1.36"
+version = "5.1.37"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.1.37"
+version = "5.1.38"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release debug codesign codesign-debug clean version e2e eval eval-quick eval-cred eval-list e2e eval eval-quick eval-list
+.PHONY: build release debug codesign codesign-debug bundle bundle-debug clean version e2e eval eval-quick eval-cred eval-list e2e eval eval-quick eval-list
 
 # Default: release build + codesign
 build: release
@@ -20,6 +20,17 @@ codesign:
 
 codesign-debug:
 	./scripts/codesign.sh
+
+# Bundle + sign into a .app. Required for Data Protection Keychain access:
+# a bare signed binary falls back to the legacy keychain and prompts on every
+# credential read. Use these for any build you intend to run.
+bundle:
+	cargo build --release -p rustykrab-cli
+	./scripts/bundle.sh --release
+
+bundle-debug:
+	cargo build -p rustykrab-cli
+	./scripts/bundle.sh --debug
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ schemas is roughly 8k tokens before any conversation, and `-np N` divides the
 context between N slots. `--jinja` is required for tool calling.
 
 Point `OPENAI_BASE_URL` at another machine on the LAN or tailnet to run
-inference on separate hardware.
+inference on separate hardware — see [Delegating to a peer node](#delegating-to-a-peer-node)
+below to also delegate whole *agent tasks*, not just inference, to that
+machine.
 
 #### Tuning the Ollama server for KV-cache reuse
 
@@ -201,6 +203,8 @@ All configuration is via environment variables. No plaintext config files.
 | `OPENAI_TEMPERATURE` | `0.1` | Sampling temperature |
 | `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
 | `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
+| `RUSTYKRAB_NODES` | unset | JSON array of peer instances the `nodes` tool can delegate to. See [Delegating to a peer node](#delegating-to-a-peer-node) |
+| `RUSTYKRAB_NODE_TIMEOUT_SECS` | `900` | Per-request timeout for delegated tasks. Generous by default: a peer running a local model at single-digit tokens/sec can legitimately take minutes |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `RUSTYKRAB_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |
@@ -455,6 +459,31 @@ $ rustykrab-cli   # restart the daemon
 
 The resolver runs entirely inside the connector — the model never sees
 the resolved values, and they are not surfaced through any tool.
+
+### Delegating to a peer node
+
+A RustyKrab instance can hand a self-contained task to another RustyKrab
+instance running on different hardware — useful for a slower machine with a
+stronger local model, or simply more compute you'd like the primary to draw
+on. This is delegation, not shared execution: the task runs entirely on the
+peer, using *its* tools and filesystem, and returns only a text result.
+
+```bash
+export RUSTYKRAB_NODES='[
+  {
+    "id": "m4max",
+    "url": "https://your-node.your-tailnet.ts.net",
+    "token": "<the node auth token>",
+    "description": "M4 Max 32GB — qwen3.8:27b-mlx. Slower but capable; good for self-contained coding tasks with its own checkout at ~/code/rustycrab."
+  }
+]'
+```
+
+The `nodes` tool (`list`, `discover`, `send`) is hidden from the model until
+`RUSTYKRAB_NODES` is set. See `scripts/setup-delegation-node.md` for standing
+up a node, exposing it safely (Tailscale Serve, not the raw gateway port),
+and measured latency expectations — a delegated task on a local model
+typically takes minutes, not seconds.
 
 ## Architecture
 

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -1,21 +1,201 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, SandboxRequirements, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
+use serde::Deserialize;
 use serde_json::{json, Value};
+use std::time::{Duration, Instant};
 
-/// A built-in tool that discovers and interacts with paired RustyKrab nodes.
+/// Default per-request timeout. Generous because a node may be running a local
+/// model at single-digit tokens/sec, where one delegated task legitimately takes
+/// minutes.
+const DEFAULT_TIMEOUT_SECS: u64 = 900;
+
+/// A peer RustyKrab instance this agent can delegate work to.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteNode {
+    /// Short identifier used as `node_id` in tool calls.
+    pub id: String,
+    /// Base URL of the peer's gateway, e.g. `http://100.97.221.58:3000`.
+    pub url: String,
+    /// Bearer token for the peer's gateway.
+    ///
+    /// This is a shared static token, not a paired-device token — the
+    /// project's device-pairing flow (`DeviceStore`: per-device tokens,
+    /// SHA-256 hashed at rest, individually revocable) exists for the phone
+    /// use case and would be the better fit here too: a node could redeem a
+    /// pairing code for its own attributable, revocable token instead of
+    /// sharing the gateway's master credential. Left as a shared token for
+    /// now — adopting device pairing is a deliberate follow-up, not an
+    /// oversight.
+    pub token: String,
+    /// Human-readable note — hardware, model, intended role. Surfaced to the
+    /// model so it can pick a node deliberately.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl RemoteNode {
+    fn api(&self, path: &str) -> String {
+        format!("{}/api{}", self.url.trim_end_matches('/'), path)
+    }
+
+    /// Origin sent on node-to-node requests.
+    ///
+    /// The peer's origin check is a CSRF defence: it stops a malicious *web page*
+    /// from driving a localhost agent (the ClawJacked class of attack). It is not
+    /// an authentication mechanism — that is the bearer token, over a private
+    /// network. A server-side client is not subject to browser origin rules and
+    /// legitimately sets its own, so we send a loopback origin the peer accepts
+    /// rather than requiring every node to widen its allowlist.
+    fn origin(&self) -> &'static str {
+        "http://127.0.0.1:3000"
+    }
+}
+
+/// Delegate work to peer RustyKrab instances over the network.
 pub struct NodesTool {
     client: reqwest::Client,
 }
 
 impl NodesTool {
     pub fn new() -> Self {
+        let timeout = std::env::var("RUSTYKRAB_NODE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
         Self {
             client: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
+                .timeout(Duration::from_secs(timeout))
+                .connect_timeout(Duration::from_secs(10))
                 .build()
                 .expect("failed to build HTTP client"),
         }
+    }
+
+    /// Parse the configured node list from `RUSTYKRAB_NODES`.
+    ///
+    /// Format is a JSON array, e.g.
+    /// `[{"id":"m4max","url":"http://100.97.221.58:3000","token":"...",
+    ///    "description":"M4 Max - qwen3.8:27b-mlx, coding"}]`
+    fn configured_nodes() -> Result<Vec<RemoteNode>> {
+        let raw = match std::env::var("RUSTYKRAB_NODES") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => return Ok(Vec::new()),
+        };
+        serde_json::from_str(&raw).map_err(|e| {
+            Error::ToolExecution(
+                format!(
+                    "RUSTYKRAB_NODES is not valid JSON ({e}). Expected an array of \
+                 {{\"id\",\"url\",\"token\",\"description\"}} objects."
+                )
+                .into(),
+            )
+        })
+    }
+
+    fn find(nodes: &[RemoteNode], id: &str) -> Result<RemoteNode> {
+        nodes.iter().find(|n| n.id == id).cloned().ok_or_else(|| {
+            let known: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+            Error::ToolExecution(
+                format!(
+                    "unknown node '{id}'. Configured nodes: {}",
+                    if known.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        known.join(", ")
+                    }
+                )
+                .into(),
+            )
+        })
+    }
+
+    /// Probe a node's public health endpoint. Returns round-trip latency.
+    async fn probe(&self, node: &RemoteNode) -> std::result::Result<u128, String> {
+        let start = Instant::now();
+        let resp = self
+            .client
+            .get(node.api("/health"))
+            .header("Origin", node.origin())
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| format!("unreachable: {e}"))?;
+        if resp.status().is_success() {
+            Ok(start.elapsed().as_millis())
+        } else {
+            Err(format!("HTTP {}", resp.status()))
+        }
+    }
+
+    /// Send a task to a node and return its reply.
+    ///
+    /// Creates a fresh conversation on the peer so delegated work does not share
+    /// context with whatever else that node is doing.
+    async fn send(&self, node: &RemoteNode, message: &str) -> Result<Value> {
+        let started = Instant::now();
+
+        let convo: Value = self
+            .post(node, &node.api("/conversations"), json!({}))
+            .await?;
+        let convo_id = convo["id"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                format!("node '{}' returned no conversation id: {convo}", node.id).into(),
+            )
+        })?;
+
+        let reply: Value = self
+            .post(
+                node,
+                &node.api(&format!("/conversations/{convo_id}/messages")),
+                json!({ "content": message }),
+            )
+            .await?;
+
+        // Assistant messages are {"content": {"type": "text", "data": "..."}}.
+        let text = reply["content"]["data"]
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| reply["content"].to_string());
+
+        Ok(json!({
+            "node_id": node.id,
+            "conversation_id": convo_id,
+            "response": text,
+            "elapsed_secs": started.elapsed().as_secs(),
+        }))
+    }
+
+    async fn post(&self, node: &RemoteNode, url: &str, body: Value) -> Result<Value> {
+        let resp = self
+            .client
+            .post(url)
+            .bearer_auth(&node.token)
+            .header("Origin", node.origin())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                Error::ToolExecution(
+                    format!("node '{}' at {} is unreachable: {e}", node.id, node.url).into(),
+                )
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let hint = match status.as_u16() {
+                401 | 403 => " (check the node's token, and that its gateway is reachable)",
+                _ => "",
+            };
+            return Err(Error::ToolExecution(
+                format!("node '{}' returned {status}{hint}: {body}", node.id).into(),
+            ));
+        }
+
+        resp.json().await.map_err(|e| {
+            Error::ToolExecution(format!("node '{}' returned invalid JSON: {e}", node.id).into())
+        })
     }
 }
 
@@ -32,7 +212,11 @@ impl Tool for NodesTool {
     }
 
     fn description(&self) -> &str {
-        "Discover and interact with paired RustyKrab nodes on the network."
+        "Delegate a task to a peer RustyKrab instance on another machine. Use \
+         'list' to see available nodes and what each is suited for, 'discover' to \
+         check which are online, and 'send' to hand a self-contained task to one \
+         and get its result. Delegated tasks run with that node's own tools and \
+         filesystem, so include everything the node needs in the message."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
@@ -40,6 +224,14 @@ impl Tool for NodesTool {
             needs_net: true,
             ..SandboxRequirements::default()
         }
+    }
+
+    /// Hidden from the model unless at least one node is configured — otherwise
+    /// it advertises a capability that cannot work.
+    fn available(&self) -> bool {
+        Self::configured_nodes()
+            .map(|n| !n.is_empty())
+            .unwrap_or(false)
     }
 
     fn schema(&self) -> ToolSchema {
@@ -52,15 +244,15 @@ impl Tool for NodesTool {
                     "action": {
                         "type": "string",
                         "enum": ["discover", "list", "send"],
-                        "description": "The action to perform: discover new nodes, list known nodes, or send a message to a node"
+                        "description": "'list' shows configured nodes, 'discover' probes which are online, 'send' delegates a task"
                     },
                     "node_id": {
                         "type": "string",
-                        "description": "Target node ID (required for 'send' action)"
+                        "description": "Target node id (required for 'send')"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Message to send to the target node (required for 'send' action)"
+                        "description": "The task to delegate (required for 'send'). Must be self-contained: the node does not share this conversation's context."
                     }
                 },
                 "required": ["action"]
@@ -71,121 +263,133 @@ impl Tool for NodesTool {
     async fn execute(&self, args: Value) -> Result<Value> {
         let action = args["action"]
             .as_str()
-            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+            .ok_or_else(|| Error::ToolExecution("missing action".into()))?;
 
-        let discovery_url = std::env::var("NODES_DISCOVERY_URL").ok();
+        let nodes = Self::configured_nodes()?;
+        if nodes.is_empty() {
+            return Err(Error::ToolExecution(
+                "no nodes configured. Set RUSTYKRAB_NODES to a JSON array of \
+                 {\"id\",\"url\",\"token\",\"description\"} objects."
+                    .into(),
+            ));
+        }
 
         match action {
+            // Never include tokens in tool output — it goes into the model's context.
+            "list" => Ok(json!({
+                "nodes": nodes.iter().map(|n| json!({
+                    "id": n.id,
+                    "url": n.url,
+                    "description": n.description,
+                })).collect::<Vec<_>>()
+            })),
+
             "discover" => {
-                if let Some(url) = &discovery_url {
-                    let resp = self
-                        .client
-                        .get(format!("{url}/discover"))
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("node discovery failed: {e}").into(),
-                            )
-                        })?;
-
-                    let body: Value = resp.json().await.map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to parse discovery response: {e}").into(),
-                        )
-                    })?;
-
-                    Ok(json!({
-                        "action": "discover",
-                        "nodes": body,
-                    }))
-                } else {
-                    Ok(json!({
-                        "action": "discover",
-                        "nodes": [],
-                        "note": "No NODES_DISCOVERY_URL configured. Only local node available.",
-                    }))
+                let mut out = Vec::new();
+                for node in &nodes {
+                    let entry = match self.probe(node).await {
+                        Ok(ms) => json!({
+                            "id": node.id, "url": node.url, "status": "online",
+                            "latency_ms": ms, "description": node.description,
+                        }),
+                        Err(e) => json!({
+                            "id": node.id, "url": node.url, "status": "offline",
+                            "error": e, "description": node.description,
+                        }),
+                    };
+                    out.push(entry);
                 }
+                Ok(json!({ "nodes": out }))
             }
-            "list" => {
-                if let Some(url) = &discovery_url {
-                    let resp = self
-                        .client
-                        .get(format!("{url}/nodes"))
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("node list failed: {e}").into(),
-                            )
-                        })?;
 
-                    let body: Value = resp.json().await.map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to parse nodes response: {e}").into(),
-                        )
-                    })?;
-
-                    Ok(json!({
-                        "action": "list",
-                        "nodes": body,
-                    }))
-                } else {
-                    let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".into());
-                    Ok(json!({
-                        "action": "list",
-                        "nodes": [{
-                            "id": "local",
-                            "name": hostname,
-                            "status": "online",
-                        }],
-                    }))
-                }
-            }
             "send" => {
-                let node_id = args["node_id"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("missing node_id for send action".into())
-                })?;
-                let message = args["message"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("missing message for send action".into())
-                })?;
-
-                let url = discovery_url.ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution(
-                        "NODES_DISCOVERY_URL required to send messages to nodes".into(),
-                    )
-                })?;
-
-                let resp = self
-                    .client
-                    .post(format!("{url}/nodes/{node_id}/send"))
-                    .json(&json!({"message": message}))
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to send to node: {e}").into(),
-                        )
-                    })?;
-
-                let status = resp.status().as_u16();
-                let body = resp.text().await.map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(
-                        format!("failed to read response: {e}").into(),
-                    )
-                })?;
-
-                Ok(json!({
-                    "action": "send",
-                    "node_id": node_id,
-                    "success": status < 400,
-                    "status": status,
-                    "response": body,
-                }))
+                let node_id = args["node_id"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("'send' requires node_id".into()))?;
+                let message = args["message"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("'send' requires message".into()))?;
+                if message.trim().is_empty() {
+                    return Err(Error::ToolExecution(
+                        "'send' requires a non-empty message".into(),
+                    ));
+                }
+                let node = Self::find(&nodes, node_id)?;
+                self.send(&node, message).await
             }
-            _ => Err(rustykrab_core::Error::ToolExecution(
-                format!("unknown nodes action: {action}").into(),
+
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}' (expected discover, list, or send)").into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nodes_json() -> String {
+        json!([
+            {"id": "m4max", "url": "http://100.97.221.58:3000/", "token": "secret-token",
+             "description": "M4 Max - qwen3.8:27b-mlx, coding"},
+            {"id": "other", "url": "http://10.0.0.5:3000", "token": "t2"}
+        ])
+        .to_string()
+    }
+
+    #[test]
+    fn parses_configured_nodes() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].id, "m4max");
+        assert_eq!(
+            nodes[0].description.as_deref(),
+            Some("M4 Max - qwen3.8:27b-mlx, coding")
+        );
+        // description is optional
+        assert!(nodes[1].description.is_none());
+    }
+
+    #[test]
+    fn builds_api_urls_without_double_slashes() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        assert_eq!(
+            nodes[0].api("/conversations"),
+            "http://100.97.221.58:3000/api/conversations"
+        );
+        assert_eq!(nodes[1].api("/health"), "http://10.0.0.5:3000/api/health");
+    }
+
+    #[test]
+    fn unknown_node_error_lists_known_ids() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        let err = NodesTool::find(&nodes, "nope").unwrap_err().to_string();
+        assert!(err.contains("m4max") && err.contains("other"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_never_leaks_tokens() {
+        // Set/remove is process-global; keep this the only test touching the var.
+        std::env::set_var("RUSTYKRAB_NODES", nodes_json());
+        let out = NodesTool::new()
+            .execute(json!({"action": "list"}))
+            .await
+            .unwrap();
+        let rendered = out.to_string();
+        assert!(rendered.contains("m4max"));
+        assert!(
+            !rendered.contains("secret-token"),
+            "tool output must not carry tokens into model context: {rendered}"
+        );
+        std::env::remove_var("RUSTYKRAB_NODES");
+    }
+
+    #[test]
+    fn malformed_config_is_a_clear_error() {
+        std::env::set_var("RUSTYKRAB_NODES", "not json");
+        let err = NodesTool::configured_nodes().unwrap_err().to_string();
+        assert!(err.contains("RUSTYKRAB_NODES"), "got: {err}");
+        std::env::remove_var("RUSTYKRAB_NODES");
     }
 }

--- a/crates/rustykrab-tools/tests/nodes_live.rs
+++ b/crates/rustykrab-tools/tests/nodes_live.rs
@@ -1,0 +1,61 @@
+//! Live delegation test for the `nodes` tool.
+//!
+//! Ignored by default — needs a peer RustyKrab gateway running and
+//! `RUSTYKRAB_NODES` pointing at it:
+//!
+//! ```sh
+//! RUSTYKRAB_NODES='[{"id":"peer","url":"http://127.0.0.1:3100","token":"...","description":"test peer"}]' \
+//!   cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
+//! ```
+
+use rustykrab_core::Tool;
+use rustykrab_tools::NodesTool;
+use serde_json::json;
+
+#[tokio::test]
+#[ignore = "requires a peer RustyKrab gateway"]
+async fn live_delegation_round_trip() {
+    let tool = NodesTool::new();
+    assert!(tool.available(), "RUSTYKRAB_NODES must be set");
+
+    let listed = tool.execute(json!({"action": "list"})).await.unwrap();
+    eprintln!("list: {listed}");
+    let id = listed["nodes"][0]["id"]
+        .as_str()
+        .expect("a node")
+        .to_string();
+
+    let discovered = tool.execute(json!({"action": "discover"})).await.unwrap();
+    eprintln!("discover: {discovered}");
+    assert_eq!(
+        discovered["nodes"][0]["status"], "online",
+        "peer should be reachable"
+    );
+
+    let result = tool
+        .execute(json!({
+            "action": "send",
+            "node_id": id,
+            "message": "Reply with exactly: DELEGATED-OK. Nothing else."
+        }))
+        .await
+        .expect("delegation failed");
+    eprintln!("send: {result}");
+
+    let response = result["response"].as_str().unwrap_or_default();
+    assert!(
+        response.contains("DELEGATED-OK"),
+        "peer did not answer the delegated task: {response:?}"
+    );
+    assert!(result["conversation_id"].is_string());
+}
+
+#[tokio::test]
+#[ignore = "requires a peer RustyKrab gateway"]
+async fn unknown_node_is_rejected() {
+    let err = NodesTool::new()
+        .execute(json!({"action": "send", "node_id": "nope", "message": "hi"}))
+        .await
+        .expect_err("expected an error");
+    assert!(err.to_string().contains("unknown node"), "got: {err}");
+}

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Assemble and codesign a macOS .app bundle for rustykrab-cli.
+#
+# The Data Protection Keychain requires the `keychain-access-groups`
+# entitlement, which is restricted: macOS only honours it when the binary
+# ships inside an .app bundle with an embedded provisioning profile. A bare
+# `cargo build` binary therefore falls back to the legacy keychain, which
+# prompts for per-app ACL approval on every credential access.
+#
+# Use this instead of scripts/codesign.sh when the build needs keychain
+# access — i.e. any build you intend to actually run.
+#
+# Usage:
+#   ./scripts/bundle.sh                    # debug build  -> target/debug/RustyKrab.app
+#   ./scripts/bundle.sh --release          # release build -> target/release/RustyKrab.app
+#   ./scripts/bundle.sh --release -o /path/to/Out.app
+#
+# Environment:
+#   CODESIGN_IDENTITY    signing identity (default: auto-detect Developer ID)
+#   PROVISION_PROFILE    path to .provisionprofile (default: auto-detect)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENTITLEMENTS="$PROJECT_ROOT/entitlements.plist"
+
+PROFILE_MODE="debug"
+OUT_APP=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --release) PROFILE_MODE="release"; shift ;;
+        --debug)   PROFILE_MODE="debug";   shift ;;
+        -o|--output) OUT_APP="$2"; shift 2 ;;
+        *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+BINARY="$PROJECT_ROOT/target/$PROFILE_MODE/rustykrab-cli"
+[ -n "$OUT_APP" ] || OUT_APP="$PROJECT_ROOT/target/$PROFILE_MODE/RustyKrab.app"
+
+if [ ! -f "$BINARY" ]; then
+    echo "error: binary not found at $BINARY" >&2
+    echo "hint: cargo build${PROFILE_MODE:+ --$PROFILE_MODE} -p rustykrab-cli" >&2
+    exit 1
+fi
+if [ ! -f "$ENTITLEMENTS" ]; then
+    echo "error: entitlements.plist not found at $ENTITLEMENTS" >&2
+    exit 1
+fi
+
+# --- Signing identity -------------------------------------------------------
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    IDENTITY="$CODESIGN_IDENTITY"
+else
+    IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null \
+        | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)".*/\1/' || true)
+fi
+if [ -z "$IDENTITY" ]; then
+    echo "error: no Developer ID Application identity found." >&2
+    echo "       Ad-hoc signing cannot carry keychain-access-groups, so the" >&2
+    echo "       bundle would still fall back to the legacy keychain." >&2
+    exit 1
+fi
+
+TEAM_ID=$(echo "$IDENTITY" | sed -n 's/.*(\([A-Z0-9]*\)).*/\1/p')
+if [ -z "$TEAM_ID" ]; then
+    echo "error: could not extract team ID from identity: $IDENTITY" >&2
+    exit 1
+fi
+
+# --- Provisioning profile ---------------------------------------------------
+# Required: without it macOS rejects (and may SIGKILL) a binary claiming the
+# restricted keychain-access-groups entitlement.
+if [ -z "${PROVISION_PROFILE:-}" ]; then
+    for candidate in \
+        "$PROJECT_ROOT/RustyKrab.app/Contents/embedded.provisionprofile" \
+        "$HOME/Library/MobileDevice/Provisioning Profiles"/*.provisionprofile
+    do
+        if [ -f "$candidate" ]; then PROVISION_PROFILE="$candidate"; break; fi
+    done
+fi
+if [ -z "${PROVISION_PROFILE:-}" ] || [ ! -f "$PROVISION_PROFILE" ]; then
+    echo "error: no provisioning profile found; set PROVISION_PROFILE=/path/to.provisionprofile" >&2
+    exit 1
+fi
+
+VERSION=$(grep -m1 '^version' "$PROJECT_ROOT/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/')
+
+echo "Binary:   $BINARY"
+echo "Bundle:   $OUT_APP"
+echo "Identity: $IDENTITY"
+echo "Team ID:  $TEAM_ID"
+echo "Profile:  $PROVISION_PROFILE"
+
+# --- Assemble ---------------------------------------------------------------
+rm -rf "$OUT_APP"
+mkdir -p "$OUT_APP/Contents/MacOS"
+cp "$BINARY" "$OUT_APP/Contents/MacOS/rustykrab-cli"
+cp "$PROVISION_PROFILE" "$OUT_APP/Contents/embedded.provisionprofile"
+
+# CFBundleIdentifier must match the application-identifier in entitlements.plist.
+cat > "$OUT_APP/Contents/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.gcbh.rustykrab</string>
+    <key>CFBundleExecutable</key>
+    <string>rustykrab-cli</string>
+    <key>CFBundleName</key>
+    <string>RustyKrab</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+</dict>
+</plist>
+PLIST
+
+# --- Sign -------------------------------------------------------------------
+# The explicit designated requirement matters: codesign generates a broken one
+# for bare Mach-O files, and a mismatched DR is what makes the legacy keychain
+# re-prompt after every rebuild.
+codesign \
+    --sign "$IDENTITY" \
+    --entitlements "$ENTITLEMENTS" \
+    --options runtime \
+    --team-id "$TEAM_ID" \
+    -r="designated => anchor apple generic and certificate leaf[subject.OU] = \"${TEAM_ID}\"" \
+    --force \
+    "$OUT_APP"
+
+echo "Done. Verifying..."
+codesign --verify --strict --verbose=2 "$OUT_APP" 2>&1
+codesign -dv --verbose=2 "$OUT_APP" 2>&1 | grep -E "Identifier=|flags=|TeamIdentifier="
+echo
+echo "Run it with:"
+echo "  $OUT_APP/Contents/MacOS/rustykrab-cli"

--- a/scripts/setup-delegation-node.md
+++ b/scripts/setup-delegation-node.md
@@ -1,0 +1,183 @@
+# Setting up a delegation node
+
+Stand up a second RustyKrab instance on another Mac and let the primary hand it
+tasks via the `nodes` tool.
+
+## Read this first: what delegation actually is
+
+A delegated task runs **entirely on the remote node**, using *that machine's*
+tools, filesystem, and model. It does not share the primary's conversation.
+
+Consequences worth planning around:
+
+- **The node needs its own checkout** of any repo it will work on. It cannot see
+  files on the primary.
+- **Results come back as text**, not as edits on the primary. To move actual code,
+  have the node commit and push a branch, then pull it here.
+- **Each `send` starts a fresh conversation** on the node, so the message must be
+  self-contained — restate the goal, paths, and constraints every time.
+
+If what you want is "one agent, more compute", this is not that. It is "a second,
+independent agent you can hand a well-specified job to."
+
+## 1. On the node machine
+
+Build and bundle (the `.app` bundle is required for keychain access — see
+`scripts/bundle.sh`):
+
+```bash
+git clone <repo> rustycrab && cd rustycrab
+make bundle          # release build + codesign into a .app
+```
+
+Set its model. **Use the MLX build, not the plain GGUF tag:**
+
+```bash
+ollama pull qwen3.8:27b-mlx
+
+export RUSTYKRAB_PROVIDER=ollama
+export OLLAMA_MODEL=qwen3.8:27b-mlx
+```
+
+The plain `qwen3.8:27b` tag ships a multi-token-prediction (MTP) head, and Ollama
+launches it with `--spec-type draft-mtp` by default. On M1/M4-class Metal that
+speculative-decoding path is a measured **regression**, not a win — see the
+tuning table below. The MLX engine avoids it.
+
+Or point at any OpenAI-compatible server (llama.cpp, mistral.rs, LM Studio):
+
+```bash
+export RUSTYKRAB_PROVIDER=llama-server
+export OPENAI_BASE_URL=http://localhost:8080
+export OPENAI_MODEL=qwen3.8:27b
+export OPENAI_MAX_TOKENS=4096      # thinking models need headroom; too low and
+                                   # the agent loops on "hit max tokens"
+```
+
+Start it and note the auth token it prints on first run (or set
+`RUSTYKRAB_AUTH_TOKEN` yourself):
+
+```bash
+./target/release/RustyKrab.app/Contents/MacOS/rustykrab-cli
+```
+
+## 2. Make it reachable
+
+The gateway binds to **loopback only, by design** — that is not configurable, and
+should stay that way. Expose it deliberately instead. Two good options:
+
+**Tailscale Serve** (recommended for always-on). Terminates on the tailnet and
+proxies to loopback, so nothing is exposed to the local network or internet:
+
+```bash
+tailscale serve --bg 3000
+tailscale serve status        # note the https://<machine>.<tailnet>.ts.net URL
+```
+
+**SSH tunnel** (fine for ad-hoc use). Run on the *primary*:
+
+```bash
+ssh -N -L 3100:localhost:3000 <node-host>
+```
+
+The node is then `http://127.0.0.1:3100` from the primary's perspective.
+
+## 3. On the primary
+
+Register the node. `description` is shown to the model, so say what the node is
+good for — it uses this to choose:
+
+```bash
+export RUSTYKRAB_NODES='[
+  {
+    "id": "m4max",
+    "url": "https://your-machine.your-tailnet.ts.net",
+    "token": "<the node's auth token>",
+    "description": "M4 Max 32GB — qwen3.8:27b. Slow but capable; good for self-contained coding tasks. Has its own checkout at ~/code/rustycrab."
+  }
+]'
+
+# Local models are slow; give delegated tasks room to finish.
+export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
+```
+
+Restart the primary so it picks up the config. The `nodes` tool stays hidden from
+the model until `RUSTYKRAB_NODES` is set.
+
+## 4. Verify
+
+```bash
+RUSTYKRAB_NODES='...' cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
+```
+
+That checks `list`, `discover` (reachability + latency), and a real `send` round
+trip.
+
+## Measured tuning findings
+
+All on an M1 Max 64GB with the **GGUF** `qwen3.8:27b` build, 8k-token prompts.
+Ratios should transfer to the M4 Max even though absolute numbers differ.
+
+| Config | Generation | 8k prefill |
+|---|---|---|
+| Ollama default (MTP on) | 7.9 tok/s | 88.7 s |
+| llama-server, flash attention **off** | 8.4 tok/s | 91.7 s |
+| llama-server, flash attention **on** | **9.9 tok/s** | **88.2 s** |
+| ...plus `-ub 2048` | 9.3 tok/s | 110.3 s |
+| ...plus MTP speculative decoding | 8.5 tok/s | 118.4 s |
+| ...plus `-ctk/-ctv q8_0` | 8.1 tok/s | 131.8 s |
+
+Four things worth knowing, three of which contradict commonly repeated advice:
+
+- **Flash attention on is the one clear win** — +18% generation. Use `-fa on`.
+- **Do not raise the prefill micro-batch.** `-ub 2048` is widely recommended for
+  Apple Silicon and it cost ~20% prefill here. Leave the default.
+- **Do not enable MTP speculative decoding on Metal.** Draft acceptance measured
+  only 38-40%, so it loses more to verification than it gains: -14% generation
+  and -25% prefill. It is a large win on CUDA, which is where most of the
+  positive reports come from.
+- **Do not quantize the KV cache.** This architecture uses 256-dim heads with
+  sparse Metal flash-attention kernel coverage; `q8_0` made both axes worse.
+  Advice to the contrary is generally measured on NVIDIA hardware.
+
+**Multi-turn is much cheaper than cold turns.** In a two-turn conversation with a
+~4.9k-token system prompt, turn 1 paid 79.5 s of prefill and turn 2 paid only
+**3.3 s** — the slot cache reuses the prefix. Long-running conversations amortize
+well; it is *fresh* delegated tasks that pay full price. Since every `nodes send`
+starts a new conversation, each delegation is a cold turn by construction.
+
+## Performance expectations
+
+Measured on an M1 Max, delegating a *trivial* task ("reply with exactly OK") to a
+peer running gemma4:26b — the fast model at ~46 tok/s:
+
+**~43 seconds.**
+
+That is the floor, not the ceiling. It is dominated by the node's ~8k-token system
+prompt plus tool schemas, and by thinking-model reasoning tokens that never reach
+the caller. On qwen3.8:27b — roughly 5x slower on both generation and prompt
+processing — the same trivial round trip is closer to **3-4 minutes**, and a real
+coding task considerably longer.
+
+Plan accordingly:
+
+- Delegate **batch or background work**, not anything interactive.
+- Prefer **few large tasks** over many small ones — per-task overhead dominates.
+- Benchmark the node first with `scripts/bench-local-models.md`. If prompt
+  processing there is slow, every delegated task inherits it.
+- A faster model on the node often beats a smarter one, because the overhead is
+  paid per task regardless. Worth A/B-ing gemma4:26b against qwen3.8:27b on your
+  actual workload before committing.
+
+## Security notes
+
+- Auth is the node's **bearer token**, over a private network. Treat the token as
+  a credential: it grants full agent access, including shell execution on that
+  machine.
+- Keep the node bound to loopback and reach it via tailnet or SSH. Do not expose
+  the gateway port directly.
+- `nodes list` deliberately never returns tokens — tool output goes into the
+  model's context.
+- The peer's Origin check is CSRF protection against browsers, not authentication;
+  node-to-node calls set their own loopback origin. The real boundary is the token
+  plus network reachability.


### PR DESCRIPTION
**Stack: 3/4** (← #527 bundle tooling · → #pr4 fleet docs)

## Summary
The `nodes` tool previously pointed at a `NODES_DISCOVERY_URL` service that nothing in the codebase implements — `discover`/`list` silently returned empty/synthetic data without it, and `send` was unusable. Replaces it with real delegation to peer RustyKrab gateways: `list`/`discover`/`send` now hit a configured peer's own REST API (create a conversation, post a message, return the reply) instead of a discovery indirection layer that was never built.

- Nodes are configured via `RUSTYKRAB_NODES`, a JSON array of `{id, url, token, description}`. `description` is shown to the model and is how it decides which node to use for what.
- The tool is hidden from the model (`available()` → `false`) until at least one node is configured, so it never advertises a capability that can't work.
- `list` never returns tokens in its output — that goes straight into the model's context.
- `scripts/setup-delegation-node.md` covers standing up a node, exposing it safely (Tailscale Serve, not the raw gateway port), and measured latency expectations.

## A deliberate scope decision
Node auth is a shared bearer token per node, not the project's device-pairing flow (`DeviceStore`: per-device, revocable, hashed at rest — #490). That's the better long-term mechanism and is noted as such on `RemoteNode::token`, but adopting it reshapes the delegation design more than this change should scope to. Flagging for discussion rather than silently picking one.

## Test plan
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` — clean
- [x] `cargo test -p rustykrab-tools --lib nodes` — 5 passed (parsing, URL building, unknown-node errors, malformed-config errors, and a token-leak check on `list`)
- [x] Live-verified: `list` / `discover` / `send` against a real peer instance, including a full task round trip (peer executes the task and returns the result) and a token-leak check on the tool output