### PR TITLE
fix(credentials): record which conversation asked for a credential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.34"
+version = "5.1.40"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rustykrab_core::active_tools::with_session_context;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, Tool};
 use std::time::Duration;
@@ -146,9 +147,15 @@ impl Tool for CredentialRequestTool {
             ));
         }
 
+        // Which conversation is asking. This is what makes the answer
+        // resumable: when the user supplies the value, this is the turn to
+        // bring back. `None` outside a runner scope — the request is still
+        // answerable in the app, it just cannot wake anything.
+        let conversation_id = with_session_context(|c| c.conversation_id);
+
         let id = self
             .requests
-            .file_fulfil(name, service.clone(), fields, reason, None)
+            .file_fulfil(name, service.clone(), fields, reason, conversation_id)
             .await
             .map_err(|e| {
                 Error::ToolExecution(format!("could not file the credential request: {e}").into())

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use rustykrab_core::active_tools::with_session_context;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use rustykrab_store::GuardedSecrets;
@@ -159,13 +160,18 @@ impl GmailTool {
                 ),
             },
         ];
+        // This is the path that actually fires in practice — measured at
+        // 25/25 against `browser`'s 1/9 — so a request filed here without
+        // a conversation would leave the common case unresumable.
+        let conversation_id = with_session_context(|c| c.conversation_id);
+
         match requests
             .file_fulfil(
                 KEY_APP_PASSWORD,
                 Some("Gmail".to_string()),
                 fields,
                 Some(format!("so it can use your Gmail account — it needs {needs}")),
-                None,
+                conversation_id,
             )
             .await
         {


### PR DESCRIPTION
**Stack 1/4** — base of the credential-acquisition work. Merges into `main`.

## Problem

Both paths that file a credential request passed `None` as the conversation id:

- `credential_request.rs` — the model-driven ask
- `gmail.rs` — filed from inside its own missing-credential path

So a filed request recorded *what* was asked but not *who* asked. When the user supplies the value there is nothing to bring back, which blocks the resume work in 2/4.

## Approach

`SESSION_TOOL_CONTEXT` already carries `conversation_id` and is already scoped by the runner around the agent loop (`runner.rs:1357`, `runner.rs:1816`). `skills`, `tools_list` and `tools_load` already read it this way, so both call sites do the same:

```rust
let conversation_id = with_session_context(|c| c.conversation_id);
```

I first tried threading an explicit `ToolContext` through a new defaulted `Tool::execute_ctx`. It worked, but it duplicated this mechanism and cost ~120 lines across three signatures and five runner call sites — and it did not survive contact with gmail, whose request is filed ten callers below `execute`. The task-local resolves at any depth, so gmail needed no threading at all.

## Why gmail matters here

It is the path that actually fires. The measurements recorded in `DEFAULT_ACTIVE_TOOLS` put routes through `gmail` at 25/25 filed, against `browser`'s 1/9. Leaving it unattributed would have left the common case unresumable.

## Notes

- `None` remains correct outside a runner scope (e.g. a cron job). Such a request is still answerable in the app; it just cannot wake anything.
- Includes a Cargo.lock sync — it was stale on `main` at 5.1.34 against a workspace version of 5.1.40, so any build corrects it.
- No behaviour change on its own. This only populates a column; 2/4 consumes it.

## Test

`cargo check -p rustykrab-tools` clean. Behavioural verification lands with the resume path in 2/4, where the column is actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)