### PR TITLE
fix(browser): tell the model that fill_credential exists

### DIFF
--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -223,6 +223,10 @@ async fn execute_credential_wake(
     // see the note on `TaskSource::CredentialFulfilled`.
     let (channel, chat_id, thread_id) = resolve_delivery_target(None, None, None, &conv);
 
+    // Message ids as they stand before this turn, so `save_turn` appends
+    // what the resume adds instead of rewriting the history.
+    let persisted: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+
     push_scheduled_user_turn(&mut conv, prompt);
 
     let run_options = rustykrab_gateway::RunOptions {
@@ -264,6 +268,23 @@ async fn execute_credential_wake(
             return;
         }
     };
+
+    // Persist before delivering. A user who receives an answer the
+    // conversation has no record of will find the agent has forgotten it
+    // on the next turn -- and the resumed turn is exactly the one that
+    // did the work they asked for.
+    if let Err(e) = state
+        .store
+        .conversations()
+        .save_turn(&conv, &persisted)
+        .await
+    {
+        tracing::error!(
+            credential = %credential_name,
+            conversation_id = %conversation_id,
+            "could not persist the resumed turn: {e}"
+        );
+    }
 
     deliver_response(
         credential_name,

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -141,6 +141,12 @@ impl Tool for BrowserTool {
          wait_for — wait for selector / network idle / fixed delay; \
          snapshot — accessibility-tree with element refs; \
          act — interact by ref (click/type/press/hover/select/drag); \
+         fill_credential — type a STORED credential into a field by ref, without \
+         ever seeing its value: pass 'ref' and 'field' ('username' or 'password'). \
+         Always sign in with this. Never use act/type for a password: you do not \
+         have the value, and typing a placeholder or the credential's own name just \
+         fails the login. If nothing is stored yet the error names the exact key — \
+         ask for it with credential_request under that name, then retry; \
          screenshot/content/evaluate/scroll/console/cookies/pdf. \
          Cookies persist across calls. Use snapshot + act for reliable element interaction. \
          If act returns status \"new_snapshot\", the page state moved on: the response \


### PR DESCRIPTION
**Stack 2/3** — targets `cred/6-ssrf-allowlist` (#560).

## What happened

`fill_credential` was added to the browser action enum in #557, but never to the tool's **description** — the prose the model reasons from, which explains every other action (`act`, `navigate`, `snapshot`, all of them). The model saw a bare enum value with nothing telling it what it was for.

Observed against gemma4:26b on a real login page, over a tailnet host. Having asked for and received the credential, it signed in like this:

```
LOGIN FAILED user='web_m1_max_64gb_tail84017e_ts_net_username' pw_len=42
```

42 characters is exactly the literal string `web_m1_max_64gb_tail84017e_ts_net_password`. It reached for `act`/`fill`, which requires a value it does not have, and typed the only strings available to it — the credential's own key names. It did this twice, including after the wake.

## Change

The description now names the action, says to sign in with it, and says explicitly not to use `act`/`type` for a password — the model has no password, so that path can only ever produce a failed login or an invented value. It also points at the error's named key when nothing is stored yet.

## What did not go wrong

The password never entered the model's context; the design never gives it one. Verified against the stored conversation: `PASSWORD EVER IN A TOOL ARGUMENT: False`. It failed safe. But a capability the model cannot discover is not a capability.

## Early signal

Re-running with the description in place, the agent stopped attempting a junk login before asking — it went navigate → navigate → snapshot → `credential_request`, with no `LOGIN FAILED` in the target site's log at all. Whether it now reaches for `fill_credential` on the resume is still being measured; #562 is required before that is even observable, because the resumed turn was not being persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)