### PR TITLE
fix(ci): correct shasum paths in Package artifact step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,7 +307,7 @@ jobs:
             cd dist
             tar czf rustykrab-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
           fi
-          shasum -a 256 dist/rustykrab-${{ matrix.target }}.* > dist/rustykrab-${{ matrix.target }}.sha256
+          shasum -a 256 rustykrab-${{ matrix.target }}.* > rustykrab-${{ matrix.target }}.sha256
 
       - name: Notarize and staple macOS bundle
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Problem

In `.github/workflows/release.yml`, the **Package artifact** step ends with:

```sh
shasum -a 256 dist/rustykrab-${{ matrix.target }}.* > dist/rustykrab-${{ matrix.target }}.sha256
```

Both branches of the preceding `if`/`else` run `cd dist`, so by the time `shasum` executes the cwd is already `dist/`. The `dist/` prefix therefore resolves to `dist/dist/rustykrab-<target>.*`, which does not exist — the glob matches nothing and the redirect targets a non-existent directory, breaking the release job.

## Fix

Drop the `dist/` prefix from both the input glob and the output path:

```sh
shasum -a 256 rustykrab-${{ matrix.target }}.* > rustykrab-${{ matrix.target }}.sha256
```

## Note

The similar `shasum` in the **Notarize and staple macOS bundle** step (lines 334-335) is intentionally left unchanged — that step never `cd`s, so it runs from the repo root and its `dist/` prefix is correct.

## Verification

- Confirmed both `if`/`else` branches `cd dist` before the `shasum` line.
- `yaml.safe_load` parses the workflow file without error.
- Single-line change, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)