### PR TITLE
fix(cli): honour harness.toml, and wire the eval switches

### DIFF
--- a/crates/rustykrab-agent/src/router.rs
+++ b/crates/rustykrab-agent/src/router.rs
@@ -11,6 +11,10 @@ use crate::harness::HarnessProfile;
 /// then returns the appropriate profile. No LLM call needed — profile
 /// detection happens instantly based on message content.
 pub struct HarnessRouter {
+    /// Profile fields the operator named explicitly, which a preset must
+    /// not override. Empty means "the operator said nothing", so the
+    /// preset decides everything.
+    pinned: Vec<String>,
     /// Base profile to use as a template. Task-specific fields get overlaid.
     base: HarnessProfile,
     /// A model provider kept for potential future use (e.g. RLM context
@@ -24,7 +28,15 @@ impl HarnessRouter {
         Self {
             _classifier: classifier,
             base: HarnessProfile::default(),
+            pinned: Vec::new(),
         }
+    }
+
+    /// Pin the profile fields the operator set explicitly, so a routed
+    /// preset cannot quietly replace them.
+    pub fn with_pinned_fields(mut self, fields: Vec<String>) -> Self {
+        self.pinned = fields;
+        self
     }
 
     /// Use a custom base profile that gets task-specific overlays applied.
@@ -50,9 +62,32 @@ impl HarnessRouter {
             _ => self.base.clone(),
         };
         // Preserve user customizations from the base profile.
+        //
+        // These three are unconditional: they describe the deployment, not
+        // the task.
         profile.agent_name = self.base.agent_name.clone();
         profile.max_context_tokens = self.base.max_context_tokens;
         profile.compaction_threshold_pct = self.base.compaction_threshold_pct;
+
+        // The loop parameters are the preset's to choose — that is what a
+        // preset is for — *unless* the operator named them. "Named" rather
+        // than "differs from the default": an operator who writes
+        // `max_tool_retries = 2` means 2, even though 2 is also the
+        // default, and a preset asking for 3 would still be overriding a
+        // stated choice.
+        for field in &self.pinned {
+            match field.as_str() {
+                "max_iterations" => profile.max_iterations = self.base.max_iterations,
+                "soft_iteration_warning" => {
+                    profile.soft_iteration_warning = self.base.soft_iteration_warning
+                }
+                "max_consecutive_errors" => {
+                    profile.max_consecutive_errors = self.base.max_consecutive_errors
+                }
+                "max_tool_retries" => profile.max_tool_retries = self.base.max_tool_retries,
+                _ => {}
+            }
+        }
         profile
     }
 }
@@ -253,5 +288,96 @@ mod tests {
             "creative"
         );
         assert_eq!(classify_profile_keywords("hello there"), "general");
+    }
+}
+
+#[cfg(test)]
+mod base_preservation_tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use rustykrab_core::error::Result;
+    use rustykrab_core::model::{ModelResponse, StopReason, Usage};
+    use rustykrab_core::types::{Message, MessageContent, Role, ToolSchema};
+    use uuid::Uuid;
+
+    /// `route` classifies by keyword and never calls the model, so the
+    /// classifier only has to exist.
+    struct UnusedProvider;
+
+    #[async_trait]
+    impl ModelProvider for UnusedProvider {
+        fn name(&self) -> &str {
+            "unused"
+        }
+        async fn chat(&self, _: &[Message], _: &[ToolSchema]) -> Result<ModelResponse> {
+            Ok(ModelResponse {
+                message: Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content: MessageContent::Text(String::new()),
+                    created_at: Utc::now(),
+                    agent_version: None,
+                },
+                usage: Usage::default(),
+                stop_reason: StopReason::EndTurn,
+                text: None,
+            })
+        }
+    }
+
+    fn router_with_base(base: HarnessProfile) -> HarnessRouter {
+        HarnessRouter::new(Arc::new(UnusedProvider)).with_base(base)
+    }
+
+    #[tokio::test]
+    async fn a_named_loop_parameter_survives_a_preset() {
+        // "write some code" classifies as coding, whose preset asks for 3
+        // tool retries. An operator who wrote 1 in harness.toml meant 1.
+        let base = HarnessProfile {
+            max_tool_retries: 1,
+            max_iterations: 20,
+            ..HarnessProfile::default()
+        };
+        let routed = router_with_base(base)
+            .with_pinned_fields(vec!["max_tool_retries".into(), "max_iterations".into()])
+            .route("please write some code for me")
+            .await;
+
+        assert_eq!(routed.max_tool_retries, 1, "the operator's value must win");
+        assert_eq!(routed.max_iterations, 20);
+    }
+
+    #[tokio::test]
+    async fn a_named_parameter_wins_even_when_it_equals_the_default() {
+        // Why this keys on "was it named" rather than "does it differ from
+        // the default": 2 is also the default, so a differs-from-default
+        // rule hands this to the preset's 3 and silently overrides a
+        // stated choice.
+        assert_eq!(HarnessProfile::default().max_tool_retries, 2);
+        let base = HarnessProfile {
+            max_tool_retries: 2,
+            ..HarnessProfile::default()
+        };
+        let routed = router_with_base(base)
+            .with_pinned_fields(vec!["max_tool_retries".into()])
+            .route("please write some code for me")
+            .await;
+
+        assert_eq!(routed.max_tool_retries, 2);
+    }
+
+    #[tokio::test]
+    async fn an_unnamed_parameter_still_comes_from_the_preset() {
+        // Where the operator expressed no opinion, the preset decides —
+        // that is the whole point of routing.
+        let routed = router_with_base(HarnessProfile::default())
+            .route("please write some code for me")
+            .await;
+        assert_eq!(
+            routed.max_tool_retries,
+            HarnessProfile::coding().max_tool_retries
+        );
     }
 }

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -412,7 +412,8 @@ async fn main() -> anyhow::Result<()> {
 
     // --- Harness profile ---
     // Load from file or use a preset. Supported: default, coding, research, creative
-    let mut profile = load_harness_profile(&data_dir)?;
+    let (mut profile, profile_context_tokens, pinned_profile_fields) =
+        load_harness_profile(&data_dir)?;
     tracing::info!(profile = %profile.name, "harness profile loaded");
 
     // --- Master key for credential encryption ---
@@ -585,7 +586,7 @@ async fn main() -> anyhow::Result<()> {
     // local Ollama deployments on consumer hardware can't chew through
     // anywhere near that before the HTTP timeout fires, so default to
     // 32k for Ollama and keep the 128k default for everything else.
-    profile.max_context_tokens = resolve_max_context_tokens(&provider_name);
+    profile.max_context_tokens = resolve_max_context_tokens(&provider_name, profile_context_tokens);
     tracing::info!(
         max_context_tokens = profile.max_context_tokens,
         provider = %provider_name,
@@ -1020,7 +1021,11 @@ async fn main() -> anyhow::Result<()> {
     // The classification prompt is ~50 tokens — negligible overhead on any model.
     let classifier: Arc<dyn ModelProvider> = provider.clone();
 
-    let router = Arc::new(HarnessRouter::new(classifier).with_base(profile));
+    let router = Arc::new(
+        HarnessRouter::new(classifier)
+            .with_base(profile)
+            .with_pinned_fields(pinned_profile_fields),
+    );
 
     // --- Build gateway state ---
     // Clone store handle so we can flush it after the server shuts down.
@@ -2237,14 +2242,23 @@ fn load_orchestration_config(data_dir: &std::path::Path) -> anyhow::Result<Orche
 ///
 /// Priority:
 /// 1. `RUSTYKRAB_MAX_CONTEXT_TOKENS` env var when set to a positive integer
-/// 2. Provider-aware default: 32k for Ollama (local inference with
+/// 2. `max_context_tokens` named in `harness.toml`, via `profile_set`
+/// 3. Provider-aware default: 32k for Ollama (local inference with
 ///    limited GPU memory), 128k for everything else (cloud models)
-fn resolve_max_context_tokens(provider_name: &str) -> usize {
+///
+/// Step 2 is the one that was missing. A `max_context_tokens` written in
+/// `harness.toml` was loaded and then immediately overwritten by the
+/// provider default — silently, so a profile asking for a small window got
+/// a large one and nothing said why.
+fn resolve_max_context_tokens(provider_name: &str, profile_set: Option<usize>) -> usize {
     if let Some(v) = std::env::var("RUSTYKRAB_MAX_CONTEXT_TOKENS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|&v| v > 0)
     {
+        return v;
+    }
+    if let Some(v) = profile_set.filter(|&v| v > 0) {
         return v;
     }
     match provider_name {
@@ -2259,12 +2273,33 @@ fn resolve_max_context_tokens(provider_name: &str) -> usize {
 /// 1. `data_dir/harness.toml` — full custom profile
 /// 2. `RUSTYKRAB_HARNESS` env var — one of: default, coding, research, creative
 /// 3. Fallback to default profile
-fn load_harness_profile(data_dir: &std::path::Path) -> anyhow::Result<HarnessProfile> {
+///
+/// Returns the profile, the context budget it named, and every key it
+/// named.
+///
+/// The last two exist because `HarnessProfile` defaults every field, so a
+/// loaded profile alone cannot tell "the operator wants 6000" from "the
+/// operator said nothing and serde filled in a default". The context
+/// resolver and the harness router both need that distinction, and both
+/// were silently overriding stated choices without it.
+fn load_harness_profile(
+    data_dir: &std::path::Path,
+) -> anyhow::Result<(HarnessProfile, Option<usize>, Vec<String>)> {
     let profile_path = data_dir.join("harness.toml");
     if profile_path.exists() {
         let contents = std::fs::read_to_string(&profile_path)?;
         let profile: HarnessProfile = toml::from_str(&contents)?;
-        return Ok(profile);
+        let table = contents.parse::<toml::Table>().ok();
+        let explicit = table
+            .as_ref()
+            .and_then(|t| t.get("max_context_tokens").and_then(|v| v.as_integer()))
+            .map(|v| v as usize);
+        // Every key the file named. The router uses this to tell a stated
+        // choice from a serde default, which it otherwise cannot do.
+        let named = table
+            .map(|t| t.keys().cloned().collect())
+            .unwrap_or_default();
+        return Ok((profile, explicit, named));
     }
 
     let preset = std::env::var("RUSTYKRAB_HARNESS").unwrap_or_else(|_| "default".to_string());
@@ -2275,7 +2310,9 @@ fn load_harness_profile(data_dir: &std::path::Path) -> anyhow::Result<HarnessPro
         _ => HarnessProfile::default(),
     };
 
-    Ok(profile)
+    // A preset names nothing of its own, so the provider default applies
+    // and the router is free to choose.
+    Ok((profile, None, Vec::new()))
 }
 
 /// Handle `skill list` and `skill install <path>` subcommands.


### PR DESCRIPTION
Stack: #521 → #524 → #533 → #534 → #535 → **this** → #537

### `max_context_tokens` was loaded, then thrown away

Written in `harness.toml`, parsed into the profile, and then — a few hundred
lines later — unconditionally overwritten by the per-provider default. An
operator asking for a small window got a large one and nothing said why.

The env var still wins; a value the file names now beats the default;
absent both, the provider default applies as before.

### Telling "set" from "defaulted"

`HarnessProfile` defaults every field, so a loaded profile alone cannot
distinguish *"the operator wants 32000"* from *"the operator said nothing
and serde filled in a default"*. `load_harness_profile` now reports which
keys the file actually named.

Both the context resolver above and the harness router in #535 need that
distinction, and **both were silently overriding stated choices without
it**. The named keys are handed to the router, completing #535.

### Two eval switches

`RUSTYKRAB_TOOL_STUBS` applies the stub file from #524 to the tool registry,
after every real tool has registered so `replace` means the whole registry.
Like `RUSTYKRAB_PROVIDER=scripted` it logs a warning naming the resulting
tool set, and must never be set on a real deployment.

`RUSTYKRAB_MODEL_CACHE_DIR` lets throwaway daemons share one
embedding-model download instead of fetching hundreds of megabytes into
each temporary data dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)