### PR TITLE
fix(ci): skip notarization when Apple secrets are absent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,9 +316,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
-          test -n "$APPLE_ID" || { echo "APPLE_ID secret is required for macOS releases" >&2; exit 1; }
-          test -n "$APPLE_TEAM_ID" || { echo "APPLE_TEAM_ID secret is required for macOS releases" >&2; exit 1; }
-          test -n "$APPLE_APP_PASSWORD" || { echo "APPLE_APP_PASSWORD secret is required for macOS releases" >&2; exit 1; }
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_TEAM_ID" ] || [ -z "$APPLE_APP_PASSWORD" ]; then
+            echo "::notice::Apple notarization secrets are not set; publishing the Developer ID-signed bundle without a notarization ticket."
+            echo "The signed tarball from the Package step is published as-is. Notarization is only"
+            echo "needed for bundles downloaded through a browser, which get a Gatekeeper quarantine"
+            echo "attribute. Set APPLE_ID, APPLE_TEAM_ID and APPLE_APP_PASSWORD to enable it."
+            exit 0
+          fi
           xcrun notarytool submit \
             "dist/rustykrab-${{ matrix.target }}.dmg" \
             --apple-id "$APPLE_ID" \


### PR DESCRIPTION
## Problem

The `Notarize and staple macOS bundle` step added in #501 hard-fails when `APPLE_ID`, `APPLE_TEAM_ID`, or `APPLE_APP_PASSWORD` are unset:

```
APPLE_ID secret is required for macOS releases
Process completed with exit code 1
```

Those three secrets have never been configured on this repo — the only secrets present (`APP_ID`, `APP_PRIVATE_KEY`, `DEVELOPER_ID_P12`, `DEVELOPER_ID_P12_PASSWORD`, `PROVISIONING_PROFILE`, `RELEASE_TOKEN`) all date from April and none is an Apple notarization credential.

Consequences since #501 merged on Aug 21:

- **No release has been published in four days.** Latest release is still `v5.1.10`.
- **The bump job tags before the build**, so every failed attempt still burned a version. `main` is now at tag `v5.1.34` against a `v5.1.10` release — 24 tags with no artifacts behind them.
- `Create GitHub Release` is skipped every run because the macOS build fails.

Codesigning itself is unaffected and has been working since #353 — *Import signing certificate* and *Codesign and bundle* both pass. This is purely the notarization submission.

## Fix

Treat notarization as optional: log a notice and `exit 0` when the secrets are missing, instead of failing the job.

When the secrets are absent, the signed tarball and `.sha256` already produced by the *Package* step are published as-is — that is the artifact `upload-artifact` uploads, and it is the exact shape the pipeline had when `v5.1.10` shipped successfully. The re-tar at the end of the notarize step exists only to capture the stapled ticket, so skipping it loses nothing.

Behaviour is **unchanged when the secrets are present**, so setting them later re-enables notarization with no further code change.

## Why this is safe for the current use

Notarization matters for bundles downloaded through a browser, which get a `com.apple.quarantine` attribute that triggers a Gatekeeper assessment. Artifacts fetched with `gh release download` / `curl` / `tar` never get that attribute. The bundle keeps its real `Developer ID Application` signature either way, which is what `scripts/install.sh` verifies (`codesign --verify --deep --strict`) and what the Data Protection Keychain entitlement needs.

If releases are ever distributed to other people via browser download, the three secrets should be set — at which point this step resumes notarizing automatically.

## Follow-up (not in this PR)

The bump job tags *before* the build runs, so any future build failure still burns a version number. Moving the tag push after a successful build would stop that.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [ ] Merging this triggers a release; expect the macOS build to pass with a `::notice::` about skipped notarization, and `Create GitHub Release` to publish tarballs

No Rust code is touched, so `cargo fmt`/`clippy`/`test` are unaffected.