### PR TITLE
docs: fleet config and local-model benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ schemas is roughly 8k tokens before any conversation, and `-np N` divides the
 context between N slots. `--jinja` is required for tool calling.
 
 Point `OPENAI_BASE_URL` at another machine on the LAN or tailnet to run
-inference on separate hardware.
+inference on separate hardware — see [Delegating to a peer node](#delegating-to-a-peer-node)
+below to also delegate whole *agent tasks*, not just inference, to that
+machine.
 
 #### Tuning the Ollama server for KV-cache reuse
 
@@ -201,6 +203,8 @@ All configuration is via environment variables. No plaintext config files.
 | `OPENAI_TEMPERATURE` | `0.1` | Sampling temperature |
 | `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
 | `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
+| `RUSTYKRAB_NODES` | unset | JSON array of peer instances the `nodes` tool can delegate to. See [Delegating to a peer node](#delegating-to-a-peer-node) |
+| `RUSTYKRAB_NODE_TIMEOUT_SECS` | `900` | Per-request timeout for delegated tasks. Generous by default: a peer running a local model at single-digit tokens/sec can legitimately take minutes |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `RUSTYKRAB_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |
@@ -455,6 +459,31 @@ $ rustykrab-cli   # restart the daemon
 
 The resolver runs entirely inside the connector — the model never sees
 the resolved values, and they are not surfaced through any tool.
+
+### Delegating to a peer node
+
+A RustyKrab instance can hand a self-contained task to another RustyKrab
+instance running on different hardware — useful for a slower machine with a
+stronger local model, or simply more compute you'd like the primary to draw
+on. This is delegation, not shared execution: the task runs entirely on the
+peer, using *its* tools and filesystem, and returns only a text result.
+
+```bash
+export RUSTYKRAB_NODES='[
+  {
+    "id": "m4max",
+    "url": "https://your-node.your-tailnet.ts.net",
+    "token": "<the node auth token>",
+    "description": "M4 Max 32GB — qwen3.8:27b-mlx. Slower but capable; good for self-contained coding tasks with its own checkout at ~/code/rustycrab."
+  }
+]'
+```
+
+The `nodes` tool (`list`, `discover`, `send`) is hidden from the model until
+`RUSTYKRAB_NODES` is set. See `scripts/setup-delegation-node.md` for standing
+up a node, exposing it safely (Tailscale Serve, not the raw gateway port),
+and measured latency expectations — a delegated task on a local model
+typically takes minutes, not seconds.
 
 ## Architecture
 

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -1,21 +1,201 @@
 use async_trait::async_trait;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Result, SandboxRequirements, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
+use serde::Deserialize;
 use serde_json::{json, Value};
+use std::time::{Duration, Instant};
 
-/// A built-in tool that discovers and interacts with paired RustyKrab nodes.
+/// Default per-request timeout. Generous because a node may be running a local
+/// model at single-digit tokens/sec, where one delegated task legitimately takes
+/// minutes.
+const DEFAULT_TIMEOUT_SECS: u64 = 900;
+
+/// A peer RustyKrab instance this agent can delegate work to.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteNode {
+    /// Short identifier used as `node_id` in tool calls.
+    pub id: String,
+    /// Base URL of the peer's gateway, e.g. `http://100.97.221.58:3000`.
+    pub url: String,
+    /// Bearer token for the peer's gateway.
+    ///
+    /// This is a shared static token, not a paired-device token — the
+    /// project's device-pairing flow (`DeviceStore`: per-device tokens,
+    /// SHA-256 hashed at rest, individually revocable) exists for the phone
+    /// use case and would be the better fit here too: a node could redeem a
+    /// pairing code for its own attributable, revocable token instead of
+    /// sharing the gateway's master credential. Left as a shared token for
+    /// now — adopting device pairing is a deliberate follow-up, not an
+    /// oversight.
+    pub token: String,
+    /// Human-readable note — hardware, model, intended role. Surfaced to the
+    /// model so it can pick a node deliberately.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl RemoteNode {
+    fn api(&self, path: &str) -> String {
+        format!("{}/api{}", self.url.trim_end_matches('/'), path)
+    }
+
+    /// Origin sent on node-to-node requests.
+    ///
+    /// The peer's origin check is a CSRF defence: it stops a malicious *web page*
+    /// from driving a localhost agent (the ClawJacked class of attack). It is not
+    /// an authentication mechanism — that is the bearer token, over a private
+    /// network. A server-side client is not subject to browser origin rules and
+    /// legitimately sets its own, so we send a loopback origin the peer accepts
+    /// rather than requiring every node to widen its allowlist.
+    fn origin(&self) -> &'static str {
+        "http://127.0.0.1:3000"
+    }
+}
+
+/// Delegate work to peer RustyKrab instances over the network.
 pub struct NodesTool {
     client: reqwest::Client,
 }
 
 impl NodesTool {
     pub fn new() -> Self {
+        let timeout = std::env::var("RUSTYKRAB_NODE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
         Self {
             client: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
+                .timeout(Duration::from_secs(timeout))
+                .connect_timeout(Duration::from_secs(10))
                 .build()
                 .expect("failed to build HTTP client"),
         }
+    }
+
+    /// Parse the configured node list from `RUSTYKRAB_NODES`.
+    ///
+    /// Format is a JSON array, e.g.
+    /// `[{"id":"m4max","url":"http://100.97.221.58:3000","token":"...",
+    ///    "description":"M4 Max - qwen3.8:27b-mlx, coding"}]`
+    fn configured_nodes() -> Result<Vec<RemoteNode>> {
+        let raw = match std::env::var("RUSTYKRAB_NODES") {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => return Ok(Vec::new()),
+        };
+        serde_json::from_str(&raw).map_err(|e| {
+            Error::ToolExecution(
+                format!(
+                    "RUSTYKRAB_NODES is not valid JSON ({e}). Expected an array of \
+                 {{\"id\",\"url\",\"token\",\"description\"}} objects."
+                )
+                .into(),
+            )
+        })
+    }
+
+    fn find(nodes: &[RemoteNode], id: &str) -> Result<RemoteNode> {
+        nodes.iter().find(|n| n.id == id).cloned().ok_or_else(|| {
+            let known: Vec<&str> = nodes.iter().map(|n| n.id.as_str()).collect();
+            Error::ToolExecution(
+                format!(
+                    "unknown node '{id}'. Configured nodes: {}",
+                    if known.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        known.join(", ")
+                    }
+                )
+                .into(),
+            )
+        })
+    }
+
+    /// Probe a node's public health endpoint. Returns round-trip latency.
+    async fn probe(&self, node: &RemoteNode) -> std::result::Result<u128, String> {
+        let start = Instant::now();
+        let resp = self
+            .client
+            .get(node.api("/health"))
+            .header("Origin", node.origin())
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| format!("unreachable: {e}"))?;
+        if resp.status().is_success() {
+            Ok(start.elapsed().as_millis())
+        } else {
+            Err(format!("HTTP {}", resp.status()))
+        }
+    }
+
+    /// Send a task to a node and return its reply.
+    ///
+    /// Creates a fresh conversation on the peer so delegated work does not share
+    /// context with whatever else that node is doing.
+    async fn send(&self, node: &RemoteNode, message: &str) -> Result<Value> {
+        let started = Instant::now();
+
+        let convo: Value = self
+            .post(node, &node.api("/conversations"), json!({}))
+            .await?;
+        let convo_id = convo["id"].as_str().ok_or_else(|| {
+            Error::ToolExecution(
+                format!("node '{}' returned no conversation id: {convo}", node.id).into(),
+            )
+        })?;
+
+        let reply: Value = self
+            .post(
+                node,
+                &node.api(&format!("/conversations/{convo_id}/messages")),
+                json!({ "content": message }),
+            )
+            .await?;
+
+        // Assistant messages are {"content": {"type": "text", "data": "..."}}.
+        let text = reply["content"]["data"]
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| reply["content"].to_string());
+
+        Ok(json!({
+            "node_id": node.id,
+            "conversation_id": convo_id,
+            "response": text,
+            "elapsed_secs": started.elapsed().as_secs(),
+        }))
+    }
+
+    async fn post(&self, node: &RemoteNode, url: &str, body: Value) -> Result<Value> {
+        let resp = self
+            .client
+            .post(url)
+            .bearer_auth(&node.token)
+            .header("Origin", node.origin())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                Error::ToolExecution(
+                    format!("node '{}' at {} is unreachable: {e}", node.id, node.url).into(),
+                )
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let hint = match status.as_u16() {
+                401 | 403 => " (check the node's token, and that its gateway is reachable)",
+                _ => "",
+            };
+            return Err(Error::ToolExecution(
+                format!("node '{}' returned {status}{hint}: {body}", node.id).into(),
+            ));
+        }
+
+        resp.json().await.map_err(|e| {
+            Error::ToolExecution(format!("node '{}' returned invalid JSON: {e}", node.id).into())
+        })
     }
 }
 
@@ -32,7 +212,11 @@ impl Tool for NodesTool {
     }
 
     fn description(&self) -> &str {
-        "Discover and interact with paired RustyKrab nodes on the network."
+        "Delegate a task to a peer RustyKrab instance on another machine. Use \
+         'list' to see available nodes and what each is suited for, 'discover' to \
+         check which are online, and 'send' to hand a self-contained task to one \
+         and get its result. Delegated tasks run with that node's own tools and \
+         filesystem, so include everything the node needs in the message."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
@@ -40,6 +224,14 @@ impl Tool for NodesTool {
             needs_net: true,
             ..SandboxRequirements::default()
         }
+    }
+
+    /// Hidden from the model unless at least one node is configured — otherwise
+    /// it advertises a capability that cannot work.
+    fn available(&self) -> bool {
+        Self::configured_nodes()
+            .map(|n| !n.is_empty())
+            .unwrap_or(false)
     }
 
     fn schema(&self) -> ToolSchema {
@@ -52,15 +244,15 @@ impl Tool for NodesTool {
                     "action": {
                         "type": "string",
                         "enum": ["discover", "list", "send"],
-                        "description": "The action to perform: discover new nodes, list known nodes, or send a message to a node"
+                        "description": "'list' shows configured nodes, 'discover' probes which are online, 'send' delegates a task"
                     },
                     "node_id": {
                         "type": "string",
-                        "description": "Target node ID (required for 'send' action)"
+                        "description": "Target node id (required for 'send')"
                     },
                     "message": {
                         "type": "string",
-                        "description": "Message to send to the target node (required for 'send' action)"
+                        "description": "The task to delegate (required for 'send'). Must be self-contained: the node does not share this conversation's context."
                     }
                 },
                 "required": ["action"]
@@ -71,121 +263,133 @@ impl Tool for NodesTool {
     async fn execute(&self, args: Value) -> Result<Value> {
         let action = args["action"]
             .as_str()
-            .ok_or_else(|| rustykrab_core::Error::ToolExecution("missing action".into()))?;
+            .ok_or_else(|| Error::ToolExecution("missing action".into()))?;
 
-        let discovery_url = std::env::var("NODES_DISCOVERY_URL").ok();
+        let nodes = Self::configured_nodes()?;
+        if nodes.is_empty() {
+            return Err(Error::ToolExecution(
+                "no nodes configured. Set RUSTYKRAB_NODES to a JSON array of \
+                 {\"id\",\"url\",\"token\",\"description\"} objects."
+                    .into(),
+            ));
+        }
 
         match action {
+            // Never include tokens in tool output — it goes into the model's context.
+            "list" => Ok(json!({
+                "nodes": nodes.iter().map(|n| json!({
+                    "id": n.id,
+                    "url": n.url,
+                    "description": n.description,
+                })).collect::<Vec<_>>()
+            })),
+
             "discover" => {
-                if let Some(url) = &discovery_url {
-                    let resp = self
-                        .client
-                        .get(format!("{url}/discover"))
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("node discovery failed: {e}").into(),
-                            )
-                        })?;
-
-                    let body: Value = resp.json().await.map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to parse discovery response: {e}").into(),
-                        )
-                    })?;
-
-                    Ok(json!({
-                        "action": "discover",
-                        "nodes": body,
-                    }))
-                } else {
-                    Ok(json!({
-                        "action": "discover",
-                        "nodes": [],
-                        "note": "No NODES_DISCOVERY_URL configured. Only local node available.",
-                    }))
+                let mut out = Vec::new();
+                for node in &nodes {
+                    let entry = match self.probe(node).await {
+                        Ok(ms) => json!({
+                            "id": node.id, "url": node.url, "status": "online",
+                            "latency_ms": ms, "description": node.description,
+                        }),
+                        Err(e) => json!({
+                            "id": node.id, "url": node.url, "status": "offline",
+                            "error": e, "description": node.description,
+                        }),
+                    };
+                    out.push(entry);
                 }
+                Ok(json!({ "nodes": out }))
             }
-            "list" => {
-                if let Some(url) = &discovery_url {
-                    let resp = self
-                        .client
-                        .get(format!("{url}/nodes"))
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            rustykrab_core::Error::ToolExecution(
-                                format!("node list failed: {e}").into(),
-                            )
-                        })?;
 
-                    let body: Value = resp.json().await.map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to parse nodes response: {e}").into(),
-                        )
-                    })?;
-
-                    Ok(json!({
-                        "action": "list",
-                        "nodes": body,
-                    }))
-                } else {
-                    let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".into());
-                    Ok(json!({
-                        "action": "list",
-                        "nodes": [{
-                            "id": "local",
-                            "name": hostname,
-                            "status": "online",
-                        }],
-                    }))
-                }
-            }
             "send" => {
-                let node_id = args["node_id"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("missing node_id for send action".into())
-                })?;
-                let message = args["message"].as_str().ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution("missing message for send action".into())
-                })?;
-
-                let url = discovery_url.ok_or_else(|| {
-                    rustykrab_core::Error::ToolExecution(
-                        "NODES_DISCOVERY_URL required to send messages to nodes".into(),
-                    )
-                })?;
-
-                let resp = self
-                    .client
-                    .post(format!("{url}/nodes/{node_id}/send"))
-                    .json(&json!({"message": message}))
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        rustykrab_core::Error::ToolExecution(
-                            format!("failed to send to node: {e}").into(),
-                        )
-                    })?;
-
-                let status = resp.status().as_u16();
-                let body = resp.text().await.map_err(|e| {
-                    rustykrab_core::Error::ToolExecution(
-                        format!("failed to read response: {e}").into(),
-                    )
-                })?;
-
-                Ok(json!({
-                    "action": "send",
-                    "node_id": node_id,
-                    "success": status < 400,
-                    "status": status,
-                    "response": body,
-                }))
+                let node_id = args["node_id"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("'send' requires node_id".into()))?;
+                let message = args["message"]
+                    .as_str()
+                    .ok_or_else(|| Error::ToolExecution("'send' requires message".into()))?;
+                if message.trim().is_empty() {
+                    return Err(Error::ToolExecution(
+                        "'send' requires a non-empty message".into(),
+                    ));
+                }
+                let node = Self::find(&nodes, node_id)?;
+                self.send(&node, message).await
             }
-            _ => Err(rustykrab_core::Error::ToolExecution(
-                format!("unknown nodes action: {action}").into(),
+
+            other => Err(Error::ToolExecution(
+                format!("unknown action '{other}' (expected discover, list, or send)").into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nodes_json() -> String {
+        json!([
+            {"id": "m4max", "url": "http://100.97.221.58:3000/", "token": "secret-token",
+             "description": "M4 Max - qwen3.8:27b-mlx, coding"},
+            {"id": "other", "url": "http://10.0.0.5:3000", "token": "t2"}
+        ])
+        .to_string()
+    }
+
+    #[test]
+    fn parses_configured_nodes() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].id, "m4max");
+        assert_eq!(
+            nodes[0].description.as_deref(),
+            Some("M4 Max - qwen3.8:27b-mlx, coding")
+        );
+        // description is optional
+        assert!(nodes[1].description.is_none());
+    }
+
+    #[test]
+    fn builds_api_urls_without_double_slashes() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        assert_eq!(
+            nodes[0].api("/conversations"),
+            "http://100.97.221.58:3000/api/conversations"
+        );
+        assert_eq!(nodes[1].api("/health"), "http://10.0.0.5:3000/api/health");
+    }
+
+    #[test]
+    fn unknown_node_error_lists_known_ids() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        let err = NodesTool::find(&nodes, "nope").unwrap_err().to_string();
+        assert!(err.contains("m4max") && err.contains("other"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn list_never_leaks_tokens() {
+        // Set/remove is process-global; keep this the only test touching the var.
+        std::env::set_var("RUSTYKRAB_NODES", nodes_json());
+        let out = NodesTool::new()
+            .execute(json!({"action": "list"}))
+            .await
+            .unwrap();
+        let rendered = out.to_string();
+        assert!(rendered.contains("m4max"));
+        assert!(
+            !rendered.contains("secret-token"),
+            "tool output must not carry tokens into model context: {rendered}"
+        );
+        std::env::remove_var("RUSTYKRAB_NODES");
+    }
+
+    #[test]
+    fn malformed_config_is_a_clear_error() {
+        std::env::set_var("RUSTYKRAB_NODES", "not json");
+        let err = NodesTool::configured_nodes().unwrap_err().to_string();
+        assert!(err.contains("RUSTYKRAB_NODES"), "got: {err}");
+        std::env::remove_var("RUSTYKRAB_NODES");
     }
 }

--- a/crates/rustykrab-tools/tests/nodes_live.rs
+++ b/crates/rustykrab-tools/tests/nodes_live.rs
@@ -1,0 +1,61 @@
+//! Live delegation test for the `nodes` tool.
+//!
+//! Ignored by default — needs a peer RustyKrab gateway running and
+//! `RUSTYKRAB_NODES` pointing at it:
+//!
+//! ```sh
+//! RUSTYKRAB_NODES='[{"id":"peer","url":"http://127.0.0.1:3100","token":"...","description":"test peer"}]' \
+//!   cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
+//! ```
+
+use rustykrab_core::Tool;
+use rustykrab_tools::NodesTool;
+use serde_json::json;
+
+#[tokio::test]
+#[ignore = "requires a peer RustyKrab gateway"]
+async fn live_delegation_round_trip() {
+    let tool = NodesTool::new();
+    assert!(tool.available(), "RUSTYKRAB_NODES must be set");
+
+    let listed = tool.execute(json!({"action": "list"})).await.unwrap();
+    eprintln!("list: {listed}");
+    let id = listed["nodes"][0]["id"]
+        .as_str()
+        .expect("a node")
+        .to_string();
+
+    let discovered = tool.execute(json!({"action": "discover"})).await.unwrap();
+    eprintln!("discover: {discovered}");
+    assert_eq!(
+        discovered["nodes"][0]["status"], "online",
+        "peer should be reachable"
+    );
+
+    let result = tool
+        .execute(json!({
+            "action": "send",
+            "node_id": id,
+            "message": "Reply with exactly: DELEGATED-OK. Nothing else."
+        }))
+        .await
+        .expect("delegation failed");
+    eprintln!("send: {result}");
+
+    let response = result["response"].as_str().unwrap_or_default();
+    assert!(
+        response.contains("DELEGATED-OK"),
+        "peer did not answer the delegated task: {response:?}"
+    );
+    assert!(result["conversation_id"].is_string());
+}
+
+#[tokio::test]
+#[ignore = "requires a peer RustyKrab gateway"]
+async fn unknown_node_is_rejected() {
+    let err = NodesTool::new()
+        .execute(json!({"action": "send", "node_id": "nope", "message": "hi"}))
+        .await
+        .expect_err("expected an error");
+    assert!(err.to_string().contains("unknown node"), "got: {err}");
+}

--- a/scripts/bench-local-models.md
+++ b/scripts/bench-local-models.md
@@ -1,0 +1,226 @@
+# Local model benchmark
+
+Portable benchmark for comparing local LLMs served by Ollama on Apple Silicon.
+Self-contained — it does not need the RustyKrab repo checked out, only Ollama.
+
+## Why these three metrics
+
+Agent workloads are dominated by two costs that a single "tokens/sec" number hides:
+
+- **Generation speed** — how fast the answer streams once it starts. Bandwidth-bound.
+- **Prompt processing** — time to first token on a large prompt. RustyKrab's system
+  prompt plus its tool schemas is **~8k tokens before any conversation**, so every
+  cold agent turn pays this. Compute-bound, and it varies far more between models
+  than generation speed does.
+- **Reasoning vs content split** — "thinking" models spend part of their token budget
+  on reasoning that never reaches the user. A model can look fast and still take a
+  long time to produce a visible answer.
+
+## Prerequisites
+
+```bash
+# Ollama must be installed and running
+ollama --version
+
+# Pull whichever models you want to compare (~17-18 GB each)
+ollama pull gemma4:26b
+ollama pull qwen3.8:27b
+ollama pull qwen3:30b-a3b
+
+df -h /System/Volumes/Data | tail -1   # check free space first
+```
+
+Each model loads fully into RAM while it is benchmarked. On a 32 GB machine run
+them one at a time; Ollama unloads the previous model automatically, but a very
+large model plus a loaded desktop can still push into swap and distort results.
+
+## Run it
+
+Copy-paste this whole block. It writes the script and runs it.
+
+```bash
+cat > /tmp/bench-models.py << 'EOF'
+import json, subprocess, sys, time, urllib.request
+
+URL = "http://localhost:11434/v1/chat/completions"
+GEN_PROMPT = "Write a detailed paragraph about the ocean."
+GEN_MAX_TOKENS = 400
+BIG_PROMPT_CHARS = 48000          # ~8k tokens, approximating an agent system prompt
+                                  # (this filler runs ~6 chars/token; the script
+                                  # reports the server's actual prompt_tokens)
+
+
+def big_prompt(model):
+    """Fixed-size large prompt with a unique prefix.
+
+    The size must not depend on the model name, or a longer name silently makes a
+    longer prompt and the numbers stop being comparable. The prefix appears once,
+    purely to defeat Ollama's prompt cache.
+    """
+    prefix = f"Session {model}. "
+    filler = "Reference material to ignore. "
+    body = filler * (BIG_PROMPT_CHARS // len(filler) + 1)
+    return prefix + body[:BIG_PROMPT_CHARS - len(prefix)] + "\nReply with exactly: ok"
+
+
+def stream(model, prompt, max_tokens):
+    """Returns (ttft, elapsed, completion_tokens, n_reasoning, n_content, prompt_tokens)."""
+    body = json.dumps({
+        "model": model, "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens, "temperature": 0, "stream": True,
+        "stream_options": {"include_usage": True},
+    }).encode()
+    req = urllib.request.Request(URL, data=body, headers={"Content-Type": "application/json"})
+    t0 = time.time(); first = None; toks = 0; n_reason = 0; n_content = 0; ptoks = 0
+    with urllib.request.urlopen(req, timeout=3600) as r:
+        for raw in r:
+            s = raw.decode().strip()
+            if not s.startswith("data: ") or s[6:] == "[DONE]":
+                continue
+            j = json.loads(s[6:])
+            if j.get("usage"):
+                toks = j["usage"]["completion_tokens"]
+                ptoks = j["usage"].get("prompt_tokens", 0)
+            ch = j.get("choices") or []
+            if not ch:
+                continue
+            d = ch[0].get("delta") or {}
+            # Thinking models stream reasoning in `delta.reasoning` with empty content.
+            if (d.get("content") or d.get("reasoning")) and first is None:
+                first = time.time() - t0
+            if d.get("reasoning"):
+                n_reason += 1
+            if d.get("content"):
+                n_content += 1
+    return first, time.time() - t0, toks, n_reason, n_content, ptoks
+
+
+def hardware():
+    try:
+        out = subprocess.run(["system_profiler", "SPHardwareDataType"],
+                             capture_output=True, text=True, timeout=60).stdout
+        chip = next((l.split(":")[1].strip() for l in out.splitlines() if "Chip:" in l), "?")
+        mem = next((l.split(":")[1].strip() for l in out.splitlines() if "Memory:" in l), "?")
+        return f"{chip}, {mem}"
+    except Exception:
+        return "unknown"
+
+
+def models():
+    if len(sys.argv) > 1:
+        return sys.argv[1:]
+    out = subprocess.run(["ollama", "list"], capture_output=True, text=True).stdout
+    return [l.split()[0] for l in out.splitlines()[1:] if l.strip()]
+
+
+print(f"Hardware: {hardware()}\n")
+rows = []
+for m in models():
+    try:
+        # Warm up twice: the first call pays model load, which would otherwise be
+        # attributed to whichever measurement ran first.
+        stream(m, "hi", 8)
+        stream(m, "warm up please", 32)
+
+        first, el, toks, n_reason, n_content, _ = stream(m, GEN_PROMPT, GEN_MAX_TOKENS)
+        gen = toks / el if el and toks else 0
+
+        big_ttft, _, _, _, _, big_ptoks = stream(m, big_prompt(m), 8)
+
+        print(f"{m:<16} gen {gen:5.1f} tok/s | first-token {first:5.2f}s | "
+              f"big prompt ({big_ptoks} tok) {big_ttft:6.2f}s | "
+              f"reasoning/content deltas {n_reason}/{n_content}")
+        rows.append((m, f"{gen:.1f}", f"{first:.2f}", f"{big_ttft:.2f}", str(big_ptoks),
+                     f"{n_reason}/{n_content}"))
+    except Exception as e:
+        print(f"{m:<16} FAILED: {e}")
+        rows.append((m, "FAIL", "-", "-", "-", "-"))
+
+print("\n--- paste-able results ---\n")
+print(f"Hardware: {hardware()}\n")
+print("| Model | Generation (tok/s) | First token (s) | Big prompt (s) | Prompt tokens | reasoning/content |")
+print("|---|---|---|---|---|---|")
+for r in rows:
+    print(f"| {r[0]} | {r[1]} | {r[2]} | {r[3]} | {r[4]} | {r[5]} |")
+EOF
+
+python3 /tmp/bench-models.py
+```
+
+To benchmark only specific models, pass them as arguments:
+
+```bash
+python3 /tmp/bench-models.py gemma4:26b qwen3.8:27b
+```
+
+## Baseline to compare against — M1 Max, 64 GB
+
+Measured with this exact script and method. Higher generation is better; **lower**
+first-token and 8k-prompt times are better.
+
+| Model | Generation (tok/s) | First token (s) | 8k prompt (s) | Prompt tokens | reasoning/content |
+|---|---|---|---|---|---|
+| qwen3:30b-a3b | **51.7** | **0.27** | 16.52 | 8025 | 377/21 |
+| gemma4:26b | 45.9 | 0.63 | **15.09** | 8028 | 352/0 |
+| qwen3.8:27b | 8.4 | 0.94 | 85.51 | 8023 | 99/294 |
+
+Reading it:
+
+- **qwen3:30b-a3b** and **gemma4:26b** are close — within ~12% on generation, and
+  gemma4 is marginally *faster* on prompt processing. Either is viable.
+  qwen3:30b-a3b (`qwen3moe`) has no vision; gemma4:26b does.
+- **qwen3.8:27b is ~5.5x slower on generation and ~5.7x slower on prompt
+  processing.** At 85s to ingest an 8k prompt, every cold agent turn stalls well
+  over a minute before the first token.
+- **`reasoning/content` shows how much of the budget is invisible thinking.**
+  gemma4 spent all 400 tokens reasoning and emitted *zero* content on this prompt —
+  it needs a higher `max_tokens` to produce a visible answer. qwen3.8 thinks
+  briefly then answers.
+
+All three pass tool-calling correctness — this table is purely about speed.
+
+Note gemma4:26b sustains ~46 tok/s from a ~17 GB model. On a 400 GB/s M1 Max a
+*dense* model that size caps out near 400/17 ≈ 23 tok/s, since every token must
+read every weight. Exceeding that ceiling means it is activating only a subset —
+evidence that gemma4:26b is sparse/MoE, though Ollama does not expose an expert
+count to confirm it directly.
+
+## What to look for on the M4 Max
+
+1. **Does qwen3.8:27b stay slow?** On the M1 Max it is ~6x slower than gemma4 on
+   *both* axes, which looks like unoptimized kernels for a very new architecture
+   rather than a bandwidth limit. If the M4 Max shows the same ratio, that
+   confirms it. If the gap narrows sharply, it was hardware-specific.
+
+2. **Scaling vs bandwidth.** The M4 Max has higher memory bandwidth than the M1
+   Max, so generation should improve roughly in proportion. Prompt processing is
+   compute-bound and should improve *more* — that is the M4 Max's bigger advantage
+   and the number that matters most for agent turns.
+
+3. **The 32 GB ceiling.** These models are ~17-18 GB. Watch for swap: if a result
+   is wildly worse than the baseline, check memory pressure before believing it.
+
+```bash
+memory_pressure | tail -3
+```
+
+## Optional: provider correctness tests
+
+Only if the RustyKrab repo is checked out on that machine. These confirm the
+OpenAI-compatible provider handles the model's tool-call format, not speed:
+
+```bash
+LIVE_OPENAI_BASE_URL=http://localhost:11434/v1 LIVE_OPENAI_MODEL=gemma4:26b \
+  cargo test -p rustykrab-providers --test openai_live -- --ignored --nocapture --test-threads=1
+```
+
+## Caveats
+
+- **Warm-up matters.** Without it the first measurement absorbs model load time and
+  can read several times worse than reality. The script warms each model twice.
+- **Prompt caching.** Repeating an identical large prompt hits Ollama's cache and
+  reports an unrealistically fast time. The script varies the filler per model.
+- **Speed is not quality.** Nothing here measures reasoning ability or answer
+  quality. A slower model may still be the right one.
+- **One sample per measurement.** Treat differences under ~15% as noise; the
+  differences worth acting on here are multiples, not percentages.

--- a/scripts/fleet.env.example
+++ b/scripts/fleet.env.example
@@ -1,0 +1,49 @@
+# RustyKrab two-machine fleet configuration.
+#
+#   M1 Max (64GB)  — primary / orchestrator. Runs gemma4:26b.
+#   M4 Max (32GB)  — subagent executor node. Runs qwen3.8:27b-mlx.
+#
+# Copy the relevant block into your shell profile or a launchd plist.
+# Do not commit a filled-in copy: it contains bearer tokens.
+
+# ---------------------------------------------------------------------------
+# PRIMARY  (M1 Max) — channels, gateway, orchestration
+# ---------------------------------------------------------------------------
+# gemma4:26b measured ~46 tok/s generation and ~15s to prefill an 8k prompt on
+# this machine, vs ~8 tok/s / ~90s for the qwen3.8 GGUF build. It also has
+# vision. It is the right model for the always-on interactive agent.
+export RUSTYKRAB_PROVIDER=ollama
+export OLLAMA_MODEL=gemma4:26b
+
+# Register the M4 Max as a delegation target. The description is shown to the
+# model and is how it decides what to hand over — be specific about what the
+# node is for and what it can reach.
+export RUSTYKRAB_NODES='[
+  {
+    "id": "m4max",
+    "url": "https://REPLACE-ME.your-tailnet.ts.net",
+    "token": "REPLACE-WITH-M4-AUTH-TOKEN",
+    "description": "M4 Max 32GB running qwen3.8:27b-mlx. Stronger reasoning than the local model but slower per task. Use for self-contained coding and analysis jobs that tolerate minutes of latency. Has its own checkout at ~/code/rustycrab; it cannot see files on this machine."
+  }
+]'
+
+# Delegated tasks on a local model take minutes. Default is 900s.
+export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
+
+# ---------------------------------------------------------------------------
+# NODE  (M4 Max) — headless executor, no channels
+# ---------------------------------------------------------------------------
+# Use the MLX build, NOT the plain qwen3.8:27b GGUF tag. The GGUF tag ships an
+# MTP speculative-decoding head that Ollama enables by default, and MTP is a
+# measured *regression* on M1/M4-class Metal (draft acceptance ~38-40%; see
+# scripts/bench-local-models.md). The MLX engine avoids that path entirely.
+#
+#   ollama pull qwen3.8:27b-mlx
+#
+# export RUSTYKRAB_PROVIDER=ollama
+# export OLLAMA_MODEL=qwen3.8:27b-mlx
+# export RUSTYKRAB_AUTH_TOKEN=<generate 64 hex chars; the primary needs this>
+#
+# Reasoning tokens dominate latency on a thinking model at single-digit tok/s.
+# Ollama exposes think=false but NOT reasoning_effort. If you need effort
+# control, run llama-server directly and pass it per-request instead.

--- a/scripts/setup-delegation-node.md
+++ b/scripts/setup-delegation-node.md
@@ -1,0 +1,183 @@
+# Setting up a delegation node
+
+Stand up a second RustyKrab instance on another Mac and let the primary hand it
+tasks via the `nodes` tool.
+
+## Read this first: what delegation actually is
+
+A delegated task runs **entirely on the remote node**, using *that machine's*
+tools, filesystem, and model. It does not share the primary's conversation.
+
+Consequences worth planning around:
+
+- **The node needs its own checkout** of any repo it will work on. It cannot see
+  files on the primary.
+- **Results come back as text**, not as edits on the primary. To move actual code,
+  have the node commit and push a branch, then pull it here.
+- **Each `send` starts a fresh conversation** on the node, so the message must be
+  self-contained — restate the goal, paths, and constraints every time.
+
+If what you want is "one agent, more compute", this is not that. It is "a second,
+independent agent you can hand a well-specified job to."
+
+## 1. On the node machine
+
+Build and bundle (the `.app` bundle is required for keychain access — see
+`scripts/bundle.sh`):
+
+```bash
+git clone <repo> rustycrab && cd rustycrab
+make bundle          # release build + codesign into a .app
+```
+
+Set its model. **Use the MLX build, not the plain GGUF tag:**
+
+```bash
+ollama pull qwen3.8:27b-mlx
+
+export RUSTYKRAB_PROVIDER=ollama
+export OLLAMA_MODEL=qwen3.8:27b-mlx
+```
+
+The plain `qwen3.8:27b` tag ships a multi-token-prediction (MTP) head, and Ollama
+launches it with `--spec-type draft-mtp` by default. On M1/M4-class Metal that
+speculative-decoding path is a measured **regression**, not a win — see the
+tuning table below. The MLX engine avoids it.
+
+Or point at any OpenAI-compatible server (llama.cpp, mistral.rs, LM Studio):
+
+```bash
+export RUSTYKRAB_PROVIDER=llama-server
+export OPENAI_BASE_URL=http://localhost:8080
+export OPENAI_MODEL=qwen3.8:27b
+export OPENAI_MAX_TOKENS=4096      # thinking models need headroom; too low and
+                                   # the agent loops on "hit max tokens"
+```
+
+Start it and note the auth token it prints on first run (or set
+`RUSTYKRAB_AUTH_TOKEN` yourself):
+
+```bash
+./target/release/RustyKrab.app/Contents/MacOS/rustykrab-cli
+```
+
+## 2. Make it reachable
+
+The gateway binds to **loopback only, by design** — that is not configurable, and
+should stay that way. Expose it deliberately instead. Two good options:
+
+**Tailscale Serve** (recommended for always-on). Terminates on the tailnet and
+proxies to loopback, so nothing is exposed to the local network or internet:
+
+```bash
+tailscale serve --bg 3000
+tailscale serve status        # note the https://<machine>.<tailnet>.ts.net URL
+```
+
+**SSH tunnel** (fine for ad-hoc use). Run on the *primary*:
+
+```bash
+ssh -N -L 3100:localhost:3000 <node-host>
+```
+
+The node is then `http://127.0.0.1:3100` from the primary's perspective.
+
+## 3. On the primary
+
+Register the node. `description` is shown to the model, so say what the node is
+good for — it uses this to choose:
+
+```bash
+export RUSTYKRAB_NODES='[
+  {
+    "id": "m4max",
+    "url": "https://your-machine.your-tailnet.ts.net",
+    "token": "<the node's auth token>",
+    "description": "M4 Max 32GB — qwen3.8:27b. Slow but capable; good for self-contained coding tasks. Has its own checkout at ~/code/rustycrab."
+  }
+]'
+
+# Local models are slow; give delegated tasks room to finish.
+export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
+```
+
+Restart the primary so it picks up the config. The `nodes` tool stays hidden from
+the model until `RUSTYKRAB_NODES` is set.
+
+## 4. Verify
+
+```bash
+RUSTYKRAB_NODES='...' cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
+```
+
+That checks `list`, `discover` (reachability + latency), and a real `send` round
+trip.
+
+## Measured tuning findings
+
+All on an M1 Max 64GB with the **GGUF** `qwen3.8:27b` build, 8k-token prompts.
+Ratios should transfer to the M4 Max even though absolute numbers differ.
+
+| Config | Generation | 8k prefill |
+|---|---|---|
+| Ollama default (MTP on) | 7.9 tok/s | 88.7 s |
+| llama-server, flash attention **off** | 8.4 tok/s | 91.7 s |
+| llama-server, flash attention **on** | **9.9 tok/s** | **88.2 s** |
+| ...plus `-ub 2048` | 9.3 tok/s | 110.3 s |
+| ...plus MTP speculative decoding | 8.5 tok/s | 118.4 s |
+| ...plus `-ctk/-ctv q8_0` | 8.1 tok/s | 131.8 s |
+
+Four things worth knowing, three of which contradict commonly repeated advice:
+
+- **Flash attention on is the one clear win** — +18% generation. Use `-fa on`.
+- **Do not raise the prefill micro-batch.** `-ub 2048` is widely recommended for
+  Apple Silicon and it cost ~20% prefill here. Leave the default.
+- **Do not enable MTP speculative decoding on Metal.** Draft acceptance measured
+  only 38-40%, so it loses more to verification than it gains: -14% generation
+  and -25% prefill. It is a large win on CUDA, which is where most of the
+  positive reports come from.
+- **Do not quantize the KV cache.** This architecture uses 256-dim heads with
+  sparse Metal flash-attention kernel coverage; `q8_0` made both axes worse.
+  Advice to the contrary is generally measured on NVIDIA hardware.
+
+**Multi-turn is much cheaper than cold turns.** In a two-turn conversation with a
+~4.9k-token system prompt, turn 1 paid 79.5 s of prefill and turn 2 paid only
+**3.3 s** — the slot cache reuses the prefix. Long-running conversations amortize
+well; it is *fresh* delegated tasks that pay full price. Since every `nodes send`
+starts a new conversation, each delegation is a cold turn by construction.
+
+## Performance expectations
+
+Measured on an M1 Max, delegating a *trivial* task ("reply with exactly OK") to a
+peer running gemma4:26b — the fast model at ~46 tok/s:
+
+**~43 seconds.**
+
+That is the floor, not the ceiling. It is dominated by the node's ~8k-token system
+prompt plus tool schemas, and by thinking-model reasoning tokens that never reach
+the caller. On qwen3.8:27b — roughly 5x slower on both generation and prompt
+processing — the same trivial round trip is closer to **3-4 minutes**, and a real
+coding task considerably longer.
+
+Plan accordingly:
+
+- Delegate **batch or background work**, not anything interactive.
+- Prefer **few large tasks** over many small ones — per-task overhead dominates.
+- Benchmark the node first with `scripts/bench-local-models.md`. If prompt
+  processing there is slow, every delegated task inherits it.
+- A faster model on the node often beats a smarter one, because the overhead is
+  paid per task regardless. Worth A/B-ing gemma4:26b against qwen3.8:27b on your
+  actual workload before committing.
+
+## Security notes
+
+- Auth is the node's **bearer token**, over a private network. Treat the token as
+  a credential: it grants full agent access, including shell execution on that
+  machine.
+- Keep the node bound to loopback and reach it via tailnet or SSH. Do not expose
+  the gateway port directly.
+- `nodes list` deliberately never returns tokens — tool output goes into the
+  model's context.
+- The peer's Origin check is CSRF protection against browsers, not authentication;
+  node-to-node calls set their own loopback origin. The real boundary is the token
+  plus network reachability.


### PR DESCRIPTION
**Stack: final PR** (base: #526, #549, #552, all merged)

Replaces #553 — GitHub blocks changing a stacked PR's base branch via the API. Same content, rebased directly onto `main` now that the rest of the stack is merged.

## Summary
Pure docs, no code changes.

- `scripts/bench-local-models.md` — a portable, self-contained benchmark (needs only Ollama, not a repo checkout) for comparing local models on Apple Silicon: generation tok/s, time-to-first-token, and prompt-processing time on an ~8k-token prompt sized to match RustyKrab's system prompt + tool schemas. Includes a measured M1 Max baseline across three models.
- `scripts/fleet.env.example` — a concrete two-machine config: a primary on `gemma4:26b` (fastest measured locally, has vision) delegating to a node on `qwen3.8:27b-mlx`. Specifically the MLX build, not the plain GGUF tag — the GGUF tag ships MTP speculative decoding that measurably regresses on M1/M4-class Metal (~38-40% draft acceptance, documented in the benchmark doc), which the MLX engine avoids.

## Test plan
- [x] Benchmark script's embedded Python parses (`ast.parse`)
- [x] Field names in `fleet.env.example` match `RemoteNode`'s schema (merged in #552)
- [x] Re-verified after rebasing onto current `main`