### PR TITLE
fix(agent): an input budget of zero turned compaction into a model-call storm

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -91,6 +91,24 @@ const DEFAULT_ACTIVE_TOOLS: &[&str] = &[
     "todo_read",
 ];
 
+/// Tool names to seed into every conversation's active set on top of
+/// [`DEFAULT_ACTIVE_TOOLS`], from `RUSTYKRAB_ACTIVE_TOOLS` (comma
+/// separated). Read once: the environment does not change under a running
+/// daemon, and this is on the path of every turn.
+fn extra_active_tools() -> &'static [String] {
+    static EXTRA: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+    EXTRA.get_or_init(|| {
+        std::env::var("RUSTYKRAB_ACTIVE_TOOLS")
+            .map(|raw| {
+                raw.split(',')
+                    .map(|n| n.trim().to_string())
+                    .filter(|n| !n.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    })
+}
+
 use crate::sandbox::{tool_timeout_secs, Sandbox, SandboxPolicy, DEFAULT_NET_TOOL_TIMEOUT_SECS};
 use crate::trace::{ExecutionTracer, ToolTrace};
 
@@ -150,6 +168,11 @@ fn compaction_context_ceiling() -> usize {
 /// deciding whether a single-shot summarization call will fit. Subtracted
 /// from `effective_context_limit()` to derive the input budget.
 const SUMMARIZER_RESPONSE_RESERVE_TOKENS: usize = 4_096;
+
+/// Floor for a single compaction call's input budget. Chunking history
+/// into pieces smaller than this costs one model call per piece and
+/// summarizes too little context per call to be worth it.
+const MIN_COMPACTION_INPUT_TOKENS: usize = 512;
 
 /// Fraction of `effective_context_limit()` that any single compaction call
 /// may consume as input. Kept well below a regular request's budget
@@ -966,6 +989,14 @@ impl AgentRunner {
         // the filter below.
         self.active_tools
             .activate(conv_id, DEFAULT_ACTIVE_TOOLS.iter().copied());
+        // Names from RUSTYKRAB_ACTIVE_TOOLS are seeded alongside the
+        // defaults. Lazy activation keeps thirty schemas out of the
+        // prompt, but it also means a freshly registered tool is invisible
+        // to the model until something calls `tools_load` — which a
+        // deployment that registered the tool on purpose, or an eval
+        // pinning one scenario to one tool, has no way to arrange.
+        self.active_tools
+            .activate(conv_id, extra_active_tools().iter().map(String::as_str));
         self.active_tools.with_active(conv_id, |version, active| {
             let schemas = self
                 .tools
@@ -2850,8 +2881,20 @@ impl AgentRunner {
         // tool turns, so individual prompt sizes are smaller in practice).
         let ceiling = self.effective_context_limit();
         let ratio = compaction_input_budget_ratio();
-        let input_budget =
-            ((ceiling as f64 * ratio) as usize).saturating_sub(SUMMARIZER_RESPONSE_RESERVE_TOKENS);
+        let ratioed = (ceiling as f64 * ratio) as usize;
+        // The response reserve is a fixed 4096, which is larger than the
+        // whole ratioed budget once the context limit is modest. Subtracting
+        // it flat then yields 0, and an input budget of 0 does not fail —
+        // it sends the recursive path into chunks of nothing, one model call
+        // per fragment. Observed cost: a compaction that should take seconds
+        // ran for 31 minutes.
+        //
+        // Cap the reserve at half the budget it is being taken out of, so
+        // there is always room left to actually put history in.
+        let reserve = SUMMARIZER_RESPONSE_RESERVE_TOKENS.min(ratioed / 2);
+        let input_budget = ratioed
+            .saturating_sub(reserve)
+            .max(MIN_COMPACTION_INPUT_TOKENS);
         let summary_cap_tokens = self.effective_compaction_summary_cap();
         tracing::debug!(
             ceiling,
@@ -5670,5 +5713,49 @@ mod outcome_capture_tests {
     async fn no_sink_configured_is_a_no_op() {
         let (runner, session, mut conv) = make_runner(false);
         assert!(runner.run(&mut conv, &session).await.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod compaction_budget_tests {
+    use super::*;
+
+    /// The budget a compaction call gets, for a given effective context
+    /// limit — mirrors the arithmetic in `compact_history`.
+    fn input_budget_for(ceiling: usize) -> usize {
+        let ratioed = (ceiling as f64 * DEFAULT_COMPACTION_INPUT_BUDGET_RATIO) as usize;
+        let reserve = SUMMARIZER_RESPONSE_RESERVE_TOKENS.min(ratioed / 2);
+        ratioed
+            .saturating_sub(reserve)
+            .max(MIN_COMPACTION_INPUT_TOKENS)
+    }
+
+    #[test]
+    fn a_modest_context_limit_still_leaves_room_for_input() {
+        // A flat 4096 reserve is larger than the whole ratioed budget here.
+        // Subtracting it left 0, and a budget of 0 chunks the history into
+        // pieces of nothing — one model call each.
+        for ceiling in [1_024, 1_536, 4_096, 8_192] {
+            let budget = input_budget_for(ceiling);
+            assert!(
+                budget >= MIN_COMPACTION_INPUT_TOKENS,
+                "ceiling {ceiling} produced an unusable budget of {budget}"
+            );
+            assert!(
+                budget < ceiling,
+                "ceiling {ceiling} produced a budget larger than the window"
+            );
+        }
+    }
+
+    #[test]
+    fn a_large_context_limit_keeps_the_full_response_reserve() {
+        // Where the reserve is affordable, nothing changes.
+        let ceiling = 120_000;
+        let ratioed = (ceiling as f64 * DEFAULT_COMPACTION_INPUT_BUDGET_RATIO) as usize;
+        assert_eq!(
+            input_budget_for(ceiling),
+            ratioed - SUMMARIZER_RESPONSE_RESERVE_TOKENS
+        );
     }
 }

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -151,6 +151,11 @@ const FRAMING_OVERHEAD_TOKENS: u32 = 512;
 /// thing instead.
 const ASSUMED_TOOL_TOKENS: u32 = 2048;
 
+/// Smallest input budget [`OllamaProvider::context_limit`] will report when
+/// the reserves exceed the window. Small enough to be honest about a tiny
+/// window, large enough that a caller does not compact on every turn.
+const MIN_REPORTED_INPUT_BUDGET: u32 = 512;
+
 /// Percentage of the trimming budget to cut down to once trimming fires.
 /// See `trim_to_budget` for why this is well below 100.
 const TRIM_TARGET_PCT: u32 = 75;
@@ -852,11 +857,37 @@ impl ModelProvider for OllamaProvider {
     /// here restores the intended order: compact first, trim only as a
     /// backstop.
     fn context_limit(&self) -> Option<usize> {
-        self.effective_ctx()
-            .map(|window| {
-                input_budget(window, self.config.num_predict, ASSUMED_TOOL_TOKENS) as usize
-            })
-            .filter(|&v| v > 0)
+        self.effective_ctx().map(|window| {
+            let budget = input_budget(window, self.config.num_predict, ASSUMED_TOOL_TOKENS);
+            if budget > 0 {
+                return budget as usize;
+            }
+            // The reserves swallowed the whole window. Reporting `None`
+            // here reads as "I don't know my limit", and the caller then
+            // falls back to the profile's `max_context_tokens` — a number
+            // this provider will never honour, because the per-request
+            // path still trims against the real budget. The visible
+            // result is that compaction never fires and history is
+            // silently trimmed away instead of being summarised.
+            //
+            // Report a floor instead, so the caller compacts at a point
+            // that is actually reachable, and say once why.
+            let floor = (window / 4).max(MIN_REPORTED_INPUT_BUDGET);
+            static WARNED: std::sync::Once = std::sync::Once::new();
+            WARNED.call_once(|| {
+                tracing::warn!(
+                    num_ctx = window,
+                    num_predict = self.config.num_predict,
+                    assumed_tool_tokens = ASSUMED_TOOL_TOKENS,
+                    framing_overhead = FRAMING_OVERHEAD_TOKENS,
+                    reported_budget = floor,
+                    "num_predict and the fixed reserves exceed num_ctx, leaving no room for \
+                     input; reporting a floor so compaction still engages. Raise \
+                     RUSTYKRAB_NUM_CTX or lower num_predict."
+                );
+            });
+            floor as usize
+        })
     }
 
     fn supports_vision(&self) -> bool {
@@ -2398,15 +2429,34 @@ mod tests {
     }
 
     #[test]
-    fn context_limit_is_none_when_reservations_exceed_the_window() {
-        // A window smaller than the reservations would otherwise report 0 and
-        // make every downstream budget collapse to nothing.
+    fn context_limit_floors_when_reservations_exceed_the_window() {
+        // A window smaller than the reservations must not report 0, which
+        // would collapse every downstream budget to nothing. It must not
+        // report `None` either: the caller reads that as "unknown" and
+        // falls back to the profile's max_context_tokens — a number this
+        // provider will never honour, because the per-request path still
+        // trims against the real budget. Compaction then never fires and
+        // history is silently trimmed away instead of summarised.
         let provider = OllamaProvider::new("probe").with_config(OllamaConfig {
             num_ctx: Some(1024),
             num_predict: 4096,
             ..OllamaConfig::default()
         });
-        assert_eq!(provider.context_limit(), None);
+        let limit = provider
+            .context_limit()
+            .expect("a configured window reports something");
+        assert!(limit > 0, "0 would collapse every downstream budget");
+        assert!(limit < 1024, "the floor stays below the window");
+    }
+
+    #[test]
+    fn context_limit_floor_is_a_quarter_of_the_window() {
+        let provider = OllamaProvider::new("probe").with_config(OllamaConfig {
+            num_ctx: Some(6144),
+            num_predict: 4096,
+            ..OllamaConfig::default()
+        });
+        assert_eq!(provider.context_limit(), Some(1536));
     }
 
     #[test]


### PR DESCRIPTION
Stack: #521 → #524 → #533 → **this** → #535 → #536 → #537

Only reachable once #533 lands — which is why it had never been seen. Fix
the provider so compaction runs at all, and it immediately runs like this.

### The bug

The summariser's response reserve is a flat 4096 tokens, subtracted from
half the effective context limit. Once that limit is modest, the reserve is
larger than the budget it comes out of and the subtraction saturates to
**zero**.

Zero does not fail. It goes to the recursive path, which chunks history
into pieces of that size — **one model call per fragment**. One compaction
ran for **31 minutes** on a local 26B before finishing. The only clue was a
long silence after `compacting conversation history`.

```
effective_context_limit = 1536
× 0.5 ratio             =  768
− 4096 reserve          →    0   ← chunk size
```

### The fix

The reserve is capped at half the budget it is taken from, so there is
always room left for actual input, and the result is floored at 512 tokens
so chunks stay big enough to be worth a call. Where the reserve is
affordable — any cloud-sized window — nothing changes, and a test pins that
in both directions.

Same scenario after the fix: **31 minutes → 3.7 minutes**, then to ~4
minutes steady.

### Also here: `RUSTYKRAB_ACTIVE_TOOLS`

Tool schemas are only sent for tools in the conversation's *active* set —
`DEFAULT_ACTIVE_TOOLS` plus whatever `tools_load` has pulled in. That keeps
thirty schemas out of the prompt and is the right default, but a tool
registered on purpose is then invisible until something calls `tools_load`,
and neither a deployment that registered it nor a test pinning one scenario
to one tool has any way to arrange that.

The model said so itself, in its own reasoning:

> *"Looking at my available tools... I don't see any tool definitions in the
> prompt."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)