### PR TITLE
fix(install): forward the credential-page settings to the installed daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.34"
+version = "5.1.38"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ All configuration is via environment variables. No plaintext config files.
 | `RUST_LOG` | `info` | Log level (`info`, `debug`, `rustykrab_gateway=debug`) |
 | `RUSTYKRAB_LOG_STDOUT` | auto | Force stdout logging on (`1`) or off (`0`). Default: enabled only when stdout is a terminal. The rolling log file under the data directory is always written |
 | `RUSTYKRAB_OUTCOME_CAPTURE` | `0` | Record how each completed run went, and which skill, memories, and tools were in play, into the `outcome_records` table. Observational only — it changes nothing about how the agent behaves. Groundwork for the self-improvement outer loop; see `DREAMING.md` |
+| `RUSTYKRAB_PUBLIC_URL` | unset | Base URL the agent puts in a credential link, e.g. `https://mac.tailnet.ts.net`. Unset, the agent falls back to telling the user a prompt is waiting in the app — so a link is never minted and the failure is silent |
+| `RUSTYKRAB_TAILNET_USERS` | unset | Comma-separated tailnet logins allowed to open a credential page. Empty means any authenticated tailnet user. Requires `tailscale serve` in front to inject `Tailscale-User-Login` |
 | | | When enabled, this also starts a **downtime analysis worker**: read-only, it aggregates recorded outcomes and logs a digest once the system has been quiet for 10 minutes, abandoning a pass if activity arrives mid-flight. It never writes and never calls a model |
 
 ### Persisting credentials
@@ -271,6 +273,35 @@ docker run --rm \
 Per-credential values (Anthropic, Notion, Telegram, etc.) come from their `RUSTYKRAB_*`/service-specific env vars — see the table above and the registry at `crates/rustykrab-store/src/registry.rs`. Anything resolved from an env var is also persisted into the encrypted SQLite store on first run, so subsequent restarts only need `RUSTYKRAB_MASTER_KEY` plus whatever you want to rotate.
 
 The `rustykrab-cli keychain` subcommand is macOS-only; on Linux/Docker use env vars or the gateway's secrets API.
+
+### Serving the credential page over your tailnet
+
+The gateway binds loopback. `tailscale serve` fronts it with a real
+Let's Encrypt certificate so a phone on the tailnet can open the secure
+form the agent links to.
+
+```sh
+# 1. Enable HTTPS certificates for the tailnet, once, in the admin console:
+#    https://login.tailscale.com/admin/dns  ->  HTTPS Certificates  ->  Enable
+
+# 2. Front the gateway (3000 is the default port):
+tailscale serve --bg https / http://127.0.0.1:3000
+tailscale serve status          # confirms the https:// URL it now answers on
+
+# 3. Point the daemon at that name, and say who may answer:
+export RUSTYKRAB_PUBLIC_URL=https://<mac>.<tailnet>.ts.net
+export RUSTYKRAB_TAILNET_USERS=you@example.com
+export RUSTYKRAB_ALLOWED_ORIGINS=https://<mac>.<tailnet>.ts.net
+```
+
+`RUSTYKRAB_ALLOWED_ORIGINS` matters: the form posts back from that origin,
+and the origin check rejects a POST it does not recognise.
+
+Without `tailscale serve` in front there is no `Tailscale-User-Login`
+header, so the page refuses every request — which is the intended failure.
+`RUSTYKRAB_CREDENTIAL_PAGE_ANONYMOUS=1` turns that check off and exists
+only for loopback development; `scripts/install.sh` deliberately does not
+forward it, so it cannot be inherited into an installed service.
 
 ## Usage
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,9 +69,14 @@ PB=(/usr/libexec/PlistBuddy -c)
 "${PB[@]}" "Add :EnvironmentVariables:HOME string $HOME" "$PLIST"
 "${PB[@]}" 'Add :EnvironmentVariables:PATH string /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin' "$PLIST"
 
+# Anything not listed here never reaches the installed daemon, however it was
+# set at install time. The credential-page settings are on the list because
+# without RUSTYKRAB_PUBLIC_URL the agent cannot mint a link at all, and the
+# failure is silent — it just falls back to telling the user to open the app.
 for key in RUSTYKRAB_PROVIDER RUSTYKRAB_PORT RUSTYKRAB_WEB_UI RUST_LOG \
     OLLAMA_BASE_URL OLLAMA_MODEL OLLAMA_NUM_CTX RUSTYKRAB_NUM_CTX \
-    TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN; do
+    TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN \
+    RUSTYKRAB_PUBLIC_URL RUSTYKRAB_TAILNET_USERS RUSTYKRAB_ALLOWED_ORIGINS; do
     if [[ -n "${!key:-}" ]]; then
         "${PB[@]}" "Add :EnvironmentVariables:$key string ${!key}" "$PLIST"
     fi


### PR DESCRIPTION
`install.sh` copies a fixed list of environment variables into the launchd
plist, and anything absent from that list never reaches the installed
service however it was set at install time.

`RUSTYKRAB_PUBLIC_URL` was not on it, so an installed daemon could not
mint a credential link at all — and the failure is silent, because the
tool falls back to telling the user a prompt is waiting in the app. The
tailnet allowlist and the origin allowlist were missing for the same
reason; without the latter the form's POST is rejected by the origin
check.

`RUSTYKRAB_CREDENTIAL_PAGE_ANONYMOUS` and `RUSTYKRAB_CREDENTIAL_BACKEND`
are deliberately still absent. They turn off the page's identity check and
substitute an in-memory credential store respectively — both exist for
development and the evaluation harness, and neither should be inheritable
by an installed service.

Also documents the `tailscale serve` setup, which had lived only in a
conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)