### PR TITLE
fix(tools): stop the nodes tests racing over a process-global env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -82,7 +82,13 @@ impl NodesTool {
             Ok(v) if !v.trim().is_empty() => v,
             _ => return Ok(Vec::new()),
         };
-        serde_json::from_str(&raw).map_err(|e| {
+        Self::parse_nodes(&raw)
+    }
+
+    /// Parse a node list, separated from reading the environment so it can
+    /// be exercised without touching a process-global variable.
+    fn parse_nodes(raw: &str) -> Result<Vec<RemoteNode>> {
+        serde_json::from_str(raw).map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "RUSTYKRAB_NODES is not valid JSON ({e}). Expected an array of \
@@ -387,9 +393,12 @@ mod tests {
 
     #[test]
     fn malformed_config_is_a_clear_error() {
-        std::env::set_var("RUSTYKRAB_NODES", "not json");
-        let err = NodesTool::configured_nodes().unwrap_err().to_string();
+        // Parsed directly rather than through the environment. Setting a
+        // process-global var races every other test in this binary --
+        // cargo runs them as threads of one process -- and this test
+        // previously fought `list_never_leaks_tokens` for RUSTYKRAB_NODES,
+        // failing whichever one lost the interleaving.
+        let err = NodesTool::parse_nodes("not json").unwrap_err().to_string();
         assert!(err.contains("RUSTYKRAB_NODES"), "got: {err}");
-        std::env::remove_var("RUSTYKRAB_NODES");
     }
 }


### PR DESCRIPTION
`list_never_leaks_tokens` and `malformed_config_is_a_clear_error` both set and remove `RUSTYKRAB_NODES`. Cargo runs a crate's tests as threads of one process, so the two race: whichever reads the variable after the other has removed it fails. `list_never_leaks_tokens` then panics with "no nodes configured", which reads like a bug in the tool rather than a test that lost an interleaving.

The comment on `list_never_leaks_tokens` already said to keep it the only test touching the var — the other one simply predated or ignored that.

Splits parsing from reading the environment: `configured_nodes` still reads the var, and a new `parse_nodes` takes the raw string. The malformed-config test parses directly and touches no environment at all, so the race is gone by construction rather than by serialising.

**This is flaky on `main`, not specific to any branch — and it is currently the reason #560 is red.** That PR's change (an SSRF allowlist) is unrelated to this file; it merges cleanly and is level with `main`. Merging this should unblock it on a re-run.

Verified by running `cargo test -p rustykrab-tools --lib` five times: 173 passed each time.

Bottom of stack #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)