### PR TITLE
e2e: adopt the better mechanisms from the parallel investigation (#532)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4211,6 +4211,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -91,24 +91,6 @@ const DEFAULT_ACTIVE_TOOLS: &[&str] = &[
     "todo_read",
 ];
 
-/// Tool names to seed into every conversation's active set on top of
-/// [`DEFAULT_ACTIVE_TOOLS`], from `RUSTYKRAB_ACTIVE_TOOLS` (comma
-/// separated). Read once: the environment does not change under a running
-/// daemon, and this is on the path of every turn.
-fn extra_active_tools() -> &'static [String] {
-    static EXTRA: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
-    EXTRA.get_or_init(|| {
-        std::env::var("RUSTYKRAB_ACTIVE_TOOLS")
-            .map(|raw| {
-                raw.split(',')
-                    .map(|n| n.trim().to_string())
-                    .filter(|n| !n.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default()
-    })
-}
-
 use crate::sandbox::{tool_timeout_secs, Sandbox, SandboxPolicy, DEFAULT_NET_TOOL_TIMEOUT_SECS};
 use crate::trace::{ExecutionTracer, ToolTrace};
 
@@ -989,14 +971,6 @@ impl AgentRunner {
         // the filter below.
         self.active_tools
             .activate(conv_id, DEFAULT_ACTIVE_TOOLS.iter().copied());
-        // Names from RUSTYKRAB_ACTIVE_TOOLS are seeded alongside the
-        // defaults. Lazy activation keeps thirty schemas out of the
-        // prompt, but it also means a freshly registered tool is invisible
-        // to the model until something calls `tools_load` — which a
-        // deployment that registered the tool on purpose, or an eval
-        // pinning one scenario to one tool, has no way to arrange.
-        self.active_tools
-            .activate(conv_id, extra_active_tools().iter().map(String::as_str));
         self.active_tools.with_active(conv_id, |version, active| {
             let schemas = self
                 .tools

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1016,16 +1016,78 @@ async fn main() -> anyhow::Result<()> {
         None => tools,
     };
 
+    // A stubbed registry is a closed world: the harness has already said
+    // "these are the only tools." Progressive disclosure exists to keep a
+    // thirty-tool registry from swamping a small model, and `replace` mode
+    // removes `tools_load` itself — so without this the stubs are
+    // registered but never active, and the model is sent no schemas at
+    // all. Seed them so they are visible from turn 0.
+    //
+    // RUSTYKRAB_ACTIVE_TOOLS seeds names directly, for the case a stub file
+    // cannot express: activating *real* tools. The credential scenarios
+    // need `gmail` and `browser` live from turn 0 — they stub nothing,
+    // because their whole premise is that the real tools cannot run
+    // without a credential — and without the seed they measure whether the
+    // model discovers a tool rather than what it does when it lacks a
+    // secret.
+    let mut seed: Vec<String> = Vec::new();
+    if std::env::var_os("RUSTYKRAB_TOOL_STUBS").is_some() {
+        seed.extend(tools.iter().map(|t| t.name().to_string()));
+    }
+    if let Ok(raw) = std::env::var("RUSTYKRAB_ACTIVE_TOOLS") {
+        seed.extend(
+            raw.split(',')
+                .map(str::trim)
+                .filter(|n| !n.is_empty())
+                .map(str::to_string),
+        );
+    }
+    let active_tools = if seed.is_empty() {
+        Arc::new(rustykrab_core::active_tools::ActiveToolsRegistry::new())
+    } else {
+        tracing::warn!(
+            seeded = ?seed,
+            "tools seeded active from turn 0 — an evaluation switch, not a deployment one"
+        );
+        Arc::new(rustykrab_core::active_tools::ActiveToolsRegistry::with_seed(seed))
+    };
+
     // --- Harness router (auto-selects profile per message) ---
     // Reuses the main provider for classification to avoid model swapping.
     // The classification prompt is ~50 tokens — negligible overhead on any model.
     let classifier: Arc<dyn ModelProvider> = provider.clone();
 
-    let router = Arc::new(
-        HarnessRouter::new(classifier)
-            .with_base(profile)
-            .with_pinned_fields(pinned_profile_fields),
+    // Two separate concerns, both needed.
+    //
+    // Pinning fixes the silent override for everyone: the router swaps in a
+    // preset per message and restores only three of the seven profile
+    // fields, so a harness.toml naming `max_tool_retries` quietly lost it.
+    // The pinned names come from the keys the file actually set.
+    //
+    // RUSTYKRAB_HARNESS_ROUTER=off goes further and pins the whole profile,
+    // which is what an eval wants: one configured profile for every
+    // message, no classification in the loop at all. (From #532.)
+    let routing_enabled = !matches!(
+        std::env::var("RUSTYKRAB_HARNESS_ROUTER")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "off" | "0" | "false" | "no"
     );
+    let router = routing_enabled.then(|| {
+        Arc::new(
+            HarnessRouter::new(classifier)
+                .with_base(profile.clone())
+                .with_pinned_fields(pinned_profile_fields),
+        )
+    });
+    if !routing_enabled {
+        tracing::info!(
+            profile = %profile.name,
+            "harness routing disabled — using the configured profile for every message"
+        );
+    }
 
     // --- Build gateway state ---
     // Clone store handle so we can flush it after the server shuts down.
@@ -1034,7 +1096,10 @@ async fn main() -> anyhow::Result<()> {
         // Loopback is always allowed; this adds the names other clients
         // reach us by, e.g. the tailnet hostname the phone uses.
         .with_origin_policy(rustykrab_gateway::OriginPolicy::from_env())
-        .with_harness_router(router)
+        // Also the fallback the gateway uses when routing is off, so
+        // `harness.toml` still decides the caps in that mode.
+        .with_harness_profile(profile)
+        .with_harness_router_opt(router)
         .with_orchestration_config(orchestration_config)
         .with_skill_registry(skill_registry)
         .with_memory(Arc::clone(&memory_system), agent_id)
@@ -1043,6 +1108,7 @@ async fn main() -> anyhow::Result<()> {
         .with_retrieval_log(retrieval_log)
         .with_activity_tracker(activity_tracker.clone())
         .with_outcome_capture(outcome_capture_enabled);
+    state.active_tools = active_tools;
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {

--- a/crates/rustykrab-core/src/active_tools.rs
+++ b/crates/rustykrab-core/src/active_tools.rs
@@ -34,19 +34,49 @@ struct ActiveEntry {
     version: u64,
 }
 
+impl ActiveEntry {
+    /// A fresh entry pre-populated with the registry's seed. Version stays
+    /// 0: the seed is where every conversation starts, not a change to it.
+    fn seeded(seed: &HashSet<String>) -> Self {
+        Self {
+            names: seed.clone(),
+            version: 0,
+        }
+    }
+}
+
 /// Tracks which tools are "active" for each conversation.
 ///
-/// Conversations start with an empty active set. The meta-tool `tools_load`
-/// populates it; the runner filters the schemas sent to the model down to
-/// (meta tools) ∪ (active set).
+/// Conversations start with the seed set (empty unless one was given). The
+/// meta-tool `tools_load` adds to it; the runner filters the schemas sent
+/// to the model down to (meta tools) ∪ (active set).
 #[derive(Debug, Default)]
 pub struct ActiveToolsRegistry {
     inner: RwLock<HashMap<Uuid, ActiveEntry>>,
+    /// Names every conversation starts with, in addition to whatever
+    /// `tools_load` turns on later. Empty for a normal deployment, where
+    /// discovery is the point; used when the registry is small and known
+    /// up front, so requiring a `tools_load` round-trip to reach it would
+    /// be pure overhead.
+    seed: HashSet<String>,
 }
 
 impl ActiveToolsRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// A registry whose conversations all start with `names` already
+    /// active.
+    pub fn with_seed<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+            seed: names.into_iter().map(Into::into).collect(),
+        }
     }
 
     /// Mark the given tools as active for a conversation. Bumps the
@@ -59,7 +89,9 @@ impl ActiveToolsRegistry {
         S: Into<String>,
     {
         let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
-        let entry = guard.entry(conversation_id).or_default();
+        let entry = guard
+            .entry(conversation_id)
+            .or_insert_with(|| ActiveEntry::seeded(&self.seed));
         let mut changed = false;
         for name in names {
             changed |= entry.names.insert(name.into());
@@ -78,7 +110,7 @@ impl ActiveToolsRegistry {
         guard
             .get(&conversation_id)
             .map(|entry| entry.names.clone())
-            .unwrap_or_default()
+            .unwrap_or_else(|| self.seed.clone())
     }
 
     /// Run `f` against the active set for a conversation without cloning
@@ -93,7 +125,7 @@ impl ActiveToolsRegistry {
         let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
         match guard.get(&conversation_id) {
             Some(entry) => f(entry.version, &entry.names),
-            None => f(0, &HashSet::new()),
+            None => f(0, &self.seed),
         }
     }
 
@@ -115,7 +147,7 @@ impl ActiveToolsRegistry {
         guard
             .get(&conversation_id)
             .map(|entry| entry.names.contains(name))
-            .unwrap_or(false)
+            .unwrap_or_else(|| self.seed.contains(name))
     }
 
     /// Forget the active set for a conversation (used on session teardown).

--- a/crates/rustykrab-e2e/Cargo.toml
+++ b/crates/rustykrab-e2e/Cargo.toml
@@ -23,3 +23,4 @@ tempfile = "3"
 # the tables the plan specifies (secret_versions, secret_audit,
 # credential_requests) and not just on what the REST API reveals.
 rusqlite = { version = "0.34", features = ["bundled"] }
+uuid.workspace = true

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -1029,6 +1029,26 @@ fn spawn_daemon(bin: &str, data_dir: &std::path::Path, port: u16) -> Result<Chil
     spawn_daemon_with(bin, data_dir, port, &Backend::Scripted)
 }
 
+/// The budget the daemon picks for Ollama when nothing overrides it
+/// (`resolve_max_context_tokens`). A scenario asking for less than this is
+/// shrinking the window on purpose.
+const OLLAMA_DEFAULT_CONTEXT_BUDGET: usize = 32_000;
+
+/// Read `max_context_tokens` back out of the `harness.toml` a scenario
+/// wrote, if it set one.
+fn harness_context_budget(data_dir: &std::path::Path) -> Option<usize> {
+    let toml = std::fs::read_to_string(data_dir.join("harness.toml")).ok()?;
+    toml.lines()
+        .find_map(|line| line.trim().strip_prefix("max_context_tokens"))
+        .and_then(|rest| {
+            rest.trim()
+                .strip_prefix('=')
+                .map(str::trim)
+                .map(str::to_string)
+        })
+        .and_then(|v| v.parse().ok())
+}
+
 fn spawn_daemon_with(
     bin: &str,
     data_dir: &std::path::Path,
@@ -1092,13 +1112,45 @@ fn spawn_daemon_with(
         } => {
             command
                 .env("RUSTYKRAB_PROVIDER", "ollama")
+                // Scenarios set their own iteration caps, retry budget and
+                // context window; the auto-router would replace the whole
+                // profile with a preset and discard them.
+                .env("RUSTYKRAB_HARNESS_ROUTER", "off")
                 .env("OLLAMA_MODEL", model)
                 .env("OLLAMA_BASE_URL", ollama_url)
                 // Compaction summarisation on a local model is
                 // prefill-heavy; the default would cut it off.
-                .env("OLLAMA_TIMEOUT_SECS", "900");
+                .env("OLLAMA_TIMEOUT_SECS", "900")
+                // One configured profile for every message. Routing
+                // classifies per message and swaps presets, which makes a
+                // scenario's iteration cap and retry budget depend on how
+                // its prompt happens to read. (From #532.)
+                .env("RUSTYKRAB_HARNESS_ROUTER", "off");
             if let Some(n) = num_ctx {
                 command.env("RUSTYKRAB_NUM_CTX", n.to_string());
+            }
+
+            // `max_context_tokens` from `harness.toml` is overwritten at
+            // startup by a provider-derived default (32k for Ollama), so a
+            // scenario that shrinks the window to force compaction never
+            // gets it. `RUSTYKRAB_MAX_CONTEXT_TOKENS` is the documented
+            // override that survives; carry the profile's value through it
+            // so the toml stays the single source of truth.
+            // Only when the scenario is deliberately shrinking the window.
+            // The ordinary profiles set a budget far above Ollama's own
+            // default, and pinning `num_ctx` that high would allocate a KV
+            // cache to match for every scenario.
+            if let Some(budget) =
+                harness_context_budget(data_dir).filter(|&b| b < OLLAMA_DEFAULT_CONTEXT_BUDGET)
+            {
+                command.env("RUSTYKRAB_MAX_CONTEXT_TOKENS", budget.to_string());
+                // The runner sizes the compaction threshold off the
+                // *provider's* reported window in preference to the
+                // profile's budget, so leaving Ollama at its default 64k
+                // puts the trigger ~55k out of reach and compaction never
+                // fires however small the profile says the window is.
+                // Shrink the provider window to match.
+                command.env("RUSTYKRAB_NUM_CTX", budget.to_string());
             }
 
             // An empty spec means "leave the registry alone" — the

--- a/crates/rustykrab-e2e/src/transcript.rs
+++ b/crates/rustykrab-e2e/src/transcript.rs
@@ -60,11 +60,10 @@ impl Transcript {
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
         )?;
 
-        // Not read for its contents — compaction state lives in the
-        // messages on this branch — but a missing row means the caller
-        // handed us an id that never existed, which should say so rather
-        // than come back as an empty transcript.
-        let _: String = conn.query_row(
+        // Carries the compaction state; a missing row also means the
+        // caller handed us an id that never existed, which should say so
+        // rather than come back as an empty transcript.
+        let meta_raw: String = conn.query_row(
             "SELECT data FROM conversations WHERE id = ?1",
             [conv_id],
             |row| row.get(0),
@@ -78,7 +77,8 @@ impl Transcript {
             .filter_map(|raw| serde_json::from_str::<Value>(&raw).ok())
             .collect();
 
-        let mut transcript = Self::parse(&messages);
+        let meta: Value = serde_json::from_str(&meta_raw)?;
+        let mut transcript = Self::parse(&meta, &messages);
         // Displaced history lives in recall_archive, not in the
         // conversation — this is where a compaction's cost is visible.
         transcript.archived_chars = conn
@@ -92,8 +92,8 @@ impl Transcript {
         Ok(transcript)
     }
 
-    /// Assemble from the conversation's messages.
-    pub fn parse(messages: &[Value]) -> Self {
+    /// Assemble from the conversation metadata and its messages.
+    pub fn parse(conv: &Value, messages: &[Value]) -> Self {
         let empty = Vec::new();
 
         let mut assistant_texts = Vec::new();
@@ -155,29 +155,24 @@ impl Transcript {
             }
         }
 
-        // The runner appends this verbatim after every compaction.
-        const CONTINUATION: &str = "Continue from the summary above";
-        let compacted_at = messages.iter().position(|m| {
-            m["content"]["type"].as_str() == Some("text")
-                && m["content"]["data"]
-                    .as_str()
-                    .is_some_and(|t| t.contains(CONTINUATION))
-        });
-        // The summary is the assistant turn immediately before it.
-        let summary = compacted_at.and_then(|i| {
-            messages[..i]
-                .iter()
-                .rev()
-                .find(|m| m["role"].as_str() == Some("assistant"))
-                .and_then(|m| m["content"]["data"].as_str())
-                .map(str::to_string)
-        });
+        // `summary` is the compaction state a Conversation actually
+        // carries — `compact_history` sets it, and there is a test in the
+        // runner asserting so. An earlier version of this inferred
+        // compaction from the continuation turn the runner injects, which
+        // works but reads a side effect rather than the state itself; the
+        // field is both simpler and harder to fool.
+        //
+        // (Adopted from the parallel investigation in #532.)
+        let summary = conv["summary"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
 
         Self {
             final_text: assistant_texts.last().cloned().unwrap_or_default(),
             assistant_texts,
             calls,
-            compacted: compacted_at.is_some(),
+            compacted: summary.is_some(),
             summary,
             archived_chars: 0,
             live_messages: messages.len(),
@@ -249,7 +244,7 @@ mod tests {
 
     /// Test shim: the store hands these back separately.
     fn parse_pair(pair: &(Value, Vec<Value>)) -> Transcript {
-        Transcript::parse(&pair.1)
+        Transcript::parse(&pair.0, &pair.1)
     }
 
     #[test]
@@ -332,26 +327,24 @@ mod tests {
     }
 
     #[test]
-    fn detects_a_compaction_from_the_continuation_turn() {
-        // The summary is model-written and could say anything; the
-        // continuation the runner injects is the reliable marker.
+    fn detects_a_compaction_from_the_summary_the_runner_sets() {
+        // `compact_history` sets `conv.summary`; that field is the whole of
+        // the compaction state a Conversation carries.
         let t = parse_pair(&conv(
             json!([
                 { "id": "m1", "role": "user",
-                  "content": { "type": "text", "data": "the cluster is borealis" } },
-                { "id": "m2", "role": "assistant",
-                  "content": { "type": "text",
-                               "data": "So far: the cluster is borealis. Next: continue." } },
-                { "id": "m3", "role": "user",
-                  "content": { "type": "text",
-                               "data": "Continue from the summary above. Do not repeat \
-                                        already-completed work." } }
+                  "content": { "type": "text", "data": "the cluster is borealis" } }
             ]),
-            json!({}),
+            json!({ "summary": "So far: the cluster is borealis. Next: continue." }),
         ));
         assert!(t.compacted);
         assert!(t.summary.unwrap().contains("borealis"));
-        assert_eq!(t.live_messages, 3);
+    }
+
+    #[test]
+    fn an_empty_summary_is_not_a_compaction() {
+        let t = parse_pair(&conv(json!([]), json!({ "summary": "" })));
+        assert!(!t.compacted, "an empty summary is absence, not a fold");
     }
 
     #[test]

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -231,6 +231,12 @@ impl AppState {
         self
     }
 
+    /// Set the router, or leave static-profile mode in place when `None`.
+    pub fn with_harness_router_opt(mut self, router: Option<Arc<HarnessRouter>>) -> Self {
+        self.harness_router = router;
+        self
+    }
+
     /// Set the skill registry.
     pub fn with_skill_registry(mut self, registry: Arc<SkillRegistry>) -> Self {
         self.skill_registry = registry;


### PR DESCRIPTION
Top of stack #539. Reconciles #532, whose commit is preserved here with its
original authorship (`cherry-pick -x`).

## What happened

#532 was written independently against `evals/02-unify-harness` and found
**the same five bugs** this stack fixes — same root causes, different
implementations. It is not complementary work; it is a parallel
investigation that reached the same place, and on two points it got there
better.

Rather than close it or rebase a wall of duplicate code, this takes the
delta: the mechanisms #532 does better, plus the one that is genuinely
additional.

## Adopted from #532

**`ActiveToolsRegistry::with_seed`, replacing an env var.** Both fixes make
stubbed tools visible; #532 threads a seed through the registry, where mine
was a process-global `OnceLock` read inside the runner — blunter and
untestable per instance. The runner hack is deleted.

Generalised on the way in: #532's seed only fired when
`RUSTYKRAB_TOOL_STUBS` was set. The credential scenarios stub *nothing* —
their premise is that the real tools cannot run without a secret — so they
need `gmail` and `browser` seeded from turn 0 or they measure tool
discovery instead. The seed now takes stub names **and**
`RUSTYKRAB_ACTIVE_TOOLS`.

**Compaction detected from `conv.summary`.** `compact_history` sets that
field and a runner test asserts it. I had been inferring compaction from the
continuation turn the runner injects — a side effect rather than the state.
Theirs is simpler and harder to fool.

**`RUSTYKRAB_HARNESS_ROUTER=off`.** Complementary to #535 rather than a
replacement: #535 stops the router silently discarding the profile fields
`harness.toml` named, which every operator wants; this pins the whole
profile, which is what an eval wants — one configured profile per message,
no classification in the loop. The harness now sets it.

## Kept from this stack

**The transcript**, which is a superset: reads from the store, pairs tool
results to their calls by id, handles multi-part content, and reads
`recall_archive` so a compaction scenario can assert the displaced history
was preserved rather than dropped. Only its detection was worse, and that is
now #532's.

**The model suite** (19 scenarios, verified) and the stub guard, which
already permitted the empty-replace case #532 fixed.

## Not in #532, and worth noting

It does not touch the four deepest bugs in this stack: `memory_search`
returning `count: 0` for every search (#537), `context_limit()` returning
`None` and disabling compaction (#533), the zero input budget causing
31-minute compactions (#534), or `harness.toml`'s context budget being
overwritten (#536).

## Verification

| suite | result |
|---|---|
| scripted | **17/17** |
| model | **19/19**, exit 0 |
| workspace unit tests | 0 failures |

My transcript test still asserted the old detection after the swap and
failed — caught by running, not by reading the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)