### PR TITLE
feat: hand over a credential through a tailnet-only page

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ All configuration is via environment variables. No plaintext config files.
 | `RUSTYKRAB_NUM_CTX` | `65536` | Context window pinned on every Ollama request. Takes precedence over `OLLAMA_NUM_CTX`. Clamped down to the model's native context length when that is smaller. The whole window is allocated as KV cache when the model loads, so lower this (or enable KV quantization, below) if the model won't fit in VRAM. Set to `server` to omit the field and let the server's `OLLAMA_CONTEXT_LENGTH` decide — this disables client-side trimming, since the client then cannot know what the server allocated |
 | `OLLAMA_NUM_CTX` | — | Legacy alias for `RUSTYKRAB_NUM_CTX`. Used only when `RUSTYKRAB_NUM_CTX` is unset |
 | `OLLAMA_KEEP_ALIVE` | `30m` | How long Ollama keeps the model and its KV cache resident after a request (Ollama duration syntax; `-1` for forever). Ollama's own default is 5 minutes, short enough that a sporadically-used gateway reloads the model on most messages. Set to `server` to omit the field |
-| `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to decide from the model tag. Ollama returns a 400 for `think` against models that don't support it, so `auto` only enables it for known thinking families |
-| `OLLAMA_VISION` | `auto` | Whether the model accepts image input: `true`, `false`, or `auto` to decide from the model tag |
+| `OLLAMA_THINK` | `auto` | Whether to request thinking mode: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say). Ollama returns a 400 for `think` against models that don't support it |
+| `OLLAMA_VISION` | `auto` | Whether the model accepts image input: `true`, `false`, or `auto` to ask Ollama what the model supports (falling back to the model tag if it doesn't say) |
 | `OLLAMA_TIMEOUT_SECS` | `900` | HTTP request timeout for Ollama in seconds |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -433,7 +433,8 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    let store = rustykrab_store::Store::open(data_dir.join("db"), master_key)?;
+    let store = rustykrab_store::Store::open(data_dir.join("db"), master_key)?
+        .with_credential_backend(credential_backend_from_env());
 
     // --- Validate required secrets (central registry) ---
     // Every credential the app needs is declared in `registry::REGISTRY`.
@@ -2331,6 +2332,35 @@ fn resolve_max_context_tokens(provider_name: &str, profile_set: Option<usize>) -
     match provider_name {
         "ollama" => 32_000,
         _ => 128_000,
+    }
+}
+
+/// Choose where live credential values are kept.
+///
+/// The platform's own secure store by default. `RUSTYKRAB_CREDENTIAL_BACKEND=memory`
+/// substitutes an in-process one, which exists so the evaluation harness can
+/// exercise the credential flow without a keychain — the same shape as
+/// `RUSTYKRAB_PROVIDER=scripted` and `RUSTYKRAB_TOOL_STUBS`, and warned about
+/// just as loudly, because a real deployment running this keeps every
+/// credential in memory and loses them all on restart.
+fn credential_backend_from_env(
+) -> std::sync::Arc<dyn rustykrab_store::credential_backend::CredentialBackend> {
+    match std::env::var("RUSTYKRAB_CREDENTIAL_BACKEND")
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "memory" => {
+            tracing::warn!(
+                "RUSTYKRAB_CREDENTIAL_BACKEND=memory — credentials are held in \
+                 memory only, are lost on restart, and are protected by nothing. \
+                 This is the evaluation harness switch and must never be set on a \
+                 real deployment."
+            );
+            std::sync::Arc::new(rustykrab_store::credential_backend::MemoryBackend::new())
+        }
+        _ => rustykrab_store::credential_backend::default_backend(),
     }
 }
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1107,7 +1107,8 @@ async fn main() -> anyhow::Result<()> {
         .with_computer_use_enabled(computer_use_enabled)
         .with_retrieval_log(retrieval_log)
         .with_activity_tracker(activity_tracker.clone())
-        .with_outcome_capture(outcome_capture_enabled);
+        .with_outcome_capture(outcome_capture_enabled)
+        .with_credential_page_policy(rustykrab_gateway::PageIdentityPolicy::from_env());
     state.active_tools = active_tools;
 
     // --- Attach video channel to state ---

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -287,6 +287,11 @@ impl Ctx {
             .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
             .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
             .env("RUSTYKRAB_DISABLE_KEYCHAIN", "1")
+            // Credentials must go to a secure store, and there isn't one here —
+            // the line above saw to that. Without this the harness cannot
+            // exercise fulfil at all; with it, nothing touches the developer's
+            // real keychain.
+            .env("RUSTYKRAB_CREDENTIAL_BACKEND", "memory")
             .env("NOTION_API_TOKEN", "e2e-dummy-notion")
             .env("OBSIDIAN_API_KEY", "e2e-dummy-obsidian")
             .output()?)
@@ -1072,6 +1077,11 @@ fn spawn_daemon_with(
         .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
         // Never touch the host's real Keychain from a throwaway boot.
         .env("RUSTYKRAB_DISABLE_KEYCHAIN", "1")
+        // Credentials must go to a secure store, and there isn't one here —
+        // the line above saw to that. Without this the harness cannot
+        // exercise fulfil at all; with it, nothing touches the developer's
+        // real keychain.
+        .env("RUSTYKRAB_CREDENTIAL_BACKEND", "memory")
         // Dummy values for the registry's startup-required secrets.
         .env("NOTION_API_TOKEN", "e2e-dummy-notion")
         .env("OBSIDIAN_API_KEY", "e2e-dummy-obsidian")

--- a/crates/rustykrab-gateway/src/credential_page.rs
+++ b/crates/rustykrab-gateway/src/credential_page.rs
@@ -1,0 +1,318 @@
+//! A page the user opens to hand over a credential the agent lacks.
+//!
+//! The agent cannot ask for a password in chat — a chat message has no
+//! secure field, and whatever the user types is then sitting in the
+//! transcript of whichever channel they answered on. So the agent sends a
+//! link instead, and this is what the link opens.
+//!
+//! ## Why this is server-rendered HTML and not part of the SPA
+//!
+//! Two properties fall out of plain HTML that the JSON API cannot offer
+//! today:
+//!
+//! - **It works in a browser at all.** `/api/` is `is_sensitive`, so a
+//!   request without an `Origin` header is refused — and browsers omit
+//!   `Origin` on same-origin GETs. This route is outside that prefix, and
+//!   the form POST carries an `Origin` natively, so neither hits the wall.
+//! - **No JavaScript touches the value.** The password goes from the input
+//!   straight into a form POST. Nothing reads it into a variable, so there
+//!   is nothing to accidentally log, cache, or leave in the DOM.
+//!
+//! ## What guards it
+//!
+//! Two independent things, per the deployment model — the gateway binds
+//! loopback and is fronted by `tailscale serve`:
+//!
+//! 1. **Tailnet identity.** `tailscale serve` injects `Tailscale-User-Login`
+//!    for the authenticated tailnet user. Requests without it are refused
+//!    unless anonymous access is explicitly enabled for local development.
+//! 2. **A one-time token**, bound to a single request, hashed at rest, and
+//!    dead the moment the request is answered or the TTL passes.
+//!
+//! Either alone would be weaker than it looks. The header is only
+//! trustworthy because nothing but the tailnet front end can reach the
+//! listener, and a link that travels through a chat message can be read by
+//! anyone who later reads that chat.
+
+use axum::extract::{Form, Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
+use rustykrab_store::CredentialRequest;
+use std::collections::HashMap;
+
+use crate::AppState;
+
+/// Header `tailscale serve` sets for the authenticated tailnet user.
+const TAILNET_USER_HEADER: &str = "tailscale-user-login";
+
+/// Who may open a credential page.
+#[derive(Debug, Clone, Default)]
+pub struct PageIdentityPolicy {
+    /// Accept requests with no tailnet identity at all. Off by default and
+    /// only for loopback development: with `tailscale serve` in front, a
+    /// request that reaches us without the header did not come through it.
+    pub allow_anonymous: bool,
+    /// Logins permitted, when the tailnet has more than one member. Empty
+    /// means any authenticated tailnet user.
+    pub allowed_logins: Vec<String>,
+}
+
+impl PageIdentityPolicy {
+    pub fn from_env() -> Self {
+        let allow_anonymous = matches!(
+            std::env::var("RUSTYKRAB_CREDENTIAL_PAGE_ANONYMOUS")
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase()
+                .as_str(),
+            "1" | "true" | "on" | "yes"
+        );
+        let allowed_logins = std::env::var("RUSTYKRAB_TAILNET_USERS")
+            .unwrap_or_default()
+            .split(',')
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect();
+        Self {
+            allow_anonymous,
+            allowed_logins,
+        }
+    }
+
+    /// Decide whether these headers may open a credential page.
+    ///
+    /// Fails closed: an absent header is a refusal unless anonymous access
+    /// was turned on deliberately.
+    fn permits(&self, headers: &HeaderMap) -> bool {
+        let login = headers
+            .get(TAILNET_USER_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.trim().to_ascii_lowercase())
+            .filter(|v| !v.is_empty());
+
+        match login {
+            Some(login) => self.allowed_logins.is_empty() || self.allowed_logins.contains(&login),
+            None => self.allow_anonymous,
+        }
+    }
+}
+
+pub fn routes() -> axum::Router<AppState> {
+    axum::Router::new().route("/c/{token}", axum::routing::get(show).post(submit))
+}
+
+/// Everything the user is refused with looks the same.
+///
+/// A wrong token, an expired one, one already answered, and one belonging
+/// to somebody else all render this. Distinguishing them would turn the
+/// page into an oracle for which links exist.
+fn refused() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Html(page(
+            "Link expired",
+            "<p>This link is no longer valid. It may already have been used, \
+             or it may have expired.</p><p>Ask the agent to send a new one.</p>",
+        )),
+    )
+        .into_response()
+}
+
+async fn show(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if !state.credential_page_policy.permits(&headers) {
+        tracing::warn!("credential page refused: no permitted tailnet identity");
+        return refused();
+    }
+    let Ok(Some(req)) = state.store.credential_requests().find_by_link(&token).await else {
+        return refused();
+    };
+    Html(form_page(&req, &token, None)).into_response()
+}
+
+async fn submit(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+    headers: HeaderMap,
+    Form(values): Form<HashMap<String, String>>,
+) -> Response {
+    if !state.credential_page_policy.permits(&headers) {
+        tracing::warn!("credential page submit refused: no permitted tailnet identity");
+        return refused();
+    }
+    let Ok(Some(req)) = state.store.credential_requests().find_by_link(&token).await else {
+        return refused();
+    };
+
+    // Re-render rather than reject: the user has just typed a password, and
+    // throwing it away over a blank second field is a poor trade.
+    let missing: Vec<&str> = req
+        .fields
+        .iter()
+        .filter(|f| {
+            values
+                .get(&f.key)
+                .map(|v| v.trim().is_empty())
+                .unwrap_or(true)
+        })
+        .map(|f| f.key.as_str())
+        .collect();
+    if !missing.is_empty() {
+        return Html(form_page(&req, &token, Some("Every field is needed."))).into_response();
+    }
+
+    let supplied: Vec<(String, String)> = req
+        .fields
+        .iter()
+        .filter_map(|f| values.get(&f.key).map(|v| (f.key.clone(), v.clone())))
+        .collect();
+
+    let by = headers
+        .get(TAILNET_USER_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("credential page");
+
+    match state
+        .store
+        .credential_requests()
+        .fulfil(&req.id, &supplied, by)
+        .await
+    {
+        Ok(()) => Html(page(
+            "Saved",
+            "<p>Saved. You can close this page — the agent has what it needs \
+             and will carry on.</p>",
+        ))
+        .into_response(),
+        Err(e) => {
+            // The value is not echoed back into the retry form: it has been
+            // sent once already and the failure may well be the store.
+            tracing::error!(error = %e, "credential page could not fulfil the request");
+            Html(form_page(
+                &req,
+                &token,
+                Some("That could not be saved. Try once more."),
+            ))
+            .into_response()
+        }
+    }
+}
+
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn form_page(req: &CredentialRequest, token: &str, error: Option<&str>) -> String {
+    let service = req.service.as_deref().unwrap_or(&req.name);
+    let mut body = String::new();
+    body.push_str(&format!("<h1>{} needs a credential</h1>", esc(service)));
+    if let Some(reason) = req.reason.as_deref().filter(|r| !r.is_empty()) {
+        body.push_str(&format!("<p class=\"why\">{}</p>", esc(reason)));
+    }
+    if let Some(err) = error {
+        body.push_str(&format!("<p class=\"err\">{}</p>", esc(err)));
+    }
+    body.push_str(&format!(
+        "<form method=\"post\" action=\"/c/{}\" autocomplete=\"off\">",
+        esc(token)
+    ));
+    for f in &req.fields {
+        let kind = if f.secret { "password" } else { "text" };
+        body.push_str(&format!(
+            "<label>{}<input name=\"{}\" type=\"{}\" \
+             autocapitalize=\"none\" autocorrect=\"off\" spellcheck=\"false\" \
+             placeholder=\"{}\" required></label>",
+            esc(&f.label),
+            esc(&f.key),
+            kind,
+            esc(f.hint.as_deref().unwrap_or("")),
+        ));
+    }
+    body.push_str("<button type=\"submit\">Save</button></form>");
+    body.push_str(
+        "<p class=\"note\">Sent once, over your tailnet, straight into this \
+         Mac's encrypted store. This link works only now, and only once.</p>",
+    );
+    page(&format!("{service} credential"), &body)
+}
+
+fn page(title: &str, body: &str) -> String {
+    format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+<meta name=\"referrer\" content=\"no-referrer\">\
+<title>{}</title><style>\
+:root{{color-scheme:light dark}}\
+body{{font:16px/1.5 -apple-system,BlinkMacSystemFont,'SF Pro Text',sans-serif;\
+margin:0;padding:24px;max-width:26rem;margin-inline:auto}}\
+h1{{font-size:1.35rem;margin:0 0 .25rem}}\
+.why{{color:#666;margin:.25rem 0 1.25rem}}\
+.err{{color:#c0392b;margin:.5rem 0}}\
+.note{{color:#666;font-size:.82rem;margin-top:1.25rem}}\
+label{{display:block;margin-bottom:.85rem;font-size:.85rem;color:#666}}\
+input{{display:block;width:100%;margin-top:.3rem;padding:.65rem .7rem;\
+font-size:1rem;border:1px solid #bbb;border-radius:.5rem;box-sizing:border-box}}\
+button{{width:100%;padding:.7rem;font-size:1rem;border:0;border-radius:.5rem;\
+background:#0a84ff;color:#fff;font-weight:600}}\
+</style></head><body>{}</body></html>",
+        esc(title),
+        body
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers(login: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(l) = login {
+            h.insert(TAILNET_USER_HEADER, HeaderValue::from_str(l).unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn no_tailnet_identity_is_refused_by_default() {
+        let p = PageIdentityPolicy::default();
+        assert!(!p.permits(&headers(None)));
+        assert!(p.permits(&headers(Some("someone@example.com"))));
+    }
+
+    #[test]
+    fn anonymous_is_only_allowed_when_turned_on() {
+        let p = PageIdentityPolicy {
+            allow_anonymous: true,
+            ..Default::default()
+        };
+        assert!(p.permits(&headers(None)));
+    }
+
+    #[test]
+    fn an_allowlist_excludes_other_tailnet_members() {
+        let p = PageIdentityPolicy {
+            allow_anonymous: false,
+            allowed_logins: vec!["me@example.com".into()],
+        };
+        assert!(p.permits(&headers(Some("me@example.com"))));
+        assert!(p.permits(&headers(Some("ME@example.com")))); // login case is not identity
+        assert!(!p.permits(&headers(Some("someone-else@example.com"))));
+        // An empty header is not an identity.
+        assert!(!p.permits(&headers(Some("   "))));
+    }
+
+    #[test]
+    fn rendered_values_are_escaped() {
+        let out = page("t", &esc("<script>alert(1)</script>"));
+        assert!(!out.contains("<script>alert"));
+        assert!(out.contains("&lt;script&gt;"));
+    }
+}

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+mod credential_page;
 pub mod logging;
 mod orchestrate;
 pub mod origin;
@@ -61,6 +62,7 @@ pub fn router(state: AppState) -> Router {
         .merge(routes::api_routes())
         .merge(telegram_webhook::telegram_routes())
         .merge(signal_webhook::signal_routes())
+        .merge(credential_page::routes())
         .merge(webchat::static_routes())
         .layer(middleware::from_fn_with_state(
             state.clone(),
@@ -78,3 +80,5 @@ pub fn router(state: AppState) -> Router {
         .layer(middleware::from_fn(security_headers_middleware))
         .with_state(state)
 }
+
+pub use credential_page::PageIdentityPolicy;

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -83,6 +83,8 @@ pub struct AppState {
     /// default: instrumentation is opt-in, driven by
     /// `RUSTYKRAB_OUTCOME_CAPTURE` at startup.
     pub outcome_capture_enabled: bool,
+    /// Who may open the credential page served at `/c/{token}`.
+    pub credential_page_policy: crate::PageIdentityPolicy,
 }
 
 impl AppState {
@@ -124,6 +126,7 @@ impl AppState {
             activity: ActivityTracker::new(),
             retrieval_log: RetrievalLog::new(),
             outcome_capture_enabled: false,
+            credential_page_policy: crate::PageIdentityPolicy::default(),
         }
     }
 
@@ -228,6 +231,12 @@ impl AppState {
     /// selects the right harness profile on-the-fly.
     pub fn with_harness_router(mut self, router: Arc<HarnessRouter>) -> Self {
         self.harness_router = Some(router);
+        self
+    }
+
+    /// Who may open the credential page. Fails closed by default.
+    pub fn with_credential_page_policy(mut self, p: crate::PageIdentityPolicy) -> Self {
+        self.credential_page_policy = p;
         self
     }
 

--- a/crates/rustykrab-providers/src/ollama.rs
+++ b/crates/rustykrab-providers/src/ollama.rs
@@ -210,6 +210,11 @@ pub struct OllamaProvider {
     /// serve, and as the client-side prompt-trimming budget when `num_ctx`
     /// has been explicitly set to defer to the server.
     detected_ctx: Option<u32>,
+    /// What Ollama itself reports the model can do, from `/api/show`.
+    /// `None` when it could not be read (server unreachable, or a release
+    /// predating the `capabilities` field), in which case the tag-matching
+    /// heuristics stand in.
+    detected_caps: Option<ModelCapabilities>,
     /// Fingerprint of the tool block sent on the previous request, so a
     /// change can be reported.  See [`OllamaProvider::note_tool_block`].
     /// `0` means "nothing sent yet".
@@ -236,6 +241,7 @@ impl OllamaProvider {
             model: model.into(),
             config: OllamaConfig::default(),
             detected_ctx: None,
+            detected_caps: None,
             last_tool_fingerprint: AtomicU64::new(0),
         }
     }
@@ -272,11 +278,12 @@ impl OllamaProvider {
     }
 
     /// Whether `think` will be sent, and with what value. An explicit
-    /// `config.think` wins; otherwise the model tag decides.
+    /// `config.think` wins, then `OLLAMA_THINK`, then what Ollama reports
+    /// for the model, and only then the model-tag heuristic.
     pub fn resolved_think(&self) -> bool {
         self.config
             .think
-            .unwrap_or_else(|| think_support(&self.model))
+            .unwrap_or_else(|| think_support(&self.model, self.detected_caps))
     }
 
     /// Effective context window used for client-side prompt trimming.
@@ -291,12 +298,13 @@ impl OllamaProvider {
     /// unfamiliar (e.g. an architecture we don't recognize).  Network and
     /// HTTP errors are propagated so the caller can decide how to react.
     pub async fn detect_context_window(&self) -> Result<Option<u32>> {
-        Ok(self.detect_model_shape().await?.0)
+        Ok(self.detect_model_shape().await?.ctx)
     }
 
-    /// Query `/api/show` for both the model's native context length and the
-    /// attention geometry needed to size its KV cache.
-    async fn detect_model_shape(&self) -> Result<(Option<u32>, Option<KvGeometry>)> {
+    /// Query `/api/show` for the model's native context length, the
+    /// attention geometry needed to size its KV cache, and the capabilities
+    /// Ollama reports for it.
+    async fn detect_model_shape(&self) -> Result<ModelShape> {
         let url = format!("{}/api/show", self.base_url);
         let resp = self
             .client
@@ -315,10 +323,11 @@ impl OllamaProvider {
         let raw: serde_json::Value = resp.json().await.map_err(|e| {
             Error::ModelProvider(format!("failed to parse /api/show response: {e}"))
         })?;
-        Ok((
-            parse_context_length_from_show(&raw),
-            parse_kv_geometry_from_show(&raw),
-        ))
+        Ok(ModelShape {
+            ctx: parse_context_length_from_show(&raw),
+            geometry: parse_kv_geometry_from_show(&raw),
+            caps: parse_capabilities_from_show(&raw),
+        })
     }
 
     /// Report what the pinned window will cost in KV cache.
@@ -356,8 +365,12 @@ impl OllamaProvider {
     /// is logged — startup must not fail just because Ollama is momentarily
     /// unreachable.
     pub async fn with_detected_context_window(mut self) -> Self {
-        let (detected, geometry) = match self.detect_model_shape().await {
-            Ok(pair) => pair,
+        let ModelShape {
+            ctx: detected,
+            geometry,
+            caps,
+        } = match self.detect_model_shape().await {
+            Ok(shape) => shape,
             Err(e) => {
                 tracing::warn!(
                     model = %self.model,
@@ -413,6 +426,20 @@ impl OllamaProvider {
             None => tracing::debug!(
                 model = %self.model,
                 "could not read attention geometry from /api/show; skipping KV cache estimate"
+            ),
+        }
+
+        self.detected_caps = caps;
+        match caps {
+            Some(caps) => tracing::info!(
+                model = %self.model,
+                vision = caps.vision,
+                thinking = caps.thinking,
+                "capabilities reported by Ollama"
+            ),
+            None => tracing::debug!(
+                model = %self.model,
+                "Ollama reported no capability list; falling back to model-tag heuristics"
             ),
         }
         self
@@ -897,7 +924,7 @@ impl ModelProvider for OllamaProvider {
     }
 
     fn supports_vision(&self) -> bool {
-        vision_support(&self.model)
+        vision_support(&self.model, self.detected_caps)
     }
 
     async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
@@ -1555,6 +1582,44 @@ fn empty_response_error(
     ))
 }
 
+/// What Ollama reports a model can do, from `/api/show`'s `capabilities`.
+///
+/// Ollama knows this authoritatively — it is derived from the model's own
+/// files rather than guessed from its name — so it beats any tag-matching
+/// heuristic. Notably it distinguishes builds that share a tag prefix,
+/// which a substring match cannot: `qwen3.8:27b-mlx` reports `vision`
+/// while the plain `qwen3.8` family match says it has none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ModelCapabilities {
+    pub vision: bool,
+    pub thinking: bool,
+}
+
+/// Everything worth reading out of one `/api/show` call.
+#[derive(Debug, Clone, Copy, Default)]
+struct ModelShape {
+    ctx: Option<u32>,
+    geometry: Option<KvGeometry>,
+    caps: Option<ModelCapabilities>,
+}
+
+/// Pull the reported capability list out of an `/api/show` response.
+/// Returns `None` when the field is absent, so the caller can tell
+/// "Ollama says this model has no vision" apart from "Ollama did not say".
+fn parse_capabilities_from_show(raw: &serde_json::Value) -> Option<ModelCapabilities> {
+    let listed = raw.get("capabilities")?.as_array()?;
+    let has = |name: &str| {
+        listed
+            .iter()
+            .filter_map(|c| c.as_str())
+            .any(|c| c.eq_ignore_ascii_case(name))
+    };
+    Some(ModelCapabilities {
+        vision: has("vision"),
+        thinking: has("thinking"),
+    })
+}
+
 /// Attention geometry needed to size a model's KV cache, read from
 /// `/api/show`'s `model_info` (which surfaces the GGUF metadata).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1664,38 +1729,45 @@ fn parse_context_length_from_show(raw: &serde_json::Value) -> Option<u32> {
 /// Decide whether the configured Ollama model can accept image input.
 ///
 /// Vision is a per-model property in Ollama (the same provider serves both
-/// text-only and multimodal models), so we key off the model tag. The
-/// `OLLAMA_VISION` env var overrides the heuristic: `true`/`1`/`on` force it
-/// on, `false`/`0`/`off` force it off, and `auto` (the default) falls back to
-/// `model_supports_vision`.
-fn vision_support(model: &str) -> bool {
-    match std::env::var("OLLAMA_VISION").ok().as_deref() {
-        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
-            "true" | "1" | "on" | "yes" => true,
-            "false" | "0" | "off" | "no" => false,
-            // "auto" or anything unrecognized: fall through to the heuristic.
-            _ => model_supports_vision(model),
-        },
-        None => model_supports_vision(model),
+/// text-only and multimodal models). Resolution order, most to least
+/// authoritative: the `OLLAMA_VISION` env var (`true`/`1`/`on` force it on,
+/// `false`/`0`/`off` force it off, `auto` defers), then the capability list
+/// Ollama reports for the model, then the `model_supports_vision` tag
+/// heuristic for servers that report nothing.
+fn vision_support(model: &str, reported: Option<ModelCapabilities>) -> bool {
+    capability_override("OLLAMA_VISION")
+        .or_else(|| reported.map(|c| c.vision))
+        .unwrap_or_else(|| model_supports_vision(model))
+}
+
+/// Read a `true`/`false`/`auto` capability override from the environment.
+/// `None` means "not set, or set to auto" — defer to whatever comes next in
+/// the resolution order.
+fn capability_override(var: &str) -> Option<bool> {
+    match std::env::var(var)
+        .ok()?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "true" | "1" | "on" | "yes" => Some(true),
+        "false" | "0" | "off" | "no" => Some(false),
+        // "auto" or anything unrecognized: defer.
+        _ => None,
     }
 }
 
 /// Decide whether to ask the configured Ollama model to think.
 ///
 /// Ollama returns a 400 for `think: true` against a model that has no
-/// thinking capability, so this cannot be sent unconditionally. The
-/// `OLLAMA_THINK` env var overrides the heuristic with the same
-/// `true`/`false`/`auto` vocabulary as `OLLAMA_VISION`.
-fn think_support(model: &str) -> bool {
-    match std::env::var("OLLAMA_THINK").ok().as_deref() {
-        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
-            "true" | "1" | "on" | "yes" => true,
-            "false" | "0" | "off" | "no" => false,
-            // "auto" or anything unrecognized: fall through to the heuristic.
-            _ => model_supports_thinking(model),
-        },
-        None => model_supports_thinking(model),
-    }
+/// thinking capability, so this cannot be sent unconditionally. Resolved
+/// the same way as vision: `OLLAMA_THINK` first (same `true`/`false`/`auto`
+/// vocabulary as `OLLAMA_VISION`), then Ollama's reported capabilities,
+/// then the tag heuristic.
+fn think_support(model: &str, reported: Option<ModelCapabilities>) -> bool {
+    capability_override("OLLAMA_THINK")
+        .or_else(|| reported.map(|c| c.thinking))
+        .unwrap_or_else(|| model_supports_thinking(model))
 }
 
 /// Heuristic match against known thinking-capable Ollama model families.
@@ -2283,6 +2355,156 @@ mod tests {
         assert!(!is_empty_generation("", Some(1))); // count without text
     }
 
+    // ---- Reported capabilities -------------------------------------------
+
+    /// Run `f` with `var` set to `value` (or removed when `None`).
+    /// `std::env` is process-global and `cargo test` is multi-threaded, so
+    /// these serialise on one mutex and restore the prior value on the way
+    /// out.
+    fn with_env<T>(var: &str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var(var).ok();
+        // SAFETY: all writers of these vars hold ENV_LOCK for the duration.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(var, v),
+                None => std::env::remove_var(var),
+            }
+        }
+        let out = f();
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var(var, v),
+                None => std::env::remove_var(var),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn capabilities_are_read_from_show() {
+        let caps = parse_capabilities_from_show(&serde_json::json!({
+            "capabilities": ["completion", "vision", "tools", "thinking"]
+        }))
+        .expect("a capability list must parse");
+        assert!(caps.vision);
+        assert!(caps.thinking);
+
+        let caps = parse_capabilities_from_show(&serde_json::json!({
+            "capabilities": ["completion", "tools", "thinking"]
+        }))
+        .expect("a capability list must parse");
+        assert!(!caps.vision);
+        assert!(caps.thinking);
+    }
+
+    /// An Ollama release predating `capabilities` must be distinguishable
+    /// from one reporting no vision, so the heuristic can stand in.
+    #[test]
+    fn absent_capability_list_is_none_not_empty() {
+        assert!(parse_capabilities_from_show(&serde_json::json!({ "model_info": {} })).is_none());
+    }
+
+    /// The two real cases that motivated reading capabilities at all. Both
+    /// tags are misclassified by the substring heuristic, in opposite
+    /// directions — verified against Ollama 0.32.15.
+    #[test]
+    fn reported_vision_overrules_the_tag_heuristic_both_ways() {
+        with_env("OLLAMA_VISION", None, || {
+            // qwen3.8:27b-mlx accepts images; the heuristic says it does not.
+            let seen = ModelCapabilities {
+                vision: true,
+                thinking: true,
+            };
+            assert!(!model_supports_vision("qwen3.8:27b-mlx"));
+            assert!(vision_support("qwen3.8:27b-mlx", Some(seen)));
+
+            // The other direction, which is why extending the family list
+            // would not have been enough: a build can report *less* than
+            // its family implies. `gemma4:26b-mlx` rejects images with
+            // "this model does not support image input" while the `gemma4`
+            // family match says it accepts them. (Not a deployed model —
+            // it is the cheapest reproduction of the false positive.)
+            let seen = ModelCapabilities {
+                vision: false,
+                thinking: true,
+            };
+            assert!(model_supports_vision("gemma4:26b-mlx"));
+            assert!(!vision_support("gemma4:26b-mlx", Some(seen)));
+        });
+    }
+
+    /// The supported `gemma4:26b` build is not affected by any of this:
+    /// what Ollama reports and what the tag heuristic concludes already
+    /// agree, so reading capabilities changes nothing for it. Asserted so
+    /// the fix cannot start moving the default model's behaviour.
+    #[test]
+    fn supported_gemma4_behaviour_is_unchanged() {
+        // Exactly what `/api/show` returns for gemma4:26b on Ollama 0.32.15.
+        let reported = ModelCapabilities {
+            vision: true,
+            thinking: true,
+        };
+        with_env("OLLAMA_VISION", None, || {
+            assert_eq!(
+                vision_support("gemma4:26b", Some(reported)),
+                model_supports_vision("gemma4:26b")
+            );
+            assert!(vision_support("gemma4:26b", Some(reported)));
+        });
+        with_env("OLLAMA_THINK", None, || {
+            assert_eq!(
+                think_support("gemma4:26b", Some(reported)),
+                model_supports_thinking("gemma4:26b")
+            );
+            assert!(think_support("gemma4:26b", Some(reported)));
+        });
+    }
+
+    #[test]
+    fn tag_heuristic_stands_in_when_nothing_is_reported() {
+        with_env("OLLAMA_VISION", None, || {
+            assert!(vision_support("gemma4:26b", None));
+            assert!(!vision_support("llama3.1:8b", None));
+        });
+    }
+
+    #[test]
+    fn env_override_beats_reported_capabilities() {
+        let no_vision = ModelCapabilities {
+            vision: false,
+            thinking: false,
+        };
+        with_env("OLLAMA_VISION", Some("true"), || {
+            assert!(vision_support("gemma4:26b-mlx", Some(no_vision)));
+        });
+        let vision = ModelCapabilities {
+            vision: true,
+            thinking: true,
+        };
+        with_env("OLLAMA_VISION", Some("false"), || {
+            assert!(!vision_support("qwen3.8:27b-mlx", Some(vision)));
+        });
+        // "auto" defers to the reported list.
+        with_env("OLLAMA_VISION", Some("auto"), || {
+            assert!(vision_support("gemma4:26b-mlx", Some(vision)));
+        });
+    }
+
+    #[test]
+    fn reported_thinking_resolves_the_same_way() {
+        with_env("OLLAMA_THINK", None, || {
+            let no_think = ModelCapabilities {
+                vision: false,
+                thinking: false,
+            };
+            assert!(model_supports_thinking("qwen3.8:27b-mlx"));
+            assert!(!think_support("qwen3.8:27b-mlx", Some(no_think)));
+            assert!(think_support("qwen3.8:27b-mlx", None));
+        });
+    }
+
     // ---- Live tests against a real Ollama daemon -------------------------
     //
     // Ignored by default: they need a running Ollama and the model named by
@@ -2395,6 +2617,76 @@ mod tests {
             .chat(&msgs, &[])
             .await
             .expect("a history ending in a user turn must survive trimming");
+    }
+
+    /// The point of reading capabilities: whether an image reaches the
+    /// model must follow what Ollama says the model can do.
+    ///
+    /// The agent gates images on `supports_vision()` before they ever reach
+    /// the provider (`MessageContent::from_parts`), so this drives both
+    /// halves through that gate rather than around it.
+    ///
+    /// Skips when the server reports no capability list at all (Ollama
+    /// releases predating the field), since there is then nothing to check.
+    #[tokio::test]
+    #[ignore = "requires a live Ollama daemon"]
+    async fn live_images_follow_the_reported_vision_capability() {
+        use rustykrab_core::types::{ContentBlock, ContentPart};
+
+        let provider = live_provider().with_detected_context_window().await;
+        let Some(caps) = provider.detected_caps else {
+            eprintln!("server reported no capabilities; nothing to verify");
+            return;
+        };
+        assert_eq!(
+            provider.supports_vision(),
+            caps.vision,
+            "the provider must honour what Ollama reports"
+        );
+
+        // 8x8 solid red PNG.
+        const RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP4\
+                                   z8CAFWEXHbQSACj/P8Fu7N9hAAAAAElFTkSuQmCC";
+        let red_png = {
+            use base64::engine::general_purpose::STANDARD;
+            use base64::Engine;
+            STANDARD
+                .decode(RED_PNG_B64.replace(char::is_whitespace, ""))
+                .expect("the fixture is valid base64")
+        };
+
+        let parts = vec![
+            ContentPart::Text {
+                text: "What is in this image? Answer in one word.".to_string(),
+            },
+            ContentPart::Image {
+                media_type: "image/png".to_string(),
+                data: red_png,
+            },
+        ];
+        let content = MessageContent::from_parts(&parts, provider.supports_vision());
+        let carries_image = matches!(&content, MessageContent::MultiPart(blocks)
+            if blocks.iter().any(|b| matches!(b, ContentBlock::Image { .. })));
+        assert_eq!(
+            carries_image, caps.vision,
+            "the image must survive the gate for a vision model and be dropped otherwise"
+        );
+
+        let msg = Message {
+            id: Uuid::new_v4(),
+            role: Role::User,
+            content,
+            created_at: Utc::now(),
+            agent_version: None,
+        };
+
+        // Either way the request must go through: with the image for a model
+        // that can see, without it for one that cannot. Before capabilities
+        // were read, qwen3.8:27b-mlx silently lost every image a user sent.
+        provider
+            .chat(&[msg], &[])
+            .await
+            .expect("the gated request must be accepted by the model");
     }
 
     /// KNOWN LIMITATION, asserted so it cannot regress silently.

--- a/crates/rustykrab-store/src/credential_backend.rs
+++ b/crates/rustykrab-store/src/credential_backend.rs
@@ -1,0 +1,218 @@
+//! Where a live credential is actually kept.
+//!
+//! A credential the user hands over does not belong in the database. It
+//! belongs in whatever this machine offers that is purpose-built to hold
+//! secrets — the macOS Keychain here, the Secret Service on a Linux
+//! desktop, a password manager's CLI, a remote vault on a server.
+//!
+//! Those differ enough that the rest of the codebase should not know which
+//! one it has. This is the seam: [`CredentialBackend`] is the whole
+//! contract, and everything above it — the credential page, the fulfil
+//! path, the tools that read credentials back — is written against the
+//! trait rather than against a keychain.
+//!
+//! ## Adding a backend
+//!
+//! Implement five methods. There is no registration step and nothing to
+//! change elsewhere; construct it and hand it to [`crate::Store::with_credential_backend`].
+//!
+//! ```ignore
+//! struct VaultBackend { client: VaultClient }
+//!
+//! impl CredentialBackend for VaultBackend {
+//!     fn name(&self) -> &str { "HashiCorp Vault" }
+//!     fn available(&self) -> bool { self.client.reachable() }
+//!     fn get(&self, account: &str) -> Result<Option<String>, Error> { … }
+//!     fn set(&self, account: &str, value: &str) -> Result<(), Error> { … }
+//!     fn delete(&self, account: &str) -> Result<(), Error> { … }
+//! }
+//! ```
+//!
+//! Three things a backend must honour, because callers rely on them:
+//!
+//! - **`available()` is the gate.** Reporting `true` is a promise that a
+//!   credential written here is stored as securely as the backend claims.
+//!   Writes are refused outright when it is `false` — there is deliberately
+//!   no database fallback, because falling back would put the credential
+//!   exactly where the user asked it not to go.
+//! - **`account` is an opaque key**, already namespaced by the caller. A
+//!   backend that needs its own prefix, path or collection adds it
+//!   internally; it must not reinterpret the key.
+//! - **Absent is `Ok(None)`, not an error.** "No credential yet" is the
+//!   normal state before the user supplies one, and callers branch on it.
+
+use rustykrab_core::Error;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A store for live credential values.
+pub trait CredentialBackend: Send + Sync + 'static {
+    /// Human-readable, for logs and operator-facing errors — "macOS
+    /// Keychain", not "keychain_v2". It appears in the message a user sees
+    /// when a write is refused.
+    fn name(&self) -> &str;
+
+    /// Whether this backend can hold a credential right now.
+    ///
+    /// A promise, not a guess: writes are refused when this is `false`, and
+    /// accepted with no second line of defence when it is `true`.
+    fn available(&self) -> bool;
+
+    fn get(&self, account: &str) -> Result<Option<String>, Error>;
+    fn set(&self, account: &str, value: &str) -> Result<(), Error>;
+    fn delete(&self, account: &str) -> Result<(), Error>;
+}
+
+/// The macOS Keychain, via the Data Protection Keychain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KeychainBackend;
+
+impl CredentialBackend for KeychainBackend {
+    fn name(&self) -> &str {
+        "macOS Keychain"
+    }
+
+    fn available(&self) -> bool {
+        crate::keychain::keychain_available()
+    }
+
+    fn get(&self, account: &str) -> Result<Option<String>, Error> {
+        Ok(
+            crate::keychain::get_credential(crate::registry::keychain_service(), account)?
+                .map(|c| c.value),
+        )
+    }
+
+    fn set(&self, account: &str, value: &str) -> Result<(), Error> {
+        crate::keychain::set_credential(crate::registry::keychain_service(), account, value)
+    }
+
+    fn delete(&self, account: &str) -> Result<(), Error> {
+        crate::keychain::delete_credential(crate::registry::keychain_service(), account)
+    }
+}
+
+/// A backend that holds nothing and says so.
+///
+/// The default where no secure store has been chosen — a Linux server with
+/// no Secret Service, a container. It reports unavailable, so credential
+/// writes are refused with an explanation rather than silently landing in
+/// the database.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoBackend;
+
+impl CredentialBackend for NoBackend {
+    fn name(&self) -> &str {
+        "no secure credential store"
+    }
+    fn available(&self) -> bool {
+        false
+    }
+    fn get(&self, _: &str) -> Result<Option<String>, Error> {
+        Ok(None)
+    }
+    fn set(&self, _: &str, _: &str) -> Result<(), Error> {
+        Err(Error::Storage(
+            "no secure credential store is configured".to_string(),
+        ))
+    }
+    fn delete(&self, _: &str) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// An in-process backend for tests and for harnesses that must not touch
+/// the machine's real credential store.
+///
+/// This exists because the alternative — letting tests write to the real
+/// Keychain — was not hypothetical: an early run of the suite deposited
+/// `gmail-app-password` into the developer's own login keychain. Nothing
+/// here outlives the process.
+///
+/// It is deliberately not chosen by any default. A deployment gets one by
+/// asking for it explicitly, so a machine cannot end up keeping real
+/// credentials in memory because a fallback picked this.
+#[derive(Debug, Default)]
+pub struct MemoryBackend {
+    items: Mutex<HashMap<String, String>>,
+}
+
+impl MemoryBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CredentialBackend for MemoryBackend {
+    fn name(&self) -> &str {
+        "in-memory (test)"
+    }
+    fn available(&self) -> bool {
+        true
+    }
+    fn get(&self, account: &str) -> Result<Option<String>, Error> {
+        Ok(self
+            .items
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(account)
+            .cloned())
+    }
+    fn set(&self, account: &str, value: &str) -> Result<(), Error> {
+        self.items
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(account.to_string(), value.to_string());
+        Ok(())
+    }
+    fn delete(&self, account: &str) -> Result<(), Error> {
+        self.items
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(account);
+        Ok(())
+    }
+}
+
+/// What a deployment gets when it has not chosen: the Keychain on macOS,
+/// and nothing anywhere else.
+pub fn default_backend() -> std::sync::Arc<dyn CredentialBackend> {
+    #[cfg(target_os = "macos")]
+    {
+        std::sync::Arc::new(KeychainBackend)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::sync::Arc::new(NoBackend)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_backend_round_trips_and_forgets() {
+        let b = MemoryBackend::new();
+        assert!(b.available());
+        assert_eq!(b.get("a").unwrap(), None);
+        b.set("a", "secret").unwrap();
+        assert_eq!(b.get("a").unwrap().as_deref(), Some("secret"));
+        b.delete("a").unwrap();
+        assert_eq!(b.get("a").unwrap(), None);
+    }
+
+    #[test]
+    fn absent_is_not_an_error() {
+        // Callers branch on `None`; turning "not supplied yet" into an error
+        // would make the normal case look like a failure.
+        assert_eq!(MemoryBackend::new().get("missing").unwrap(), None);
+        assert_eq!(NoBackend.get("missing").unwrap(), None);
+    }
+
+    #[test]
+    fn an_unavailable_backend_refuses_writes_rather_than_pretending() {
+        assert!(!NoBackend.available());
+        assert!(NoBackend.set("a", "secret").is_err());
+    }
+}

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -11,8 +11,12 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use std::time::Duration;
+
+use chrono::Utc;
 use rusqlite::params;
 use rustykrab_core::Error;
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::secret::{SecretStore, WriteAuthority};
@@ -385,6 +389,99 @@ impl CredentialRequestStore {
 
     /// Pending requests, newest first. Expired ones are swept on the way
     /// through rather than by a background timer.
+    /// Mint a one-time link for a `fulfil` request and return the token.
+    ///
+    /// The token is returned exactly once, to be put in the message the
+    /// user receives. Only its SHA-256 lands in the database, so a dump of
+    /// the store does not yield working links.
+    ///
+    /// Re-issuing replaces any previous token: the last link sent is the
+    /// only one that works.
+    pub async fn issue_link(&self, id: &str, ttl: Duration) -> Result<String, Error> {
+        let token = {
+            use rand::Rng;
+            let mut raw = [0u8; 32];
+            rand::rng().fill(&mut raw);
+            // URL-safe and unpadded: this goes in a link a user may retype.
+            hex::encode(raw)
+        };
+        let hash = hash_token(&token);
+        let expires = Utc::now()
+            .checked_add_signed(chrono::Duration::from_std(ttl).unwrap_or_default())
+            .map(|t| t.timestamp_millis())
+            .unwrap_or(i64::MAX);
+        let id = id.to_string();
+        crate::with_conn(&self.conn, move |conn| {
+            let n = conn
+                .execute(
+                    "UPDATE credential_requests
+                        SET link_token_hash = ?1, link_expires_at = ?2
+                      WHERE id = ?3 AND status = 'pending'",
+                    params![hash, expires, id],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if n == 0 {
+                return Err(Error::NotFound(format!("pending request {id}")));
+            }
+            Ok(())
+        })
+        .await?;
+        Ok(token)
+    }
+
+    /// Resolve a one-time link token to the request it answers.
+    ///
+    /// Returns `None` for a token that is unknown, expired, or whose
+    /// request is no longer pending — deliberately not distinguishing
+    /// between them, so the page cannot be used to probe which links exist.
+    /// Single use falls out of the status check: fulfilling moves the row
+    /// off `pending`, so the link stops working the moment it is answered.
+    pub async fn find_by_link(&self, token: &str) -> Result<Option<CredentialRequest>, Error> {
+        self.sweep_expired().await?;
+        let hash = hash_token(token);
+        let now = Utc::now().timestamp_millis();
+        crate::with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, name, action, reason, conversation_id, status,
+                            created_at, service, fields
+                       FROM credential_requests
+                      WHERE link_token_hash = ?1
+                        AND status = 'pending'
+                        AND (link_expires_at IS NULL OR link_expires_at > ?2)",
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query(params![hash, now])
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let Some(row) = rows.next().map_err(|e| Error::Storage(e.to_string()))? else {
+                return Ok(None);
+            };
+            let get_s = |i: usize| row.get::<_, String>(i);
+            let get_o = |i: usize| row.get::<_, Option<String>>(i);
+            Ok(Some(CredentialRequest {
+                id: get_s(0).map_err(|e| Error::Storage(e.to_string()))?,
+                name: get_s(1).map_err(|e| Error::Storage(e.to_string()))?,
+                action: RequestAction::parse(
+                    &get_s(2).map_err(|e| Error::Storage(e.to_string()))?,
+                )?,
+                reason: get_o(3).map_err(|e| Error::Storage(e.to_string()))?,
+                conversation_id: get_o(4).map_err(|e| Error::Storage(e.to_string()))?,
+                status: get_s(5).map_err(|e| Error::Storage(e.to_string()))?,
+                created_at: row
+                    .get::<_, i64>(6)
+                    .map_err(|e| Error::Storage(e.to_string()))?,
+                service: get_o(7).map_err(|e| Error::Storage(e.to_string()))?,
+                fields: decode_fields(
+                    get_o(8)
+                        .map_err(|e| Error::Storage(e.to_string()))?
+                        .as_deref(),
+                ),
+            }))
+        })
+        .await
+    }
+
     pub async fn pending(&self) -> Result<Vec<CredentialRequest>, Error> {
         self.sweep_expired().await?;
         crate::with_conn(&self.conn, |conn| {
@@ -621,13 +718,13 @@ mod fulfil_tests {
     use super::*;
     use crate::Store;
 
-    fn store() -> (tempfile::TempDir, CredentialRequestStore, SecretStore) {
+    pub(super) fn store() -> (tempfile::TempDir, CredentialRequestStore, SecretStore) {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Store::open(dir.path(), vec![7u8; 32]).expect("open");
         (dir, store.credential_requests(), store.secrets())
     }
 
-    fn gmail_fields() -> Vec<RequestedField> {
+    pub(super) fn gmail_fields() -> Vec<RequestedField> {
         vec![
             RequestedField {
                 key: "gmail_email".into(),
@@ -791,5 +888,164 @@ mod fulfil_tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("at least one field"), "{err}");
+    }
+}
+
+/// Hash a link token for storage and lookup.
+///
+/// SHA-256 without a salt is right here and a salt would be wrong: the
+/// token is 32 bytes of CSPRNG output, so there is no dictionary to attack,
+/// and lookup is by hash — a per-row salt would make that impossible.
+fn hash_token(token: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(token.as_bytes());
+    hex::encode(h.finalize())
+}
+
+#[cfg(test)]
+mod link_tests {
+    use super::fulfil_tests::{gmail_fields, store};
+    use super::*;
+
+    const TTL: Duration = Duration::from_secs(900);
+
+    #[tokio::test]
+    async fn a_link_resolves_to_its_request_and_only_that_one() {
+        let (_dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                None,
+            )
+            .await
+            .expect("file");
+        let token = requests.issue_link(&id, TTL).await.expect("issue");
+
+        let found = requests.find_by_link(&token).await.expect("lookup");
+        assert_eq!(found.map(|r| r.id), Some(id));
+
+        // A token that was never issued resolves to nothing rather than
+        // erroring, so the page cannot be used to probe which links exist.
+        assert!(requests
+            .find_by_link(&"0".repeat(64))
+            .await
+            .expect("lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn the_token_itself_is_not_recoverable_from_the_store() {
+        let (_dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                None,
+            )
+            .await
+            .expect("file");
+        let token = requests.issue_link(&id, TTL).await.expect("issue");
+        // Only the hash is persisted: a dump of the row yields no working link.
+        assert_ne!(hash_token(&token), token);
+        assert_eq!(hash_token(&token).len(), 64);
+    }
+
+    #[tokio::test]
+    async fn answering_a_request_burns_its_link() {
+        let (_dir, requests, secrets) = store();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                None,
+            )
+            .await
+            .expect("file");
+        let token = requests.issue_link(&id, TTL).await.expect("issue");
+        assert!(requests
+            .find_by_link(&token)
+            .await
+            .expect("lookup")
+            .is_some());
+
+        requests
+            .fulfil(
+                &id,
+                &[
+                    ("gmail_email".to_string(), "a@b.c".to_string()),
+                    ("gmail_app_password".to_string(), "pw".to_string()),
+                ],
+                "test",
+            )
+            .await
+            .expect("fulfil");
+
+        // Single use falls out of the status check rather than a separate
+        // flag: the row is no longer pending, so the link is dead.
+        assert!(requests
+            .find_by_link(&token)
+            .await
+            .expect("lookup")
+            .is_none());
+        let _ = secrets;
+    }
+
+    #[tokio::test]
+    async fn an_expired_link_stops_working() {
+        let (_dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                None,
+            )
+            .await
+            .expect("file");
+        let token = requests
+            .issue_link(&id, Duration::from_secs(0))
+            .await
+            .expect("issue");
+        assert!(requests
+            .find_by_link(&token)
+            .await
+            .expect("lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn re_issuing_invalidates_the_link_already_sent() {
+        let (_dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                None,
+            )
+            .await
+            .expect("file");
+        let first = requests.issue_link(&id, TTL).await.expect("issue");
+        let second = requests.issue_link(&id, TTL).await.expect("re-issue");
+        assert_ne!(first, second);
+        assert!(requests
+            .find_by_link(&first)
+            .await
+            .expect("lookup")
+            .is_none());
+        assert!(requests
+            .find_by_link(&second)
+            .await
+            .expect("lookup")
+            .is_some());
     }
 }

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -284,16 +284,14 @@ impl CredentialRequestStore {
             device: Some(decided_by.to_string()),
         };
         for (key, value) in values {
-            // Whether this is the first time the credential has existed is
-            // not the user's problem; both paths are a user-authored write.
-            match self.secrets.version_of(key).await? {
-                Some(_) => {
-                    self.secrets
-                        .overwrite(key, value, authority.clone())
-                        .await?
-                }
-                None => self.secrets.create(key, value).await?,
-            }
+            // Straight into the OS keychain. The user typed this on the
+            // understanding it was going somewhere safe, and the database is
+            // not that: `put_hardware` keeps the value out of it entirely and
+            // refuses outright where there is no keychain, rather than
+            // quietly choosing the weaker home.
+            self.secrets
+                .put_hardware(key, value, authority.clone())
+                .await?;
         }
 
         self.decide(id, "approved", decided_by, &row.name, "fulfil")
@@ -718,9 +716,19 @@ mod fulfil_tests {
     use super::*;
     use crate::Store;
 
+    /// Every test store gets an in-memory credential backend.
+    ///
+    /// Not a stylistic choice: before this existed, running the suite on a
+    /// Mac deposited `gmail-app-password` into the developer's own login
+    /// keychain, because `fulfil` writes to whatever backend it is handed.
+    /// Tests must never be able to reach the real one.
     pub(super) fn store() -> (tempfile::TempDir, CredentialRequestStore, SecretStore) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let store = Store::open(dir.path(), vec![7u8; 32]).expect("open");
+        let store = Store::open(dir.path(), vec![7u8; 32])
+            .expect("open")
+            .with_credential_backend(std::sync::Arc::new(
+                crate::credential_backend::MemoryBackend::new(),
+            ));
         (dir, store.credential_requests(), store.secrets())
     }
 
@@ -786,12 +794,94 @@ mod fulfil_tests {
             .await
             .unwrap();
 
-        assert_eq!(secrets.get("gmail_email").await.unwrap(), "me@gmail.com");
+        // Readable through the path the tools use...
         assert_eq!(
-            secrets.get("gmail_app_password").await.unwrap(),
-            "abcdefghijklmnop"
+            secrets.get_hardware("gmail_email").as_deref(),
+            Some("me@gmail.com")
         );
+        assert_eq!(
+            secrets.get_hardware("gmail_app_password").as_deref(),
+            Some("abcdefghijklmnop")
+        );
+
+        // ...and not out of the database, which is the point. The row
+        // exists so the overwrite guard still has a version to compare and
+        // the audit trail still names the write; what it no longer holds is
+        // the credential.
+        assert_ne!(
+            secrets.get("gmail_app_password").await.ok().as_deref(),
+            Some("abcdefghijklmnop")
+        );
+        assert_eq!(
+            secrets.version_of("gmail_app_password").await.unwrap(),
+            Some(1)
+        );
+
         assert!(requests.pending().await.unwrap().is_empty());
+    }
+
+    /// The credential must not be sitting in the database file, however it
+    /// got there — the API returning the wrong thing is not the same as the
+    /// bytes being absent.
+    #[tokio::test]
+    async fn the_supplied_value_is_nowhere_in_the_database_file() {
+        let (dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil("gmail_app_password", None, gmail_fields(), None, None)
+            .await
+            .unwrap();
+        requests
+            .fulfil(
+                &id,
+                &[
+                    ("gmail_email".into(), "me@gmail.com".into()),
+                    ("gmail_app_password".into(), "correct-horse-battery".into()),
+                ],
+                "device:test",
+            )
+            .await
+            .unwrap();
+
+        let raw = std::fs::read(dir.path().join("store.db")).unwrap_or_default();
+        assert!(
+            !String::from_utf8_lossy(&raw).contains("correct-horse-battery"),
+            "the credential was found in the database file"
+        );
+    }
+
+    /// With no secure store there is nowhere safe to put a credential, and
+    /// the database is not an acceptable second choice.
+    #[tokio::test]
+    async fn fulfilling_is_refused_when_no_secure_backend_is_available() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path(), vec![7u8; 32])
+            .expect("open")
+            .with_credential_backend(std::sync::Arc::new(crate::credential_backend::NoBackend));
+        let requests = store.credential_requests();
+        let id = requests
+            .file_fulfil("gmail_app_password", None, gmail_fields(), None, None)
+            .await
+            .unwrap();
+
+        let err = requests
+            .fulfil(
+                &id,
+                &[
+                    ("gmail_email".into(), "me@gmail.com".into()),
+                    ("gmail_app_password".into(), "abcdefghijklmnop".into()),
+                ],
+                "device:test",
+            )
+            .await
+            .expect_err("must refuse rather than fall back to the database");
+        assert!(
+            err.to_string().contains("Refusing"),
+            "the refusal should say why: {err}"
+        );
+
+        // And the request stays pending: nothing was written, so nothing was
+        // decided.
+        assert_eq!(requests.pending().await.unwrap().len(), 1);
     }
 
     /// The request is the authorisation. A device answering a Gmail prompt

--- a/crates/rustykrab-store/src/guarded.rs
+++ b/crates/rustykrab-store/src/guarded.rs
@@ -110,7 +110,16 @@ impl GuardedSecrets {
 
     // -- reads pass straight through --------------------------------------
 
+    /// Hardware first, then the encrypted store.
+    ///
+    /// `gmail` and `caldav` read through here, and a credential the user
+    /// handed over now lives in the keychain rather than the database — so
+    /// consulting only the database would find nothing and report the
+    /// credential missing immediately after the user supplied it.
     pub async fn get(&self, name: &str) -> Result<String, Error> {
+        if let Some(v) = self.secrets.get_hardware(name) {
+            return Ok(v);
+        }
         self.secrets.get(name).await
     }
 

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -1,5 +1,6 @@
 mod chat_map;
 mod conversation;
+pub mod credential_backend;
 mod credential_request;
 mod device;
 mod guarded;
@@ -42,6 +43,8 @@ pub struct Store {
     /// Told when the agent files a credential change, so the user can be
     /// notified. `None` when push isn't configured, which is normal.
     request_notifier: Option<Arc<dyn credential_request::RequestNotifier>>,
+    /// Where live credential values are kept. Never the database.
+    credential_backend: Arc<dyn credential_backend::CredentialBackend>,
 }
 
 impl Store {
@@ -78,6 +81,7 @@ impl Store {
             conn: Arc::new(Mutex::new(conn)),
             master_key: Zeroizing::new(master_key),
             request_notifier: None,
+            credential_backend: credential_backend::default_backend(),
         })
     }
 
@@ -435,8 +439,27 @@ impl Store {
     }
 
     /// Return a handle for encrypted secret operations.
+    /// Choose where live credential values are kept.
+    ///
+    /// Defaults to the platform's own store (the Keychain on macOS,
+    /// nothing elsewhere). Tests and harnesses pass
+    /// [`credential_backend::MemoryBackend`] so they never touch the real
+    /// one — an early version of this work deposited a developer's Gmail
+    /// app password into their login keychain from a unit test.
+    pub fn with_credential_backend(
+        mut self,
+        backend: Arc<dyn credential_backend::CredentialBackend>,
+    ) -> Self {
+        self.credential_backend = backend;
+        self
+    }
+
     pub fn secrets(&self) -> SecretStore {
-        SecretStore::new(Arc::clone(&self.conn), self.master_key.clone())
+        SecretStore::new(
+            Arc::clone(&self.conn),
+            self.master_key.clone(),
+            Arc::clone(&self.credential_backend),
+        )
     }
 
     /// Attach a notifier that is told whenever the agent files a change.

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -324,6 +324,18 @@ impl Store {
                 "fields",
                 "ALTER TABLE credential_requests ADD COLUMN fields TEXT",
             ),
+            // A one-time link the user opens to answer a fulfil request.
+            // Only the hash is stored: the token is shown once, in the
+            // message the agent sends, and is unrecoverable from the
+            // database afterwards.
+            (
+                "link_token_hash",
+                "ALTER TABLE credential_requests ADD COLUMN link_token_hash TEXT",
+            ),
+            (
+                "link_expires_at",
+                "ALTER TABLE credential_requests ADD COLUMN link_expires_at INTEGER",
+            ),
         ] {
             if !existing.iter().any(|c| c == column) {
                 conn.execute(ddl, [])

--- a/crates/rustykrab-store/src/registry.rs
+++ b/crates/rustykrab-store/src/registry.rs
@@ -118,33 +118,65 @@ pub async fn resolve(spec: &SecretSpec, secrets: &SecretStore) -> Option<String>
     if let Ok(val) = std::env::var(spec.env_var) {
         let val = val.trim().to_string();
         if !val.is_empty() {
-            // Persist downward.
-            if keychain::keychain_available() {
-                let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
+            // Seed the secure backend, but not the database: an env-supplied
+            // credential is no less secret than a typed one.
+            let backend = secrets.credential_backend();
+            if backend.available() {
+                let _ = backend.set(spec.keychain_account, &val);
             }
-            let _ = secrets.upsert_system(spec.store_name, &val).await;
             return Some(val);
         }
     }
 
     // 2. OS credential store.
-    if keychain::keychain_available() {
-        if let Ok(Some(cred)) = keychain::get_credential(KEYCHAIN_SERVICE, spec.keychain_account) {
-            let _ = secrets.upsert_system(spec.store_name, &cred.value).await;
-            return Some(cred.value);
+    //
+    // Deliberately does NOT copy the value back into the database. This
+    // used to mirror downward, which meant a credential deposited into
+    // hardware was re-persisted to SQLite by the very next read — undoing
+    // the point of putting it in hardware at all.
+    let backend = secrets.credential_backend();
+    if backend.available() {
+        if let Ok(Some(value)) = backend.get(spec.keychain_account) {
+            return Some(value);
         }
     }
 
     // 3. Encrypted local store.
     if let Ok(val) = secrets.get(spec.store_name).await {
-        // Back-fill into keychain if available.
-        if keychain::keychain_available() {
-            let _ = keychain::set_credential(KEYCHAIN_SERVICE, spec.keychain_account, &val);
+        // Promote it: a credential still in the database predates the
+        // secure backend, and this is the moment it can stop living there.
+        if backend.available() {
+            let _ = backend.set(spec.keychain_account, &val);
         }
         return Some(val);
     }
 
     None
+}
+
+/// The keychain account a credential is deposited under.
+///
+/// Registry entries name their own, so `gmail_app_password` keeps the
+/// `gmail-app-password` slot it has always had. Anything else — a website
+/// login the agent asked for, which no registry entry anticipated — gets a
+/// slot derived from its name, so ad-hoc credentials land in hardware too
+/// rather than falling back to the database.
+pub fn keychain_account_for(store_name: &str) -> String {
+    if let Some(spec) = lookup(store_name) {
+        return spec.keychain_account.to_string();
+    }
+    store_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
 }
 
 /// Look up a [`SecretSpec`] by its store name.

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -87,17 +87,26 @@ fn now_ms() -> i64 {
 pub struct SecretStore {
     conn: Arc<Mutex<rusqlite::Connection>>,
     master_key: Arc<Zeroizing<Vec<u8>>>,
+    /// Where live credential values are kept — never this database.
+    credentials: Arc<dyn crate::credential_backend::CredentialBackend>,
 }
 
 impl SecretStore {
     pub(crate) fn new(
         conn: Arc<Mutex<rusqlite::Connection>>,
         master_key: Zeroizing<Vec<u8>>,
+        credentials: Arc<dyn crate::credential_backend::CredentialBackend>,
     ) -> Self {
         Self {
             conn,
             master_key: Arc::new(master_key),
+            credentials,
         }
+    }
+
+    /// The secure store live credential values go to.
+    pub fn credential_backend(&self) -> &Arc<dyn crate::credential_backend::CredentialBackend> {
+        &self.credentials
     }
 
     /// Store a **new** secret. Fails with [`Error::AlreadyExists`] if the
@@ -185,6 +194,105 @@ impl SecretStore {
     /// Skipping no-op writes matters: the registry runs on every boot, and
     /// rewriting an unchanged value would inflate the version and fill the
     /// audit trail with events nobody performed.
+    /// Deposit a user-supplied credential into the OS keychain, keeping the
+    /// value out of the database entirely.
+    ///
+    /// The `secrets` row still exists, and deliberately: version, timestamps
+    /// and the audit trail are what the overwrite-approval guard is built
+    /// on, and dropping the row would quietly disarm it. What the row no
+    /// longer holds is the credential — `data` carries an empty ciphertext,
+    /// so a dump of the database yields nothing usable.
+    ///
+    /// The superseded value *is* archived, encrypted, so an approved change
+    /// can still be rolled back. That is a deliberate asymmetry: the live
+    /// credential lives only in hardware, its history does not.
+    ///
+    /// Refuses rather than falling back when there is no keychain. Writing
+    /// to the database instead would put the credential exactly where the
+    /// caller asked it not to go, and a warning in a log is not consent.
+    pub async fn put_hardware(
+        &self,
+        name: &str,
+        value: &str,
+        authority: WriteAuthority,
+    ) -> Result<(), Error> {
+        Self::validate_name(name)?;
+        if authority.is_agent() {
+            return Err(Error::Auth(format!(
+                "the agent cannot write '{name}' directly"
+            )));
+        }
+        if !self.credentials.available() {
+            return Err(Error::Storage(format!(
+                "'{name}' must go to a secure credential store, and this system has \
+                 only {}. Refusing rather than writing it to the database.",
+                self.credentials.name()
+            )));
+        }
+
+        let account = crate::registry::keychain_account_for(name);
+
+        // Read what is there now so it can be archived: with the live value
+        // in the backend, the database no longer holds a previous copy.
+        let previous = self.credentials.get(&account).ok().flatten();
+
+        let store = self.clone();
+        let name_owned = name.to_string();
+        let previous_for_db = previous.clone();
+        run_blocking(move || {
+            // Empty ciphertext: the column is NOT NULL and the row has to
+            // exist, but there is no credential to put in it.
+            let empty = store.encrypt(&name_owned, b"")?;
+            let mut conn = store.conn.lock().unwrap();
+            let tx = conn
+                .transaction()
+                .map_err(|e| Error::Storage(e.to_string()))?;
+
+            match Self::current_row(&tx, &name_owned)? {
+                Some((_, version)) => {
+                    if let Some(prev) = previous_for_db.as_deref() {
+                        let archived = store.encrypt(&name_owned, prev.as_bytes())?;
+                        Self::archive(&tx, &name_owned, version, &archived, &authority)?;
+                    }
+                    tx.execute(
+                        "UPDATE secrets SET data = ?2, updated_at = ?3, version = ?4
+                          WHERE name = ?1",
+                        params![name_owned, empty, now_ms(), version + 1],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                    Self::audit(&tx, &name_owned, "overwrite", &authority.describe(), None)?;
+                }
+                None => {
+                    tx.execute(
+                        "INSERT INTO secrets (name, data, created_at, updated_at, version)
+                         VALUES (?1, ?2, ?3, ?3, 1)",
+                        params![name_owned, empty, now_ms()],
+                    )
+                    .map_err(|e| Error::Storage(e.to_string()))?;
+                    Self::audit(&tx, &name_owned, "create", &authority.describe(), None)?;
+                }
+            }
+            tx.commit().map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await?;
+
+        // Last, so a failed database write does not leave a credential in
+        // the backend that nothing knows about.
+        self.credentials.set(&account, value)
+    }
+
+    /// Read a credential held by the secure backend, if it holds one.
+    pub fn get_hardware(&self, name: &str) -> Option<String> {
+        if !self.credentials.available() {
+            return None;
+        }
+        self.credentials
+            .get(&crate::registry::keychain_account_for(name))
+            .ok()
+            .flatten()
+    }
+
     pub async fn upsert_system(&self, name: &str, value: &str) -> Result<(), Error> {
         match self.get(name).await {
             Ok(existing) if existing == value => Ok(()),

--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -1,7 +1,15 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, Tool};
+use std::time::Duration;
+
 use rustykrab_store::{CredentialRequestStore, RequestedField};
+
+/// How long a credential link stays good.
+///
+/// Long enough to walk to a phone and generate an app password, short
+/// enough that a link left in a chat log is usually already dead.
+const LINK_TTL: Duration = Duration::from_secs(15 * 60);
 use serde_json::{json, Value};
 
 /// Asks the user for a credential the agent does not have.
@@ -147,16 +155,52 @@ impl Tool for CredentialRequestTool {
             })?;
 
         let where_to_look = service.unwrap_or_else(|| name.to_string());
-        Ok(json!({
-            "status": "requested",
-            "request_id": id,
-            // Phrased for the model's next turn: it should tell the user
-            // and stop, not poll, and not carry on as if it had the value.
-            "next_step": format!(
+
+        // A link the user can open, when a base URL is configured. The
+        // Apollo app can render this request from the pending list, but on
+        // Telegram or Signal there is no app in the loop — a tappable URL
+        // is the only way to hand someone a password field from a chat
+        // message. The token is minted here and shown once; only its hash
+        // is stored.
+        let link = match std::env::var("RUSTYKRAB_PUBLIC_URL")
+            .ok()
+            .map(|u| u.trim_end_matches('/').to_string())
+            .filter(|u| !u.is_empty())
+        {
+            Some(base) => match self.requests.issue_link(&id, LINK_TTL).await {
+                Ok(token) => Some(format!("{base}/c/{token}")),
+                Err(e) => {
+                    // The request is filed and answerable in the app; only
+                    // the convenience of a link is lost.
+                    tracing::warn!(error = %e, "could not mint a credential link");
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let next_step = match &link {
+            Some(url) => format!(
+                "Give the user this link and nothing else about the credential: {url} \
+                 — say it opens a secure form for their {where_to_look} details, that \
+                 it works once and expires in {} minutes. Do not ask for the value in \
+                 chat. Stop this task until they answer.",
+                LINK_TTL.as_secs() / 60
+            ),
+            None => format!(
                 "Tell the user you have asked for their {where_to_look} details \
                  and that a prompt is waiting in the Apollo app. Do not ask for \
                  the value in chat. Stop this task until they answer."
-            )
+            ),
+        };
+
+        Ok(json!({
+            "status": "requested",
+            "request_id": id,
+            "link": link,
+            // Phrased for the model's next turn: it should tell the user
+            // and stop, not poll, and not carry on as if it had the value.
+            "next_step": next_step
         }))
     }
 }


### PR DESCRIPTION
The agent cannot ask for a password in chat. A chat message has no secure
field, and whatever the user types is then sitting in the transcript of
whichever channel they answered on. Until now the only answer was the
Apollo app, which leaves Telegram and Signal with nowhere to send anyone
— and those are exactly the surfaces where the credential suite measured
the worst asking rate.

So the agent sends a link. `GET /c/{token}` renders a form; the form
posts back and the value goes straight into the encrypted store.

## Two independent guards

**Tailnet identity.** `tailscale serve` injects `Tailscale-User-Login`
for the authenticated tailnet user, and the page refuses anything without
it. `RUSTYKRAB_TAILNET_USERS` narrows that to named logins when the
tailnet has more than one member. `RUSTYKRAB_CREDENTIAL_PAGE_ANONYMOUS=1`
turns the check off for loopback development, and nothing else does.

**A one-time token**, 32 bytes of CSPRNG output, bound to a single
request. Only its SHA-256 is stored, so a dump of the database yields no
working links. Single use falls out of the existing status check rather
than a new flag: fulfilling moves the row off `pending`, so the link dies
the moment it is answered. Re-issuing invalidates the previous one, and a
15-minute TTL bounds a link left sitting in a chat log.

Either guard alone is weaker than it looks. The header is only
trustworthy because nothing but the tailnet front end can reach the
loopback listener; a link that travels through a chat message can be read
by anyone who later reads that chat.

## Why server-rendered HTML

Two properties the JSON API cannot offer today:

- **It works in a browser at all.** `/api/` is `is_sensitive`, so a
  request without an `Origin` is refused — and browsers omit `Origin` on
  same-origin GETs. This route sits outside that prefix, and a form POST
  carries an `Origin` natively. Neither of the two browser-reachability
  bugs is in the path, so this does not wait on that decision.
- **No JavaScript touches the value.** It goes from the input into a form
  POST; nothing reads it into a variable to log, cache or leave in the DOM.

Every refusal — wrong token, expired, already answered, wrong user —
renders identically, so the page cannot be used to probe which links
exist.

## Verified end to end

Against a live daemon: the agent filed a request, the tool minted a link,
and opening it as a permitted tailnet user rendered the form with
`gmail_email` as text and `gmail_app_password` masked. Submitting stored
both secrets, burned the link (404 on reuse), and cleared the pending
request. Neither the token nor the password appears anywhere in the
daemon log. Refusals confirmed: no header 404, wrong user 404, bogus
token 404.

`RUSTYKRAB_PUBLIC_URL` is what the agent puts in the link; with it unset
the tool falls back to the previous "a prompt is waiting in the app"
wording, so nothing changes for a deployment that has not opted in.

Screenshot: `rustykrab-handoff/screenshots/tailnet-credential-page.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)