### PR TITLE
fix(agent): the router preserved three of the seven fields it claimed to

### DIFF
--- a/crates/rustykrab-agent/src/router.rs
+++ b/crates/rustykrab-agent/src/router.rs
@@ -11,6 +11,10 @@ use crate::harness::HarnessProfile;
 /// then returns the appropriate profile. No LLM call needed — profile
 /// detection happens instantly based on message content.
 pub struct HarnessRouter {
+    /// Profile fields the operator named explicitly, which a preset must
+    /// not override. Empty means "the operator said nothing", so the
+    /// preset decides everything.
+    pinned: Vec<String>,
     /// Base profile to use as a template. Task-specific fields get overlaid.
     base: HarnessProfile,
     /// A model provider kept for potential future use (e.g. RLM context
@@ -24,7 +28,15 @@ impl HarnessRouter {
         Self {
             _classifier: classifier,
             base: HarnessProfile::default(),
+            pinned: Vec::new(),
         }
+    }
+
+    /// Pin the profile fields the operator set explicitly, so a routed
+    /// preset cannot quietly replace them.
+    pub fn with_pinned_fields(mut self, fields: Vec<String>) -> Self {
+        self.pinned = fields;
+        self
     }
 
     /// Use a custom base profile that gets task-specific overlays applied.
@@ -50,9 +62,32 @@ impl HarnessRouter {
             _ => self.base.clone(),
         };
         // Preserve user customizations from the base profile.
+        //
+        // These three are unconditional: they describe the deployment, not
+        // the task.
         profile.agent_name = self.base.agent_name.clone();
         profile.max_context_tokens = self.base.max_context_tokens;
         profile.compaction_threshold_pct = self.base.compaction_threshold_pct;
+
+        // The loop parameters are the preset's to choose — that is what a
+        // preset is for — *unless* the operator named them. "Named" rather
+        // than "differs from the default": an operator who writes
+        // `max_tool_retries = 2` means 2, even though 2 is also the
+        // default, and a preset asking for 3 would still be overriding a
+        // stated choice.
+        for field in &self.pinned {
+            match field.as_str() {
+                "max_iterations" => profile.max_iterations = self.base.max_iterations,
+                "soft_iteration_warning" => {
+                    profile.soft_iteration_warning = self.base.soft_iteration_warning
+                }
+                "max_consecutive_errors" => {
+                    profile.max_consecutive_errors = self.base.max_consecutive_errors
+                }
+                "max_tool_retries" => profile.max_tool_retries = self.base.max_tool_retries,
+                _ => {}
+            }
+        }
         profile
     }
 }
@@ -253,5 +288,96 @@ mod tests {
             "creative"
         );
         assert_eq!(classify_profile_keywords("hello there"), "general");
+    }
+}
+
+#[cfg(test)]
+mod base_preservation_tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use rustykrab_core::error::Result;
+    use rustykrab_core::model::{ModelResponse, StopReason, Usage};
+    use rustykrab_core::types::{Message, MessageContent, Role, ToolSchema};
+    use uuid::Uuid;
+
+    /// `route` classifies by keyword and never calls the model, so the
+    /// classifier only has to exist.
+    struct UnusedProvider;
+
+    #[async_trait]
+    impl ModelProvider for UnusedProvider {
+        fn name(&self) -> &str {
+            "unused"
+        }
+        async fn chat(&self, _: &[Message], _: &[ToolSchema]) -> Result<ModelResponse> {
+            Ok(ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content: MessageContent::Text(String::new()),
+                    created_at: Utc::now(),
+                    agent_version: None,
+                },
+                usage: Usage::default(),
+                stop_reason: StopReason::EndTurn,
+                text: None,
+            })
+        }
+    }
+
+    fn router_with_base(base: HarnessProfile) -> HarnessRouter {
+        HarnessRouter::new(Arc::new(UnusedProvider)).with_base(base)
+    }
+
+    #[tokio::test]
+    async fn a_named_loop_parameter_survives_a_preset() {
+        // "write some code" classifies as coding, whose preset asks for 3
+        // tool retries. An operator who wrote 1 in harness.toml meant 1.
+        let base = HarnessProfile {
+            max_tool_retries: 1,
+            max_iterations: 20,
+            ..HarnessProfile::default()
+        };
+        let routed = router_with_base(base)
+            .with_pinned_fields(vec!["max_tool_retries".into(), "max_iterations".into()])
+            .route("please write some code for me")
+            .await;
+
+        assert_eq!(routed.max_tool_retries, 1, "the operator's value must win");
+        assert_eq!(routed.max_iterations, 20);
+    }
+
+    #[tokio::test]
+    async fn a_named_parameter_wins_even_when_it_equals_the_default() {
+        // Why this keys on "was it named" rather than "does it differ from
+        // the default": 2 is also the default, so a differs-from-default
+        // rule hands this to the preset's 3 and silently overrides a
+        // stated choice.
+        assert_eq!(HarnessProfile::default().max_tool_retries, 2);
+        let base = HarnessProfile {
+            max_tool_retries: 2,
+            ..HarnessProfile::default()
+        };
+        let routed = router_with_base(base)
+            .with_pinned_fields(vec!["max_tool_retries".into()])
+            .route("please write some code for me")
+            .await;
+
+        assert_eq!(routed.max_tool_retries, 2);
+    }
+
+    #[tokio::test]
+    async fn an_unnamed_parameter_still_comes_from_the_preset() {
+        // Where the operator expressed no opinion, the preset decides —
+        // that is the whole point of routing.
+        let routed = router_with_base(HarnessProfile::default())
+            .route("please write some code for me")
+            .await;
+        assert_eq!(
+            routed.max_tool_retries,
+            HarnessProfile::coding().max_tool_retries
+        );
     }
 }


### PR DESCRIPTION
Stack: #521 → #524 → #533 → #534 → **this** → #536 → #537

Pairs with #536, which supplies the caller. Standalone production fix.

### The bug

`HarnessRouter::route` picks a preset by keyword, then restores what its own
comment calls *"user customizations from the base profile"* — but restores
only `agent_name`, `max_context_tokens` and `compaction_threshold_pct`. The
four loop parameters come from the preset regardless of what the operator
wrote.

A `harness.toml` asking for `max_tool_retries = 1` quietly gets **3** the
moment a message classifies as "coding". `max_iterations = 20` quietly
becomes **200**. Nothing reports the substitution — the profile name in the
startup log is still the operator's.

### How it surfaced

Writing a scenario that needed the runner to exhaust its tool retries. It
never did: **four tool invocations against a configured budget of two**. The
profile in force was the coding preset, not the one on disk.

### Why "named", not "differs from the default"

The obvious rule is "if the base differs from the shipped default, the
operator meant it". I wrote that first and it is wrong:
`max_tool_retries = 2` **is** the default, so the rule hands it to the
preset's 3 and silently overrides a stated choice — the same bug, still
present for anyone whose chosen value happens to match a default.

So this keys on which fields the file *named*. `with_pinned_fields` takes
the names; #536 supplies them from the parsed TOML table.

Where the operator expressed no opinion the preset still decides — that is
the point of routing. All three directions have a test, including the
equals-the-default case that the first attempt got wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)