### PR TITLE
docs(nodes): pair the primary instead of sharing the node's master token

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,11 @@ the same program — bounce a task between them indefinitely at minutes of
 local inference per hop. The local `subagents` depth counter cannot help,
 because it is process-local.
 
+Prefer a paired token over the node's master token for the `token` field:
+run `rustykrab-cli pair` on the node and redeem the code from the primary
+with `POST /api/pair`. The result is accepted everywhere the master token
+is, but it is attributable in the node's logs and individually revocable.
+
 **A delegated run is scoped on the node, not by the caller.** The task text
 is composed by the *peer's model*, so anything that reached that peer as
 untrusted input — a fetched page, a search result — can arrive here phrased

--- a/scripts/setup-delegation-node.md
+++ b/scripts/setup-delegation-node.md
@@ -109,6 +109,39 @@ Start it and note the auth token it prints on first run (or set
 ./target/release/RustyKrab.app/Contents/MacOS/rustykrab-cli
 ```
 
+### Give the primary its own token, not this one
+
+That token is the node's **master** credential. Handing it to the primary means
+the two machines share one secret: you cannot revoke the primary's access
+without rotating everything else that uses it, and the node's logs cannot tell
+you which of them did what.
+
+Pair the primary instead, the same way a phone pairs. On the **node**:
+
+```bash
+rustykrab-cli pair          # prints a single-use code, valid 5 minutes
+```
+
+On the **primary**, redeem it for a token of its own:
+
+```bash
+curl -s -X POST https://your-node.your-tailnet.ts.net/api/pair \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"<the code>","device_name":"m1max-primary"}'
+# -> {"device_id":"...","device_token":"..."}
+```
+
+Put that `device_token` in `RUSTYKRAB_NODES` below. It is accepted everywhere
+the master token is, but it is attributable — delegated tasks are recorded
+against `m1max-primary` rather than `master` — and individually revocable:
+
+```bash
+rustykrab-cli chat          # or: GET /api/devices, DELETE /api/devices/{id}
+```
+
+The token is stored in the node's database, so it survives restarts without
+needing `RUSTYKRAB_AUTH_TOKEN` pinned in the environment on either side.
+
 ## 2. Make it reachable
 
 The gateway binds to **loopback only, by design** — that is not configurable, and


### PR DESCRIPTION
`RUSTYKRAB_NODES` took "the node auth token", which is the node's master
credential. Sharing it means the primary's access cannot be revoked
without rotating everything else, and the node's logs cannot attribute a
delegated task to the peer that sent it.

No new mechanism is needed — `rustykrab-cli pair` already mints a
single-use code, `POST /api/pair` redeems it for a per-device token, and
the auth middleware accepts a device token everywhere it accepts the
master one, recording which device made each decision. It was only ever
documented as the phone flow. Document it as the node flow too, which is
what `nodes.rs` flagged as the better fit when the shared token went in.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>