### PR TITLE
fix(credentials): tell the resumed turn how to sign in, and bound it

### DIFF
--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -38,6 +38,18 @@ pub enum TaskSource {
     },
 }
 
+/// How many iterations a resumed turn may take before it is cut off.
+///
+/// Generous for the work it has to do, and far below the profile default,
+/// so a wake that is going nowhere says so in minutes rather than an hour.
+const WAKE_MAX_ITERATIONS: usize = 25;
+
+/// A bound, not a budget. Enforced at compile time so the reasoning
+/// cannot drift: high enough for snapshot, two fills, submit and read;
+/// far enough below the profile default of 200 that a stuck wake reports
+/// in minutes rather than an hour.
+const _: () = assert!(WAKE_MAX_ITERATIONS >= 10 && WAKE_MAX_ITERATIONS <= 30);
+
 /// The turn appended to a resumed conversation when a credential lands.
 ///
 /// Deliberately says only that the value now exists, never what it is:
@@ -46,10 +58,16 @@ pub enum TaskSource {
 pub fn credential_wake_prompt(credential_name: &str, service: Option<&str>) -> String {
     let what = service.unwrap_or(credential_name);
     format!(
-        "The {what} credential you asked for is now stored and available. \
-         Continue the task you stopped for it — retry the tool that failed. \
-         Do not ask for the credential again, and do not repeat any value \
-         back to me."
+        "The {what} credential you asked for is now stored. Carry on from where \
+         you stopped.\n\n\
+         If this is a website sign-in: take a fresh browser snapshot to get the \
+         current element refs, then fill the form with \
+         browser(action='fill_credential', ref=<ref>, field='username') and \
+         again with field='password', and submit it. That action looks the \
+         value up itself — you do not have the password and must not type one; \
+         anything you type will be wrong.\n\n\
+         Do not ask for the credential again, and do not repeat any value back \
+         to me."
     )
 }
 
@@ -232,9 +250,14 @@ async fn execute_credential_wake(
     let run_options = rustykrab_gateway::RunOptions {
         active_skill: None,
         // The point of waking is to finish the job, so the first move
-        // should be retrying the tool that failed rather than announcing
-        // that it can now be retried.
+        // should be acting rather than announcing that it can now act.
         force_tool_use_first_iteration: true,
+        // A wake resumes one stalled turn: snapshot, fill two fields,
+        // submit, read the page. The profile default of 200 is a budget,
+        // not a bound — an agent that cannot work out how to proceed
+        // spends all of it. One observed run reached 96 iterations
+        // without ever attempting the login, and would have continued.
+        max_iterations: Some(WAKE_MAX_ITERATIONS),
         ..rustykrab_gateway::RunOptions::default()
     };
 
@@ -470,6 +493,7 @@ async fn execute_cron_task(
         // reply is never the deliverable, and the model would otherwise
         // burn the slot.
         force_tool_use_first_iteration: true,
+        max_iterations: None,
         ..rustykrab_gateway::RunOptions::default()
     };
 
@@ -895,6 +919,58 @@ async fn deliver_response(
                  RUSTYKRAB_DEFAULT_CHAT_ID. Result discarded: {response_text}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod wake_prompt_tests {
+    use super::*;
+
+    /// The prompt used to say "retry the tool that failed". Nothing had
+    /// failed — the agent hit a login wall, which is not a tool error —
+    /// so the resumed turn was pointed at something that did not exist
+    /// and left to improvise. One run spent 96 iterations doing so.
+    #[test]
+    fn it_does_not_send_the_agent_after_a_failure_that_never_happened() {
+        let p = credential_wake_prompt("web_example_com_login", Some("example.com"));
+        assert!(
+            !p.contains("retry the tool that failed"),
+            "no tool failed; saying so sends the agent looking for one"
+        );
+    }
+
+    /// Naming the mechanism is what changed behaviour when the same gap
+    /// was fixed in the browser tool description, so the wake says it too.
+    #[test]
+    fn it_names_the_action_that_actually_signs_in() {
+        let p = credential_wake_prompt("web_example_com_login", Some("example.com"));
+        assert!(p.contains("fill_credential"), "{p}");
+        assert!(p.contains("field='username'"), "{p}");
+        assert!(p.contains("field='password'"), "{p}");
+        assert!(p.contains("snapshot"), "refs come from a snapshot: {p}");
+    }
+
+    /// The agent has no password. Left unsaid, it invents one — observed
+    /// typing the credential's own key name into the form.
+    #[test]
+    fn it_says_the_agent_does_not_hold_the_value() {
+        let p = credential_wake_prompt("web_example_com_login", Some("example.com"));
+        assert!(p.contains("do not have the password"), "{p}");
+        assert!(p.contains("must not type one"), "{p}");
+    }
+
+    #[test]
+    fn it_never_repeats_a_value_back() {
+        let p = credential_wake_prompt("gmail_app_password", Some("Gmail"));
+        assert!(p.contains("do not repeat any value back"), "{p}");
+        assert!(p.contains("Do not ask for the credential again"), "{p}");
+    }
+
+    /// Falls back to the store key when there is no friendly name.
+    #[test]
+    fn it_names_the_service_when_there_is_one() {
+        assert!(credential_wake_prompt("k", Some("Gmail")).contains("Gmail"));
+        assert!(credential_wake_prompt("gmail_app_password", None).contains("gmail_app_password"));
     }
 }
 

--- a/crates/rustykrab-gateway/src/orchestrate.rs
+++ b/crates/rustykrab-gateway/src/orchestrate.rs
@@ -31,6 +31,14 @@ pub struct RunOptions {
     /// for scheduled tasks so the model can't waste the slot on a
     /// greeting.
     pub force_tool_use_first_iteration: bool,
+    /// Ceiling on agent iterations for this run, overriding the profile.
+    ///
+    /// The profile default is 200 (100 on the coding profile), which is a
+    /// budget rather than a safety net: a run that cannot make progress
+    /// spends all of it. Callers that know their work should be short --
+    /// a credential wake resuming one stalled turn -- say so here, so a
+    /// stuck run reports quickly instead of grinding.
+    pub max_iterations: Option<usize>,
     /// Tools this run may not use, withheld before capabilities are
     /// granted rather than rejected at call time — a tool the session
     /// has no capability for is never offered to the model, so it does
@@ -300,6 +308,9 @@ async fn prepare_agent(
 
     let mut agent_config = profile.to_agent_config();
     agent_config.force_tool_use_first_iteration = options.force_tool_use_first_iteration;
+    if let Some(cap) = options.max_iterations {
+        agent_config.max_iterations = cap;
+    }
 
     let mut runner = AgentRunner::new(
         state.provider.clone(),


### PR DESCRIPTION
Two defects in the wake path, both mine, found by watching a resumed turn fail against a real login page.

## 1. The prompt pointed at a failure that never happened

```
"…Continue the task you stopped for it — retry the tool that failed."
```

**Nothing failed.** The agent hit a login wall, which is not a tool error. So the resumed turn was sent looking for a failure that did not exist, and the prompt never named `fill_credential` — the one action that can actually sign in. Observed result: the agent looped on `snapshot` and `content` and never attempted the form.

Naming the mechanism is exactly what fixed the same class of gap in #562, where the model had been typing the credential's own key names into the login box. The prompt now names the action, both fields, and says plainly that the agent does not hold the password and must not type one.

It does not need to name the credential *key*: `fill_credential` derives that from the page URL. The agent only needs a ref and a field.

## 2. The resumed turn was unbounded in practice

`max_iterations` defaults to **200** (100 on the coding profile). That is a budget, not a safety net — an agent that cannot work out how to proceed spends all of it. One observed wake reached **96 iterations** without ever attempting the login and was still going when I killed it. On gemma4 that is roughly an hour of a user waiting for an answer that is not coming.

`RunOptions` gains an optional ceiling and the wake sets **25**: enough for snapshot, two fills, submit and read, low enough that a stuck resume reports in minutes. Existing callers pass `None` and are unchanged.

The bound is asserted at **compile time** (`const _: () = assert!(…)`) rather than in a test, so the reasoning about why 25 cannot drift silently. Clippy is right that asserting a constant in a runtime test is a tautology.

## Test

5 tests pinning the prompt: it no longer sends the agent after a phantom failure; it names `fill_credential` and both fields; it states the agent does not hold the value; it still forbids echoing a value or re-asking; and it falls back to the store key when there is no friendly service name.

`cargo test --workspace` 809 passed. clippy and fmt clean.

## What this does not claim

It does not make the sign-in reliable, and I have not measured it yet. One run signed in correctly at iteration 12 using `fill_credential`; another wandered for 96 without trying. That is n=2 on a 26B local model. The next step is `--mode credential`, which exists to report a *rate* over trials rather than an anecdote — these two fixes are the hypothesis, not the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)