### PR TITLE
feat(credentials): resume the stalled turn when a credential arrives

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ All configuration is via environment variables. No plaintext config files.
 | `RUST_LOG` | `info` | Log level (`info`, `debug`, `rustykrab_gateway=debug`) |
 | `RUSTYKRAB_LOG_STDOUT` | auto | Force stdout logging on (`1`) or off (`0`). Default: enabled only when stdout is a terminal. The rolling log file under the data directory is always written |
 | `RUSTYKRAB_OUTCOME_CAPTURE` | `0` | Record how each completed run went, and which skill, memories, and tools were in play, into the `outcome_records` table. Observational only — it changes nothing about how the agent behaves. Groundwork for the self-improvement outer loop; see `DREAMING.md` |
+| `RUSTYKRAB_PUBLIC_URL` | unset | Base URL the agent puts in a credential link, e.g. `https://mac.tailnet.ts.net`. Unset, the agent falls back to telling the user a prompt is waiting in the app — so a link is never minted and the failure is silent |
+| `RUSTYKRAB_TAILNET_USERS` | unset | Comma-separated tailnet logins allowed to open a credential page. Empty means any authenticated tailnet user. Requires `tailscale serve` in front to inject `Tailscale-User-Login` |
 | | | When enabled, this also starts a **downtime analysis worker**: read-only, it aggregates recorded outcomes and logs a digest once the system has been quiet for 10 minutes, abandoning a pass if activity arrives mid-flight. It never writes and never calls a model |
 
 ### Persisting credentials
@@ -275,6 +277,35 @@ docker run --rm \
 Per-credential values (Anthropic, Notion, Telegram, etc.) come from their `RUSTYKRAB_*`/service-specific env vars — see the table above and the registry at `crates/rustykrab-store/src/registry.rs`. Anything resolved from an env var is also persisted into the encrypted SQLite store on first run, so subsequent restarts only need `RUSTYKRAB_MASTER_KEY` plus whatever you want to rotate.
 
 The `rustykrab-cli keychain` subcommand is macOS-only; on Linux/Docker use env vars or the gateway's secrets API.
+
+### Serving the credential page over your tailnet
+
+The gateway binds loopback. `tailscale serve` fronts it with a real
+Let's Encrypt certificate so a phone on the tailnet can open the secure
+form the agent links to.
+
+```sh
+# 1. Enable HTTPS certificates for the tailnet, once, in the admin console:
+#    https://login.tailscale.com/admin/dns  ->  HTTPS Certificates  ->  Enable
+
+# 2. Front the gateway (3000 is the default port):
+tailscale serve --bg https / http://127.0.0.1:3000
+tailscale serve status          # confirms the https:// URL it now answers on
+
+# 3. Point the daemon at that name, and say who may answer:
+export RUSTYKRAB_PUBLIC_URL=https://<mac>.<tailnet>.ts.net
+export RUSTYKRAB_TAILNET_USERS=you@example.com
+export RUSTYKRAB_ALLOWED_ORIGINS=https://<mac>.<tailnet>.ts.net
+```
+
+`RUSTYKRAB_ALLOWED_ORIGINS` matters: the form posts back from that origin,
+and the origin check rejects a POST it does not recognise.
+
+Without `tailscale serve` in front there is no `Tailscale-User-Login`
+header, so the page refuses every request — which is the intended failure.
+`RUSTYKRAB_CREDENTIAL_PAGE_ANONYMOUS=1` turns that check off and exists
+only for loopback development; `scripts/install.sh` deliberately does not
+forward it, so it cannot be inherited into an installed service.
 
 ## Usage
 

--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1399,6 +1399,11 @@ impl AgentRunner {
         // turn, but once the model has started using tools we expect an
         // explicit completion signal.
         let mut has_called_any_tool = false;
+        // Set when a tool reports the turn is now waiting on someone
+        // else. Not reset per iteration: once the agent has asked the
+        // user for something, every later EndTurn this run is a stop,
+        // not an early exit.
+        let mut turn_blocked = false;
         // Per-run cache of the schemas sent to the model, keyed by the
         // active-set version so activations performed by `tools_load`
         // during the previous iteration are reflected in the next API
@@ -1550,6 +1555,26 @@ impl AgentRunner {
                     }
                 }
 
+                // A tool that succeeded and blocks the turn (e.g. asking
+                // the user for a credential) means the right next move is
+                // one sentence and a stop.
+                if !turn_blocked {
+                    for (tool_name, _, result) in &results {
+                        if result.is_ok() {
+                            if let Some(t) = self.tool_index.get(tool_name) {
+                                if t.blocks_turn() {
+                                    turn_blocked = true;
+                                    tracing::info!(
+                                        tool = %tool_name,
+                                        "turn is blocked on the user — EndTurn will be accepted"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let had_errors = results.iter().any(|(_, _, r)| {
                     if let Ok(tr) = r {
                         tr.output.get("error").is_some()
@@ -1646,7 +1671,7 @@ impl AgentRunner {
                     // working. Cap by `TASK_COMPLETE_RETRY_LIMIT` so models
                     // that never learn the protocol fall through to the
                     // legacy accept-and-return behavior.
-                    if has_called_any_tool {
+                    if has_called_any_tool && !turn_blocked {
                         match self.reprompt_for_task_complete(
                             conv,
                             iteration,
@@ -1849,6 +1874,11 @@ impl AgentRunner {
         let mut task_complete_retries: usize = 0;
         let mut had_side_effects = false;
         let mut has_called_any_tool = false;
+        // Set when a tool reports the turn is now waiting on someone
+        // else. Not reset per iteration: once the agent has asked the
+        // user for something, every later EndTurn this run is a stop,
+        // not an early exit.
+        let mut turn_blocked = false;
         // Per-run schema cache — see run_inner for rationale.
         let mut schema_cache: Option<(u64, Vec<ToolSchema>)> = None;
 
@@ -1991,6 +2021,26 @@ impl AgentRunner {
                     }
                 }
 
+                // A tool that succeeded and blocks the turn (e.g. asking
+                // the user for a credential) means the right next move is
+                // one sentence and a stop.
+                if !turn_blocked {
+                    for (tool_name, _, result) in &results {
+                        if result.is_ok() {
+                            if let Some(t) = self.tool_index.get(tool_name) {
+                                if t.blocks_turn() {
+                                    turn_blocked = true;
+                                    tracing::info!(
+                                        tool = %tool_name,
+                                        "turn is blocked on the user — EndTurn will be accepted"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let had_errors = results.iter().any(|(_, _, r)| {
                     if let Ok(tr) = r {
                         tr.output.get("error").is_some()
@@ -2091,7 +2141,7 @@ impl AgentRunner {
                     // EndTurn no longer terminates: re-prompt the model to
                     // either call `task_complete` or keep working. See
                     // run_inner for the full rationale.
-                    if has_called_any_tool {
+                    if has_called_any_tool && !turn_blocked {
                         match self.reprompt_for_task_complete(
                             conv,
                             iteration,
@@ -5346,6 +5396,99 @@ mod task_complete_tests {
             })
             .count();
         assert_eq!(reminder_count, TASK_COMPLETE_RETRY_LIMIT);
+    }
+
+    /// A tool that blocks the turn, and is otherwise a noop.
+    struct BlockingTool;
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "ask_the_user"
+        }
+        fn description(&self) -> &str {
+            "test blocking tool"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "ask_the_user".into(),
+                description: "test blocking tool".into(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+        fn blocks_turn(&self) -> bool {
+            true
+        }
+        async fn execute(&self, _args: serde_json::Value) -> Result<serde_json::Value> {
+            Ok(serde_json::json!({"status": "requested"}))
+        }
+    }
+
+    fn runner_with_blocking_tool(provider: Arc<ScriptedProvider>) -> (AgentRunner, Session, Uuid) {
+        use rustykrab_tools::TaskCompleteTool;
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> =
+            vec![Arc::new(BlockingTool), Arc::new(TaskCompleteTool::new())];
+        let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["ask_the_user"]);
+        let caps = CapabilitySet::for_tools_permissive(&["ask_the_user", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        (runner, session, conv_id)
+    }
+
+    /// Asking the user for something is a legitimate reason to stop, and
+    /// the loop must let the turn end.
+    ///
+    /// Without this the runner demands `task_complete` after any tool
+    /// call. The model cannot honestly call it — the task is blocked, not
+    /// done — so it churns instead. Observed against gemma4:26b: the
+    /// agent filed a credential request at iteration 29 and was still
+    /// going at 46, calling `todo_write` and `exec` to fill the turns.
+    #[tokio::test]
+    async fn a_blocked_turn_ends_without_task_complete() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("ask_the_user", serde_json::json!({})),
+            // The one sentence telling the user, then stop.
+            text_response("I've asked for your Gmail app password."),
+        ]));
+        let (runner, session, conv_id) = runner_with_blocking_tool(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        // Two calls: the tool use, and the sentence. A third would mean
+        // the runner re-prompted for `task_complete`.
+        assert_eq!(
+            *provider.chat_count.lock().unwrap(),
+            2,
+            "a blocked turn must not be re-prompted for task_complete"
+        );
+    }
+
+    /// The suppression is specific to blocking tools — an ordinary tool
+    /// followed by a bare EndTurn must still be re-prompted, or this fix
+    /// would disable the completion protocol wholesale.
+    #[tokio::test]
+    async fn a_normal_tool_is_still_reprompted() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            text_response("I'll keep digging into this for you."),
+            tool_use_response("task_complete", serde_json::json!({ "summary": "done" })),
+        ]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        assert_eq!(
+            *provider.chat_count.lock().unwrap(),
+            3,
+            "a non-blocking tool must still be held to the completion protocol"
+        );
     }
 }
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -497,11 +497,20 @@ async fn main() -> anyhow::Result<()> {
             )) as std::sync::Arc<dyn rustykrab_store::RequestNotifier>
         });
 
-    // Hand the notifier to the store so filing a request tells the user.
-    let store = match push_notifier {
-        Some(notifier) => store.with_request_notifier(notifier),
-        None => store,
-    };
+    // Both halves of the credential loop go through one notifier: filing
+    // tells the user, fulfilling wakes the agent. It is attached
+    // unconditionally now — the wake half does not depend on APNs being
+    // configured, and gating on it would silently disable resume on any
+    // deployment without push.
+    //
+    // The task queue does not exist yet (it needs `state`, built below),
+    // so it arrives later through this cell.
+    let wake_queue: Arc<std::sync::OnceLock<task_queue::TaskQueue>> =
+        Arc::new(std::sync::OnceLock::new());
+    let store = store.with_request_notifier(Arc::new(CredentialNotifier {
+        push: push_notifier,
+        queue: wake_queue.clone(),
+    }));
 
     // --- Auth token ---
     // Resolution order (via registry):
@@ -1434,6 +1443,10 @@ async fn main() -> anyhow::Result<()> {
         store_handle.clone(),
     );
     infra_handles.push(queue_handle);
+    // Close the loop: from here a fulfilled credential can wake the
+    // conversation that asked for it. Requests answered before this point
+    // log and are dropped rather than queueing against a dead channel.
+    let _ = wake_queue.set(task_queue.clone());
     tracing::info!(max_concurrent, "task queue started");
 
     // --- Downtime outcome analysis (see DREAMING.md) ---
@@ -2849,6 +2862,83 @@ fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> anyhow::R
         }
     }
     Ok(())
+}
+
+/// Carries credential-request events to both parties.
+///
+/// Filing goes outward to the user (APNs, when configured). Fulfilling
+/// goes back inward to the agent, by queueing a wake for the conversation
+/// that asked. Keeping both on one notifier means the store has a single
+/// hook and neither half can be wired without the other.
+struct CredentialNotifier {
+    push: Option<Arc<dyn rustykrab_store::RequestNotifier>>,
+    /// Filled once the task queue exists. `TaskQueue` needs `AppState`,
+    /// which is built after the store, so this cannot be a plain field.
+    queue: Arc<std::sync::OnceLock<task_queue::TaskQueue>>,
+}
+
+impl std::fmt::Debug for CredentialNotifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialNotifier")
+            .field("push", &self.push.is_some())
+            .field("queue_ready", &self.queue.get().is_some())
+            .finish()
+    }
+}
+
+impl rustykrab_store::RequestNotifier for CredentialNotifier {
+    fn request_filed(&self, credential_name: &str, action: &str) {
+        if let Some(push) = &self.push {
+            push.request_filed(credential_name, action);
+        }
+    }
+
+    fn request_fulfilled(
+        &self,
+        conversation_id: Option<&str>,
+        credential_name: &str,
+        service: Option<&str>,
+    ) {
+        let Some(conversation_id) = conversation_id else {
+            // Filed outside a runner scope. The credential is stored and
+            // usable; there is simply no turn to return to.
+            tracing::debug!(
+                credential = %credential_name,
+                "credential supplied, but the request recorded no conversation — nothing to wake"
+            );
+            return;
+        };
+        let Some(queue) = self.queue.get() else {
+            tracing::warn!(
+                credential = %credential_name,
+                "credential supplied before the task queue was ready — not resuming"
+            );
+            return;
+        };
+
+        let request = task_queue::TaskRequest {
+            prompt: task_queue::credential_wake_prompt(credential_name, service),
+            source: task_queue::TaskSource::CredentialFulfilled {
+                conversation_id: conversation_id.to_string(),
+                credential_name: credential_name.to_string(),
+            },
+            // One wake per conversation. A request answered with two
+            // fields, or two requests answered together, must not start
+            // two agent runs over the same history.
+            dedupe_key: Some(format!("credential-wake:{conversation_id}")),
+        };
+
+        // `request_fulfilled` is synchronous and must not block the write
+        // that triggered it, so the submit is detached. Losing it costs
+        // the resume, never the credential.
+        let queue = queue.clone();
+        let name = credential_name.to_string();
+        tokio::spawn(async move {
+            if let Err(e) = queue.submit(request).await {
+                tracing::error!(credential = %name, "could not queue credential wake: {e}");
+            }
+        });
+    }
 }
 
 #[cfg(test)]

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -23,6 +23,34 @@ pub enum TaskSource {
         /// (numeric string). Slack: thread_ts. `None` posts at top level.
         thread_id: Option<String>,
     },
+    /// A credential the agent asked for has been supplied, and the turn
+    /// that stalled waiting for it can go again.
+    ///
+    /// Carries no channel of its own: the conversation already records
+    /// where it came from, and `resolve_delivery_target` reads it. A wake
+    /// that guessed its own target could answer somewhere the user never
+    /// asked from.
+    CredentialFulfilled {
+        /// The conversation that filed the request — the one to resume.
+        conversation_id: String,
+        /// Store key of the credential, for logs and deduplication.
+        credential_name: String,
+    },
+}
+
+/// The turn appended to a resumed conversation when a credential lands.
+///
+/// Deliberately says only that the value now exists, never what it is:
+/// this text becomes a real user message in the conversation, so anything
+/// put here is in the context window and in every transcript from now on.
+pub fn credential_wake_prompt(credential_name: &str, service: Option<&str>) -> String {
+    let what = service.unwrap_or(credential_name);
+    format!(
+        "The {what} credential you asked for is now stored and available. \
+         Continue the task you stopped for it — retry the tool that failed. \
+         Do not ask for the credential again, and do not repeat any value \
+         back to me."
+    )
 }
 
 /// A unit of work submitted to the task queue.
@@ -145,7 +173,107 @@ async fn execute_task(task: &TaskRequest, state: &AppState, store: &rustykrab_st
             )
             .await;
         }
+        TaskSource::CredentialFulfilled {
+            conversation_id,
+            credential_name,
+        } => {
+            execute_credential_wake(conversation_id, credential_name, &task.prompt, state).await;
+        }
     }
+}
+
+/// Resume the conversation that asked for a credential, now that it has
+/// one.
+///
+/// Unlike a scheduled job there is nothing to record and nothing to
+/// disable on failure: the credential is already stored, and the worst
+/// case is that the user asks again by hand. So every failure here logs
+/// and returns rather than trying to repair anything.
+async fn execute_credential_wake(
+    conversation_id: &str,
+    credential_name: &str,
+    prompt: &str,
+    state: &AppState,
+) {
+    let Ok(uuid) = Uuid::parse_str(conversation_id) else {
+        tracing::warn!(
+            credential = %credential_name,
+            conversation_id = %conversation_id,
+            "credential wake has a malformed conversation id; nothing to resume"
+        );
+        return;
+    };
+
+    let mut conv = match state.store.conversations().get(uuid).await {
+        Ok(c) => c,
+        Err(e) => {
+            // The conversation was deleted between asking and answering.
+            // The credential is still stored and usable; only the resume
+            // is lost.
+            tracing::warn!(
+                credential = %credential_name,
+                conversation_id = %conversation_id,
+                "cannot resume conversation for credential wake: {e}"
+            );
+            return;
+        }
+    };
+
+    // Where the answer goes. Read from the conversation, never guessed —
+    // see the note on `TaskSource::CredentialFulfilled`.
+    let (channel, chat_id, thread_id) = resolve_delivery_target(None, None, None, &conv);
+
+    push_scheduled_user_turn(&mut conv, prompt);
+
+    let run_options = rustykrab_gateway::RunOptions {
+        active_skill: None,
+        // The point of waking is to finish the job, so the first move
+        // should be retrying the tool that failed rather than announcing
+        // that it can now be retried.
+        force_tool_use_first_iteration: true,
+    };
+
+    let trace_id = Uuid::new_v4();
+    tracing::info!(
+        %trace_id,
+        credential = %credential_name,
+        conversation_id = %conversation_id,
+        "credential supplied — resuming the turn that stalled"
+    );
+
+    let no_op_event = |_event: AgentEvent| {};
+    let response_text = match rustykrab_gateway::run_agent_streaming_with_options(
+        state,
+        &mut conv,
+        prompt,
+        &no_op_event,
+        trace_id,
+        &run_options,
+    )
+    .await
+    {
+        Ok(msg) => match &msg.content {
+            MessageContent::Text(t) => t.clone(),
+            _ => return,
+        },
+        Err(e) => {
+            tracing::error!(
+                credential = %credential_name,
+                "agent error resuming after credential fulfilment: {e}"
+            );
+            return;
+        }
+    };
+
+    deliver_response(
+        credential_name,
+        channel.as_deref(),
+        chat_id.as_deref(),
+        thread_id.as_deref(),
+        &response_text,
+        state,
+    )
+    .await;
 }
 
 /// Append the scheduled prompt to `conv` as a real user turn.
@@ -362,76 +490,15 @@ async fn execute_cron_task(
     };
 
     // Route the response to the originating channel.
-    match effective_channel.as_deref() {
-        Some("telegram") => {
-            if let (Some(tg), Some(cid)) = (&state.telegram, effective_chat_id.as_deref()) {
-                if let Ok(chat_id_num) = cid.parse::<i64>() {
-                    let tg_thread = effective_thread_id
-                        .as_deref()
-                        .and_then(|s| s.parse::<i64>().ok())
-                        .unwrap_or(0);
-                    if let Err(e) = tg.send_text(chat_id_num, &response_text, tg_thread).await {
-                        tracing::error!(job_id = %job_id, "failed to send scheduled job result to Telegram: {e}");
-                    }
-                } else {
-                    tracing::error!(job_id = %job_id, chat_id = %cid, "invalid Telegram chat_id");
-                }
-            } else {
-                tracing::warn!(
-                    job_id = %job_id,
-                    has_telegram = state.telegram.is_some(),
-                    has_chat_id = effective_chat_id.is_some(),
-                    "telegram routing unavailable; result discarded: {response_text}"
-                );
-            }
-        }
-        Some("slack") => {
-            if let (Some(sl), Some(channel_id)) = (&state.slack, effective_chat_id.as_deref()) {
-                if let Err(e) = sl
-                    .send_text(channel_id, &response_text, effective_thread_id.as_deref())
-                    .await
-                {
-                    tracing::error!(job_id = %job_id, "failed to send scheduled job result to Slack: {e}");
-                }
-            } else {
-                tracing::warn!(
-                    job_id = %job_id,
-                    has_slack = state.slack.is_some(),
-                    has_chat_id = effective_chat_id.is_some(),
-                    "slack routing unavailable; result discarded: {response_text}"
-                );
-            }
-        }
-        Some("signal") => {
-            if let (Some(sig), Some(number)) = (&state.signal, effective_chat_id.as_deref()) {
-                if let Err(e) = sig.send_text(number, &response_text).await {
-                    tracing::error!(job_id = %job_id, "failed to send scheduled job result to Signal: {e}");
-                }
-            } else {
-                tracing::warn!(
-                    job_id = %job_id,
-                    has_signal = state.signal.is_some(),
-                    has_chat_id = effective_chat_id.is_some(),
-                    "signal routing unavailable; result discarded: {response_text}"
-                );
-            }
-        }
-        Some(other) => {
-            tracing::warn!(
-                job_id = %job_id,
-                channel = %other,
-                "unknown channel for scheduled job; result discarded: {response_text}"
-            );
-        }
-        None => {
-            tracing::warn!(
-                job_id = %job_id,
-                "scheduled job has no delivery channel — set channel/chat_id on the \
-                 job, or set RUSTYKRAB_DEFAULT_CHANNEL + RUSTYKRAB_DEFAULT_CHAT_ID. \
-                 Result discarded: {response_text}"
-            );
-        }
-    }
+    deliver_response(
+        job_id,
+        effective_channel.as_deref(),
+        effective_chat_id.as_deref(),
+        effective_thread_id.as_deref(),
+        &response_text,
+        state,
+    )
+    .await;
 
     // Record the run before marking executed so the result is persisted
     // even if mark_executed fails.
@@ -720,6 +787,92 @@ fn resolve_delivery_target(
         .or_else(|| std::env::var(DEFAULT_THREAD_ID_ENV).ok())
         .filter(|s| !s.is_empty());
     (channel, chat_id, thread_id)
+}
+
+/// Route a finished agent response back to the channel it came from.
+///
+/// Shared by the scheduled-job path and the credential-wake path. Both
+/// end the same way — some text, and a `(channel, chat, thread)` triple
+/// resolved from the conversation — and a second copy of this match would
+/// drift the moment one of them gained a channel the other did not.
+///
+/// `target` names the originator in logs: a job id for a scheduled run,
+/// the credential name for a wake. Everything here is best-effort; a
+/// channel that cannot be reached is logged with the text that was lost,
+/// never retried, because the agent has already run and re-running it
+/// would repeat its side effects.
+async fn deliver_response(
+    target: &str,
+    channel: Option<&str>,
+    chat_id: Option<&str>,
+    thread_id: Option<&str>,
+    response_text: &str,
+    state: &AppState,
+) {
+    match channel {
+        Some("telegram") => {
+            if let (Some(tg), Some(cid)) = (&state.telegram, chat_id) {
+                if let Ok(chat_id_num) = cid.parse::<i64>() {
+                    let tg_thread = thread_id.and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
+                    if let Err(e) = tg.send_text(chat_id_num, response_text, tg_thread).await {
+                        tracing::error!(target = %target, "failed to send result to Telegram: {e}");
+                    }
+                } else {
+                    tracing::error!(target = %target, chat_id = %cid, "invalid Telegram chat_id");
+                }
+            } else {
+                tracing::warn!(
+                    target = %target,
+                    has_telegram = state.telegram.is_some(),
+                    has_chat_id = chat_id.is_some(),
+                    "telegram routing unavailable; result discarded: {response_text}"
+                );
+            }
+        }
+        Some("slack") => {
+            if let (Some(sl), Some(channel_id)) = (&state.slack, chat_id) {
+                if let Err(e) = sl.send_text(channel_id, response_text, thread_id).await {
+                    tracing::error!(target = %target, "failed to send result to Slack: {e}");
+                }
+            } else {
+                tracing::warn!(
+                    target = %target,
+                    has_slack = state.slack.is_some(),
+                    has_chat_id = chat_id.is_some(),
+                    "slack routing unavailable; result discarded: {response_text}"
+                );
+            }
+        }
+        Some("signal") => {
+            if let (Some(sig), Some(number)) = (&state.signal, chat_id) {
+                if let Err(e) = sig.send_text(number, response_text).await {
+                    tracing::error!(target = %target, "failed to send result to Signal: {e}");
+                }
+            } else {
+                tracing::warn!(
+                    target = %target,
+                    has_signal = state.signal.is_some(),
+                    has_chat_id = chat_id.is_some(),
+                    "signal routing unavailable; result discarded: {response_text}"
+                );
+            }
+        }
+        Some(other) => {
+            tracing::warn!(
+                target = %target,
+                channel = %other,
+                "unknown channel; result discarded: {response_text}"
+            );
+        }
+        None => {
+            tracing::warn!(
+                target = %target,
+                "no delivery channel — set channel/chat_id on the originating \
+                 conversation, or set RUSTYKRAB_DEFAULT_CHANNEL + \
+                 RUSTYKRAB_DEFAULT_CHAT_ID. Result discarded: {response_text}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rustykrab-core/src/tool.rs
+++ b/crates/rustykrab-core/src/tool.rs
@@ -67,6 +67,26 @@ pub trait Tool: Send + Sync {
         SandboxRequirements::default()
     }
 
+    /// Whether a successful call leaves the turn waiting on someone else.
+    ///
+    /// The agent loop does not trust a bare `EndTurn` once tools have been
+    /// called — providers map any text-only reply to it regardless of
+    /// intent — so it re-prompts for `task_complete`. That is right for a
+    /// model that stopped early, and wrong for one that stopped because it
+    /// is blocked: the task is not complete, cannot be completed, and no
+    /// amount of nudging changes that. The model then either churns to the
+    /// iteration cap or invents progress it has not made.
+    ///
+    /// A tool that returns `true` here says the correct next move is to
+    /// tell the user and stop. The loop lets the following `EndTurn` end
+    /// the turn instead of re-prompting.
+    ///
+    /// Only consulted when the call *succeeded*. A tool that failed to
+    /// block on anything has not blocked anything.
+    fn blocks_turn(&self) -> bool {
+        false
+    }
+
     /// Execute the tool with the given arguments, returning a JSON result.
     async fn execute(&self, args: Value) -> Result<Value>;
 }

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -1189,11 +1189,23 @@ mod wake_tests {
     use super::fulfil_tests::gmail_fields;
     use super::*;
 
+    /// One `request_fulfilled` call, captured.
+    ///
+    /// A named struct rather than a tuple: the assertions read better for
+    /// it, and three string-ish fields in a row is exactly the shape
+    /// `clippy::type_complexity` objects to.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Fulfilment {
+        conversation_id: Option<String>,
+        credential: String,
+        service: Option<String>,
+    }
+
     /// Records what it was told, so the assertion reads the hook's
     /// arguments rather than trusting a log line.
     #[derive(Debug, Default)]
     struct RecordingNotifier {
-        fulfilled: Mutex<Vec<(Option<String>, String, Option<String>)>>,
+        fulfilled: Mutex<Vec<Fulfilment>>,
     }
 
     impl RequestNotifier for RecordingNotifier {
@@ -1205,11 +1217,11 @@ mod wake_tests {
             credential_name: &str,
             service: Option<&str>,
         ) {
-            self.fulfilled.lock().unwrap().push((
-                conversation_id.map(str::to_string),
-                credential_name.to_string(),
-                service.map(str::to_string),
-            ));
+            self.fulfilled.lock().unwrap().push(Fulfilment {
+                conversation_id: conversation_id.map(str::to_string),
+                credential: credential_name.to_string(),
+                service: service.map(str::to_string),
+            });
         }
     }
 
@@ -1257,13 +1269,13 @@ mod wake_tests {
         let seen = notifier.fulfilled.lock().unwrap();
         assert_eq!(seen.len(), 1, "one wake per fulfilment");
         assert_eq!(
-            seen[0].0.as_deref(),
+            seen[0].conversation_id.as_deref(),
             Some(conv.to_string().as_str()),
             "the wake must name the conversation that filed the request"
         );
-        assert_eq!(seen[0].1, "gmail_app_password");
+        assert_eq!(seen[0].credential, "gmail_app_password");
         // Carried so the resumed turn can say "Gmail", not the store key.
-        assert_eq!(seen[0].2.as_deref(), Some("Gmail"));
+        assert_eq!(seen[0].service.as_deref(), Some("Gmail"));
     }
 
     /// A request filed outside a runner scope still fulfils. It simply
@@ -1284,7 +1296,10 @@ mod wake_tests {
 
         let seen = notifier.fulfilled.lock().unwrap();
         assert_eq!(seen.len(), 1);
-        assert_eq!(seen[0].0, None, "nothing to resume, and that is fine");
+        assert_eq!(
+            seen[0].conversation_id, None,
+            "nothing to resume, and that is fine"
+        );
     }
 
     /// A failed fulfil must not announce success. The credential never

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -111,6 +111,27 @@ pub struct CredentialRequest {
 /// notification at all.
 pub trait RequestNotifier: Send + Sync + std::fmt::Debug {
     fn request_filed(&self, credential_name: &str, action: &str);
+
+    /// The user answered: the credential now exists.
+    ///
+    /// This is the other half of the loop. Filing tells the user a turn
+    /// is blocked; this tells whatever was blocked that it no longer is.
+    ///
+    /// `conversation_id` is whichever conversation filed the request.
+    /// `None` means the ask was made outside a runner scope and there is
+    /// nothing to wake — still a valid request, just not a resumable one.
+    ///
+    /// Defaulted, so a notifier that only announces new requests need not
+    /// care. Fire-and-forget for the same reason as `request_filed`: a
+    /// wake that fails must never undo a credential the user has already
+    /// handed over.
+    fn request_fulfilled(
+        &self,
+        _conversation_id: Option<&str>,
+        _credential_name: &str,
+        _service: Option<&str>,
+    ) {
+    }
 }
 
 #[derive(Clone)]
@@ -295,7 +316,20 @@ impl CredentialRequestStore {
         }
 
         self.decide(id, "approved", decided_by, &row.name, "fulfil")
-            .await
+            .await?;
+
+        // Only once the credential is durable and the row is decided. A
+        // wake fired earlier could reach a turn that then reads a
+        // credential which is not there yet, and the resumed agent would
+        // conclude the user's answer had failed.
+        if let Some(notifier) = &self.notifier {
+            notifier.request_fulfilled(
+                row.conversation_id.as_deref(),
+                &row.name,
+                row.service.as_deref(),
+            );
+        }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -660,7 +694,8 @@ impl CredentialRequestStore {
         crate::with_conn(&self.conn, move |conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT name, action, proposed_data, status, target_version, fields
+                    "SELECT name, action, proposed_data, status, target_version, fields,
+                            conversation_id, service
                      FROM credential_requests WHERE id = ?1",
                 )
                 .map_err(|e| Error::Storage(e.to_string()))?;
@@ -673,6 +708,8 @@ impl CredentialRequestStore {
                         row.get::<_, String>(3)?,
                         row.get::<_, Option<i64>>(4)?,
                         row.get::<_, Option<String>>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        row.get::<_, Option<String>>(7)?,
                     ))
                 })
                 .map_err(|e| match e {
@@ -688,6 +725,8 @@ impl CredentialRequestStore {
                 status: row.3,
                 target_version: row.4,
                 fields: decode_fields(row.5.as_deref()),
+                conversation_id: row.6,
+                service: row.7,
             })
         })
         .await
@@ -701,6 +740,11 @@ struct StoredRequest {
     status: String,
     target_version: Option<i64>,
     fields: Vec<RequestedField>,
+    /// Who asked, so fulfilling can wake them.
+    conversation_id: Option<String>,
+    /// Carried alongside so the woken turn can name the service in words
+    /// the user recognises, rather than the store key.
+    service: Option<String>,
 }
 
 /// A row written before the column existed, or one holding junk, yields no
@@ -1137,5 +1181,143 @@ mod link_tests {
             .await
             .expect("lookup")
             .is_some());
+    }
+}
+
+#[cfg(test)]
+mod wake_tests {
+    use super::fulfil_tests::gmail_fields;
+    use super::*;
+
+    /// Records what it was told, so the assertion reads the hook's
+    /// arguments rather than trusting a log line.
+    #[derive(Debug, Default)]
+    struct RecordingNotifier {
+        fulfilled: Mutex<Vec<(Option<String>, String, Option<String>)>>,
+    }
+
+    impl RequestNotifier for RecordingNotifier {
+        fn request_filed(&self, _credential_name: &str, _action: &str) {}
+
+        fn request_fulfilled(
+            &self,
+            conversation_id: Option<&str>,
+            credential_name: &str,
+            service: Option<&str>,
+        ) {
+            self.fulfilled.lock().unwrap().push((
+                conversation_id.map(str::to_string),
+                credential_name.to_string(),
+                service.map(str::to_string),
+            ));
+        }
+    }
+
+    fn store_with(notifier: Arc<RecordingNotifier>) -> (tempfile::TempDir, CredentialRequestStore) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = crate::Store::open(dir.path(), vec![7u8; 32])
+            .expect("open")
+            .with_credential_backend(Arc::new(crate::credential_backend::MemoryBackend::new()))
+            .with_request_notifier(notifier);
+        let requests = store.credential_requests();
+        (dir, requests)
+    }
+
+    fn answers() -> Vec<(String, String)> {
+        vec![
+            ("gmail_email".to_string(), "a@example.com".to_string()),
+            ("gmail_app_password".to_string(), "pw".to_string()),
+        ]
+    }
+
+    /// The wake needs the conversation that asked, and it has to survive
+    /// the round trip: written when the request is filed, read back when
+    /// it is fulfilled.
+    #[tokio::test]
+    async fn fulfilling_announces_the_conversation_that_asked() {
+        let notifier = Arc::new(RecordingNotifier::default());
+        let (_dir, requests) = store_with(notifier.clone());
+
+        let conv = Uuid::new_v4();
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                Some(conv),
+            )
+            .await
+            .expect("file");
+        requests
+            .fulfil(&id, &answers(), "test")
+            .await
+            .expect("fulfil");
+
+        let seen = notifier.fulfilled.lock().unwrap();
+        assert_eq!(seen.len(), 1, "one wake per fulfilment");
+        assert_eq!(
+            seen[0].0.as_deref(),
+            Some(conv.to_string().as_str()),
+            "the wake must name the conversation that filed the request"
+        );
+        assert_eq!(seen[0].1, "gmail_app_password");
+        // Carried so the resumed turn can say "Gmail", not the store key.
+        assert_eq!(seen[0].2.as_deref(), Some("Gmail"));
+    }
+
+    /// A request filed outside a runner scope still fulfils. It simply
+    /// has nothing to wake, which is not an error.
+    #[tokio::test]
+    async fn a_request_with_no_conversation_still_fulfils() {
+        let notifier = Arc::new(RecordingNotifier::default());
+        let (_dir, requests) = store_with(notifier.clone());
+
+        let id = requests
+            .file_fulfil("gmail_app_password", None, gmail_fields(), None, None)
+            .await
+            .expect("file");
+        requests
+            .fulfil(&id, &answers(), "test")
+            .await
+            .expect("fulfil");
+
+        let seen = notifier.fulfilled.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].0, None, "nothing to resume, and that is fine");
+    }
+
+    /// A failed fulfil must not announce success. The credential never
+    /// landed, so waking the agent would resume it into a turn that still
+    /// cannot proceed.
+    #[tokio::test]
+    async fn a_rejected_fulfil_wakes_nothing() {
+        let notifier = Arc::new(RecordingNotifier::default());
+        let (_dir, requests) = store_with(notifier.clone());
+
+        let id = requests
+            .file_fulfil(
+                "gmail_app_password",
+                Some("Gmail".into()),
+                gmail_fields(),
+                None,
+                Some(Uuid::new_v4()),
+            )
+            .await
+            .expect("file");
+        // A field the request never asked for.
+        let result = requests
+            .fulfil(
+                &id,
+                &[("anthropic_api_key".to_string(), "sk-x".to_string())],
+                "test",
+            )
+            .await;
+
+        assert!(result.is_err(), "an unrequested field must be refused");
+        assert!(
+            notifier.fulfilled.lock().unwrap().is_empty(),
+            "a refused fulfil must not wake anything"
+        );
     }
 }

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -52,6 +52,12 @@ pub struct BrowserTool {
     manager: BrowserManager,
     snapshot_store: SnapshotStore,
     adaptive_store: AdaptiveStore,
+    /// Read access to stored credentials, for `fill_credential`.
+    ///
+    /// Optional so a browser built without a store still works for
+    /// everything else; the action reports itself unavailable rather than
+    /// the tool disappearing.
+    secrets: Option<rustykrab_store::GuardedSecrets>,
 }
 
 impl BrowserTool {
@@ -60,7 +66,15 @@ impl BrowserTool {
             manager: BrowserManager::from_config(),
             snapshot_store: SnapshotStore::new(),
             adaptive_store: AdaptiveStore::new(),
+            secrets: None,
         }
+    }
+
+    /// Let the browser type a stored credential without the model ever
+    /// holding it.
+    pub fn with_secrets(mut self, secrets: rustykrab_store::GuardedSecrets) -> Self {
+        self.secrets = Some(secrets);
+        self
     }
 
     /// Resolve the profile name from args, falling back to the default.
@@ -157,9 +171,14 @@ impl Tool for BrowserTool {
                             "navigate", "snapshot", "act", "screenshot",
                             "content", "evaluate", "scroll",
                             "console", "cookies", "pdf",
-                            "fetch", "stealth_fetch", "select", "wait_for"
+                            "fetch", "stealth_fetch", "select", "wait_for",
+                            "fill_credential"
                         ],
                         "description": "Action to perform"
+                    },
+                    "field": {
+                        "type": "string",
+                        "description": "Which part of the login to fill (fill_credential action): 'username' or 'password'. Defaults to 'password'."
                     },
                     "profile": {
                         "type": "string",
@@ -572,6 +591,74 @@ impl Tool for BrowserTool {
 
                 actions::execute_act(&page, &self.snapshot_store, &key, act_action, ref_id, &args)
                     .await
+            }
+            // Type a stored credential into a field without the value
+            // passing through the model.
+            //
+            // `act` with `fill` would work mechanically, but only by
+            // putting the password in `text` — which means in the tool
+            // call, in the conversation, and in every transcript. The
+            // whole point of asking the user through a secure field is
+            // that the value never reaches the context window, and a
+            // fill action that undoes that on the way back in would make
+            // the rest of this pointless.
+            "fill_credential" => {
+                let ref_id = args["ref"].as_str().ok_or_else(|| {
+                    Error::ToolExecution(
+                        "'fill_credential' requires 'ref' from a previous snapshot".into(),
+                    )
+                })?;
+                let field = args["field"].as_str().unwrap_or(crate::PASSWORD);
+                let secrets = self.secrets.as_ref().ok_or_else(|| {
+                    Error::ToolExecution(
+                        "credential fill is unavailable: this browser has no credential store"
+                            .into(),
+                    )
+                })?;
+
+                let _ = self.manager.get_browser(&profile).await?;
+                let page = self.manager.get_page(&profile, target_id).await?;
+
+                // The page's own URL, so the key matches wherever the
+                // agent actually is rather than where it meant to be.
+                let url = match args["url"].as_str() {
+                    Some(u) => u.to_string(),
+                    None => page.url().await.ok().flatten().unwrap_or_default(),
+                };
+                let cred_key = crate::origin_credential_key(&url, field)?;
+
+                let value = secrets.get(&cred_key).await.map_err(|_| {
+                    // Names the key so the agent can ask for exactly it.
+                    Error::ToolExecution(
+                        format!(
+                            "no credential stored under '{cred_key}'. Ask the user for it with \
+                             credential_request using that exact name, then try again."
+                        )
+                        .into(),
+                    )
+                })?;
+
+                let store_key = Self::store_key(&profile, target_id);
+                let fill_args = json!({ "text": value, "clear": true });
+                actions::execute_act(
+                    &page,
+                    &self.snapshot_store,
+                    &store_key,
+                    "fill",
+                    ref_id,
+                    &fill_args,
+                )
+                .await?;
+
+                // A fresh result rather than the fill's own. Nothing
+                // derived from the value travels back to the model — not
+                // its length, which for a password is worth guessing with.
+                Ok(json!({
+                    "status": "filled",
+                    "field": field,
+                    "credentialKey": cred_key,
+                    "ref": ref_id,
+                }))
             }
 
             // ── Screenshot ─────────────────────────────────────────

--- a/crates/rustykrab-tools/src/credential_link.rs
+++ b/crates/rustykrab-tools/src/credential_link.rs
@@ -1,0 +1,98 @@
+//! Minting the one-time link a user opens to hand over a credential.
+//!
+//! Shared by every path that files a request. `credential_request` had
+//! this inline and `gmail` had nothing, which meant the tool that files
+//! most of the requests in practice — measured at 25/25 against
+//! `browser`'s 1/9 — was also the one that could only ever say "open the
+//! app". On Telegram or Signal there is no app in the loop, so that reply
+//! is a dead end.
+
+use std::time::Duration;
+
+use rustykrab_store::CredentialRequestStore;
+
+/// How long a credential link stays good.
+///
+/// Long enough to walk to a phone and generate an app password, short
+/// enough that a link left in a chat log is usually already dead.
+pub const LINK_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// A one-time URL for `request_id`, or `None` when no public base URL is
+/// configured.
+///
+/// The token is minted here and returned exactly once, to be put in the
+/// message the user receives; only its hash is stored. Failure to mint is
+/// not failure to ask — the request is already filed and answerable in
+/// the app, so this logs and returns `None` rather than propagating.
+pub async fn mint_link(requests: &CredentialRequestStore, request_id: &str) -> Option<String> {
+    let base = std::env::var("RUSTYKRAB_PUBLIC_URL")
+        .ok()
+        .map(|u| u.trim_end_matches('/').to_string())
+        .filter(|u| !u.is_empty())?;
+
+    match requests.issue_link(request_id, LINK_TTL).await {
+        Ok(token) => Some(format!("{base}/c/{token}")),
+        Err(e) => {
+            tracing::warn!(error = %e, "could not mint a credential link");
+            None
+        }
+    }
+}
+
+/// What to tell the model to do next, given a link or the lack of one.
+///
+/// Kept next to the minting so the two cannot drift: the difference
+/// between these branches is exactly whether `mint_link` returned
+/// something, and every caller needs both.
+///
+/// Both branches say to stop. An agent that files a request and then
+/// keeps working will either invent a value or report failure, and both
+/// are worse than waiting.
+pub fn next_step(link: Option<&str>, service: &str) -> String {
+    match link {
+        Some(url) => format!(
+            "Give the user this link and nothing else about the credential: {url} \
+             — say it opens a secure form for their {service} details, that it \
+             works once and expires in {} minutes. Do not ask for the value in \
+             chat. Stop this task until they answer.",
+            LINK_TTL.as_secs() / 60
+        ),
+        None => format!(
+            "Tell the user you have asked for their {service} details and that a \
+             prompt is waiting in the Apollo app. Do not ask for the value in \
+             chat. Stop this task until they answer."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_link_branch_carries_the_url_and_its_lifetime() {
+        let s = next_step(Some("https://mac.example.ts.net/c/abc"), "Gmail");
+        assert!(s.contains("https://mac.example.ts.net/c/abc"));
+        assert!(
+            s.contains("15 minutes"),
+            "the user needs to know it expires"
+        );
+        assert!(s.contains("Gmail"));
+    }
+
+    #[test]
+    fn both_branches_tell_the_agent_to_stop() {
+        // An agent that carries on after asking is the failure mode this
+        // whole flow exists to avoid; neither branch may omit it.
+        assert!(next_step(Some("https://x/c/t"), "Gmail").contains("Stop this task"));
+        assert!(next_step(None, "Gmail").contains("Stop this task"));
+    }
+
+    #[test]
+    fn neither_branch_invites_asking_in_chat() {
+        assert!(
+            next_step(Some("https://x/c/t"), "Gmail").contains("Do not ask for the value in chat")
+        );
+        assert!(next_step(None, "Gmail").contains("Do not ask for the value in chat"));
+    }
+}

--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -2,15 +2,7 @@ use async_trait::async_trait;
 use rustykrab_core::active_tools::with_session_context;
 use rustykrab_core::types::ToolSchema;
 use rustykrab_core::{Error, Result, Tool};
-use std::time::Duration;
-
 use rustykrab_store::{CredentialRequestStore, RequestedField};
-
-/// How long a credential link stays good.
-///
-/// Long enough to walk to a phone and generate an app password, short
-/// enough that a link left in a chat log is usually already dead.
-const LINK_TTL: Duration = Duration::from_secs(15 * 60);
 use serde_json::{json, Value};
 
 /// Asks the user for a credential the agent does not have.
@@ -58,7 +50,33 @@ impl Tool for CredentialRequestTool {
          {\"name\": \"gmail_app_password\", \"service\": \"Gmail\", \
          \"reason\": \"to search your inbox\", \"fields\": [\
          {\"key\": \"gmail_email\", \"label\": \"Gmail address\", \"secret\": false}, \
-         {\"key\": \"gmail_app_password\", \"label\": \"App password\", \"secret\": true}]}"
+         {\"key\": \"gmail_app_password\", \"label\": \"App password\", \"secret\": true}]}\n\n\
+         For a website login, name the keys after the site's host so the same \
+         site always gets the same names: web_<host>_username and \
+         web_<host>_password, with every dot and dash written as an \
+         underscore. https://portal.example.com/login therefore gives \
+         web_portal_example_com_username and web_portal_example_com_password. \
+         Drop any leading 'www.'. Getting this right matters — the browser \
+         looks the credential up under exactly this name.\n\n\
+         Example — a website login:\n\
+         {\"name\": \"web_portal_example_com_password\", \"service\": \
+         \"portal.example.com\", \"reason\": \"to download your invoice\", \
+         \"fields\": [\
+         {\"key\": \"web_portal_example_com_username\", \"label\": \"Username\", \"secret\": false}, \
+         {\"key\": \"web_portal_example_com_password\", \"label\": \"Password\", \"secret\": true}]}\n\n\
+         Once stored, sign in with browser(action='fill_credential', ref=..., \
+         field='username'|'password') — it types the value straight into the \
+         page. Never read a password back with credential_read to type it \
+         yourself: that puts it in this conversation, which is the one thing \
+         this whole flow exists to avoid."
+    }
+
+    /// Once the request is filed there is nothing further the agent can
+    /// do until the user answers, so the turn should end with one
+    /// sentence saying so — not be pushed toward a `task_complete` it
+    /// cannot honestly call.
+    fn blocks_turn(&self) -> bool {
+        true
     }
 
     fn schema(&self) -> ToolSchema {
@@ -167,39 +185,9 @@ impl Tool for CredentialRequestTool {
         // Apollo app can render this request from the pending list, but on
         // Telegram or Signal there is no app in the loop — a tappable URL
         // is the only way to hand someone a password field from a chat
-        // message. The token is minted here and shown once; only its hash
-        // is stored.
-        let link = match std::env::var("RUSTYKRAB_PUBLIC_URL")
-            .ok()
-            .map(|u| u.trim_end_matches('/').to_string())
-            .filter(|u| !u.is_empty())
-        {
-            Some(base) => match self.requests.issue_link(&id, LINK_TTL).await {
-                Ok(token) => Some(format!("{base}/c/{token}")),
-                Err(e) => {
-                    // The request is filed and answerable in the app; only
-                    // the convenience of a link is lost.
-                    tracing::warn!(error = %e, "could not mint a credential link");
-                    None
-                }
-            },
-            None => None,
-        };
-
-        let next_step = match &link {
-            Some(url) => format!(
-                "Give the user this link and nothing else about the credential: {url} \
-                 — say it opens a secure form for their {where_to_look} details, that \
-                 it works once and expires in {} minutes. Do not ask for the value in \
-                 chat. Stop this task until they answer.",
-                LINK_TTL.as_secs() / 60
-            ),
-            None => format!(
-                "Tell the user you have asked for their {where_to_look} details \
-                 and that a prompt is waiting in the Apollo app. Do not ask for \
-                 the value in chat. Stop this task until they answer."
-            ),
-        };
+        // message.
+        let link = crate::credential_link::mint_link(&self.requests, &id).await;
+        let next_step = crate::credential_link::next_step(link.as_deref(), &where_to_look);
 
         Ok(json!({
             "status": "requested",

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -170,13 +170,24 @@ impl GmailTool {
                 KEY_APP_PASSWORD,
                 Some("Gmail".to_string()),
                 fields,
-                Some(format!("so it can use your Gmail account — it needs {needs}")),
+                Some(format!(
+                    "so it can use your Gmail account — it needs {needs}"
+                )),
                 conversation_id,
             )
             .await
         {
-            Ok(_) => " A prompt asking for them is now waiting in the Apollo app —                        tell the user that, in one sentence, and stop. Do not ask for                        the password in chat and do not retry until they answer."
-                .to_string(),
+            Ok(id) => {
+                // Gmail files most of the requests that ever get filed, so
+                // without this it is also the path that most often leaves
+                // the user with "open the app" and no way to answer from
+                // the chat they are actually in.
+                let link = crate::credential_link::mint_link(requests, &id).await;
+                format!(
+                    " {}",
+                    crate::credential_link::next_step(link.as_deref(), "Gmail")
+                )
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "could not file a Gmail credential request");
                 String::new()

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "512"]
 
 // Security utilities
+pub mod credential_link;
+pub mod origin_key;
 pub mod sanitize;
 pub mod security;
 pub mod stub;
@@ -191,6 +193,7 @@ pub use wiki::WikiTool;
 pub use credential_read::CredentialReadTool;
 pub use credential_request::CredentialRequestTool;
 pub use credential_write::CredentialWriteTool;
+pub use origin_key::{origin_credential_key, PASSWORD, USERNAME};
 
 // Skills
 pub use self::skills::{SkillTool, SkillsTool};
@@ -241,7 +244,7 @@ pub fn builtin_tools(
         // Media
         std::sync::Arc::new(ImageTool::new()),
         // UI
-        std::sync::Arc::new(BrowserTool::new()),
+        std::sync::Arc::new(BrowserTool::new().with_secrets(guarded.clone())),
         std::sync::Arc::new(CanvasTool::new()),
         // Devices
         std::sync::Arc::new(NodesTool::new()),

--- a/crates/rustykrab-tools/src/origin_key.rs
+++ b/crates/rustykrab-tools/src/origin_key.rs
@@ -1,0 +1,159 @@
+//! Deterministic store keys for website logins.
+//!
+//! A website credential has no natural name the way `gmail_app_password`
+//! does. Left to invent one, the agent picks a different string each time
+//! — and `name` is the dedupe key on a credential request, so three
+//! spellings of the same login become three pending asks and none of them
+//! can be found again afterwards.
+//!
+//! Deriving the key from the URL removes the choice. The same site always
+//! produces the same key, so the agent can file a request for a login it
+//! has never seen and read it back later without anything recording a
+//! mapping.
+
+use rustykrab_core::{Error, Result};
+
+/// The value a person types into the first box.
+pub const USERNAME: &str = "username";
+/// The value a person types into the second box.
+pub const PASSWORD: &str = "password";
+
+/// Store key for one field of a website login.
+///
+/// Keyed on host alone — not scheme, not port. A site reached over http
+/// once and https thereafter, or on an explicit port, is the same login
+/// to the person typing it; splitting the key would ask them for it
+/// twice. `www.` is stripped for the same reason.
+///
+/// ```text
+/// https://portal.example.com/login  + password -> web_portal_example_com_password
+/// https://www.portal.example.com/   + username -> web_portal_example_com_username
+/// ```
+///
+/// The result is restricted to the character set `SecretStore::validate_name`
+/// accepts, so a host with a hyphen or an internationalised name cannot
+/// produce a key the store will refuse.
+pub fn origin_credential_key(url: &str, field: &str) -> Result<String> {
+    let parsed = url::Url::parse(url).map_err(|e| {
+        Error::ToolExecution(format!("cannot derive a credential key from '{url}': {e}").into())
+    })?;
+    let host = parsed.host_str().ok_or_else(|| {
+        Error::ToolExecution(format!("'{url}' has no host, so there is no login to key on").into())
+    })?;
+    let host = host.strip_prefix("www.").unwrap_or(host);
+    if host.is_empty() {
+        return Err(Error::ToolExecution(
+            format!("'{url}' has an empty host").into(),
+        ));
+    }
+
+    let field = field.trim();
+    if field.is_empty() {
+        return Err(Error::ToolExecution(
+            "a credential key needs a field name, e.g. 'username' or 'password'".into(),
+        ));
+    }
+
+    let mut key = String::with_capacity(4 + host.len() + 1 + field.len());
+    key.push_str("web_");
+    push_sanitised(&mut key, host);
+    key.push('_');
+    push_sanitised(&mut key, field);
+    Ok(key)
+}
+
+/// Lowercase ASCII alphanumerics survive; everything else becomes `_`.
+///
+/// Deliberately lossy and deliberately not reversible. The key only has
+/// to be stable and legal, and collapsing punctuation means a host cannot
+/// smuggle a character the store rejects — or, worse, one that reads as a
+/// different key.
+fn push_sanitised(out: &mut String, raw: &str) {
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_same_site_always_yields_the_same_key() {
+        // Different paths, different schemes, one login.
+        let a = origin_credential_key("https://portal.example.com/login", PASSWORD).unwrap();
+        let b = origin_credential_key("https://portal.example.com/account/2", PASSWORD).unwrap();
+        let c = origin_credential_key("http://portal.example.com", PASSWORD).unwrap();
+        assert_eq!(a, "web_portal_example_com_password");
+        assert_eq!(a, b);
+        assert_eq!(a, c, "scheme is not part of the identity of a login");
+    }
+
+    #[test]
+    fn www_is_not_a_different_site() {
+        assert_eq!(
+            origin_credential_key("https://www.example.com/", USERNAME).unwrap(),
+            origin_credential_key("https://example.com/", USERNAME).unwrap()
+        );
+    }
+
+    #[test]
+    fn username_and_password_are_separate_keys() {
+        let u = origin_credential_key("https://example.com", USERNAME).unwrap();
+        let p = origin_credential_key("https://example.com", PASSWORD).unwrap();
+        assert_ne!(u, p);
+        assert_eq!(u, "web_example_com_username");
+        assert_eq!(p, "web_example_com_password");
+    }
+
+    #[test]
+    fn a_port_does_not_split_the_login() {
+        assert_eq!(
+            origin_credential_key("https://example.com:8443/login", PASSWORD).unwrap(),
+            origin_credential_key("https://example.com/login", PASSWORD).unwrap()
+        );
+    }
+
+    /// Every derived key must be storable. `SecretStore::validate_name`
+    /// accepts only alphanumerics, `_`, `-` and `.`, so a host carrying
+    /// anything else has to be collapsed rather than passed through.
+    #[test]
+    fn derived_keys_are_always_storable() {
+        for url in [
+            "https://my-bank.example.co.uk/login",
+            "https://xn--bcher-kva.example/",
+            "https://198.51.100.7:9000/",
+            "https://a_b.example.com/",
+        ] {
+            let key = origin_credential_key(url, PASSWORD).unwrap();
+            assert!(
+                key.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.'),
+                "{url} produced an unstorable key: {key}"
+            );
+            assert!(!key.is_empty());
+        }
+    }
+
+    #[test]
+    fn distinct_hosts_do_not_collide() {
+        let a = origin_credential_key("https://a.example.com", PASSWORD).unwrap();
+        let b = origin_credential_key("https://b.example.com", PASSWORD).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn a_url_with_no_host_is_refused() {
+        assert!(origin_credential_key("not a url", PASSWORD).is_err());
+        assert!(origin_credential_key("file:///etc/passwd", PASSWORD).is_err());
+    }
+
+    #[test]
+    fn an_empty_field_is_refused() {
+        assert!(origin_credential_key("https://example.com", "  ").is_err());
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,9 +69,14 @@ PB=(/usr/libexec/PlistBuddy -c)
 "${PB[@]}" "Add :EnvironmentVariables:HOME string $HOME" "$PLIST"
 "${PB[@]}" 'Add :EnvironmentVariables:PATH string /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin' "$PLIST"
 
+# Anything not listed here never reaches the installed daemon, however it was
+# set at install time. The credential-page settings are on the list because
+# without RUSTYKRAB_PUBLIC_URL the agent cannot mint a link at all, and the
+# failure is silent — it just falls back to telling the user to open the app.
 for key in RUSTYKRAB_PROVIDER RUSTYKRAB_PORT RUSTYKRAB_WEB_UI RUST_LOG \
     OLLAMA_BASE_URL OLLAMA_MODEL OLLAMA_NUM_CTX RUSTYKRAB_NUM_CTX \
-    TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN; do
+    TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN \
+    RUSTYKRAB_PUBLIC_URL RUSTYKRAB_TAILNET_USERS RUSTYKRAB_ALLOWED_ORIGINS; do
     if [[ -n "${!key:-}" ]]; then
         "${PB[@]}" "Add :EnvironmentVariables:$key string ${!key}" "$PLIST"
     fi


### PR DESCRIPTION
**Stack 2/4** — targets `cred/1-attribute-ask` (#555). Review that one first; this reads the column it populates.

## Problem

Filing a request told the user a turn was blocked. Nothing told the turn when it stopped being blocked. `fulfil()` wrote the credential, marked the row approved, returned `204` — and the conversation sat there until the user thought to ask again.

## Approach

`RequestNotifier` gains a defaulted `request_fulfilled`, fired from `fulfil()` **after** the credential is durable and the row is decided. Firing earlier could resume a turn that then reads a credential which is not there yet, and the agent would conclude the user's answer had failed.

In the CLI, `CredentialNotifier` carries both halves of the loop — filing goes outward (APNs), fulfilling goes inward (task queue) — so the store keeps one hook and neither half can be wired without the other.

## Three decisions worth flagging

**Attached unconditionally.** The push notifier was created only when APNs was configured. Reusing that gate would have silently disabled resume on any deployment without push — including this one, where `apns_auth_key` is unset. The wake does not need APNs.

**The wake carries no channel.** `TaskSource::CredentialFulfilled` holds only the conversation and credential name. The conversation already records where it came from and `resolve_delivery_target` reads it, so a resumed answer lands where the user actually asked. A wake that guessed its own target could answer somewhere they never spoke from.

**`OnceLock` for the queue.** `TaskQueue` needs `AppState`, which is built well after the store, so the notifier cannot hold it directly. A credential answered before the queue is ready logs and drops rather than queueing against a dead channel.

## Refactor included

Cron's ~70-line channel-routing match is extracted as `deliver_response` and shared. Both paths end identically — some text and a `(channel, chat, thread)` triple — and a second copy would drift the moment one gained a channel the other did not. Behaviour is unchanged; the log field is now `target` rather than `job_id`, since it names a credential on the wake path.

## Dedupe

Keyed on the conversation. Answering two fields of one request, or two requests together, must not start two agent runs over the same history.

## Test

Three new tests in `wake_tests`, and they assert against the hook's arguments rather than a log line:

- the wake names the conversation that filed the request, surviving the round trip through SQLite
- a request filed with no conversation still fulfils — nothing to wake is not an error
- **a refused fulfil wakes nothing** — an unrequested field is rejected and no wake fires, so the agent is never resumed into a turn that still cannot proceed

`cargo test -p rustykrab-store` 80 passed. fmt and clippy clean.

## Not covered here

End-to-end proof that a resumed agent finishes the job needs the link path to be reachable, which is 4/4. The parts under test here are the hook, its arguments, and its refusal cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)