### PR TITLE
fix(agent): let a turn end when it is blocked on the user

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1399,6 +1399,11 @@ impl AgentRunner {
         // turn, but once the model has started using tools we expect an
         // explicit completion signal.
         let mut has_called_any_tool = false;
+        // Set when a tool reports the turn is now waiting on someone
+        // else. Not reset per iteration: once the agent has asked the
+        // user for something, every later EndTurn this run is a stop,
+        // not an early exit.
+        let mut turn_blocked = false;
         // Per-run cache of the schemas sent to the model, keyed by the
         // active-set version so activations performed by `tools_load`
         // during the previous iteration are reflected in the next API
@@ -1550,6 +1555,26 @@ impl AgentRunner {
                     }
                 }
 
+                // A tool that succeeded and blocks the turn (e.g. asking
+                // the user for a credential) means the right next move is
+                // one sentence and a stop.
+                if !turn_blocked {
+                    for (tool_name, _, result) in &results {
+                        if result.is_ok() {
+                            if let Some(t) = self.tool_index.get(tool_name) {
+                                if t.blocks_turn() {
+                                    turn_blocked = true;
+                                    tracing::info!(
+                                        tool = %tool_name,
+                                        "turn is blocked on the user — EndTurn will be accepted"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let had_errors = results.iter().any(|(_, _, r)| {
                     if let Ok(tr) = r {
                         tr.output.get("error").is_some()
@@ -1646,7 +1671,7 @@ impl AgentRunner {
                     // working. Cap by `TASK_COMPLETE_RETRY_LIMIT` so models
                     // that never learn the protocol fall through to the
                     // legacy accept-and-return behavior.
-                    if has_called_any_tool {
+                    if has_called_any_tool && !turn_blocked {
                         match self.reprompt_for_task_complete(
                             conv,
                             iteration,
@@ -1849,6 +1874,11 @@ impl AgentRunner {
         let mut task_complete_retries: usize = 0;
         let mut had_side_effects = false;
         let mut has_called_any_tool = false;
+        // Set when a tool reports the turn is now waiting on someone
+        // else. Not reset per iteration: once the agent has asked the
+        // user for something, every later EndTurn this run is a stop,
+        // not an early exit.
+        let mut turn_blocked = false;
         // Per-run schema cache — see run_inner for rationale.
         let mut schema_cache: Option<(u64, Vec<ToolSchema>)> = None;
 
@@ -1991,6 +2021,26 @@ impl AgentRunner {
                     }
                 }
 
+                // A tool that succeeded and blocks the turn (e.g. asking
+                // the user for a credential) means the right next move is
+                // one sentence and a stop.
+                if !turn_blocked {
+                    for (tool_name, _, result) in &results {
+                        if result.is_ok() {
+                            if let Some(t) = self.tool_index.get(tool_name) {
+                                if t.blocks_turn() {
+                                    turn_blocked = true;
+                                    tracing::info!(
+                                        tool = %tool_name,
+                                        "turn is blocked on the user — EndTurn will be accepted"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let had_errors = results.iter().any(|(_, _, r)| {
                     if let Ok(tr) = r {
                         tr.output.get("error").is_some()
@@ -2091,7 +2141,7 @@ impl AgentRunner {
                     // EndTurn no longer terminates: re-prompt the model to
                     // either call `task_complete` or keep working. See
                     // run_inner for the full rationale.
-                    if has_called_any_tool {
+                    if has_called_any_tool && !turn_blocked {
                         match self.reprompt_for_task_complete(
                             conv,
                             iteration,
@@ -5346,6 +5396,99 @@ mod task_complete_tests {
             })
             .count();
         assert_eq!(reminder_count, TASK_COMPLETE_RETRY_LIMIT);
+    }
+
+    /// A tool that blocks the turn, and is otherwise a noop.
+    struct BlockingTool;
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "ask_the_user"
+        }
+        fn description(&self) -> &str {
+            "test blocking tool"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema {
+                name: "ask_the_user".into(),
+                description: "test blocking tool".into(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+        fn blocks_turn(&self) -> bool {
+            true
+        }
+        async fn execute(&self, _args: serde_json::Value) -> Result<serde_json::Value> {
+            Ok(serde_json::json!({"status": "requested"}))
+        }
+    }
+
+    fn runner_with_blocking_tool(provider: Arc<ScriptedProvider>) -> (AgentRunner, Session, Uuid) {
+        use rustykrab_tools::TaskCompleteTool;
+        let active = Arc::new(ActiveToolsRegistry::new());
+        let tools: Vec<Arc<dyn Tool>> =
+            vec![Arc::new(BlockingTool), Arc::new(TaskCompleteTool::new())];
+        let runner = AgentRunner::new(provider, tools, Arc::new(NoSandbox))
+            .with_active_tools(active.clone());
+        let conv_id = Uuid::new_v4();
+        active.activate(conv_id, ["ask_the_user"]);
+        let caps = CapabilitySet::for_tools_permissive(&["ask_the_user", "task_complete"]);
+        let session = Session::with_capabilities(conv_id, caps);
+        (runner, session, conv_id)
+    }
+
+    /// Asking the user for something is a legitimate reason to stop, and
+    /// the loop must let the turn end.
+    ///
+    /// Without this the runner demands `task_complete` after any tool
+    /// call. The model cannot honestly call it — the task is blocked, not
+    /// done — so it churns instead. Observed against gemma4:26b: the
+    /// agent filed a credential request at iteration 29 and was still
+    /// going at 46, calling `todo_write` and `exec` to fill the turns.
+    #[tokio::test]
+    async fn a_blocked_turn_ends_without_task_complete() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("ask_the_user", serde_json::json!({})),
+            // The one sentence telling the user, then stop.
+            text_response("I've asked for your Gmail app password."),
+        ]));
+        let (runner, session, conv_id) = runner_with_blocking_tool(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        // Two calls: the tool use, and the sentence. A third would mean
+        // the runner re-prompted for `task_complete`.
+        assert_eq!(
+            *provider.chat_count.lock().unwrap(),
+            2,
+            "a blocked turn must not be re-prompted for task_complete"
+        );
+    }
+
+    /// The suppression is specific to blocking tools — an ordinary tool
+    /// followed by a bare EndTurn must still be re-prompted, or this fix
+    /// would disable the completion protocol wholesale.
+    #[tokio::test]
+    async fn a_normal_tool_is_still_reprompted() {
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            tool_use_response("noop", serde_json::json!({})),
+            text_response("I'll keep digging into this for you."),
+            tool_use_response("task_complete", serde_json::json!({ "summary": "done" })),
+        ]));
+        let (runner, session, conv_id) = make_runner(provider.clone());
+        let mut conv = make_conv();
+        conv.id = conv_id;
+
+        runner.run(&mut conv, &session).await.unwrap();
+
+        assert_eq!(
+            *provider.chat_count.lock().unwrap(),
+            3,
+            "a non-blocking tool must still be held to the completion protocol"
+        );
     }
 }
 

--- a/crates/rustykrab-core/src/tool.rs
+++ b/crates/rustykrab-core/src/tool.rs
@@ -67,6 +67,26 @@ pub trait Tool: Send + Sync {
         SandboxRequirements::default()
     }
 
+    /// Whether a successful call leaves the turn waiting on someone else.
+    ///
+    /// The agent loop does not trust a bare `EndTurn` once tools have been
+    /// called — providers map any text-only reply to it regardless of
+    /// intent — so it re-prompts for `task_complete`. That is right for a
+    /// model that stopped early, and wrong for one that stopped because it
+    /// is blocked: the task is not complete, cannot be completed, and no
+    /// amount of nudging changes that. The model then either churns to the
+    /// iteration cap or invents progress it has not made.
+    ///
+    /// A tool that returns `true` here says the correct next move is to
+    /// tell the user and stop. The loop lets the following `EndTurn` end
+    /// the turn instead of re-prompting.
+    ///
+    /// Only consulted when the call *succeeded*. A tool that failed to
+    /// block on anything has not blocked anything.
+    fn blocks_turn(&self) -> bool {
+        false
+    }
+
     /// Execute the tool with the given arguments, returning a JSON result.
     async fn execute(&self, args: Value) -> Result<Value>;
 }

--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -71,6 +71,14 @@ impl Tool for CredentialRequestTool {
          this whole flow exists to avoid."
     }
 
+    /// Once the request is filed there is nothing further the agent can
+    /// do until the user answers, so the turn should end with one
+    /// sentence saying so — not be pushed toward a `task_complete` it
+    /// cannot honestly call.
+    fn blocks_turn(&self) -> bool {
+        true
+    }
+
     fn schema(&self) -> ToolSchema {
         ToolSchema {
             name: self.name().to_string(),


### PR DESCRIPTION
**Stack 5/5** — targets `cred/4-produce-the-link` (#558).

## The behaviour

From the credential eval, against gemma4:26b:

```
iteration=29  tools=["credential_request"]   tool call succeeded
iteration=30  EndTurn without task_complete — re-prompting
iteration=44  tools=["todo_write"]
iteration=45  tools=["exec"]
...still running at 46
```

The agent asked for the credential correctly at 29, then kept working for another seventeen iterations with nothing to do. One trial ran over nine minutes without finishing.

## Why

The loop does not trust a bare `EndTurn` once tools have been called — providers map any text-only reply to `EndTurn` regardless of intent — so it re-prompts for `task_complete`. That is correct for a model that stopped early. It is wrong for one that stopped because it is *blocked*: the task is not complete, cannot be completed, and no amount of nudging will change that. The model's options are to churn or to claim progress it has not made.

`credential_request`'s own `next_step` already tells it to stop. The harness was overriding that.

## Change

`Tool::blocks_turn()` — defaulted `false` — lets a tool declare that a successful call leaves the turn waiting on someone else. `credential_request` returns `true`. The loop tracks it and skips the re-prompt.

Three details:

- **Only on success.** A tool that failed to block on anything has not blocked anything, so the flag is set from the same `result.is_ok()` scan that drives `had_side_effects`.
- **Sticky for the run**, not per-iteration. Once the user has been asked, every later `EndTurn` this run is a stop.
- **Both loops.** The streaming and non-streaming paths carry separate copies of this logic; missing one would leave the bug live on whichever surface used it.

## Test

- `a_blocked_turn_ends_without_task_complete` — exactly two provider calls: the tool use, then the sentence. A third would mean it re-prompted.
- `a_normal_tool_is_still_reprompted` — an ordinary tool followed by a bare `EndTurn` is still held to the protocol. Without this the fix could disable completion enforcement wholesale and the first test would not notice.

`cargo test -p rustykrab-agent` 122 passed. clippy and fmt clean.

## Why it matters beyond the churn

Every rate the credential suite reports is measured from trials that run to completion. While the agent burns seventeen iterations after a successful ask, trials time out and land in `Outcome::Timeout` — which scores as neither a success nor an honest failure. The numbers are not trustworthy until this is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)