### PR TITLE
feat(nodes): asynchronous peer delegation with a node-side task queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.1.40"
+version = "5.2.0"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ All configuration is via environment variables. No plaintext config files.
 | `OPENAI_TEMPERATURE` | `0.1` | Sampling temperature |
 | `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
 | `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
-| `RUSTYKRAB_NODES` | unset | JSON array of peer instances the `nodes` tool can delegate to. See [Delegating to a peer node](#delegating-to-a-peer-node) |
-| `RUSTYKRAB_NODE_TIMEOUT_SECS` | `900` | Per-request timeout for delegated tasks. Generous by default: a peer running a local model at single-digit tokens/sec can legitimately take minutes |
+| `RUSTYKRAB_NODES` | unset | JSON array of peer instances the `nodes` tool can delegate to: `{id, url, token, description, hop_budget}`. `hop_budget` defaults to `0`, which denies the node onward delegation. See [Delegating to a peer node](#delegating-to-a-peer-node) |
+| `RUSTYKRAB_NODE_TIMEOUT_SECS` | `900` | HTTP timeout for calls to a peer. Since delegation is asynchronous these calls are short (submit, poll, cancel); the generous default now only covers the fallback path against a peer too old to have the task queue |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
 | `RUSTYKRAB_MASTER_KEY` | auto-generated | Encryption key for secrets at rest |
@@ -505,16 +505,41 @@ export RUSTYKRAB_NODES='[
     "id": "m4max",
     "url": "https://your-node.your-tailnet.ts.net",
     "token": "<the node auth token>",
-    "description": "M4 Max 32GB — qwen3.8:27b-mlx. Slower but capable; good for self-contained coding tasks with its own checkout at ~/code/rustycrab."
+    "description": "M4 Max 32GB — qwen3.8:27b-mlx. Slower but capable; good for self-contained coding tasks with its own checkout at ~/code/rustycrab.",
+    "hop_budget": 0
   }
 ]'
 ```
 
-The `nodes` tool (`list`, `discover`, `send`) is hidden from the model until
-`RUSTYKRAB_NODES` is set. See `scripts/setup-delegation-node.md` for standing
-up a node, exposing it safely (Tailscale Serve, not the raw gateway port),
-and measured latency expectations — a delegated task on a local model
-typically takes minutes, not seconds.
+The `nodes` tool (`list`, `discover`, `send`, `check`, `cancel`) is hidden
+from the model until `RUSTYKRAB_NODES` is set.
+
+**Delegation is asynchronous.** `send` submits the task and returns a
+`task_id` in about a second; the node runs it in the background and the
+model collects the result with `check` on a later turn. That split is not a
+convenience — a delegated task on a local model routinely runs for minutes,
+and the agent loop caps a network tool call at 120 seconds, so a synchronous
+delegation would be killed on the caller while the node kept working on a
+result nobody could collect. `cancel` calls one off, aborting it mid-run if
+the node has already started.
+
+Pass the `conversation_id` from a previous `check` back into the next `send`
+to continue the same thread on the node. Worth doing for any follow-up: a
+continued thread reuses the prompt prefix the node already evaluated, where
+a fresh one re-reads the whole system prompt and tool schemas first — a
+measured 79.5s versus 3.3s on the same machine.
+
+`hop_budget` is the recursion guard, and defaults to `0`. A node given zero
+hops runs the task itself and is denied the `nodes` tool outright, so it
+cannot hand any part of the work onward. Without this, two peers that each
+list the other — the natural configuration when the node is another copy of
+the same program — bounce a task between them indefinitely at minutes of
+local inference per hop. The local `subagents` depth counter cannot help,
+because it is process-local.
+
+See `scripts/setup-delegation-node.md` for standing up a node, exposing it
+safely (Tailscale Serve, not the raw gateway port), and measured latency
+expectations.
 
 ## Architecture
 

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1466,6 +1466,19 @@ async fn main() -> anyhow::Result<()> {
         infra_handles.push(tokio::spawn(worker.run()));
     }
 
+    // --- Delegated-task worker (peer delegation) ---
+    // Drains tasks a peer node submitted with POST /api/tasks. One at a
+    // time: this machine's model has a single KV-cache slot, so running
+    // two delegated conversations at once evicts both prompt prefixes and
+    // is slower than running them back to back.
+    {
+        let worker_state = state.clone();
+        infra_handles.push(tokio::spawn(async move {
+            rustykrab_gateway::run_task_worker(worker_state).await;
+        }));
+        tracing::info!("delegated-task worker started");
+    }
+
     // --- Job executor (scheduled task runner) ---
     {
         let executor_store = store_handle.clone();

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -235,6 +235,7 @@ async fn execute_credential_wake(
         // should be retrying the tool that failed rather than announcing
         // that it can now be retried.
         force_tool_use_first_iteration: true,
+        ..rustykrab_gateway::RunOptions::default()
     };
 
     let trace_id = Uuid::new_v4();

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -469,6 +469,7 @@ async fn execute_cron_task(
         // reply is never the deliverable, and the model would otherwise
         // burn the slot.
         force_tool_use_first_iteration: true,
+        ..rustykrab_gateway::RunOptions::default()
     };
 
     // Run the agent. Mint a fresh trace id per scheduled run so prompt-log

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -8,6 +8,7 @@ pub mod rate_limit;
 mod routes;
 mod signal_webhook;
 mod state;
+pub mod tasks;
 mod telegram_webhook;
 mod webchat;
 
@@ -20,6 +21,7 @@ pub use origin::OriginPolicy;
 pub use push::{ApnsClient, ApnsConfig, ApnsEnvironment, PushNotifier};
 pub use rate_limit::RateLimitConfig;
 pub use state::AppState;
+pub use tasks::{run_task_worker, TaskQueueSignal};
 
 use axum::extract::Request;
 use axum::http::header;

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -31,6 +31,14 @@ pub struct RunOptions {
     /// for scheduled tasks so the model can't waste the slot on a
     /// greeting.
     pub force_tool_use_first_iteration: bool,
+    /// Tools this run may not use, withheld before capabilities are
+    /// granted rather than rejected at call time — a tool the session
+    /// has no capability for is never offered to the model, so it does
+    /// not waste a turn discovering it is forbidden.
+    ///
+    /// Used by the delegated-task worker to deny onward delegation to a
+    /// run whose hop budget is spent.
+    pub denied_tools: Vec<String>,
 }
 
 /// Build the system prompt and inject it as the first message in the conversation.
@@ -279,6 +287,7 @@ async fn prepare_agent(
         .iter()
         .filter(|t| t.available())
         .map(|t| t.name())
+        .filter(|name| !options.denied_tools.iter().any(|denied| denied == name))
         .collect();
     tracing::debug!(
         tool_count = tool_names.len(),

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -57,6 +57,8 @@ pub fn api_routes() -> Router<AppState> {
             "/api/credential-requests/{id}/fulfil",
             post(fulfil_credential_request),
         )
+        .route("/api/tasks", post(submit_task).get(list_tasks))
+        .route("/api/tasks/{id}", get(get_task).delete(cancel_task))
         .route("/api/pair", post(pair_device))
         .route("/api/devices", get(list_devices))
         .route("/api/devices/{id}", axum::routing::delete(revoke_device))
@@ -409,6 +411,187 @@ async fn send_message(
         }
     };
     Ok(Json(response))
+}
+
+// ---------------------------------------------------------------------------
+// Delegated tasks
+//
+// The asynchronous half of peer delegation: a peer submits work and gets
+// an id back at once, then polls. The synchronous alternative — holding
+// the HTTP request open for the whole agent turn — cannot work here,
+// because a delegated task on a local model routinely runs for minutes
+// and the caller's own tool-call timeout fires long before it returns.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct SubmitTaskRequest {
+    /// The instruction to run. Self-contained: this node does not share
+    /// the caller's conversation.
+    message: String,
+    /// Continue an earlier delegated thread instead of opening a fresh
+    /// conversation. Worth passing whenever the work is a follow-up: a
+    /// continued thread reuses its evaluated prompt prefix, where a new
+    /// one re-prefills the whole system prompt and tool schemas.
+    #[serde(default, rename = "conversationId")]
+    conversation_id: Option<String>,
+    /// How many further delegation hops this task may make. Absent or
+    /// zero means the run may not delegate onward at all.
+    #[serde(default, rename = "hopBudget")]
+    hop_budget: Option<i64>,
+    /// The caller's trace id, so one delegation is greppable across both
+    /// machines' logs.
+    #[serde(default, rename = "traceId")]
+    trace_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TaskResponse {
+    id: String,
+    status: String,
+    #[serde(rename = "conversationId", skip_serializing_if = "Option::is_none")]
+    conversation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
+    started_at: Option<String>,
+    #[serde(rename = "finishedAt", skip_serializing_if = "Option::is_none")]
+    finished_at: Option<String>,
+    /// Seconds the task has been alive, so a caller can report progress
+    /// without tracking submission time itself.
+    #[serde(rename = "elapsedSecs")]
+    elapsed_secs: i64,
+}
+
+impl TaskResponse {
+    fn from_task(task: rustykrab_store::DelegatedTask) -> Self {
+        let until = task.finished_at.unwrap_or_else(Utc::now);
+        Self {
+            id: task.id,
+            status: task.status.as_str().to_string(),
+            conversation_id: task.conversation_id,
+            result: task.result,
+            error: task.error,
+            created_at: task.created_at.to_rfc3339(),
+            started_at: task.started_at.map(|t| t.to_rfc3339()),
+            finished_at: task.finished_at.map(|t| t.to_rfc3339()),
+            elapsed_secs: (until - task.created_at).num_seconds().max(0),
+        }
+    }
+}
+
+/// Accept a delegated task and return its handle. Runs nothing inline —
+/// the worker picks it up.
+async fn submit_task(
+    State(state): State<AppState>,
+    Extension(TraceId(trace_id)): Extension<TraceId>,
+    principal: Option<Extension<rustykrab_store::Principal>>,
+    Json(body): Json<SubmitTaskRequest>,
+) -> Result<(StatusCode, Json<TaskResponse>), StatusCode> {
+    if body.message.len() > MAX_MESSAGE_SIZE {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+    if body.message.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    // Attribute the task to the peer that sent it. Without this a
+    // delegated turn is indistinguishable from local user input in the
+    // node's own logs.
+    let who = principal.map(|Extension(p)| p.describe());
+
+    // Fall back to this request's own trace id so the task is always
+    // correlatable, even from a caller that sends none.
+    let trace = body
+        .trace_id
+        .clone()
+        .unwrap_or_else(|| trace_id.to_string());
+
+    let task = state
+        .store
+        .tasks()
+        .enqueue(
+            &body.message,
+            body.conversation_id.as_deref(),
+            who.as_deref(),
+            body.hop_budget.unwrap_or(0),
+            Some(&trace),
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "could not enqueue delegated task");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!(
+        task_id = %task.id,
+        principal = task.principal.as_deref().unwrap_or("unknown"),
+        "accepted delegated task"
+    );
+    state.task_signal.wake();
+
+    Ok((StatusCode::ACCEPTED, Json(TaskResponse::from_task(task))))
+}
+
+async fn get_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<TaskResponse>, StatusCode> {
+    match state.store.tasks().get(&id).await {
+        Ok(Some(task)) => Ok(Json(TaskResponse::from_task(task))),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(e) => {
+            tracing::error!(error = %e, "could not read delegated task");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// Recent tasks, newest first. Bounded so a long-lived node cannot
+/// return an unbounded history.
+async fn list_tasks(State(state): State<AppState>) -> Result<Json<Vec<TaskResponse>>, StatusCode> {
+    match state.store.tasks().list(50).await {
+        Ok(tasks) => Ok(Json(
+            tasks.into_iter().map(TaskResponse::from_task).collect(),
+        )),
+        Err(e) => {
+            tracing::error!(error = %e, "could not list delegated tasks");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
+/// Cancel a task. Marks the row terminal, and additionally aborts the
+/// agent loop when the task is already running — otherwise a cancel
+/// would return promptly while the node kept burning inference on work
+/// nobody will collect.
+async fn cancel_task(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<TaskResponse>, StatusCode> {
+    let previous = state.store.tasks().cancel(&id).await.map_err(|e| {
+        tracing::error!(error = %e, "could not cancel delegated task");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let Some(previous) = previous else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+    if previous == rustykrab_store::TaskStatus::Running {
+        let aborted = state.task_signal.abort(&id);
+        tracing::info!(task_id = %id, aborted, "cancelled a running delegated task");
+    }
+
+    match state.store.tasks().get(&id).await {
+        Ok(Some(task)) => Ok(Json(TaskResponse::from_task(task))),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(e) => {
+            tracing::error!(error = %e, "could not read cancelled task");
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
 }
 
 /// Look for embedded app specs in an assistant message. Today the

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -85,6 +85,10 @@ pub struct AppState {
     pub outcome_capture_enabled: bool,
     /// Who may open the credential page served at `/c/{token}`.
     pub credential_page_policy: crate::PageIdentityPolicy,
+    /// Wake-up channel and cancellation registry for the delegated-task
+    /// queue. Shared between the `/api/tasks` handlers, which enqueue and
+    /// cancel, and the worker, which drains.
+    pub task_signal: crate::tasks::TaskQueueSignal,
 }
 
 impl AppState {
@@ -127,6 +131,7 @@ impl AppState {
             retrieval_log: RetrievalLog::new(),
             outcome_capture_enabled: false,
             credential_page_policy: crate::PageIdentityPolicy::default(),
+            task_signal: crate::tasks::TaskQueueSignal::new(),
         }
     }
 

--- a/crates/rustykrab-gateway/src/tasks.rs
+++ b/crates/rustykrab-gateway/src/tasks.rs
@@ -1,0 +1,354 @@
+//! Node-side worker that drains the delegated-task queue.
+//!
+//! A peer submits work with `POST /api/tasks` and gets an id back
+//! immediately; this worker runs it. Splitting submission from execution
+//! is what lets a delegation outlive the caller's tool-call budget — the
+//! old synchronous path held an HTTP request open for the whole agent
+//! turn, which on a local model routinely exceeds any sane timeout.
+//!
+//! Exactly one task runs at a time, by design. See
+//! `rustykrab_store::TaskStore` for why serialising beats sharing on a
+//! machine whose model has one KV-cache slot.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use chrono::Utc;
+use rustykrab_core::types::{Message, MessageContent, Role};
+use rustykrab_store::{DelegatedTask, TaskStatus};
+use tokio::sync::Notify;
+use tokio::task::AbortHandle;
+use uuid::Uuid;
+
+use crate::orchestrate::{run_agent_with_options, RunOptions};
+use crate::AppState;
+
+/// Fallback poll interval. The queue also rings [`TaskQueueSignal`] on
+/// submit, so this only covers a missed notification or a task enqueued
+/// by a previous process.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How long a finished task's record is retained before the sweeper
+/// deletes it. Long enough that a peer whose own process restarted can
+/// still collect a result it never read.
+const RESULT_RETENTION_HOURS: i64 = 48;
+
+/// Wake-up channel and cancellation registry shared between the HTTP
+/// handlers and the worker.
+#[derive(Clone, Default)]
+pub struct TaskQueueSignal {
+    notify: Arc<Notify>,
+    /// Abort handles for tasks currently executing, keyed by task id.
+    /// Only ever holds one entry today — the worker is single-threaded —
+    /// but keyed so a second worker would not need a different shape.
+    running: Arc<Mutex<HashMap<String, AbortHandle>>>,
+}
+
+impl TaskQueueSignal {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Tell the worker there is something to pick up.
+    pub fn wake(&self) {
+        self.notify.notify_one();
+    }
+
+    /// Abort a task's agent loop if it is mid-run. Returns whether one
+    /// was actually running: a queued task needs no abort, its row is
+    /// already terminal and the worker will skip it.
+    pub fn abort(&self, task_id: &str) -> bool {
+        let mut running = self.running.lock().unwrap_or_else(|e| e.into_inner());
+        match running.remove(task_id) {
+            Some(handle) => {
+                handle.abort();
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn register(&self, task_id: &str, handle: AbortHandle) {
+        self.running
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(task_id.to_string(), handle);
+    }
+
+    fn unregister(&self, task_id: &str) {
+        self.running
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(task_id);
+    }
+}
+
+/// Drain the delegated-task queue until the process shuts down.
+///
+/// Spawned once at startup and held in the CLI's `infra_handles`.
+pub async fn run_task_worker(state: AppState) {
+    let signal = state.task_signal.clone();
+    let store = state.store.tasks();
+
+    // Tasks left `running` belonged to an agent loop that died with the
+    // previous process. Nothing will ever complete them, so fail them
+    // now rather than leaving a peer polling forever.
+    match store.fail_orphaned().await {
+        Ok(0) => {}
+        Ok(n) => tracing::warn!(count = n, "failed delegated tasks orphaned by a restart"),
+        Err(e) => tracing::error!(error = %e, "could not reconcile orphaned delegated tasks"),
+    }
+
+    // Thread affinity: bias the next claim toward the conversation just
+    // run, so a multi-step delegation keeps its warm prompt prefix.
+    let mut last_conversation: Option<String> = None;
+
+    loop {
+        let claimed = match store.claim_next(last_conversation.as_deref()).await {
+            Ok(claimed) => claimed,
+            Err(e) => {
+                tracing::error!(error = %e, "delegated task claim failed");
+                None
+            }
+        };
+
+        let Some(task) = claimed else {
+            // Nothing queued. Sweep expired results while idle, then wait
+            // for either a submission or the fallback tick.
+            if let Err(e) = store
+                .sweep(chrono::Duration::hours(RESULT_RETENTION_HOURS))
+                .await
+            {
+                tracing::warn!(error = %e, "delegated task sweep failed");
+            }
+            tokio::select! {
+                _ = signal.notify.notified() => {}
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
+            continue;
+        };
+
+        let task_id = task.id.clone();
+        tracing::info!(
+            task_id = %task_id,
+            principal = task.principal.as_deref().unwrap_or("unknown"),
+            hop_budget = task.hop_budget,
+            continuing = task.conversation_id.is_some(),
+            "running delegated task"
+        );
+
+        // Spawn rather than await inline so a cancel can abort the agent
+        // loop. The handle is registered before the first await point so
+        // a cancel arriving immediately still finds it.
+        let handle = tokio::spawn(execute(state.clone(), task.clone()));
+        signal.register(&task_id, handle.abort_handle());
+        let outcome = handle.await;
+        signal.unregister(&task_id);
+
+        match outcome {
+            Ok(Ok(reply)) => {
+                last_conversation = reply.conversation_id.clone();
+                if let Err(e) = store.finish(&task_id, &reply.text).await {
+                    tracing::error!(task_id = %task_id, error = %e, "could not record task result");
+                }
+                tracing::info!(task_id = %task_id, "delegated task done");
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(task_id = %task_id, error = %e, "delegated task failed");
+                if let Err(e) = store.fail(&task_id, &e).await {
+                    tracing::error!(task_id = %task_id, error = %e, "could not record task failure");
+                }
+            }
+            // Aborted by a cancel, or the run panicked. `cancel` already
+            // wrote the terminal row in the first case; `fail` is a no-op
+            // against a row that is no longer queued or running, so this
+            // is safe for both.
+            Err(join_err) => {
+                let reason = if join_err.is_cancelled() {
+                    "cancelled by the delegating peer".to_string()
+                } else {
+                    format!("the agent loop panicked: {join_err}")
+                };
+                tracing::warn!(task_id = %task_id, reason = %reason, "delegated task ended early");
+                if let Err(e) = store.fail(&task_id, &reason).await {
+                    tracing::error!(task_id = %task_id, error = %e, "could not record task failure");
+                }
+            }
+        }
+    }
+}
+
+/// What a completed run hands back to the worker.
+struct TaskReply {
+    text: String,
+    conversation_id: Option<String>,
+}
+
+/// Run one delegated task to completion.
+///
+/// Mirrors the `send_message` HTTP handler: load or open a conversation,
+/// append the peer's instruction, run the agent, persist the turn.
+async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, String> {
+    // Continue the caller's thread when it named one. A conversation that
+    // has since been deleted falls back to a fresh one rather than
+    // failing the task — the message is self-contained by contract, so
+    // losing the thread costs prefill, not correctness.
+    let mut conv = match task
+        .conversation_id
+        .as_deref()
+        .and_then(|id| id.parse().ok())
+    {
+        Some(id) => match state.store.conversations().get(id).await {
+            Ok(conv) => conv,
+            Err(_) => {
+                tracing::warn!(
+                    task_id = %task.id,
+                    conversation_id = %id,
+                    "delegated task named an unknown conversation; opening a fresh one"
+                );
+                state
+                    .store
+                    .conversations()
+                    .create()
+                    .await
+                    .map_err(|e| format!("could not open a conversation: {e}"))?
+            }
+        },
+        None => state
+            .store
+            .conversations()
+            .create()
+            .await
+            .map_err(|e| format!("could not open a conversation: {e}"))?,
+    };
+
+    let conversation_id = conv.id.to_string();
+    if task.conversation_id.as_deref() != Some(conversation_id.as_str()) {
+        // Record it before the run, not after: a task that dies mid-turn
+        // should still tell the peer which thread to resume.
+        if let Err(e) = state
+            .store
+            .tasks()
+            .set_conversation(&task.id, &conversation_id)
+            .await
+        {
+            tracing::warn!(task_id = %task.id, error = %e, "could not record task conversation");
+        }
+    }
+
+    let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
+    conv.messages.push(Message {
+        id: Uuid::new_v4(),
+        role: Role::User,
+        content: MessageContent::Text(task.message.clone()),
+        created_at: Utc::now(),
+        agent_version: Message::version_stamp(),
+    });
+    conv.updated_at = Utc::now();
+
+    // Correlate both machines' logs under the delegating peer's trace id
+    // when it sent one.
+    let trace_id = task
+        .trace_id
+        .as_deref()
+        .and_then(|id| id.parse().ok())
+        .unwrap_or_else(Uuid::new_v4);
+
+    let options = RunOptions {
+        denied_tools: denied_tools_for(&task),
+        ..RunOptions::default()
+    };
+
+    let assistant = run_agent_with_options(&state, &mut conv, &task.message, trace_id, &options)
+        .await
+        .map_err(|status| format!("the agent run failed ({status})"))?;
+
+    conv.updated_at = Utc::now();
+    if let Err(e) = state
+        .store
+        .conversations()
+        .save_turn(&conv, &persisted_ids)
+        .await
+    {
+        // The work is done and the reply is in hand; failing the task
+        // over a persistence error would throw away minutes of local
+        // inference. Report it and return the result.
+        tracing::error!(task_id = %task.id, error = %e, "could not persist delegated turn");
+    }
+
+    let text = match &assistant.content {
+        MessageContent::Text(text) => text.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| String::new()),
+    };
+
+    Ok(TaskReply {
+        text,
+        conversation_id: Some(conversation_id),
+    })
+}
+
+/// Tools a delegated run may not use, given its remaining hop budget.
+///
+/// With no hops left the node may not delegate onward. That is the
+/// cross-machine analogue of the local recursion guard in the
+/// `subagents` tool, and without it a node whose own `RUSTYKRAB_NODES`
+/// points back at the primary would recurse indefinitely — each hop
+/// costing minutes of local inference.
+fn denied_tools_for(task: &DelegatedTask) -> Vec<String> {
+    if task.hop_budget > 0 {
+        Vec::new()
+    } else {
+        vec!["nodes".to_string()]
+    }
+}
+
+/// Whether a status means the caller should keep polling.
+pub fn is_pending(status: TaskStatus) -> bool {
+    !status.is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(hop_budget: i64) -> DelegatedTask {
+        DelegatedTask {
+            id: "t1".to_string(),
+            message: "do the thing".to_string(),
+            conversation_id: None,
+            status: TaskStatus::Queued,
+            result: None,
+            error: None,
+            principal: None,
+            hop_budget,
+            trace_id: None,
+            created_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn a_spent_hop_budget_denies_onward_delegation() {
+        assert_eq!(denied_tools_for(&task(0)), vec!["nodes".to_string()]);
+        assert_eq!(denied_tools_for(&task(-1)), vec!["nodes".to_string()]);
+        assert!(denied_tools_for(&task(1)).is_empty());
+    }
+
+    #[test]
+    fn abort_reports_whether_a_task_was_running() {
+        let signal = TaskQueueSignal::new();
+        // Nothing registered: a queued task needs no abort.
+        assert!(!signal.abort("t1"));
+    }
+
+    #[test]
+    fn pending_covers_exactly_the_non_terminal_states() {
+        assert!(is_pending(TaskStatus::Queued));
+        assert!(is_pending(TaskStatus::Running));
+        assert!(!is_pending(TaskStatus::Done));
+        assert!(!is_pending(TaskStatus::Failed));
+        assert!(!is_pending(TaskStatus::Cancelled));
+    }
+}

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -11,6 +11,7 @@ mod recall_archive;
 pub mod registry;
 mod secret;
 mod slack_chat_map;
+mod tasks;
 
 use std::path::Path;
 use std::sync::Arc;
@@ -31,6 +32,7 @@ pub use outcomes::OutcomeStore;
 pub use recall_archive::RecallArchiveStore;
 pub use secret::{SecretMeta, SecretStore, WriteAuthority};
 pub use slack_chat_map::SlackChatMapStore;
+pub use tasks::{DelegatedTask, TaskStatus, TaskStore};
 
 /// Top-level database handle wrapping a SQLite connection.
 ///
@@ -222,6 +224,28 @@ impl Store {
                 revoked_at   INTEGER,
                 push_token   TEXT
             );
+
+            -- Tasks a peer node delegated to this instance. The caller
+            -- holds only the id, so the row is the authoritative record of
+            -- a delegation's progress and result.
+            CREATE TABLE IF NOT EXISTS delegated_tasks (
+                id              TEXT PRIMARY KEY,
+                message         TEXT NOT NULL,
+                conversation_id TEXT,
+                status          TEXT NOT NULL,
+                result          TEXT,
+                error           TEXT,
+                principal       TEXT,
+                hop_budget      INTEGER NOT NULL DEFAULT 0,
+                trace_id        TEXT,
+                created_at      TEXT NOT NULL,
+                started_at      TEXT,
+                finished_at     TEXT
+            );
+
+            -- The worker's only hot query is the oldest queued task.
+            CREATE INDEX IF NOT EXISTS idx_delegated_tasks_queue
+                ON delegated_tasks (status, created_at);
 
             -- One-time pairing codes: hashed, short-lived, single use.
             CREATE TABLE IF NOT EXISTS pairing_codes (
@@ -492,6 +516,12 @@ impl Store {
     /// Handle for paired devices and pairing codes.
     pub fn devices(&self) -> DeviceStore {
         DeviceStore::new(Arc::clone(&self.conn))
+    }
+
+    /// Return a handle for the delegated-task queue drained by the
+    /// node worker (`rustykrab_gateway::tasks`).
+    pub fn tasks(&self) -> TaskStore {
+        TaskStore::new(Arc::clone(&self.conn))
     }
 
     /// Return a handle for scheduled-job operations.

--- a/crates/rustykrab-store/src/tasks.rs
+++ b/crates/rustykrab-store/src/tasks.rs
@@ -1,0 +1,571 @@
+//! Durable queue for tasks delegated by a peer RustyKrab instance.
+//!
+//! A delegating peer no longer blocks on the agent turn it asked for
+//! (`POST /api/tasks` returns a handle immediately); the work is queued
+//! here and drained by a single worker. Persistence is what makes the
+//! handle meaningful — the caller can poll across its own restarts, and
+//! a task interrupted by a daemon restart is reported as failed rather
+//! than silently lost.
+//!
+//! One worker, not a pool. Delegation nodes run local models where the
+//! KV cache is pinned to a single slot (`OLLAMA_NUM_PARALLEL=1`), so
+//! interleaving two conversations evicts both prefixes and each turn
+//! re-pays full prompt evaluation. Serialising is faster than sharing.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Row};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use rustykrab_core::Error;
+
+use crate::with_conn;
+
+/// Lifecycle of a delegated task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    /// Accepted and waiting for the worker.
+    Queued,
+    /// The worker is running the agent turn now.
+    Running,
+    /// Finished; `result` holds the agent's reply.
+    Done,
+    /// Finished; `error` explains why there is no result.
+    Failed,
+    /// Cancelled by the caller, before or during the run.
+    Cancelled,
+}
+
+impl TaskStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TaskStatus::Queued => "queued",
+            TaskStatus::Running => "running",
+            TaskStatus::Done => "done",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Cancelled => "cancelled",
+        }
+    }
+
+    fn parse(raw: &str) -> TaskStatus {
+        match raw {
+            "queued" => TaskStatus::Queued,
+            "running" => TaskStatus::Running,
+            "done" => TaskStatus::Done,
+            "cancelled" => TaskStatus::Cancelled,
+            // Anything unrecognised is treated as terminal-failed rather
+            // than re-queued: a row we cannot interpret must never become
+            // work the agent runs.
+            _ => TaskStatus::Failed,
+        }
+    }
+
+    /// Whether no further state transition is expected.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            TaskStatus::Done | TaskStatus::Failed | TaskStatus::Cancelled
+        )
+    }
+}
+
+/// A task submitted by a peer for this node to run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegatedTask {
+    pub id: String,
+    /// The instruction to run. Self-contained by contract: the peer's
+    /// conversation is not shared with this node.
+    pub message: String,
+    /// Conversation the task runs in. Supplied by the caller to continue
+    /// an earlier thread (and reuse its warm prompt prefix), or assigned
+    /// by the worker when it opens a fresh one.
+    pub conversation_id: Option<String>,
+    pub status: TaskStatus,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    /// Who submitted it, from the gateway's authenticated principal.
+    /// Recorded so a delegated turn is attributable to the peer that
+    /// asked for it rather than looking like local user input.
+    pub principal: Option<String>,
+    /// Remaining delegation hops. A node may only hand work onward while
+    /// this is above zero, which is what stops A -> B -> A recursion.
+    pub hop_budget: i64,
+    /// The caller's trace id, so one delegation correlates across both
+    /// machines' logs.
+    pub trace_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+impl DelegatedTask {
+    fn from_row(row: &Row) -> rusqlite::Result<DelegatedTask> {
+        let parse_time = |raw: Option<String>| -> Option<DateTime<Utc>> {
+            raw.and_then(|s| DateTime::parse_from_rfc3339(&s).ok())
+                .map(|t| t.with_timezone(&Utc))
+        };
+        let created: String = row.get("created_at")?;
+        Ok(DelegatedTask {
+            id: row.get("id")?,
+            message: row.get("message")?,
+            conversation_id: row.get("conversation_id")?,
+            status: TaskStatus::parse(&row.get::<_, String>("status")?),
+            result: row.get("result")?,
+            error: row.get("error")?,
+            principal: row.get("principal")?,
+            hop_budget: row.get("hop_budget")?,
+            trace_id: row.get("trace_id")?,
+            created_at: parse_time(Some(created)).unwrap_or_else(Utc::now),
+            started_at: parse_time(row.get("started_at")?),
+            finished_at: parse_time(row.get("finished_at")?),
+        })
+    }
+}
+
+const COLUMNS: &str = "id, message, conversation_id, status, result, error, principal, \
+                       hop_budget, trace_id, created_at, started_at, finished_at";
+
+/// Handle for delegated-task CRUD, backed by SQLite.
+///
+/// Like the other stores, every method runs its rusqlite work on the
+/// blocking pool so async workers never park on disk I/O.
+#[derive(Clone)]
+pub struct TaskStore {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+impl TaskStore {
+    pub(crate) fn new(conn: Arc<Mutex<rusqlite::Connection>>) -> Self {
+        Self { conn }
+    }
+
+    /// Queue a task and return the handle the caller polls.
+    pub async fn enqueue(
+        &self,
+        message: &str,
+        conversation_id: Option<&str>,
+        principal: Option<&str>,
+        hop_budget: i64,
+        trace_id: Option<&str>,
+    ) -> Result<DelegatedTask, Error> {
+        let task = DelegatedTask {
+            id: Uuid::new_v4().to_string(),
+            message: message.to_string(),
+            conversation_id: conversation_id.map(str::to_string),
+            status: TaskStatus::Queued,
+            result: None,
+            error: None,
+            principal: principal.map(str::to_string),
+            hop_budget: hop_budget.max(0),
+            trace_id: trace_id.map(str::to_string),
+            created_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+        };
+
+        let row = task.clone();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "INSERT INTO delegated_tasks (id, message, conversation_id, status, principal, \
+                 hop_budget, trace_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    row.id,
+                    row.message,
+                    row.conversation_id,
+                    row.status.as_str(),
+                    row.principal,
+                    row.hop_budget,
+                    row.trace_id,
+                    row.created_at.to_rfc3339(),
+                ],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await?;
+
+        Ok(task)
+    }
+
+    pub async fn get(&self, id: &str) -> Result<Option<DelegatedTask>, Error> {
+        let id = id.to_string();
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {COLUMNS} FROM delegated_tasks WHERE id = ?1"
+                ))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut rows = stmt
+                .query_map(params![id], DelegatedTask::from_row)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            match rows.next() {
+                Some(row) => Ok(Some(row.map_err(|e| Error::Storage(e.to_string()))?)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
+    /// Most recent tasks first.
+    pub async fn list(&self, limit: u32) -> Result<Vec<DelegatedTask>, Error> {
+        with_conn(&self.conn, move |conn| {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT {COLUMNS} FROM delegated_tasks ORDER BY created_at DESC LIMIT ?1"
+                ))
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let rows = stmt
+                .query_map(params![limit], DelegatedTask::from_row)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let mut out = Vec::new();
+            for row in rows {
+                out.push(row.map_err(|e| Error::Storage(e.to_string()))?);
+            }
+            Ok(out)
+        })
+        .await
+    }
+
+    /// Claim the next queued task, flipping it to `running`.
+    ///
+    /// `prefer_conversation` biases selection toward a task continuing the
+    /// conversation the worker just ran. That is thread affinity, and on a
+    /// local model it is worth real time: continuing a warm conversation
+    /// re-uses its evaluated prompt prefix, where switching threads pays
+    /// full prefill again. FIFO breaks the tie, so a preferred thread can
+    /// never starve older work indefinitely — only jump ahead of it while
+    /// it has queued steps.
+    pub async fn claim_next(
+        &self,
+        prefer_conversation: Option<&str>,
+    ) -> Result<Option<DelegatedTask>, Error> {
+        let preferred = prefer_conversation.map(str::to_string);
+        let now = Utc::now().to_rfc3339();
+        with_conn(&self.conn, move |conn| {
+            // No explicit transaction: `with_conn` holds the connection
+            // mutex for the whole closure, and a single worker claims, so
+            // select-then-update cannot interleave. The `status = 'queued'`
+            // guard on the UPDATE keeps that assumption enforced rather
+            // than merely assumed.
+            let id: Option<String> = conn
+                .query_row(
+                    "SELECT id FROM delegated_tasks WHERE status = 'queued' \
+                     ORDER BY (conversation_id IS NOT NULL AND conversation_id = ?1) DESC, \
+                     created_at ASC LIMIT 1",
+                    params![preferred],
+                    |row| row.get(0),
+                )
+                .ok();
+            let Some(id) = id else {
+                return Ok(None);
+            };
+
+            let claimed = conn
+                .execute(
+                    "UPDATE delegated_tasks SET status = 'running', started_at = ?2 \
+                     WHERE id = ?1 AND status = 'queued'",
+                    params![id, now],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            if claimed == 0 {
+                return Ok(None);
+            }
+
+            let task = conn
+                .query_row(
+                    &format!("SELECT {COLUMNS} FROM delegated_tasks WHERE id = ?1"),
+                    params![id],
+                    DelegatedTask::from_row,
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(Some(task))
+        })
+        .await
+    }
+
+    /// Record the conversation the worker opened for a task, so a follow-up
+    /// `send` can continue the same thread.
+    pub async fn set_conversation(&self, id: &str, conversation_id: &str) -> Result<(), Error> {
+        let (id, conversation_id) = (id.to_string(), conversation_id.to_string());
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE delegated_tasks SET conversation_id = ?2 WHERE id = ?1",
+                params![id, conversation_id],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Move a task to a terminal state.
+    ///
+    /// Refuses to overwrite an existing terminal state, so a cancel that
+    /// lands while the agent is mid-turn is not undone by the run's own
+    /// completion a moment later.
+    async fn settle(
+        &self,
+        id: &str,
+        status: TaskStatus,
+        result: Option<String>,
+        error: Option<String>,
+    ) -> Result<(), Error> {
+        let id = id.to_string();
+        let now = Utc::now().to_rfc3339();
+        with_conn(&self.conn, move |conn| {
+            conn.execute(
+                "UPDATE delegated_tasks SET status = ?2, result = ?3, error = ?4, \
+                 finished_at = ?5 WHERE id = ?1 AND status IN ('queued', 'running')",
+                params![id, status.as_str(), result, error, now],
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn finish(&self, id: &str, result: &str) -> Result<(), Error> {
+        self.settle(id, TaskStatus::Done, Some(result.to_string()), None)
+            .await
+    }
+
+    pub async fn fail(&self, id: &str, error: &str) -> Result<(), Error> {
+        self.settle(id, TaskStatus::Failed, None, Some(error.to_string()))
+            .await
+    }
+
+    /// Cancel a task, returning the status it held beforehand.
+    ///
+    /// `Running` in the return means the worker still has to be told to
+    /// abort — the row is already terminal, but the agent loop is not.
+    pub async fn cancel(&self, id: &str) -> Result<Option<TaskStatus>, Error> {
+        let previous = match self.get(id).await? {
+            Some(task) => task.status,
+            None => return Ok(None),
+        };
+        if previous.is_terminal() {
+            return Ok(Some(previous));
+        }
+        self.settle(
+            id,
+            TaskStatus::Cancelled,
+            None,
+            Some("cancelled by the delegating peer".to_string()),
+        )
+        .await?;
+        Ok(Some(previous))
+    }
+
+    /// Fail every task left `running` by a previous process.
+    ///
+    /// Called once at startup. The agent loop that owned them died with
+    /// the process, so without this they stay `running` forever and a
+    /// polling peer waits on work that will never finish.
+    pub async fn fail_orphaned(&self) -> Result<usize, Error> {
+        let now = Utc::now().to_rfc3339();
+        with_conn(&self.conn, move |conn| {
+            let n = conn
+                .execute(
+                    "UPDATE delegated_tasks SET status = 'failed', \
+                     error = 'interrupted: the node restarted mid-task', finished_at = ?1 \
+                     WHERE status = 'running'",
+                    params![now],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(n)
+        })
+        .await
+    }
+
+    /// Delete terminal tasks older than `max_age`. Queued and running rows
+    /// are never swept, however old — an unfinished task is not garbage.
+    pub async fn sweep(&self, max_age: chrono::Duration) -> Result<usize, Error> {
+        let cutoff = (Utc::now() - max_age).to_rfc3339();
+        with_conn(&self.conn, move |conn| {
+            let n = conn
+                .execute(
+                    "DELETE FROM delegated_tasks WHERE status NOT IN ('queued', 'running') \
+                     AND finished_at IS NOT NULL AND finished_at < ?1",
+                    params![cutoff],
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(n)
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> TaskStore {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::Store::run_migrations(&conn).unwrap();
+        TaskStore::new(Arc::new(Mutex::new(conn)))
+    }
+
+    #[tokio::test]
+    async fn a_submitted_task_is_claimable_exactly_once() {
+        let s = store();
+        let task = s
+            .enqueue("do it", None, Some("m1max"), 0, None)
+            .await
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Queued);
+
+        let claimed = s.claim_next(None).await.unwrap().expect("a queued task");
+        assert_eq!(claimed.id, task.id);
+        assert_eq!(claimed.status, TaskStatus::Running);
+        assert!(claimed.started_at.is_some());
+
+        // A second worker (or the same one looping) must not re-run it.
+        assert!(
+            s.claim_next(None).await.unwrap().is_none(),
+            "a claimed task must not be handed out again"
+        );
+    }
+
+    #[tokio::test]
+    async fn claims_are_fifo_but_prefer_the_warm_conversation() {
+        let s = store();
+        let older = s
+            .enqueue("first", Some("convo-a"), None, 0, None)
+            .await
+            .unwrap();
+        let newer = s
+            .enqueue("second", Some("convo-b"), None, 0, None)
+            .await
+            .unwrap();
+
+        // Affinity: continuing convo-b reuses its evaluated prompt prefix,
+        // which is worth more than strict arrival order on a local model.
+        let claimed = s.claim_next(Some("convo-b")).await.unwrap().unwrap();
+        assert_eq!(claimed.id, newer.id);
+
+        // With no preference, the remaining work comes out oldest-first.
+        let claimed = s.claim_next(None).await.unwrap().unwrap();
+        assert_eq!(claimed.id, older.id);
+    }
+
+    #[tokio::test]
+    async fn a_cancel_mid_run_survives_the_run_finishing() {
+        let s = store();
+        let task = s.enqueue("long job", None, None, 0, None).await.unwrap();
+        s.claim_next(None).await.unwrap();
+
+        let previous = s.cancel(&task.id).await.unwrap();
+        assert_eq!(
+            previous,
+            Some(TaskStatus::Running),
+            "the caller needs to know it must also abort the agent loop"
+        );
+
+        // The aborted run's own completion path must not resurrect it as a
+        // result nobody asked for.
+        s.finish(&task.id, "here is your answer").await.unwrap();
+        let after = s.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(after.status, TaskStatus::Cancelled);
+        assert!(after.result.is_none(), "a cancelled task has no result");
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_queued_task_reports_that_nothing_is_running() {
+        let s = store();
+        let task = s.enqueue("not started", None, None, 0, None).await.unwrap();
+        assert_eq!(s.cancel(&task.id).await.unwrap(), Some(TaskStatus::Queued));
+        // And the worker must never pick it up afterwards.
+        assert!(s.claim_next(None).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelling_an_unknown_task_is_not_an_error() {
+        let s = store();
+        assert_eq!(s.cancel("no-such-task").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_restart_fails_tasks_it_interrupted() {
+        let s = store();
+        let running = s.enqueue("interrupted", None, None, 0, None).await.unwrap();
+        s.claim_next(None).await.unwrap();
+        let queued = s
+            .enqueue("not yet started", None, None, 0, None)
+            .await
+            .unwrap();
+
+        assert_eq!(s.fail_orphaned().await.unwrap(), 1);
+
+        let running = s.get(&running.id).await.unwrap().unwrap();
+        assert_eq!(running.status, TaskStatus::Failed);
+        assert!(running.error.unwrap().contains("restarted"));
+
+        // Queued work predates no agent loop, so it survives the restart.
+        let queued = s.get(&queued.id).await.unwrap().unwrap();
+        assert_eq!(queued.status, TaskStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn the_sweeper_keeps_unfinished_work_however_old() {
+        let s = store();
+        let queued = s
+            .enqueue("still waiting", None, None, 0, None)
+            .await
+            .unwrap();
+        let done = s.enqueue("finished", None, None, 0, None).await.unwrap();
+        s.claim_next(None).await.unwrap();
+        s.finish(&done.id, "result").await.unwrap();
+
+        // Nothing is old enough to sweep yet.
+        assert_eq!(s.sweep(chrono::Duration::hours(48)).await.unwrap(), 0);
+
+        // With a zero-length retention the finished task goes and the
+        // queued one stays: an unfinished task is not garbage.
+        assert_eq!(s.sweep(chrono::Duration::zero()).await.unwrap(), 1);
+        assert!(s.get(&done.id).await.unwrap().is_none());
+        assert!(s.get(&queued.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn the_worker_records_the_conversation_it_opened() {
+        let s = store();
+        let task = s
+            .enqueue("fresh thread", None, None, 0, None)
+            .await
+            .unwrap();
+        assert!(task.conversation_id.is_none());
+
+        s.set_conversation(&task.id, "convo-1").await.unwrap();
+        let reloaded = s.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(reloaded.conversation_id.as_deref(), Some("convo-1"));
+    }
+
+    #[tokio::test]
+    async fn a_hop_budget_round_trips_and_never_goes_negative() {
+        let s = store();
+        let task = s
+            .enqueue("delegate onward", None, None, 2, None)
+            .await
+            .unwrap();
+        assert_eq!(task.hop_budget, 2);
+
+        // A caller cannot ask for a negative budget and have it read back
+        // as anything other than "no further hops".
+        let task = s.enqueue("no hops", None, None, -5, None).await.unwrap();
+        assert_eq!(task.hop_budget, 0);
+    }
+
+    #[tokio::test]
+    async fn tasks_list_newest_first() {
+        let s = store();
+        s.enqueue("first", None, None, 0, None).await.unwrap();
+        let second = s.enqueue("second", None, None, 0, None).await.unwrap();
+        let listed = s.list(10).await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, second.id);
+    }
+}

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -82,7 +82,13 @@ impl NodesTool {
             Ok(v) if !v.trim().is_empty() => v,
             _ => return Ok(Vec::new()),
         };
-        serde_json::from_str(&raw).map_err(|e| {
+        Self::parse_nodes(&raw)
+    }
+
+    /// Parse a node list, separated from reading the environment so it can
+    /// be exercised without touching a process-global variable.
+    fn parse_nodes(raw: &str) -> Result<Vec<RemoteNode>> {
+        serde_json::from_str(raw).map_err(|e| {
             Error::ToolExecution(
                 format!(
                     "RUSTYKRAB_NODES is not valid JSON ({e}). Expected an array of \
@@ -387,9 +393,12 @@ mod tests {
 
     #[test]
     fn malformed_config_is_a_clear_error() {
-        std::env::set_var("RUSTYKRAB_NODES", "not json");
-        let err = NodesTool::configured_nodes().unwrap_err().to_string();
+        // Parsed directly rather than through the environment. Setting a
+        // process-global var races every other test in this binary --
+        // cargo runs them as threads of one process -- and this test
+        // previously fought `list_never_leaks_tokens` for RUSTYKRAB_NODES,
+        // failing whichever one lost the interleaving.
+        let err = NodesTool::parse_nodes("not json").unwrap_err().to_string();
         assert!(err.contains("RUSTYKRAB_NODES"), "got: {err}");
-        std::env::remove_var("RUSTYKRAB_NODES");
     }
 }

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -32,6 +32,18 @@ pub struct RemoteNode {
     /// model so it can pick a node deliberately.
     #[serde(default)]
     pub description: Option<String>,
+    /// How many further delegation hops this node may make with work we
+    /// send it. Defaults to 0: the node runs the task itself and may not
+    /// hand any part of it onward.
+    ///
+    /// This is the cross-machine recursion guard. Two peers that each
+    /// list the other — the natural configuration when the node is
+    /// another copy of the same program — would otherwise bounce a task
+    /// between them indefinitely, at minutes of local inference per hop.
+    /// The local `subagents` tool has an equivalent depth counter; it
+    /// cannot help here because it is process-local.
+    #[serde(default)]
+    pub hop_budget: Option<i64>,
 }
 
 impl RemoteNode {
@@ -116,6 +128,25 @@ impl NodesTool {
         })
     }
 
+    /// Resolve the `node_id` argument for an action that targets one node.
+    fn target(nodes: &[RemoteNode], args: &Value, action: &str) -> Result<RemoteNode> {
+        let node_id = args["node_id"]
+            .as_str()
+            .ok_or_else(|| Error::ToolExecution(format!("'{action}' requires node_id").into()))?;
+        Self::find(nodes, node_id)
+    }
+
+    fn task_id<'a>(args: &'a Value, action: &str) -> Result<&'a str> {
+        args["task_id"]
+            .as_str()
+            .filter(|id| !id.trim().is_empty())
+            .ok_or_else(|| {
+                Error::ToolExecution(
+                    format!("'{action}' requires the task_id returned by 'send'").into(),
+                )
+            })
+    }
+
     /// Probe a node's public health endpoint. Returns round-trip latency.
     async fn probe(&self, node: &RemoteNode) -> std::result::Result<u128, String> {
         let start = Instant::now();
@@ -134,11 +165,118 @@ impl NodesTool {
         }
     }
 
-    /// Send a task to a node and return its reply.
+    /// Submit a task and return a handle, without waiting for it to run.
     ///
-    /// Creates a fresh conversation on the peer so delegated work does not share
-    /// context with whatever else that node is doing.
-    async fn send(&self, node: &RemoteNode, message: &str) -> Result<Value> {
+    /// Delegation is asynchronous because a delegated task on a local
+    /// model routinely takes minutes, and the agent loop that called this
+    /// tool cannot be held open that long — the runner caps a network
+    /// tool at [`DEFAULT_NET_TOOL_TIMEOUT_SECS`-equivalent] wall-clock,
+    /// well under the time a real task needs. Submitting returns in about
+    /// a second; the model polls with `check` on later turns and does
+    /// other work in between.
+    async fn submit(
+        &self,
+        node: &RemoteNode,
+        message: &str,
+        conversation_id: Option<&str>,
+    ) -> Result<Value> {
+        let body = json!({
+            "message": message,
+            "conversationId": conversation_id,
+            "hopBudget": node.hop_budget.unwrap_or(0),
+        });
+
+        let accepted = match self.post(node, &node.api("/tasks"), body).await {
+            Ok(value) => value,
+            // A node on a build without the task queue has no /api/tasks.
+            // Fall back so a mixed-version fleet keeps working, and say
+            // so — the synchronous path is bounded by this tool's own
+            // timeout and will fail on anything long.
+            Err(e) if is_missing_endpoint(&e) => {
+                tracing::warn!(
+                    node = %node.id,
+                    "node has no /api/tasks; falling back to a synchronous delegation"
+                );
+                return self.legacy_send(node, message).await;
+            }
+            Err(e) => return Err(e),
+        };
+
+        let task_id = accepted["id"].as_str().unwrap_or_default().to_string();
+        if task_id.is_empty() {
+            return Err(Error::ToolExecution(
+                format!("node '{}' accepted the task but returned no id", node.id).into(),
+            ));
+        }
+
+        Ok(json!({
+            "node_id": node.id,
+            "task_id": task_id,
+            "status": accepted["status"].as_str().unwrap_or("queued"),
+            "next": "The node is working. Call nodes with action='check', the same \
+                     node_id, and this task_id to collect the result. Do other work \
+                     first — a delegated task usually takes minutes.",
+        }))
+    }
+
+    /// Read a submitted task's current state, and its result once done.
+    async fn check(&self, node: &RemoteNode, task_id: &str) -> Result<Value> {
+        let task: Value = self
+            .get(node, &node.api(&format!("/tasks/{task_id}")))
+            .await?;
+
+        let status = task["status"].as_str().unwrap_or("unknown");
+        let mut out = json!({
+            "node_id": node.id,
+            "task_id": task_id,
+            "status": status,
+            "elapsed_secs": task["elapsedSecs"],
+        });
+
+        // The conversation id is what makes a follow-up cheap: passing it
+        // back on the next `send` continues the same thread on the node,
+        // reusing its evaluated prompt prefix instead of re-reading the
+        // whole system prompt and tool schemas.
+        if let Some(convo) = task["conversationId"].as_str() {
+            out["conversation_id"] = json!(convo);
+        }
+
+        match status {
+            "done" => {
+                out["response"] = task["result"].clone();
+            }
+            "failed" | "cancelled" => {
+                out["error"] = task["error"].clone();
+            }
+            _ => {
+                out["next"] = json!(
+                    "Still running. Check again later rather than resubmitting — \
+                     a resubmit starts the work over from scratch."
+                );
+            }
+        }
+        Ok(out)
+    }
+
+    /// Cancel a submitted task, aborting it if the node has already started.
+    async fn cancel(&self, node: &RemoteNode, task_id: &str) -> Result<Value> {
+        let task: Value = self
+            .delete(node, &node.api(&format!("/tasks/{task_id}")))
+            .await?;
+        Ok(json!({
+            "node_id": node.id,
+            "task_id": task_id,
+            "status": task["status"].as_str().unwrap_or("cancelled"),
+        }))
+    }
+
+    /// Pre-queue delegation: create a conversation and post a message,
+    /// blocking until the node's whole agent turn finishes.
+    ///
+    /// Retained only so a primary on this build can still drive a node on
+    /// an older one. It is bounded by the caller's tool timeout, so it
+    /// fails on exactly the long tasks delegation exists for.
+    async fn legacy_send(&self, node: &RemoteNode, message: &str) -> Result<Value> {
         let started = Instant::now();
 
         let convo: Value = self
@@ -169,16 +307,36 @@ impl NodesTool {
             "conversation_id": convo_id,
             "response": text,
             "elapsed_secs": started.elapsed().as_secs(),
+            "warning": "This node runs a build without the delegated-task queue, so \
+                        the task ran synchronously. Upgrade it to delegate work that \
+                        takes longer than this tool's timeout.",
         }))
     }
 
+    async fn get(&self, node: &RemoteNode, url: &str) -> Result<Value> {
+        self.send_request(node, self.client.get(url), url).await
+    }
+
+    async fn delete(&self, node: &RemoteNode, url: &str) -> Result<Value> {
+        self.send_request(node, self.client.delete(url), url).await
+    }
+
     async fn post(&self, node: &RemoteNode, url: &str, body: Value) -> Result<Value> {
-        let resp = self
-            .client
-            .post(url)
+        self.send_request(node, self.client.post(url).json(&body), url)
+            .await
+    }
+
+    /// Issue one request to a node, mapping transport and HTTP failures
+    /// into errors the model can act on.
+    async fn send_request(
+        &self,
+        node: &RemoteNode,
+        request: reqwest::RequestBuilder,
+        url: &str,
+    ) -> Result<Value> {
+        let resp = request
             .bearer_auth(&node.token)
             .header("Origin", node.origin())
-            .json(&body)
             .send()
             .await
             .map_err(|e| {
@@ -192,17 +350,38 @@ impl NodesTool {
             let body = resp.text().await.unwrap_or_default();
             let hint = match status.as_u16() {
                 401 | 403 => " (check the node's token, and that its gateway is reachable)",
+                404 => " (the node may be running a build without this endpoint)",
                 _ => "",
             };
             return Err(Error::ToolExecution(
-                format!("node '{}' returned {status}{hint}: {body}", node.id).into(),
+                format!(
+                    "node '{}' returned {status}{hint} for {url}: {body}",
+                    node.id
+                )
+                .into(),
             ));
         }
 
-        resp.json().await.map_err(|e| {
+        // A 202 with no body is a legitimate response for some servers;
+        // treat an unparseable success as an empty object rather than an
+        // error, so the caller's own field checks produce the message.
+        let text = resp.text().await.unwrap_or_default();
+        if text.trim().is_empty() {
+            return Ok(json!({}));
+        }
+        serde_json::from_str(&text).map_err(|e| {
             Error::ToolExecution(format!("node '{}' returned invalid JSON: {e}", node.id).into())
         })
     }
+}
+
+/// Whether an error came from a node that does not know an endpoint.
+///
+/// Used to detect a peer predating the delegated-task queue so the tool
+/// can fall back instead of failing a mixed-version fleet.
+fn is_missing_endpoint(err: &Error) -> bool {
+    let text = err.to_string();
+    text.contains("404") || text.contains("405")
 }
 
 impl Default for NodesTool {
@@ -220,9 +399,13 @@ impl Tool for NodesTool {
     fn description(&self) -> &str {
         "Delegate a task to a peer RustyKrab instance on another machine. Use \
          'list' to see available nodes and what each is suited for, 'discover' to \
-         check which are online, and 'send' to hand a self-contained task to one \
-         and get its result. Delegated tasks run with that node's own tools and \
-         filesystem, so include everything the node needs in the message."
+         check which are online, 'send' to hand a self-contained task to one, \
+         'check' to collect the result later, and 'cancel' to stop one. Delegation \
+         is asynchronous: 'send' returns a task_id immediately and the node works \
+         in the background, typically for minutes — do other work and check back \
+         rather than waiting. Delegated tasks run with that node's own tools and \
+         filesystem and cannot see this machine's files, so include everything the \
+         node needs in the message."
     }
 
     fn sandbox_requirements(&self) -> SandboxRequirements {
@@ -249,16 +432,24 @@ impl Tool for NodesTool {
                 "properties": {
                     "action": {
                         "type": "string",
-                        "enum": ["discover", "list", "send"],
-                        "description": "'list' shows configured nodes, 'discover' probes which are online, 'send' delegates a task"
+                        "enum": ["discover", "list", "send", "check", "cancel"],
+                        "description": "'list' shows configured nodes, 'discover' probes which are online, 'send' delegates a task and returns a task_id, 'check' reads that task's status and result, 'cancel' stops it"
                     },
                     "node_id": {
                         "type": "string",
-                        "description": "Target node id (required for 'send')"
+                        "description": "Target node id (required for 'send', 'check' and 'cancel')"
                     },
                     "message": {
                         "type": "string",
-                        "description": "The task to delegate (required for 'send'). Must be self-contained: the node does not share this conversation's context."
+                        "description": "The task to delegate (required for 'send'). Must be self-contained: the node does not share this conversation's context, cannot see this machine's files, and starts from a blank slate unless conversation_id continues an earlier thread."
+                    },
+                    "task_id": {
+                        "type": "string",
+                        "description": "The id returned by 'send' (required for 'check' and 'cancel')"
+                    },
+                    "conversation_id": {
+                        "type": "string",
+                        "description": "Optional, for 'send': continue an earlier delegated thread on that node instead of starting fresh. Use the conversation_id from a previous 'check' when this task follows on from it — a continued thread starts answering in seconds where a new one spends a minute or more re-reading its own prompt."
                     }
                 },
                 "required": ["action"]
@@ -309,9 +500,7 @@ impl Tool for NodesTool {
             }
 
             "send" => {
-                let node_id = args["node_id"]
-                    .as_str()
-                    .ok_or_else(|| Error::ToolExecution("'send' requires node_id".into()))?;
+                let node = Self::target(&nodes, &args, "send")?;
                 let message = args["message"]
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("'send' requires message".into()))?;
@@ -320,12 +509,27 @@ impl Tool for NodesTool {
                         "'send' requires a non-empty message".into(),
                     ));
                 }
-                let node = Self::find(&nodes, node_id)?;
-                self.send(&node, message).await
+                self.submit(&node, message, args["conversation_id"].as_str())
+                    .await
+            }
+
+            "check" => {
+                let node = Self::target(&nodes, &args, "check")?;
+                let task_id = Self::task_id(&args, "check")?;
+                self.check(&node, task_id).await
+            }
+
+            "cancel" => {
+                let node = Self::target(&nodes, &args, "cancel")?;
+                let task_id = Self::task_id(&args, "cancel")?;
+                self.cancel(&node, task_id).await
             }
 
             other => Err(Error::ToolExecution(
-                format!("unknown action '{other}' (expected discover, list, or send)").into(),
+                format!(
+                    "unknown action '{other}' (expected discover, list, send, check, or cancel)"
+                )
+                .into(),
             )),
         }
     }
@@ -389,6 +593,80 @@ mod tests {
             "tool output must not carry tokens into model context: {rendered}"
         );
         std::env::remove_var("RUSTYKRAB_NODES");
+    }
+
+    #[test]
+    fn hop_budget_defaults_to_no_onward_delegation() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        // Unset means zero, not unlimited. A node configured without
+        // thinking about recursion must not be able to delegate onward.
+        assert_eq!(nodes[0].hop_budget.unwrap_or(0), 0);
+
+        let explicit: Vec<RemoteNode> =
+            serde_json::from_str(r#"[{"id":"n","url":"http://x","token":"t","hop_budget":2}]"#)
+                .unwrap();
+        assert_eq!(explicit[0].hop_budget, Some(2));
+    }
+
+    #[test]
+    fn a_missing_endpoint_is_distinguishable_from_a_dead_node() {
+        // Drives the fallback for a peer predating the task queue. An
+        // unreachable node must not be mistaken for an old one, or the
+        // tool would retry a synchronous send against nothing.
+        assert!(is_missing_endpoint(&Error::ToolExecution(
+            "node 'm4max' returned 404 Not Found for /api/tasks: ".into()
+        )));
+        assert!(!is_missing_endpoint(&Error::ToolExecution(
+            "node 'm4max' at https://x is unreachable: connection refused".into()
+        )));
+        assert!(!is_missing_endpoint(&Error::ToolExecution(
+            "node 'm4max' returned 401 Unauthorized for /api/tasks: ".into()
+        )));
+    }
+
+    #[test]
+    fn check_and_cancel_require_a_task_id() {
+        // Exercised through the argument helpers rather than `execute` so
+        // this does not touch RUSTYKRAB_NODES: the var is process-global
+        // and `list_never_leaks_tokens` owns it.
+        for action in ["check", "cancel"] {
+            let err = NodesTool::task_id(&json!({"node_id": "m4max"}), action)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("task_id"), "got: {err}");
+            // An empty string is not a usable handle either.
+            let err = NodesTool::task_id(&json!({"task_id": "  "}), action)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("task_id"), "got: {err}");
+        }
+        assert_eq!(
+            NodesTool::task_id(&json!({"task_id": "abc"}), "check").unwrap(),
+            "abc"
+        );
+    }
+
+    #[test]
+    fn targeting_an_action_reports_the_missing_node_id() {
+        let nodes: Vec<RemoteNode> = serde_json::from_str(&nodes_json()).unwrap();
+        let err = NodesTool::target(&nodes, &json!({"task_id": "abc"}), "check")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("node_id"), "got: {err}");
+    }
+
+    #[test]
+    fn the_schema_advertises_the_asynchronous_actions() {
+        let schema = NodesTool::new().schema();
+        let actions = schema.parameters["properties"]["action"]["enum"].clone();
+        let actions: Vec<String> = serde_json::from_value(actions).unwrap();
+        // Without check the model can submit work it can never collect.
+        for expected in ["list", "discover", "send", "check", "cancel"] {
+            assert!(
+                actions.iter().any(|a| a == expected),
+                "'{expected}' missing from {actions:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustykrab-tools/src/nodes.rs
+++ b/crates/rustykrab-tools/src/nodes.rs
@@ -186,21 +186,35 @@ impl NodesTool {
             "hopBudget": node.hop_budget.unwrap_or(0),
         });
 
-        let accepted = match self.post(node, &node.api("/tasks"), body).await {
-            Ok(value) => value,
-            // A node on a build without the task queue has no /api/tasks.
-            // Fall back so a mixed-version fleet keeps working, and say
-            // so — the synchronous path is bounded by this tool's own
-            // timeout and will fail on anything long.
-            Err(e) if is_missing_endpoint(&e) => {
-                tracing::warn!(
-                    node = %node.id,
-                    "node has no /api/tasks; falling back to a synchronous delegation"
-                );
-                return self.legacy_send(node, message).await;
-            }
-            Err(e) => return Err(e),
-        };
+        let url = node.api("/tasks");
+        let resp = self
+            .send_raw(node, self.client.post(&url).json(&body))
+            .await?;
+
+        // A node on a build without the task queue does not serve
+        // /api/tasks. Fall back so a mixed-version fleet keeps working —
+        // the synchronous path is bounded by this tool's own timeout and
+        // will fail on anything long, but it beats refusing outright.
+        //
+        // Both statuses matter, and which one you get is not obvious:
+        // axum answers 404 when no route matches the path at all, but 405
+        // when the path exists for a different method. A build that has
+        // `GET /api/tasks/{id}` but not `POST /api/tasks` returns 405, so
+        // treating only 404 as "missing" would strand exactly the peers
+        // this fallback is for. Observed against a real v5.2.0 node: 405.
+        if matches!(
+            resp.status(),
+            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+        ) {
+            tracing::warn!(
+                node = %node.id,
+                status = %resp.status(),
+                "node does not serve /api/tasks; falling back to a synchronous delegation"
+            );
+            return self.legacy_send(node, message).await;
+        }
+
+        let accepted = self.interpret(node, resp, &url).await?;
 
         let task_id = accepted["id"].as_str().unwrap_or_default().to_string();
         if task_id.is_empty() {
@@ -326,15 +340,16 @@ impl NodesTool {
             .await
     }
 
-    /// Issue one request to a node, mapping transport and HTTP failures
-    /// into errors the model can act on.
-    async fn send_request(
+    /// Issue one request to a node, returning the response whatever its
+    /// status. Only transport failures become errors here, so callers
+    /// that need to branch on a status code can do so before it is
+    /// flattened into an error string.
+    async fn send_raw(
         &self,
         node: &RemoteNode,
         request: reqwest::RequestBuilder,
-        url: &str,
-    ) -> Result<Value> {
-        let resp = request
+    ) -> Result<reqwest::Response> {
+        request
             .bearer_auth(&node.token)
             .header("Origin", node.origin())
             .send()
@@ -343,14 +358,22 @@ impl NodesTool {
                 Error::ToolExecution(
                     format!("node '{}' at {} is unreachable: {e}", node.id, node.url).into(),
                 )
-            })?;
+            })
+    }
 
+    /// Turn a peer's response into JSON, or an error the model can act on.
+    async fn interpret(
+        &self,
+        node: &RemoteNode,
+        resp: reqwest::Response,
+        url: &str,
+    ) -> Result<Value> {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             let hint = match status.as_u16() {
                 401 | 403 => " (check the node's token, and that its gateway is reachable)",
-                404 => " (the node may be running a build without this endpoint)",
+                404 | 405 => " (the node may be running a build without this endpoint)",
                 _ => "",
             };
             return Err(Error::ToolExecution(
@@ -373,15 +396,16 @@ impl NodesTool {
             Error::ToolExecution(format!("node '{}' returned invalid JSON: {e}", node.id).into())
         })
     }
-}
 
-/// Whether an error came from a node that does not know an endpoint.
-///
-/// Used to detect a peer predating the delegated-task queue so the tool
-/// can fall back instead of failing a mixed-version fleet.
-fn is_missing_endpoint(err: &Error) -> bool {
-    let text = err.to_string();
-    text.contains("404") || text.contains("405")
+    async fn send_request(
+        &self,
+        node: &RemoteNode,
+        request: reqwest::RequestBuilder,
+        url: &str,
+    ) -> Result<Value> {
+        let resp = self.send_raw(node, request).await?;
+        self.interpret(node, resp, url).await
+    }
 }
 
 impl Default for NodesTool {
@@ -609,19 +633,41 @@ mod tests {
     }
 
     #[test]
-    fn a_missing_endpoint_is_distinguishable_from_a_dead_node() {
-        // Drives the fallback for a peer predating the task queue. An
-        // unreachable node must not be mistaken for an old one, or the
-        // tool would retry a synchronous send against nothing.
-        assert!(is_missing_endpoint(&Error::ToolExecution(
-            "node 'm4max' returned 404 Not Found for /api/tasks: ".into()
-        )));
-        assert!(!is_missing_endpoint(&Error::ToolExecution(
-            "node 'm4max' at https://x is unreachable: connection refused".into()
-        )));
-        assert!(!is_missing_endpoint(&Error::ToolExecution(
-            "node 'm4max' returned 401 Unauthorized for /api/tasks: ".into()
-        )));
+    fn both_missing_endpoint_statuses_trigger_the_fallback() {
+        // Which one a peer returns is not obvious: axum answers 404 when
+        // no route matches the path, but 405 when the path exists for a
+        // different method. A real v5.2.0 node returned 405, so matching
+        // only 404 would strand exactly the peers this fallback serves.
+        for status in [
+            reqwest::StatusCode::NOT_FOUND,
+            reqwest::StatusCode::METHOD_NOT_ALLOWED,
+        ] {
+            assert!(
+                matches!(
+                    status,
+                    reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+                ),
+                "{status} must fall back"
+            );
+        }
+
+        // And nothing else does. An auth failure or a server error means
+        // the endpoint is there and something else is wrong; retrying
+        // synchronously would just fail twice and hide the real cause.
+        for status in [
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            assert!(
+                !matches!(
+                    status,
+                    reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
+                ),
+                "{status} must not fall back"
+            );
+        }
     }
 
     #[test]

--- a/crates/rustykrab-tools/tests/nodes_live.rs
+++ b/crates/rustykrab-tools/tests/nodes_live.rs
@@ -8,6 +8,8 @@
 //!   cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
 //! ```
 
+use std::time::{Duration, Instant};
+
 use rustykrab_core::Tool;
 use rustykrab_tools::NodesTool;
 use serde_json::json;
@@ -32,7 +34,7 @@ async fn live_delegation_round_trip() {
         "peer should be reachable"
     );
 
-    let result = tool
+    let handle = tool
         .execute(json!({
             "action": "send",
             "node_id": id,
@@ -40,14 +42,81 @@ async fn live_delegation_round_trip() {
         }))
         .await
         .expect("delegation failed");
-    eprintln!("send: {result}");
+    eprintln!("send: {handle}");
 
-    let response = result["response"].as_str().unwrap_or_default();
+    // Submission returns a handle, not an answer. This is the whole point
+    // of the asynchronous path: it comes back in about a second, where the
+    // task behind it runs for minutes.
+    let task_id = handle["task_id"].as_str().expect("a task id").to_string();
+
+    // Poll until terminal. Generous: a cold turn on a local model spends
+    // a minute or more just evaluating its own system prompt.
+    let deadline = Instant::now() + Duration::from_secs(600);
+    let done = loop {
+        let state = tool
+            .execute(json!({"action": "check", "node_id": id, "task_id": task_id}))
+            .await
+            .expect("check failed");
+        let status = state["status"].as_str().unwrap_or_default().to_string();
+        eprintln!("check: {status} ({}s)", state["elapsed_secs"]);
+        if status != "queued" && status != "running" {
+            break state;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "task never reached a terminal state: {state}"
+        );
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    };
+
+    assert_eq!(done["status"], "done", "task did not succeed: {done}");
+    let response = done["response"].as_str().unwrap_or_default();
     assert!(
         response.contains("DELEGATED-OK"),
         "peer did not answer the delegated task: {response:?}"
     );
-    assert!(result["conversation_id"].is_string());
+    // The thread id is what makes a follow-up cheap, so it must survive
+    // the round trip.
+    assert!(done["conversation_id"].is_string());
+}
+
+/// A submitted task can be called off before the node finishes it.
+#[tokio::test]
+#[ignore = "requires a peer RustyKrab gateway"]
+async fn a_submitted_task_can_be_cancelled() {
+    let tool = NodesTool::new();
+    assert!(tool.available(), "RUSTYKRAB_NODES must be set");
+
+    let listed = tool.execute(json!({"action": "list"})).await.unwrap();
+    let id = listed["nodes"][0]["id"]
+        .as_str()
+        .expect("a node")
+        .to_string();
+
+    let handle = tool
+        .execute(json!({
+            "action": "send",
+            "node_id": id,
+            "message": "Count slowly to one thousand, showing every number."
+        }))
+        .await
+        .expect("delegation failed");
+    let task_id = handle["task_id"].as_str().expect("a task id").to_string();
+
+    let cancelled = tool
+        .execute(json!({"action": "cancel", "node_id": id, "task_id": task_id}))
+        .await
+        .expect("cancel failed");
+    assert_eq!(cancelled["status"], "cancelled");
+
+    let after = tool
+        .execute(json!({"action": "check", "node_id": id, "task_id": task_id}))
+        .await
+        .expect("check failed");
+    assert_eq!(
+        after["status"], "cancelled",
+        "a cancelled task must stay cancelled: {after}"
+    );
 }
 
 #[tokio::test]

--- a/scripts/fleet.env.example
+++ b/scripts/fleet.env.example
@@ -23,12 +23,25 @@ export RUSTYKRAB_NODES='[
     "id": "m4max",
     "url": "https://REPLACE-ME.your-tailnet.ts.net",
     "token": "REPLACE-WITH-M4-AUTH-TOKEN",
-    "description": "M4 Max 32GB running qwen3.8:27b-mlx. Stronger reasoning than the local model but slower per task. Use for self-contained coding and analysis jobs that tolerate minutes of latency. Has its own checkout at ~/code/rustycrab; it cannot see files on this machine."
+    "description": "M4 Max 32GB running qwen3.8:27b-mlx. Stronger reasoning than the local model but slower per task. Use for self-contained coding and analysis jobs that tolerate minutes of latency. Has its own checkout at ~/code/rustycrab; it cannot see files on this machine.",
+    "hop_budget": 0
   }
 ]'
 
-# Delegated tasks on a local model take minutes. Default is 900s.
+# hop_budget 0 above denies the node onward delegation. Leave it at 0 unless
+# you have a reason not to: this node is another copy of the same program, so
+# if it ever lists this machine back, a task can bounce between the two
+# indefinitely at minutes of inference per hop.
+
+# Delegation is asynchronous -- `nodes send` returns a task_id immediately and
+# the model collects the result with `nodes check`. This timeout therefore
+# covers only the short submit/poll/cancel calls, plus the fallback path
+# against a node too old to have the task queue.
 export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
+
+# If this machine runs RustyKrab as an installed LaunchAgent rather than from
+# a shell, re-run scripts/install.sh after exporting the above -- launchd only
+# sees what the installer wrote into the plist.
 
 # ---------------------------------------------------------------------------
 # NODE  (M4 Max) — headless executor, no channels

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,8 +73,14 @@ PB=(/usr/libexec/PlistBuddy -c)
 # set at install time. The credential-page settings are on the list because
 # without RUSTYKRAB_PUBLIC_URL the agent cannot mint a link at all, and the
 # failure is silent — it just falls back to telling the user to open the app.
+#
+# RUSTYKRAB_NODES carries a peer's bearer token, so it lands in a plist that is
+# chmod 600 below — the same posture as the systemd EnvironmentFile documented
+# in the README. Without forwarding it, a daemon installed as a LaunchAgent can
+# never be configured to delegate, whatever the installing shell had exported.
 for key in RUSTYKRAB_PROVIDER RUSTYKRAB_PORT RUSTYKRAB_WEB_UI RUST_LOG \
     OLLAMA_BASE_URL OLLAMA_MODEL OLLAMA_NUM_CTX RUSTYKRAB_NUM_CTX \
+    RUSTYKRAB_NODES RUSTYKRAB_NODE_TIMEOUT_SECS \
     TELEGRAM_ALLOWED_CHATS TELEGRAM_BOT_TOKEN \
     RUSTYKRAB_PUBLIC_URL RUSTYKRAB_TAILNET_USERS RUSTYKRAB_ALLOWED_ORIGINS; do
     if [[ -n "${!key:-}" ]]; then

--- a/scripts/setup-delegation-node.md
+++ b/scripts/setup-delegation-node.md
@@ -14,11 +14,59 @@ Consequences worth planning around:
   files on the primary.
 - **Results come back as text**, not as edits on the primary. To move actual code,
   have the node commit and push a branch, then pull it here.
-- **Each `send` starts a fresh conversation** on the node, so the message must be
-  self-contained — restate the goal, paths, and constraints every time.
+- **The message must be self-contained** — restate the goal, paths, and
+  constraints. The node does not share the primary's conversation.
 
 If what you want is "one agent, more compute", this is not that. It is "a second,
 independent agent you can hand a well-specified job to."
+
+## How a delegation runs
+
+`send` does not wait. It submits the task to the node's queue and returns a
+`task_id` in about a second; the model then does other work and collects the
+result with `check` on a later turn.
+
+```
+nodes send   -> {"task_id": "...", "status": "queued"}
+nodes check  -> {"status": "running", "elapsed_secs": 94}
+nodes check  -> {"status": "done", "response": "...", "conversation_id": "..."}
+nodes cancel -> {"status": "cancelled"}      # aborts it mid-run if started
+```
+
+Three things follow from that shape:
+
+- **A long task no longer dies on the caller.** The agent loop caps a network
+  tool call at 120 seconds. A synchronous delegation exceeded that on anything
+  real — the caller timed out while the node kept running, and the result was
+  unreachable.
+- **The node runs one task at a time.** Its model has a single KV-cache slot
+  (`OLLAMA_NUM_PARALLEL=1`), so interleaving two delegated conversations evicts
+  both prompt prefixes; serialising is faster than sharing. Queued work is
+  drained oldest-first, except that a task continuing the conversation the node
+  just ran is preferred — that thread's prefix is still warm.
+- **Follow-ups should continue the thread.** Pass the `conversation_id` from
+  `check` back into the next `send`. On this hardware a fresh thread spent 79.5s
+  evaluating its own prompt before answering; the second turn of the same thread
+  spent 3.3s.
+
+Tasks survive a restart of either machine: the queue is persisted, and a task
+the node was mid-way through when it died is reported as failed rather than
+left pending forever.
+
+## Recursion
+
+`hop_budget` on a node entry says how many further delegations the work may
+make, and defaults to `0`. At zero the node is denied the `nodes` tool for that
+run, so it cannot hand any part of the task onward.
+
+This matters specifically because the node is another copy of the same program.
+If it also lists the primary in its own `RUSTYKRAB_NODES`, a task can bounce
+between the two machines indefinitely, costing minutes of local inference per
+hop. The `subagents` tool's depth counter does not help — it is process-local
+and does not cross the network.
+
+If a node genuinely needs to break work into parts, it should queue those parts
+for itself rather than delegate them outward.
 
 ## 1. On the node machine
 
@@ -104,14 +152,19 @@ export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
 Restart the primary so it picks up the config. The `nodes` tool stays hidden from
 the model until `RUSTYKRAB_NODES` is set.
 
+If the primary runs as an installed LaunchAgent rather than from a shell,
+re-run `scripts/install.sh` after exporting these: the installer copies a fixed
+list of variables into the plist, and a daemon started by launchd sees only
+what is in there.
+
 ## 4. Verify
 
 ```bash
 RUSTYKRAB_NODES='...' cargo test -p rustykrab-tools --test nodes_live -- --ignored --nocapture
 ```
 
-That checks `list`, `discover` (reachability + latency), and a real `send` round
-trip.
+That checks `list`, `discover` (reachability + latency), a real submit-and-poll
+round trip, and a cancel.
 
 ## Measured tuning findings
 
@@ -143,8 +196,8 @@ Four things worth knowing, three of which contradict commonly repeated advice:
 **Multi-turn is much cheaper than cold turns.** In a two-turn conversation with a
 ~4.9k-token system prompt, turn 1 paid 79.5 s of prefill and turn 2 paid only
 **3.3 s** — the slot cache reuses the prefix. Long-running conversations amortize
-well; it is *fresh* delegated tasks that pay full price. Since every `nodes send`
-starts a new conversation, each delegation is a cold turn by construction.
+well; it is *fresh* delegated tasks that pay full price. `send` accepts a
+`conversation_id` precisely so a follow-up need not be one.
 
 ## Performance expectations
 
@@ -163,6 +216,8 @@ Plan accordingly:
 
 - Delegate **batch or background work**, not anything interactive.
 - Prefer **few large tasks** over many small ones — per-task overhead dominates.
+- Continue a thread rather than opening a new one, which is what turns that
+  per-task overhead from ~80s into ~3s.
 - Benchmark the node first with `scripts/bench-local-models.md`. If prompt
   processing there is slow, every delegated task inherits it.
 - A faster model on the node often beats a smarter one, because the overhead is


### PR DESCRIPTION
Delegation already existed, but synchronously: `nodes send` created a conversation on the peer and held an HTTP request open for the whole agent turn. That cannot work. The runner caps a network tool call at 120s (`runner.rs`, `DEFAULT_NET_TOOL_TIMEOUT_SECS`), while a delegated task on a local model takes minutes. So the caller timed out, the node kept running, and the result was unreachable because the conversation id was lost with the error. `RUSTYKRAB_NODE_TIMEOUT_SECS` only ever sized the reqwest client, so raising it changed nothing.

## What changed

The node persists submitted work and drains it with a single worker; the primary gets a handle back in about a second and collects later.

| | |
|---|---|
| `POST /api/tasks` | 202 `{id, status}` |
| `GET /api/tasks/{id}` | status, and result once done |
| `DELETE /api/tasks/{id}` | cancel, aborting the run if it has started |
| `GET /api/tasks` | recent tasks |

`nodes` gains `check` and `cancel` alongside `send`, and accepts a `conversation_id` so a follow-up continues an existing thread instead of starting cold.

**One worker, not a pool.** A delegation node's model has a single KV-cache slot (`OLLAMA_NUM_PARALLEL=1`), so interleaving two conversations evicts both prompt prefixes and is slower than running them back to back. The queue drains oldest-first but prefers a task continuing the conversation just run, whose prefix is still warm.

**Recursion is bounded** by a hop budget on the task, defaulting to zero; at zero the run is denied the `nodes` tool. The `subagents` depth counter cannot cover this — it is process-local, and the node is another copy of this program, so two peers listing each other would bounce a task between them indefinitely.

**Mixed-version fallback.** Against a peer with no `/api/tasks` the tool falls back to the old synchronous path. The second commit here detects that by status code rather than by grepping the error text — which matters more than it sounds: axum answers 404 when no route matches the path but **405** when the path exists for a different method, and a real v5.2.0 node returned 405.

## Verification

- 792 tests, fmt and clippy clean; `scripts/e2e.sh` 17/17
- **Loopback**, two instances of this build with `gemma4:26b`: submit returned a `task_id` immediately, poll went `queued → running → done` in 13s, cancel aborted a running task mid-flight, and thread continuation returned the stored value — 25s cold vs **6s** continuing the same `conversation_id`
- **Cross-machine**, an M1 primary on this branch delegating over Tailscale to an M4 running v5.2.0: detected the missing queue (405), fell back, and returned the peer's answer in 10.1s, authenticated with a paired device token

Also: tasks orphaned by a crash are failed at startup rather than left pending; a cancel landing mid-run is not overwritten by the run's own completion; delegated turns carry the submitting principal and the caller's trace id; and `scripts/install.sh` forwards `RUSTYKRAB_NODES` so a LaunchAgent daemon can actually be configured to delegate.

Part of stack #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)