### PR TITLE
feat(nodes): scope what a delegated task may do on the node it runs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ All configuration is via environment variables. No plaintext config files.
 | `OPENAI_MAX_TOKENS` | `8192` | Max tokens to generate per response |
 | `OPENAI_INCLUDE_USAGE` | `1` | Request usage in the final stream chunk; set `0` for servers that reject `stream_options` |
 | `RUSTYKRAB_NODES` | unset | JSON array of peer instances the `nodes` tool can delegate to: `{id, url, token, description, hop_budget}`. `hop_budget` defaults to `0`, which denies the node onward delegation. See [Delegating to a peer node](#delegating-to-a-peer-node) |
+| `RUSTYKRAB_DELEGATION_TOOLS` | unset | On a *node*: which tools a task delegated by a peer may use. Unset applies the default posture (everything registered except the credential family, `message` and `gateway`); `all` lifts the allowlist but not those fixed denials; a comma-separated list names the only tools a delegated run may touch. Node-authoritative — a submitting peer can narrow this per task but never widen it. The sub-agent tool family is withheld from delegated runs unconditionally |
 | `RUSTYKRAB_NODE_TIMEOUT_SECS` | `900` | HTTP timeout for calls to a peer. Since delegation is asynchronous these calls are short (submit, poll, cancel); the generous default now only covers the fallback path against a peer too old to have the task queue |
 | `CHROME_CDP_URL` | `ws://127.0.0.1:9222` | Chrome DevTools Protocol endpoint |
 | `RUSTYKRAB_AUTH_TOKEN` | auto-generated | Bearer token for API auth |
@@ -536,6 +537,17 @@ list the other — the natural configuration when the node is another copy of
 the same program — bounce a task between them indefinitely at minutes of
 local inference per hop. The local `subagents` depth counter cannot help,
 because it is process-local.
+
+**A delegated run is scoped on the node, not by the caller.** The task text
+is composed by the *peer's model*, so anything that reached that peer as
+untrusted input — a fetched page, a search result — can arrive here phrased
+as an instruction. So the node withholds the credential family, `message`
+and `gateway` from every delegated run, and withholds the sub-agent tool
+family unconditionally: a node is a sub-agent, and work it needs to break up
+it queues for itself rather than spawning further agents. Narrow it further
+with `RUSTYKRAB_DELEGATION_TOOLS`. A submitting peer may request a tighter
+limit still (`allowedTools` on the task), which intersects with the node's
+policy and can never widen it.
 
 See `scripts/setup-delegation-node.md` for standing up a node, exposing it
 safely (Tailscale Serve, not the raw gateway port), and measured latency

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -438,6 +438,11 @@ struct SubmitTaskRequest {
     /// zero means the run may not delegate onward at all.
     #[serde(default, rename = "hopBudget")]
     hop_budget: Option<i64>,
+    /// Tools the caller wants this task limited to. Intersected with this
+    /// node's own policy, never substituted for it — a peer can ask for
+    /// less than the node allows and never more.
+    #[serde(default, rename = "allowedTools")]
+    allowed_tools: Option<Vec<String>>,
     /// The caller's trace id, so one delegation is greppable across both
     /// machines' logs.
     #[serde(default, rename = "traceId")]
@@ -518,6 +523,7 @@ async fn submit_task(
             body.conversation_id.as_deref(),
             who.as_deref(),
             body.hop_budget.unwrap_or(0),
+            body.allowed_tools.clone(),
             Some(&trace),
         )
         .await

--- a/crates/rustykrab-gateway/src/tasks.rs
+++ b/crates/rustykrab-gateway/src/tasks.rs
@@ -256,7 +256,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
         .unwrap_or_else(Uuid::new_v4);
 
     let options = RunOptions {
-        denied_tools: denied_tools_for(&task),
+        denied_tools: denied_tools_for(&available_tool_names(&state), &task),
         ..RunOptions::default()
     };
 
@@ -288,19 +288,102 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
     })
 }
 
-/// Tools a delegated run may not use, given its remaining hop budget.
+/// Tool names this node currently offers, which the ceiling is expressed
+/// against — a denial only means anything for a tool that exists.
+fn available_tool_names(state: &AppState) -> Vec<&str> {
+    state
+        .tools
+        .iter()
+        .filter(|t| t.available())
+        .map(|t| t.name())
+        .collect()
+}
+
+/// Tools withheld from every delegated run regardless of configuration.
 ///
-/// With no hops left the node may not delegate onward. That is the
-/// cross-machine analogue of the local recursion guard in the
-/// `subagents` tool, and without it a node whose own `RUSTYKRAB_NODES`
-/// points back at the primary would recurse indefinitely — each hop
-/// costing minutes of local inference.
-fn denied_tools_for(task: &DelegatedTask) -> Vec<String> {
-    if task.hop_budget > 0 {
-        Vec::new()
-    } else {
-        vec!["nodes".to_string()]
+/// The credential family and the outbound `message` tool are the two
+/// ways a delegated instruction could reach past the task it was given —
+/// into this machine's stored secrets, or out through its own Telegram
+/// and Signal accounts. A delegated instruction is composed by the
+/// peer's *model*, so anything that reaches the peer as untrusted text
+/// (a fetched web page, a search result) can end up phrased as a task
+/// for this node. Withholding these here means the node's own operator
+/// decides that, not the sentence that arrived over the network.
+const ALWAYS_DENIED: &[&str] = &[
+    "credential_read",
+    "credential_write",
+    "credential_request",
+    "message",
+    "gateway",
+];
+
+/// Tools a delegated run may use, as configured on this node.
+///
+/// `RUSTYKRAB_DELEGATION_TOOLS` is node-authoritative: unset applies the
+/// default posture below, `all` lifts it, and a comma-separated list
+/// names the only tools a delegated run may use. The submitting peer can
+/// narrow this further per task but can never widen it — this machine
+/// decides what a peer may do on it, not the peer.
+fn configured_allowlist() -> Option<Vec<String>> {
+    let raw = std::env::var("RUSTYKRAB_DELEGATION_TOOLS").ok()?;
+    let raw = raw.trim();
+    if raw.is_empty() || raw.eq_ignore_ascii_case("all") {
+        return None;
     }
+    Some(
+        raw.split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect(),
+    )
+}
+
+/// Tools this particular delegated run may not use.
+///
+/// Three layers, most specific last:
+///
+/// 1. The sub-agent family, always. A node is a sub-agent; letting it
+///    spawn its own would make the topology a tree of unknown depth
+///    across machines. Work it needs to break up, it queues for itself.
+/// 2. [`ALWAYS_DENIED`], plus anything outside this node's configured
+///    allowlist.
+/// 3. `nodes`, once the hop budget is spent, so the task cannot be
+///    handed onward. Without it two peers listing each other bounce a
+///    task between them indefinitely, at minutes of local inference per
+///    hop; the `subagents` depth counter cannot help, being process-local.
+fn denied_tools_for(available: &[&str], task: &DelegatedTask) -> Vec<String> {
+    let mut denied: Vec<String> = rustykrab_core::capability::SUBAGENT_TOOL_NAMES
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    denied.extend(ALWAYS_DENIED.iter().map(|t| t.to_string()));
+
+    if let Some(allowed) = configured_allowlist() {
+        for name in available {
+            if !allowed.iter().any(|a| a == name) {
+                denied.push((*name).to_string());
+            }
+        }
+    }
+
+    // Per-task narrowing from the submitting peer. Intersects with the
+    // above rather than replacing it: a task may ask for less than the
+    // node allows, never more.
+    if let Some(requested) = task.allowed_tools.as_ref() {
+        for name in available {
+            if !requested.iter().any(|a| a == name) {
+                denied.push((*name).to_string());
+            }
+        }
+    }
+
+    if task.hop_budget <= 0 {
+        denied.push("nodes".to_string());
+    }
+
+    denied.sort();
+    denied.dedup();
+    denied
 }
 
 /// Whether a status means the caller should keep polling.
@@ -312,6 +395,22 @@ pub fn is_pending(status: TaskStatus) -> bool {
 mod tests {
     use super::*;
 
+    /// A representative slice of what a node actually offers.
+    const AVAILABLE: &[&str] = &[
+        "read",
+        "write",
+        "exec",
+        "web_fetch",
+        "nodes",
+        "subagents",
+        "agents_list",
+        "credential_read",
+        "credential_write",
+        "credential_request",
+        "message",
+        "gateway",
+    ];
+
     fn task(hop_budget: i64) -> DelegatedTask {
         DelegatedTask {
             id: "t1".to_string(),
@@ -322,6 +421,7 @@ mod tests {
             error: None,
             principal: None,
             hop_budget,
+            allowed_tools: None,
             trace_id: None,
             created_at: Utc::now(),
             started_at: None,
@@ -329,11 +429,101 @@ mod tests {
         }
     }
 
+    fn denied(task: &DelegatedTask) -> Vec<String> {
+        denied_tools_for(AVAILABLE, task)
+    }
+
     #[test]
     fn a_spent_hop_budget_denies_onward_delegation() {
-        assert_eq!(denied_tools_for(&task(0)), vec!["nodes".to_string()]);
-        assert_eq!(denied_tools_for(&task(-1)), vec!["nodes".to_string()]);
-        assert!(denied_tools_for(&task(1)).is_empty());
+        assert!(denied(&task(0)).contains(&"nodes".to_string()));
+        assert!(denied(&task(-1)).contains(&"nodes".to_string()));
+        assert!(
+            !denied(&task(1)).contains(&"nodes".to_string()),
+            "a node with hops left may delegate onward"
+        );
+    }
+
+    #[test]
+    fn a_delegated_run_never_gets_the_subagent_family() {
+        // This is what makes the node a sub-agent rather than another
+        // orchestrator: it does its own work, and splits it by queueing
+        // for itself rather than spawning further agents.
+        let denied = denied(&task(5));
+        for tool in rustykrab_core::capability::SUBAGENT_TOOL_NAMES {
+            assert!(
+                denied.contains(&tool.to_string()),
+                "'{tool}' must be withheld from a delegated run"
+            );
+        }
+    }
+
+    #[test]
+    fn credentials_and_outbound_messaging_are_always_withheld() {
+        // A delegated instruction is composed by the peer's model, so it
+        // can carry text this node never vetted. It must not be able to
+        // reach this machine's secrets or send from its accounts.
+        let denied = denied(&task(0));
+        for tool in ALWAYS_DENIED {
+            assert!(
+                denied.contains(&tool.to_string()),
+                "'{tool}' must be withheld from a delegated run"
+            );
+        }
+        // Ordinary work is still possible.
+        assert!(!denied.contains(&"read".to_string()));
+        assert!(!denied.contains(&"exec".to_string()));
+    }
+
+    #[test]
+    fn a_task_can_narrow_the_ceiling_but_not_widen_it() {
+        let mut narrowed = task(9);
+        // Asks for read plus two tools the node always withholds.
+        narrowed.allowed_tools = Some(vec![
+            "read".to_string(),
+            "credential_read".to_string(),
+            "message".to_string(),
+        ]);
+        let denied = denied(&narrowed);
+
+        assert!(!denied.contains(&"read".to_string()), "read was requested");
+        // Everything else the node offers is now off, because the task
+        // asked to be limited.
+        assert!(denied.contains(&"exec".to_string()));
+        assert!(denied.contains(&"web_fetch".to_string()));
+        // And the request cannot buy back what the node withholds.
+        assert!(denied.contains(&"credential_read".to_string()));
+        assert!(denied.contains(&"message".to_string()));
+    }
+
+    #[test]
+    fn the_node_allowlist_overrides_what_a_task_may_touch() {
+        // Process-global: this is the only test that sets the var.
+        std::env::set_var("RUSTYKRAB_DELEGATION_TOOLS", "read, web_fetch");
+        let denied = denied(&task(0));
+        assert!(!denied.contains(&"read".to_string()));
+        assert!(!denied.contains(&"web_fetch".to_string()));
+        assert!(
+            denied.contains(&"exec".to_string()),
+            "a tool outside the node's allowlist must be withheld"
+        );
+
+        // `all` lifts the allowlist without lifting the fixed denials.
+        std::env::set_var("RUSTYKRAB_DELEGATION_TOOLS", "all");
+        let denied = denied_tools_for(AVAILABLE, &task(0));
+        assert!(!denied.contains(&"exec".to_string()));
+        assert!(denied.contains(&"credential_read".to_string()));
+
+        std::env::remove_var("RUSTYKRAB_DELEGATION_TOOLS");
+    }
+
+    #[test]
+    fn denials_are_deduplicated() {
+        // `nodes` can be denied by both the hop budget and an allowlist;
+        // the runner should see it once.
+        let denied = denied(&task(0));
+        let mut unique = denied.clone();
+        unique.dedup();
+        assert_eq!(denied, unique);
     }
 
     #[test]

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -237,6 +237,7 @@ impl Store {
                 error           TEXT,
                 principal       TEXT,
                 hop_budget      INTEGER NOT NULL DEFAULT 0,
+                allowed_tools   TEXT,
                 trace_id        TEXT,
                 created_at      TEXT NOT NULL,
                 started_at      TEXT,

--- a/crates/rustykrab-store/src/tasks.rs
+++ b/crates/rustykrab-store/src/tasks.rs
@@ -94,6 +94,11 @@ pub struct DelegatedTask {
     /// Remaining delegation hops. A node may only hand work onward while
     /// this is above zero, which is what stops A -> B -> A recursion.
     pub hop_budget: i64,
+    /// Tools the submitting peer asked to limit this task to. Advisory in
+    /// one direction only: the node intersects it with its own policy, so
+    /// a task can ask for less than the node allows and never more.
+    /// `None` means the peer expressed no preference.
+    pub allowed_tools: Option<Vec<String>>,
     /// The caller's trace id, so one delegation correlates across both
     /// machines' logs.
     pub trace_id: Option<String>,
@@ -118,6 +123,11 @@ impl DelegatedTask {
             error: row.get("error")?,
             principal: row.get("principal")?,
             hop_budget: row.get("hop_budget")?,
+            // A row we cannot parse must not silently widen the ceiling,
+            // so an unreadable list is treated as "allow nothing".
+            allowed_tools: row
+                .get::<_, Option<String>>("allowed_tools")?
+                .map(|raw| serde_json::from_str(&raw).unwrap_or_default()),
             trace_id: row.get("trace_id")?,
             created_at: parse_time(Some(created)).unwrap_or_else(Utc::now),
             started_at: parse_time(row.get("started_at")?),
@@ -127,7 +137,8 @@ impl DelegatedTask {
 }
 
 const COLUMNS: &str = "id, message, conversation_id, status, result, error, principal, \
-                       hop_budget, trace_id, created_at, started_at, finished_at";
+                       hop_budget, allowed_tools, trace_id, created_at, started_at, \
+                       finished_at";
 
 /// Handle for delegated-task CRUD, backed by SQLite.
 ///
@@ -150,6 +161,7 @@ impl TaskStore {
         conversation_id: Option<&str>,
         principal: Option<&str>,
         hop_budget: i64,
+        allowed_tools: Option<Vec<String>>,
         trace_id: Option<&str>,
     ) -> Result<DelegatedTask, Error> {
         let task = DelegatedTask {
@@ -161,6 +173,7 @@ impl TaskStore {
             error: None,
             principal: principal.map(str::to_string),
             hop_budget: hop_budget.max(0),
+            allowed_tools,
             trace_id: trace_id.map(str::to_string),
             created_at: Utc::now(),
             started_at: None,
@@ -171,7 +184,8 @@ impl TaskStore {
         with_conn(&self.conn, move |conn| {
             conn.execute(
                 "INSERT INTO delegated_tasks (id, message, conversation_id, status, principal, \
-                 hop_budget, trace_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                 hop_budget, allowed_tools, trace_id, created_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![
                     row.id,
                     row.message,
@@ -179,6 +193,9 @@ impl TaskStore {
                     row.status.as_str(),
                     row.principal,
                     row.hop_budget,
+                    row.allowed_tools
+                        .as_ref()
+                        .map(|t| serde_json::to_string(t).unwrap_or_default()),
                     row.trace_id,
                     row.created_at.to_rfc3339(),
                 ],
@@ -413,7 +430,7 @@ mod tests {
     async fn a_submitted_task_is_claimable_exactly_once() {
         let s = store();
         let task = s
-            .enqueue("do it", None, Some("m1max"), 0, None)
+            .enqueue("do it", None, Some("m1max"), 0, None, None)
             .await
             .unwrap();
         assert_eq!(task.status, TaskStatus::Queued);
@@ -434,11 +451,11 @@ mod tests {
     async fn claims_are_fifo_but_prefer_the_warm_conversation() {
         let s = store();
         let older = s
-            .enqueue("first", Some("convo-a"), None, 0, None)
+            .enqueue("first", Some("convo-a"), None, 0, None, None)
             .await
             .unwrap();
         let newer = s
-            .enqueue("second", Some("convo-b"), None, 0, None)
+            .enqueue("second", Some("convo-b"), None, 0, None, None)
             .await
             .unwrap();
 
@@ -455,7 +472,10 @@ mod tests {
     #[tokio::test]
     async fn a_cancel_mid_run_survives_the_run_finishing() {
         let s = store();
-        let task = s.enqueue("long job", None, None, 0, None).await.unwrap();
+        let task = s
+            .enqueue("long job", None, None, 0, None, None)
+            .await
+            .unwrap();
         s.claim_next(None).await.unwrap();
 
         let previous = s.cancel(&task.id).await.unwrap();
@@ -476,7 +496,10 @@ mod tests {
     #[tokio::test]
     async fn cancelling_a_queued_task_reports_that_nothing_is_running() {
         let s = store();
-        let task = s.enqueue("not started", None, None, 0, None).await.unwrap();
+        let task = s
+            .enqueue("not started", None, None, 0, None, None)
+            .await
+            .unwrap();
         assert_eq!(s.cancel(&task.id).await.unwrap(), Some(TaskStatus::Queued));
         // And the worker must never pick it up afterwards.
         assert!(s.claim_next(None).await.unwrap().is_none());
@@ -491,10 +514,13 @@ mod tests {
     #[tokio::test]
     async fn a_restart_fails_tasks_it_interrupted() {
         let s = store();
-        let running = s.enqueue("interrupted", None, None, 0, None).await.unwrap();
+        let running = s
+            .enqueue("interrupted", None, None, 0, None, None)
+            .await
+            .unwrap();
         s.claim_next(None).await.unwrap();
         let queued = s
-            .enqueue("not yet started", None, None, 0, None)
+            .enqueue("not yet started", None, None, 0, None, None)
             .await
             .unwrap();
 
@@ -513,10 +539,13 @@ mod tests {
     async fn the_sweeper_keeps_unfinished_work_however_old() {
         let s = store();
         let queued = s
-            .enqueue("still waiting", None, None, 0, None)
+            .enqueue("still waiting", None, None, 0, None, None)
             .await
             .unwrap();
-        let done = s.enqueue("finished", None, None, 0, None).await.unwrap();
+        let done = s
+            .enqueue("finished", None, None, 0, None, None)
+            .await
+            .unwrap();
         s.claim_next(None).await.unwrap();
         s.finish(&done.id, "result").await.unwrap();
 
@@ -534,7 +563,7 @@ mod tests {
     async fn the_worker_records_the_conversation_it_opened() {
         let s = store();
         let task = s
-            .enqueue("fresh thread", None, None, 0, None)
+            .enqueue("fresh thread", None, None, 0, None, None)
             .await
             .unwrap();
         assert!(task.conversation_id.is_none());
@@ -548,22 +577,86 @@ mod tests {
     async fn a_hop_budget_round_trips_and_never_goes_negative() {
         let s = store();
         let task = s
-            .enqueue("delegate onward", None, None, 2, None)
+            .enqueue("delegate onward", None, None, 2, None, None)
             .await
             .unwrap();
         assert_eq!(task.hop_budget, 2);
 
         // A caller cannot ask for a negative budget and have it read back
         // as anything other than "no further hops".
-        let task = s.enqueue("no hops", None, None, -5, None).await.unwrap();
+        let task = s
+            .enqueue("no hops", None, None, -5, None, None)
+            .await
+            .unwrap();
         assert_eq!(task.hop_budget, 0);
+    }
+
+    #[tokio::test]
+    async fn a_requested_tool_limit_round_trips() {
+        let s = store();
+        let task = s
+            .enqueue(
+                "read-only please",
+                None,
+                None,
+                0,
+                Some(vec!["read".to_string(), "web_fetch".to_string()]),
+                None,
+            )
+            .await
+            .unwrap();
+        let reloaded = s.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(
+            reloaded.allowed_tools,
+            Some(vec!["read".to_string(), "web_fetch".to_string()])
+        );
+
+        // No preference stays absent rather than becoming an empty list —
+        // the two mean opposite things to the node's ceiling.
+        let task = s
+            .enqueue("anything goes", None, None, 0, None, None)
+            .await
+            .unwrap();
+        let reloaded = s.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(reloaded.allowed_tools, None);
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_tool_limit_allows_nothing() {
+        // A corrupt column must not read back as "no preference", which
+        // would silently widen the ceiling to whatever the node permits.
+        let s = store();
+        let task = s
+            .enqueue(
+                "limited",
+                None,
+                None,
+                0,
+                Some(vec!["read".to_string()]),
+                None,
+            )
+            .await
+            .unwrap();
+        {
+            let conn = s.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE delegated_tasks SET allowed_tools = 'not json' WHERE id = ?1",
+                params![task.id],
+            )
+            .unwrap();
+        }
+        let reloaded = s.get(&task.id).await.unwrap().unwrap();
+        assert_eq!(reloaded.allowed_tools, Some(Vec::new()));
     }
 
     #[tokio::test]
     async fn tasks_list_newest_first() {
         let s = store();
-        s.enqueue("first", None, None, 0, None).await.unwrap();
-        let second = s.enqueue("second", None, None, 0, None).await.unwrap();
+        s.enqueue("first", None, None, 0, None, None).await.unwrap();
+        let second = s
+            .enqueue("second", None, None, 0, None, None)
+            .await
+            .unwrap();
         let listed = s.list(10).await.unwrap();
         assert_eq!(listed.len(), 2);
         assert_eq!(listed[0].id, second.id);

--- a/scripts/fleet.env.example
+++ b/scripts/fleet.env.example
@@ -57,6 +57,15 @@ export RUSTYKRAB_NODE_TIMEOUT_SECS=1800
 # export OLLAMA_MODEL=qwen3.8:27b-mlx
 # export RUSTYKRAB_AUTH_TOKEN=<generate 64 hex chars; the primary needs this>
 #
+# What a delegated task may touch on this machine. The credential family,
+# `message`, `gateway` and the whole sub-agent family are withheld from
+# delegated runs whatever this says -- the task text is written by the
+# primary's model, so it can carry input the primary never vetted. Set an
+# allowlist to narrow it further; `all` lifts the allowlist but not those
+# fixed denials.
+#
+# export RUSTYKRAB_DELEGATION_TOOLS='read,write,edit,apply_patch,exec,web_fetch'
+#
 # Reasoning tokens dominate latency on a thinking model at single-digit tok/s.
 # Ollama exposes think=false but NOT reasoning_effort. If you need effort
 # control, run llama-server directly and pass it per-request instead.

--- a/scripts/setup-delegation-node.md
+++ b/scripts/setup-delegation-node.md
@@ -224,11 +224,41 @@ Plan accordingly:
   paid per task regardless. Worth A/B-ing gemma4:26b against qwen3.8:27b on your
   actual workload before committing.
 
+## What a delegated task is allowed to do
+
+A delegated instruction is written by the *primary's model*, not by you. If
+something the primary read — a web page, a search result, an email — carried
+instructions, they can arrive on this node phrased as a task. So the node, not
+the caller, decides what a delegation may touch.
+
+Withheld from every delegated run, regardless of configuration:
+
+- the credential family (`credential_read`, `credential_write`,
+  `credential_request`) and the node's own stored secrets;
+- `message` and `gateway`, which would let a delegated task send from this
+  machine's Telegram or Signal accounts;
+- the sub-agent family (`subagents`, `agents_list`, `sessions_*`). This is what
+  makes the node a sub-agent rather than a second orchestrator.
+
+Narrow it further with an allowlist:
+
+```bash
+# Only these tools, for anything a peer delegates here.
+export RUSTYKRAB_DELEGATION_TOOLS='read,write,edit,apply_patch,exec,web_fetch'
+
+# Or lift the allowlist entirely (the fixed denials above still apply).
+export RUSTYKRAB_DELEGATION_TOOLS=all
+```
+
+The submitting peer can ask for a tighter limit per task, which intersects with
+this list. It cannot ask for more than the node allows.
+
 ## Security notes
 
 - Auth is the node's **bearer token**, over a private network. Treat the token as
   a credential: it grants full agent access, including shell execution on that
-  machine.
+  machine. `RUSTYKRAB_DELEGATION_TOOLS` bounds what a *delegated task* may do;
+  it does not bound what the token can do through the rest of the API.
 - Keep the node bound to loopback and reach it via tailnet or SSH. Do not expose
   the gateway port directly.
 - `nodes list` deliberately never returns tokens — tool output goes into the


### PR DESCRIPTION
A delegated run took the node's full capability set: `prepare_agent`
grants capabilities for every registered, available tool, and does so
identically whether the request came from the operator's own WebChat or
from a peer over the tailnet. The node had no way to distinguish them
and no way to say no.

That matters because the task text is composed by the *peer's model*, not
by a person. Anything that reached the primary as untrusted input — a
fetched page, a search result — can arrive here phrased as an
instruction, and would have run with filesystem, shell, credential and
outbound-messaging access.

Scope it on the node, since the node is the machine at risk:

- The credential family, `message` and `gateway` are withheld from every
  delegated run regardless of configuration. They are the two ways a
  delegated instruction could reach past its own task — into this
  machine's stored secrets, or out through its accounts.
- The sub-agent family is withheld unconditionally. A node is a
  sub-agent; letting it spawn its own would make the topology a tree of
  unknown depth across machines. Work it needs to break up, it queues
  for itself.
- `RUSTYKRAB_DELEGATION_TOOLS` narrows further: a comma-separated
  allowlist, or `all` to lift the allowlist while keeping the fixed
  denials.
- A task may carry `allowedTools` to request a tighter limit still. It
  intersects with the node's policy and can never widen it — the node
  stays authoritative about its own machine, and a peer can only
  volunteer to do less.

An unreadable `allowed_tools` column reads back as "allow nothing"
rather than "no preference", so a corrupt row cannot silently widen the
ceiling.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>