### PR TITLE
feat(credentials): send the link as its own message, not through the model

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -863,6 +863,7 @@ async fn main() -> anyhow::Result<()> {
         store.secrets(),
         store.guarded_secrets(),
         store.credential_requests(),
+        store.pending_links(),
     );
     tools.extend(rustykrab_tools::memory_tools(memory_backend.clone()));
     tools.extend(rustykrab_tools::skill_tools(
@@ -1762,6 +1763,16 @@ async fn telegram_agent_loop(
             // Send response back to Telegram (in the correct thread).
             if let Err(e) = tg.send_text(chat_id, &reply, thread_id).await {
                 tracing::error!(chat_id, thread_id, "failed to send Telegram reply: {e}");
+            }
+
+            // Then any credential link the turn asked for, as its own
+            // message. It goes after the agent's text so the user reads
+            // why before they are handed the form, and it never passed
+            // through the model, so it cannot have been truncated.
+            for link in state.store.pending_links().take(conv_id) {
+                if let Err(e) = tg.send_text(chat_id, &link, thread_id).await {
+                    tracing::error!(chat_id, thread_id, "failed to send credential link: {e}");
+                }
             }
         });
     }

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -21,6 +21,7 @@ use zeroize::Zeroizing;
 
 pub use chat_map::ChatMapStore;
 pub use conversation::{ConversationStore, ConversationSummary};
+pub mod pending_links;
 pub use credential_request::{
     CredentialRequest, CredentialRequestStore, RequestAction, RequestNotifier, RequestedField,
 };
@@ -28,6 +29,7 @@ pub use device::{Device, DeviceStore, Principal};
 pub use guarded::{GuardedSecrets, WriteOutcome};
 pub use jobs::{JobRun, JobStore, ScheduledJob};
 pub use outcomes::OutcomeStore;
+pub use pending_links::PendingLinks;
 pub use recall_archive::RecallArchiveStore;
 pub use secret::{SecretMeta, SecretStore, WriteAuthority};
 pub use slack_chat_map::SlackChatMapStore;
@@ -45,6 +47,9 @@ pub struct Store {
     request_notifier: Option<Arc<dyn credential_request::RequestNotifier>>,
     /// Where live credential values are kept. Never the database.
     credential_backend: Arc<dyn credential_backend::CredentialBackend>,
+    /// Credential links minted this turn, waiting to be sent to the user
+    /// once the agent has finished speaking. In memory only.
+    pending_links: PendingLinks,
 }
 
 impl Store {
@@ -82,6 +87,7 @@ impl Store {
             master_key: Zeroizing::new(master_key),
             request_notifier: None,
             credential_backend: credential_backend::default_backend(),
+            pending_links: PendingLinks::new(),
         })
     }
 
@@ -473,6 +479,13 @@ impl Store {
 
     /// Handle for the credential-change requests the agent files and the
     /// user resolves.
+    /// Links minted but not yet delivered.
+    ///
+    /// Shared handle: the tool pushes, the channel that just spoke takes.
+    pub fn pending_links(&self) -> PendingLinks {
+        self.pending_links.clone()
+    }
+
     pub fn credential_requests(&self) -> CredentialRequestStore {
         let requests = CredentialRequestStore::new(Arc::clone(&self.conn), self.secrets());
         match &self.request_notifier {

--- a/crates/rustykrab-store/src/pending_links.rs
+++ b/crates/rustykrab-store/src/pending_links.rs
@@ -1,0 +1,111 @@
+//! Credential links held back until the turn that minted them has spoken.
+//!
+//! The link used to be handed to the model in the tool result, and the
+//! model was asked to relay it. That makes an LLM responsible for copying
+//! 64 hex characters exactly, and it does not reliably manage it —
+//! observed against gemma4:26b relaying 55 of 64, which the user then
+//! opens to a page saying "Link expired". Deliberately indistinguishable
+//! from a real expiry, so nobody can tell a typo from a timeout.
+//!
+//! Parking the link here instead means the model never sees it, so it
+//! cannot truncate, paraphrase, or omit it — and the URL never enters the
+//! context window, which matters because a live credential-capture link
+//! in a transcript is a capture form anyone reading the history can open
+//! for as long as it lives.
+//!
+//! In memory on purpose. The plaintext token exists only between minting
+//! and delivery; only its hash is ever written down. A link that does not
+//! survive a restart is a link an operator has to ask for again, which is
+//! the correct outcome — the alternative is storing a live credential
+//! capture URL on disk.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use uuid::Uuid;
+
+/// Links awaiting delivery, keyed by the conversation that asked.
+#[derive(Clone, Default)]
+pub struct PendingLinks {
+    inner: Arc<Mutex<HashMap<Uuid, Vec<String>>>>,
+}
+
+impl PendingLinks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queue a link for delivery once the current turn finishes.
+    ///
+    /// Keyed by conversation rather than request id: the deliverer knows
+    /// which conversation just spoke, and nothing else.
+    pub fn push(&self, conversation_id: Uuid, link: String) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(conversation_id)
+            .or_default()
+            .push(link);
+    }
+
+    /// Take everything queued for a conversation, leaving it empty.
+    ///
+    /// Taking rather than reading: a link delivered twice is a second
+    /// message the user has to reason about, and the token only works
+    /// once anyway.
+    pub fn take(&self, conversation_id: Uuid) -> Vec<String> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&conversation_id)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_link_is_delivered_once_and_then_gone() {
+        let links = PendingLinks::new();
+        let conv = Uuid::new_v4();
+        links.push(conv, "https://host/c/abc".into());
+
+        assert_eq!(links.take(conv), vec!["https://host/c/abc".to_string()]);
+        assert!(
+            links.take(conv).is_empty(),
+            "a second delivery would be a duplicate message for a single-use token"
+        );
+    }
+
+    #[test]
+    fn conversations_do_not_see_each_others_links() {
+        let links = PendingLinks::new();
+        let (a, b) = (Uuid::new_v4(), Uuid::new_v4());
+        links.push(a, "https://host/c/aaa".into());
+        links.push(b, "https://host/c/bbb".into());
+
+        assert_eq!(links.take(a), vec!["https://host/c/aaa".to_string()]);
+        assert_eq!(links.take(b), vec!["https://host/c/bbb".to_string()]);
+    }
+
+    /// An agent that asks for two credentials in one turn owes the user
+    /// two links, in the order it asked for them.
+    #[test]
+    fn several_links_in_one_turn_are_kept_in_order() {
+        let links = PendingLinks::new();
+        let conv = Uuid::new_v4();
+        links.push(conv, "first".into());
+        links.push(conv, "second".into());
+        assert_eq!(
+            links.take(conv),
+            vec!["first".to_string(), "second".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_conversation_that_asked_for_nothing_yields_nothing() {
+        assert!(PendingLinks::new().take(Uuid::new_v4()).is_empty());
+    }
+}

--- a/crates/rustykrab-tools/src/credential_link.rs
+++ b/crates/rustykrab-tools/src/credential_link.rs
@@ -65,6 +65,29 @@ pub fn next_step(link: Option<&str>, service: &str) -> String {
     }
 }
 
+/// What to tell the model when the link is delivered out of band.
+///
+/// The model must not invent, guess, or promise a URL it has not been
+/// given — it has not been given one, on purpose. Its job is to say a
+/// request has been made and stop.
+pub fn next_step_out_of_band(link_queued: bool, service: &str) -> String {
+    if link_queued {
+        format!(
+            "Tell the user, in one sentence, that you have asked for their {service} \
+             details and that a secure link is being sent to them right now. Do NOT \
+             write a URL yourself — you have not been given one and any link you \
+             compose will be wrong. Do not ask for the value in chat. Stop this task \
+             until they answer."
+        )
+    } else {
+        format!(
+            "Tell the user you have asked for their {service} details and that a \
+             prompt is waiting in the Apollo app. Do not write a URL. Do not ask for \
+             the value in chat. Stop this task until they answer."
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,6 +109,25 @@ mod tests {
         // whole flow exists to avoid; neither branch may omit it.
         assert!(next_step(Some("https://x/c/t"), "Gmail").contains("Stop this task"));
         assert!(next_step(None, "Gmail").contains("Stop this task"));
+    }
+
+    #[test]
+    fn the_out_of_band_wording_never_hands_the_model_a_url() {
+        for queued in [true, false] {
+            let s = next_step_out_of_band(queued, "Gmail");
+            assert!(
+                !s.contains("http"),
+                "the model must not be given a URL to copy: {s}"
+            );
+            assert!(s.contains("Stop this task"), "{s}");
+            assert!(s.contains("Do not ask for the value in chat"), "{s}");
+        }
+    }
+
+    #[test]
+    fn it_tells_the_model_not_to_invent_a_link() {
+        assert!(next_step_out_of_band(true, "Gmail").contains("Do NOT"));
+        assert!(next_step_out_of_band(false, "Gmail").contains("Do not write a URL"));
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -19,11 +19,26 @@ use serde_json::{json, Value};
 /// a website's username and password are all the same request shape.
 pub struct CredentialRequestTool {
     requests: CredentialRequestStore,
+    /// Where a minted link waits until the turn has finished speaking.
+    ///
+    /// Optional so the tool still constructs without one; without it the
+    /// request is filed and answerable in the app, there is simply no
+    /// link to send.
+    pending_links: Option<rustykrab_store::PendingLinks>,
 }
 
 impl CredentialRequestTool {
     pub fn new(requests: CredentialRequestStore) -> Self {
-        Self { requests }
+        Self {
+            requests,
+            pending_links: None,
+        }
+    }
+
+    /// Deliver minted links out of band, after the turn.
+    pub fn with_pending_links(mut self, links: rustykrab_store::PendingLinks) -> Self {
+        self.pending_links = Some(links);
+        self
     }
 }
 
@@ -186,15 +201,32 @@ impl Tool for CredentialRequestTool {
         // Telegram or Signal there is no app in the loop — a tappable URL
         // is the only way to hand someone a password field from a chat
         // message.
+        // The link is minted here and handed to the deliverer, never to
+        // the model. Asking a model to relay 64 hex characters verbatim
+        // does not work reliably -- observed relaying 55 of 64, which the
+        // user opens to a page that says "Link expired" and cannot
+        // distinguish from a real timeout. Keeping it out of the result
+        // also keeps it out of the transcript, where a live credential
+        // capture URL would otherwise sit for as long as it works.
         let link = crate::credential_link::mint_link(&self.requests, &id).await;
-        let next_step = crate::credential_link::next_step(link.as_deref(), &where_to_look);
+        let queued = match (&self.pending_links, conversation_id, &link) {
+            (Some(pending), Some(conv), Some(url)) => {
+                pending.push(conv, url.clone());
+                true
+            }
+            _ => false,
+        };
+
+        let next_step = crate::credential_link::next_step_out_of_band(queued, &where_to_look);
 
         Ok(json!({
             "status": "requested",
             "request_id": id,
-            "link": link,
-            // Phrased for the model's next turn: it should tell the user
-            // and stop, not poll, and not carry on as if it had the value.
+            // Deliberately no link. Reporting whether one is on its way is
+            // enough for the model to describe what happens next.
+            "link_sent_separately": queued,
+            // Phrased for the model's next turn: tell the user and stop,
+            // do not poll, and do not carry on as if it had the value.
             "next_step": next_step
         }))
     }

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -217,6 +217,7 @@ pub fn builtin_tools(
     secrets: rustykrab_store::SecretStore,
     guarded: rustykrab_store::GuardedSecrets,
     requests: rustykrab_store::CredentialRequestStore,
+    pending_links: rustykrab_store::PendingLinks,
 ) -> Vec<std::sync::Arc<dyn rustykrab_core::Tool>> {
     vec![
         // Meta — tool discovery and lazy schema loading. Always registered.
@@ -265,7 +266,7 @@ pub fn builtin_tools(
         std::sync::Arc::new(CredentialWriteTool::new(guarded)),
         // Asking for a credential nobody has stored yet — the only one of
         // the three that produces a prompt on the user's phone.
-        std::sync::Arc::new(CredentialRequestTool::new(requests)),
+        std::sync::Arc::new(CredentialRequestTool::new(requests).with_pending_links(pending_links)),
     ]
 }
 


### PR DESCRIPTION
**Stack 4/4** — targets `cred/8-persist-wake-turn` (#563). Your design, and it's better than the one I proposed.

## The failure it removes

The link was returned in the tool result and the model was asked to relay it. On a real run, gemma4:26b relayed **55 of the token's 64 hex characters**:

```
…/c/e1f01e2569066de9eaaa09a5508f903882846d3b9f0f4a3c64cb893
```

The user opens that and gets **"Link expired"** — which `refused()` returns deliberately for wrong, expired, used and unauthorised tokens alike, so nobody can use the page as an oracle. Correct for security, and it means a transcription slip is indistinguishable from a real timeout. Silent, and intermittent: an earlier run relayed all 64 correctly.

Asking an LLM to copy 64 hex characters verbatim is not a thing to build on.

## Change

Mint the link, park it in `PendingLinks`, send it as its own message once the turn has finished speaking. The tool result no longer contains a URL; it reports only `link_sent_separately`. The model is told a link is on its way and told explicitly **not to write a URL**, because it doesn't have one.

## Two properties, not one

**It cannot be corrupted** — the model never holds it.

**It never enters the context window or the transcript.** This is the part I'd underweighted when I proposed appending it to the model's text. A live credential-capture URL in the conversation history is a working capture form for anyone who reads that history, for as long as the link lives. Keeping it out is the same principle already applied to the password.

## Design notes

- **`PendingLinks` is in memory on purpose.** The plaintext token exists only between minting and delivery; only its hash is written down. A link that doesn't survive a restart has to be asked for again — the alternative is storing a live capture URL on disk.
- **`take` not `read`** — the token works once, so a second delivery is just a confusing second message.
- **Ordered after the agent's text**, so the user reads *why* before being handed a form.
- **Keyed by conversation**, because the deliverer knows which conversation just spoke and nothing else.

## Scope

Telegram today. Apollo and WebChat render the pending request natively from `/api/credential-requests` and never needed the link, so the gateway path is unchanged. Signal and Slack would each need the same three lines at their send site — I've left them rather than write delivery I can't exercise here.

## Test

4 tests on `PendingLinks` (delivered once then gone; conversations isolated; multiple links keep order; empty case), plus 2 on the new wording asserting **no branch ever hands the model a URL** and both still say to stop.

`cargo test --workspace` 780 passed, clippy and fmt clean.

One unrelated observation: `exec::error_typing_tests::command_timeouts_are_typed_as_timeout` failed once on a heavily loaded machine and passed 3/3 in isolation and on two subsequent full runs. Pre-existing and timing-sensitive, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)