### PR TITLE
e2e: make the model suite actually measure the model

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1005,12 +1005,47 @@ async fn main() -> anyhow::Result<()> {
         None => tools,
     };
 
+    // A stubbed registry is a closed world: the harness has already said
+    // "these are the only tools." Progressive disclosure exists to keep a
+    // thirty-tool registry from swamping a small model, and `replace` mode
+    // removes `tools_load` itself — so without this the stubs are
+    // registered but never active, and the model is sent no schemas at
+    // all. Seed them so they are visible from turn 0.
+    let active_tools = match std::env::var_os("RUSTYKRAB_TOOL_STUBS") {
+        Some(_) => Arc::new(
+            rustykrab_core::active_tools::ActiveToolsRegistry::with_seed(
+                tools.iter().map(|t| t.name().to_string()),
+            ),
+        ),
+        None => Arc::new(rustykrab_core::active_tools::ActiveToolsRegistry::new()),
+    };
+
     // --- Harness router (auto-selects profile per message) ---
     // Reuses the main provider for classification to avoid model swapping.
     // The classification prompt is ~50 tokens — negligible overhead on any model.
     let classifier: Arc<dyn ModelProvider> = provider.clone();
 
-    let router = Arc::new(HarnessRouter::new(classifier).with_base(profile));
+    // The router classifies each message and swaps in a preset profile,
+    // which discards the configured one — including its iteration caps,
+    // retry budget and context window. `RUSTYKRAB_HARNESS_ROUTER=off`
+    // pins the configured profile instead, so a caller that has set those
+    // deliberately (the evaluation harness) actually gets them.
+    let routing_enabled = !matches!(
+        std::env::var("RUSTYKRAB_HARNESS_ROUTER")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "off" | "0" | "false" | "no"
+    );
+    let router = routing_enabled
+        .then(|| Arc::new(HarnessRouter::new(classifier).with_base(profile.clone())));
+    if !routing_enabled {
+        tracing::info!(
+            profile = %profile.name,
+            "harness routing disabled — using the configured profile for every message"
+        );
+    }
 
     // --- Build gateway state ---
     // Clone store handle so we can flush it after the server shuts down.
@@ -1019,12 +1054,16 @@ async fn main() -> anyhow::Result<()> {
         // Loopback is always allowed; this adds the names other clients
         // reach us by, e.g. the tailnet hostname the phone uses.
         .with_origin_policy(rustykrab_gateway::OriginPolicy::from_env())
-        .with_harness_router(router)
+        // Also the fallback the gateway uses when routing is off, so
+        // `harness.toml` still decides the caps in that mode.
+        .with_harness_profile(profile)
+        .with_harness_router_opt(router)
         .with_orchestration_config(orchestration_config)
         .with_skill_registry(skill_registry)
         .with_memory(Arc::clone(&memory_system), agent_id)
         .with_subagents_enabled(subagents_enabled)
         .with_computer_use_enabled(computer_use_enabled);
+    state.active_tools = active_tools;
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-core/src/active_tools.rs
+++ b/crates/rustykrab-core/src/active_tools.rs
@@ -34,19 +34,49 @@ struct ActiveEntry {
     version: u64,
 }
 
+impl ActiveEntry {
+    /// A fresh entry pre-populated with the registry's seed. Version stays
+    /// 0: the seed is where every conversation starts, not a change to it.
+    fn seeded(seed: &HashSet<String>) -> Self {
+        Self {
+            names: seed.clone(),
+            version: 0,
+        }
+    }
+}
+
 /// Tracks which tools are "active" for each conversation.
 ///
-/// Conversations start with an empty active set. The meta-tool `tools_load`
-/// populates it; the runner filters the schemas sent to the model down to
-/// (meta tools) ∪ (active set).
+/// Conversations start with the seed set (empty unless one was given). The
+/// meta-tool `tools_load` adds to it; the runner filters the schemas sent
+/// to the model down to (meta tools) ∪ (active set).
 #[derive(Debug, Default)]
 pub struct ActiveToolsRegistry {
     inner: RwLock<HashMap<Uuid, ActiveEntry>>,
+    /// Names every conversation starts with, in addition to whatever
+    /// `tools_load` turns on later. Empty for a normal deployment, where
+    /// discovery is the point; used when the registry is small and known
+    /// up front, so requiring a `tools_load` round-trip to reach it would
+    /// be pure overhead.
+    seed: HashSet<String>,
 }
 
 impl ActiveToolsRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// A registry whose conversations all start with `names` already
+    /// active.
+    pub fn with_seed<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            seed: names.into_iter().map(Into::into).collect(),
+        }
     }
 
     /// Mark the given tools as active for a conversation. Bumps the
@@ -59,7 +89,9 @@ impl ActiveToolsRegistry {
         S: Into<String>,
     {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        let entry = guard.entry(conversation_id).or_default();
+        let entry = guard
+            .entry(conversation_id)
+            .or_insert_with(|| ActiveEntry::seeded(&self.seed));
         let mut changed = false;
         for name in names {
             changed |= entry.names.insert(name.into());
@@ -78,7 +110,7 @@ impl ActiveToolsRegistry {
         guard
             .get(&conversation_id)
             .map(|entry| entry.names.clone())
-            .unwrap_or_default()
+            .unwrap_or_else(|| self.seed.clone())
     }
 
     /// Run `f` against the active set for a conversation without cloning
@@ -93,7 +125,7 @@ impl ActiveToolsRegistry {
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         match guard.get(&conversation_id) {
             Some(entry) => f(entry.version, &entry.names),
-            None => f(0, &HashSet::new()),
+            None => f(0, &self.seed),
         }
     }
 
@@ -115,7 +147,7 @@ impl ActiveToolsRegistry {
         guard
             .get(&conversation_id)
             .map(|entry| entry.names.contains(name))
-            .unwrap_or(false)
+            .unwrap_or_else(|| self.seed.contains(name))
     }
 
     /// Forget the active set for a conversation (used on session teardown).

--- a/crates/rustykrab-e2e/Cargo.toml
+++ b/crates/rustykrab-e2e/Cargo.toml
@@ -23,3 +23,4 @@ tempfile = "3"
 # the tables the plan specifies (secret_versions, secret_audit,
 # credential_requests) and not just on what the REST API reveals.
 rusqlite = { version = "0.34", features = ["bundled"] }
+uuid.workspace = true

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -383,17 +383,6 @@ impl Ctx {
         Ok(resp.json().await?)
     }
 
-    /// Read a conversation back out of the daemon's store. The reply body
-    /// is only the last assistant message; this is the whole exchange,
-    /// tool traffic and compaction bookmark included.
-    async fn conversation(&self, conv_id: &str) -> Result<Value> {
-        let resp = self.get(&format!("/api/conversations/{conv_id}")).await?;
-        if resp.status() != 200 {
-            bail!("get conversation returned {}", resp.status());
-        }
-        Ok(resp.json().await?)
-    }
-
     /// Create a conversation, send one message, return the assistant reply.
     async fn chat(&self, content: &str) -> Result<Value> {
         let conv: Value = self
@@ -1031,6 +1020,26 @@ fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Chil
     spawn_daemon_with(bin, data_dir, port, &Backend::Scripted)
 }
 
+/// The budget the daemon picks for Ollama when nothing overrides it
+/// (`resolve_max_context_tokens`). A scenario asking for less than this is
+/// shrinking the window on purpose.
+const OLLAMA_DEFAULT_CONTEXT_BUDGET: usize = 32_000;
+
+/// Read `max_context_tokens` back out of the `harness.toml` a scenario
+/// wrote, if it set one.
+fn harness_context_budget(data_dir: &std::path::Path) -> Option<usize> {
+    let toml = std::fs::read_to_string(data_dir.join("harness.toml")).ok()?;
+    toml.lines()
+        .find_map(|line| line.trim().strip_prefix("max_context_tokens"))
+        .and_then(|rest| {
+            rest.trim()
+                .strip_prefix('=')
+                .map(str::trim)
+                .map(str::to_string)
+        })
+        .and_then(|v| v.parse().ok())
+}
+
 fn spawn_daemon_with(
     bin: &str,
     data_dir: &std::path::Path,
@@ -1085,11 +1094,38 @@ fn spawn_daemon_with(
         } => {
             command
                 .env("RUSTYKRAB_PROVIDER", "ollama")
+                // Scenarios set their own iteration caps, retry budget and
+                // context window; the auto-router would replace the whole
+                // profile with a preset and discard them.
+                .env("RUSTYKRAB_HARNESS_ROUTER", "off")
                 .env("OLLAMA_MODEL", model)
                 .env("OLLAMA_BASE_URL", ollama_url)
                 // Compaction summarisation on a local model is
                 // prefill-heavy; the default would cut it off.
                 .env("OLLAMA_TIMEOUT_SECS", "900");
+
+            // `max_context_tokens` from `harness.toml` is overwritten at
+            // startup by a provider-derived default (32k for Ollama), so a
+            // scenario that shrinks the window to force compaction never
+            // gets it. `RUSTYKRAB_MAX_CONTEXT_TOKENS` is the documented
+            // override that survives; carry the profile's value through it
+            // so the toml stays the single source of truth.
+            // Only when the scenario is deliberately shrinking the window.
+            // The ordinary profiles set a budget far above Ollama's own
+            // default, and pinning `num_ctx` that high would allocate a KV
+            // cache to match for every scenario.
+            if let Some(budget) =
+                harness_context_budget(data_dir).filter(|&b| b < OLLAMA_DEFAULT_CONTEXT_BUDGET)
+            {
+                command.env("RUSTYKRAB_MAX_CONTEXT_TOKENS", budget.to_string());
+                // The runner sizes the compaction threshold off the
+                // *provider's* reported window in preference to the
+                // profile's budget, so leaving Ollama at its default 64k
+                // puts the trigger ~55k out of reach and compaction never
+                // fires however small the profile says the window is.
+                // Shrink the provider window to match.
+                command.env("RUSTYKRAB_NUM_CTX", budget.to_string());
+            }
 
             // An empty spec means "leave the registry alone" — the
             // credential suite needs the real tools, because its premise

--- a/crates/rustykrab-e2e/src/model_suite.rs
+++ b/crates/rustykrab-e2e/src/model_suite.rs
@@ -64,8 +64,11 @@ impl ModelCase {
             turns: Vec::new(),
             // Replace the registry by default: thirty real tools give a
             // small model thirty ways to wander off, and the scenario stops
-            // measuring what it meant to.
-            stubs: json!({ "mode": "replace", "keep": [], "tools": [] }),
+            // measuring what it meant to. `task_complete` stays, because
+            // it is how the runner is told the work is done — without it
+            // every scenario ends on the "you did not call task_complete"
+            // nudge instead of on its answer.
+            stubs: json!({ "mode": "replace", "keep": ["task_complete"], "tools": [] }),
             harness_toml: None,
             assertions: Vec::new(),
             judge: None,
@@ -89,8 +92,14 @@ impl ModelCase {
 
     /// Keep these real tools alongside the stubs — the memory scenarios
     /// need the genuine `memory_*` tools, since those are what they test.
+    /// Adds to the default kept set rather than replacing it, so a
+    /// scenario does not silently lose `task_complete` by asking for
+    /// something else.
     fn keeping(mut self, names: &[&str]) -> Self {
-        self.stubs["keep"] = json!(names);
+        let keep = self.stubs["keep"].as_array_mut().unwrap();
+        for name in names {
+            keep.push(json!(name));
+        }
         self
     }
 
@@ -126,6 +135,17 @@ fn tight_harness() -> String {
 
 /// The default config for non-compaction scenarios: a normal window, but a
 /// low iteration cap so a wandering model fails fast instead of slowly.
+/// [`bounded_harness`] with the runner's own tool retries switched off.
+///
+/// `execute_with_retries` retries a failed tool up to `max_tool_retries`
+/// times before the model ever hears about it, so with the default of 2 a
+/// "fails once, then succeeds" stub is absorbed inside a single
+/// model-visible call — the model has nothing to recover from. Scenarios
+/// measuring how the *model* handles a tool failure have to let it through.
+fn no_retry_harness() -> String {
+    bounded_harness().replace("max_tool_retries = 2", "max_tool_retries = 0")
+}
+
 fn bounded_harness() -> String {
     "name = \"e2e\"\n\
      agent_name = \"RustyKrab\"\n\
@@ -316,7 +336,7 @@ pub fn cases() -> Vec<ModelCase> {
             "model-recovers-from-a-transient-tool-error",
             "A tool that fails once and then succeeds still produces a correct answer",
         )
-        .with_harness(bounded_harness())
+        .with_harness(no_retry_harness())
         .with_tool(tool(
             "weather_lookup",
             "Get the current weather for a city. Returns temperature in Celsius and conditions.",
@@ -713,7 +733,18 @@ async fn run_once(
         for turn in &case.turns {
             ctx.send(&conv_id, turn).await?;
         }
-        let conv = ctx.conversation(&conv_id).await?;
+        // Read the conversation out of the daemon's own store rather than
+        // over HTTP. `GET /api/conversations/{id}` returns the Apollo
+        // projection — id, title, timestamps, no messages — and
+        // `/messages` renders each turn to a display string that has
+        // already thrown away the structured tool calls an assertion is
+        // about. The store holds the real thing.
+        let conv = serde_json::to_value(
+            store
+                .conversations()
+                .get(uuid::Uuid::parse_str(&conv_id)?)
+                .await?,
+        )?;
         let mut transcript = Transcript::parse(&conv);
         transcript.duration_ms = started.elapsed().as_millis();
         Ok::<_, anyhow::Error>(transcript)

--- a/crates/rustykrab-e2e/src/transcript.rs
+++ b/crates/rustykrab-e2e/src/transcript.rs
@@ -108,24 +108,21 @@ impl Transcript {
             }
         }
 
-        let folded_messages = match conv["compacted_through"].as_str() {
-            Some(bookmark) => messages
-                .iter()
-                .position(|m| m["id"].as_str() == Some(bookmark))
-                .map(|i| i + 1)
-                .unwrap_or(0),
-            None => 0,
-        };
+        // A compacted conversation is one carrying a summary: `summary` is
+        // the only compaction state a `Conversation` actually holds. There
+        // is no bookmark field and no generation counter, so how much was
+        // folded away cannot be read back — only that it happened.
+        let compacted = conv["summary"].as_str().is_some_and(|s| !s.is_empty());
 
         Self {
             final_text: assistant_texts.last().cloned().unwrap_or_default(),
             assistant_texts,
             calls,
-            compacted: !conv["compacted_through"].is_null(),
-            compaction_generation: conv["compaction_generation"].as_u64().unwrap_or(0),
+            compacted,
+            compaction_generation: u64::from(compacted),
             summary: conv["summary"].as_str().map(str::to_string),
-            folded_messages,
-            live_messages: messages.len().saturating_sub(folded_messages),
+            folded_messages: 0,
+            live_messages: messages.len(),
             total_messages: messages.len(),
             duration_ms: 0,
             error: None,
@@ -272,21 +269,28 @@ mod tests {
     }
 
     #[test]
-    fn reads_the_compaction_bookmark() {
+    fn reads_compaction_state_from_the_summary() {
+        let messages = json!([
+            { "id": "m1", "role": "user", "content": { "type": "text", "data": "old" } },
+            { "id": "m2", "role": "assistant", "content": { "type": "text", "data": "older" } },
+            { "id": "m3", "role": "user", "content": { "type": "text", "data": "new" } }
+        ]);
+
+        // A summary is the whole of the compaction state a `Conversation`
+        // carries — there is no bookmark and no generation counter to read.
         let t = Transcript::parse(&conv(
-            json!([
-                { "id": "m1", "role": "user", "content": { "type": "text", "data": "old" } },
-                { "id": "m2", "role": "assistant", "content": { "type": "text", "data": "older" } },
-                { "id": "m3", "role": "user", "content": { "type": "text", "data": "new" } }
-            ]),
-            json!({ "compacted_through": "m2", "summary": "earlier chat",
-                    "compaction_generation": 2 }),
+            messages.clone(),
+            json!({ "summary": "earlier chat" }),
         ));
         assert!(t.compacted);
-        assert_eq!(t.folded_messages, 2);
-        assert_eq!(t.live_messages, 1);
-        assert_eq!(t.compaction_generation, 2);
+        assert_eq!(t.compaction_generation, 1);
+        assert_eq!(t.summary.as_deref(), Some("earlier chat"));
         // History is hidden, never destroyed.
         assert_eq!(t.total_messages, 3);
+        assert_eq!(t.live_messages, 3);
+
+        let t = Transcript::parse(&conv(messages, json!({ "summary": null })));
+        assert!(!t.compacted);
+        assert_eq!(t.compaction_generation, 0);
     }
 }

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -190,6 +190,12 @@ impl AppState {
         self
     }
 
+    /// Set the router, or leave static-profile mode in place when `None`.
+    pub fn with_harness_router_opt(mut self, router: Option<Arc<HarnessRouter>>) -> Self {
+        self.harness_router = router;
+        self
+    }
+
     /// Set the skill registry.
     pub fn with_skill_registry(mut self, registry: Arc<SkillRegistry>) -> Self {
         self.skill_registry = registry;

--- a/crates/rustykrab-tools/src/stub.rs
+++ b/crates/rustykrab-tools/src/stub.rs
@@ -171,7 +171,11 @@ impl StubFile {
             .map_err(|e| Error::Config(format!("reading tool stubs {}: {e}", path.display())))?;
         let parsed: Self = serde_json::from_str(&raw)
             .map_err(|e| Error::Config(format!("parsing tool stubs {}: {e}", path.display())))?;
-        if parsed.tools.is_empty() && parsed.mode == StubMode::Replace {
+        // Only the combination that leaves the registry genuinely empty is
+        // a mistake. `tools: []` with a non-empty `keep` is a legitimate
+        // spec — the memory scenarios stub nothing and keep the real
+        // `memory_*` tools, because those are what they are testing.
+        if parsed.tools.is_empty() && parsed.keep.is_empty() && parsed.mode == StubMode::Replace {
             return Err(Error::Config(format!(
                 "{} replaces the tool registry with nothing — the agent would have no tools",
                 path.display()


### PR DESCRIPTION
Every scenario in the model suite failed, on gemma4:26b as much as on
qwen3.8:27b-mlx. Five separate faults, none of them about the model:

**Stubbed tools were never sent to the model.** The runner filters the
schemas it sends down to (meta tools) ∪ (the conversation's *active*
set), and stub tools are in neither — while `mode: "replace"` deletes
`tools_load`, so the model could not activate them either. It received an
empty tool array and said so in its reasoning ("I don't see any tool
definitions"). A stubbed registry is a closed world the harness has
already narrowed on purpose, so seed it active: `ActiveToolsRegistry`
grows a seed set, and the daemon fills it from the stub file.

**The transcript was parsed from a response that never contained it.**
`Ctx::conversation` read `GET /api/conversations/{id}`, whose body is the
Apollo projection — id, title, timestamps, no messages. `conv["messages"]`
was therefore always absent and every transcript empty, so assertions
about tool calls and final text could not pass whatever the model did.
`/messages` is no better: it renders each turn to a display string,
discarding the structured calls. Read the conversation from the daemon's
store instead, which the harness already opens for secret assertions.

**Compaction state was read from fields that do not exist.**
`compacted_through` and `compaction_generation` appear nowhere in the
codebase; `summary` is the whole of the compaction state a `Conversation`
carries. Detect it from that, and stop reporting a fold count that cannot
be recovered.

**`tools: []` with a non-empty `keep` was rejected.** The memory scenarios
stub nothing and keep the real `memory_*` tools — the exact spec the
guard refused, stopping the daemon from booting. Only the combination
that leaves the registry genuinely empty is a mistake.

**Scenario harness profiles were discarded.** The auto-router replaces
the configured profile with a preset per message, so `max_iterations`,
`max_tool_retries` and `max_context_tokens` from a scenario's
`harness.toml` never applied — the transient-tool-error case had its
failure absorbed by retries it had switched off. Add
`RUSTYKRAB_HARNESS_ROUTER=off` to pin the configured profile, set it in
model mode, and wire that profile into the gateway state, which had only
ever received it via the router.

Compaction additionally sizes its trigger off the provider's reported
window ahead of the profile budget, so a scenario shrinking the window to
6k still measured against Ollama's 64k and never fired. Model mode now
carries a deliberately-small budget through to `RUSTYKRAB_NUM_CTX` too.

Both models now pass 14/14 with `--quick`; the scripted suite is
unchanged at 17/17.

Two known gaps, both pre-existing and neither model-specific:
`Assertion::FoldedAtLeast` has no data source now that the bookmark is
gone (the displaced messages land in the recall archive, which is where a
real count would come from), and the three slow compaction scenarios take
roughly ten minutes each once the window is small enough to fold.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
