### PR TITLE
fix(credentials): persist the turn a credential wake resumes

### DIFF
--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -223,6 +223,10 @@ async fn execute_credential_wake(
     // see the note on `TaskSource::CredentialFulfilled`.
     let (channel, chat_id, thread_id) = resolve_delivery_target(None, None, None, &conv);
 
+    // Message ids as they stand before this turn, so `save_turn` appends
+    // what the resume adds instead of rewriting the history.
+    let persisted: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+
     push_scheduled_user_turn(&mut conv, prompt);
 
     let run_options = rustykrab_gateway::RunOptions {
@@ -264,6 +268,23 @@ async fn execute_credential_wake(
             return;
         }
     };
+
+    // Persist before delivering. A user who receives an answer the
+    // conversation has no record of will find the agent has forgotten it
+    // on the next turn -- and the resumed turn is exactly the one that
+    // did the work they asked for.
+    if let Err(e) = state
+        .store
+        .conversations()
+        .save_turn(&conv, &persisted)
+        .await
+    {
+        tracing::error!(
+            credential = %credential_name,
+            conversation_id = %conversation_id,
+            "could not persist the resumed turn: {e}"
+        );
+    }
 
     deliver_response(
         credential_name,


### PR DESCRIPTION
**Stack 3/3** — targets `cred/7-advertise-fill-credential` (#562).

My bug, from #556, already merged.

## The defect

`execute_credential_wake` loads the conversation, runs the agent against it, and delivers the reply — but never writes it back. The scheduled-job path calls `save_meta`; the wake path called nothing.

So the resumed turn, the one that finally does the work the user asked for, leaves no trace. The user receives an answer and the conversation has no record of it. On the next turn the agent has forgotten both the question and what it did about it.

## How it surfaced

Not from a test — from trying to answer "which browser action actually performed the login?" after a successful run. The target site logged `LOGIN SUCCESS`, the daemon log showed seven browser calls in the resumed turn, and the stored conversation stopped dead at the credential request:

```
[2] browser {"action": "start"}
[4] browser {"action": "open", "url": "https://…/demo/"}
[6] browser {"action": "snapshot", "targetId": "tab_1"}
[8] credential_request {…}
[10] assistant: I've requested your credentials…
```

Nothing after. The work happened and was not recorded — which also means the run could not be audited, and that is how the gap became visible.

## Fix

`save_turn(&conv, &persisted)`, where `persisted` is the message ids captured before the resume, so only the new tail is appended rather than the history rewritten.

It runs **before** delivery. A user should not receive an answer the conversation cannot account for, and ordering it this way means a persistence failure is visible before the reply goes out rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)