### PR TITLE
fix(credentials): derive website credential keys instead of trusting the spelling

### DIFF
--- a/crates/rustykrab-tools/src/credential_request.rs
+++ b/crates/rustykrab-tools/src/credential_request.rs
@@ -109,6 +109,10 @@ impl Tool for CredentialRequestTool {
                         "type": "string",
                         "description": "What the user knows this as, e.g. 'Gmail' or 'secure.examplebank.com'."
                     },
+                    "url": {
+                        "type": "string",
+                        "description": "For a website login, the page URL. Supply it and the credential names are derived from it for you, so a mistyped name cannot leave the credential somewhere the browser will not look."
+                    },
                     "reason": {
                         "type": "string",
                         "description": "One short phrase on why you need it, shown to the user, e.g. 'to search your inbox'."
@@ -174,6 +178,38 @@ impl Tool for CredentialRequestTool {
                 hint: entry["hint"].as_str().map(|s| s.to_string()),
             });
         }
+        // Repair website keys against the origin before anything is
+        // stored under them.
+        //
+        // The agent authors these and has to reproduce them exactly twice
+        // -- once here, once when the browser looks them up -- and it does
+        // not reliably manage it. One observed run asked for
+        // `web_m1_max_64_gb_..._password` while the browser derived
+        // `web_m1_max_64gb_..._password`; a single underscore meant the
+        // credential was stored where nothing would ever find it, the
+        // lookup failed twelve times, and the login could not complete.
+        // The same run spelled the username correctly, so nothing looked
+        // broken from either side alone.
+        //
+        // `url` is preferred; `service` is used when it looks like a host,
+        // because the agent supplies that already.
+        let origin = args["url"]
+            .as_str()
+            .map(|u| u.to_string())
+            .or_else(|| service.as_deref().and_then(crate::origin_from_service));
+        if let Some(origin) = &origin {
+            for f in fields.iter_mut() {
+                if let Some(canonical) = crate::canonical_web_key(origin, &f.key) {
+                    tracing::info!(
+                        from = %f.key,
+                        to = %canonical,
+                        "repaired a website credential key to match the origin"
+                    );
+                    f.key = canonical;
+                }
+            }
+        }
+
         if fields.is_empty() {
             return Err(Error::ToolExecution(
                 "'fields' must name at least one value to ask for".into(),

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -197,7 +197,9 @@ pub use wiki::WikiTool;
 pub use credential_read::CredentialReadTool;
 pub use credential_request::CredentialRequestTool;
 pub use credential_write::CredentialWriteTool;
-pub use origin_key::{origin_credential_key, PASSWORD, USERNAME};
+pub use origin_key::{
+    canonical_web_key, origin_credential_key, origin_from_service, PASSWORD, USERNAME,
+};
 
 // Skills
 pub use self::skills::{SkillTool, SkillsTool};

--- a/crates/rustykrab-tools/src/origin_key.rs
+++ b/crates/rustykrab-tools/src/origin_key.rs
@@ -157,3 +157,119 @@ mod tests {
         assert!(origin_credential_key("https://example.com", "  ").is_err());
     }
 }
+
+/// Field roles a website login key may end in.
+///
+/// Only these are canonicalised. A key ending in something else is left
+/// alone: the point is to repair a mistyped *host*, not to second-guess
+/// what the agent is asking for.
+const WEB_KEY_ROLES: &[&str] = &["username", "password", "email", "totp", "otp", "pin"];
+
+/// Rebuild a website credential key so its host matches what
+/// [`origin_credential_key`] derives, keeping the role the agent chose.
+///
+/// The agent authors these keys and must reproduce them exactly twice —
+/// once when asking, once when the browser looks them up. It does not
+/// reliably manage that. Observed against gemma4:26b: it asked for
+/// `web_m1_max_64_gb_..._password` and the browser derived
+/// `web_m1_max_64gb_..._password`, one underscore apart, so the lookup
+/// missed twelve times and the login could never complete. The same run
+/// spelled the username key correctly, which is why this survived until
+/// the two sides were compared directly.
+///
+/// Returns `None` when there is nothing to do: a key that is not a
+/// website key, has no recognised role, or already matches.
+pub fn canonical_web_key(origin: &str, key: &str) -> Option<String> {
+    if !key.starts_with("web_") {
+        return None;
+    }
+    let role = WEB_KEY_ROLES
+        .iter()
+        .find(|r| key.ends_with(&format!("_{r}")))?;
+    let canonical = origin_credential_key(origin, role).ok()?;
+    (canonical != key).then_some(canonical)
+}
+
+/// Best-effort URL for a `service` string the agent supplied.
+///
+/// `service` is meant to be what the user recognises — "Gmail",
+/// "portal.example.com/login" — so it is only usable here when it looks
+/// like a host. Anything without a dot is a product name, not an origin.
+pub fn origin_from_service(service: &str) -> Option<String> {
+    let s = service
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let host = s.split(['/', '?', '#']).next()?;
+    (host.contains('.') && !host.contains(' ')).then(|| format!("https://{host}"))
+}
+
+#[cfg(test)]
+mod canonical_tests {
+    use super::*;
+
+    /// The exact failure observed in a live run.
+    #[test]
+    fn a_mistyped_host_is_repaired() {
+        let got = canonical_web_key(
+            "https://m1-max-64gb.tail84017e.ts.net/demo/",
+            "web_m1_max_64_gb_tail84017e_ts_net_password",
+        );
+        assert_eq!(
+            got.as_deref(),
+            Some("web_m1_max_64gb_tail84017e_ts_net_password")
+        );
+    }
+
+    #[test]
+    fn a_correct_key_is_left_alone() {
+        assert_eq!(
+            canonical_web_key(
+                "https://m1-max-64gb.tail84017e.ts.net/demo/",
+                "web_m1_max_64gb_tail84017e_ts_net_username"
+            ),
+            None
+        );
+    }
+
+    /// Service credentials are not website keys and must not be rewritten.
+    #[test]
+    fn a_named_service_credential_is_untouched() {
+        assert_eq!(
+            canonical_web_key("https://example.com", "gmail_app_password"),
+            None
+        );
+        assert_eq!(
+            canonical_web_key("https://example.com", "anthropic_api_key"),
+            None
+        );
+    }
+
+    /// An unrecognised role is left alone rather than guessed at.
+    #[test]
+    fn an_unknown_role_is_not_rewritten() {
+        assert_eq!(
+            canonical_web_key("https://example.com", "web_example_com_wibble"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_service_that_looks_like_a_host_yields_an_origin() {
+        assert_eq!(
+            origin_from_service("m1-max-64gb.tail84017e.ts.net/demo/").as_deref(),
+            Some("https://m1-max-64gb.tail84017e.ts.net")
+        );
+        assert_eq!(
+            origin_from_service("https://portal.example.com/login").as_deref(),
+            Some("https://portal.example.com")
+        );
+    }
+
+    /// A product name is not an origin.
+    #[test]
+    fn a_plain_service_name_yields_nothing() {
+        assert_eq!(origin_from_service("Gmail"), None);
+        assert_eq!(origin_from_service("my bank"), None);
+    }
+}


### PR DESCRIPTION
Found by instrumenting a failing login trial, not by reading code — the two sides each looked correct in isolation.

## What happened

A website login has no natural credential name, so the agent invents one and must reproduce it **exactly twice**: once when asking the user, once when the browser looks it up to sign in.

On a live run against a real login page, gemma4:26b asked for:

```
web_m1_max_64_gb_tail84017e_ts_net_password     ← what it asked for
web_m1_max_64gb_tail84017e_ts_net_password      ← what the browser derives
```

One underscore. The credential was stored where nothing would ever look for it:

```
12 × no credential stored under 'web_m1_max_64gb_tail84017e_ts_net_password'
```

The agent behaved correctly throughout — it filled the username, could not get the password, and filed a follow-up request it never got to answer. It never clicked submit because it never had a complete form.

It spelled the **username** key correctly in the same request, so neither side looked broken alone. The mismatch was only visible by comparing what was stored against what was fetched.

## Why this is structural

Same failure as two others in this area: the credential link relayed as 55 of 64 hex characters, and a hostname truncated to `m1-max-64`. A model asked to carry a long mechanical string will occasionally drop a character. The answer isn't to ask more firmly — #571 already removed the link from its hands for exactly this reason.

## Change

`canonical_web_key` rebuilds the host portion from the origin and keeps the role the agent chose, applied in `credential_request` before anything is stored. The name it asks under is, by construction, the name the browser will look up.

Deliberately narrow:

- **only `web_*` keys** — `gmail_app_password`, `anthropic_api_key` are named service credentials and are never rewritten
- **only recognised roles** (`username`, `password`, `email`, `totp`, `otp`, `pin`); an unfamiliar suffix is left alone rather than guessed at
- **origin from the new optional `url`, else `service`** when it looks like a host — "Gmail" is a product name, not an origin, and yields no rewrite
- **every repair is logged**, so a silent correction stays visible

## Test

6 tests: the exact observed failure (`64_gb` → `64gb`), a correct key left untouched, and the three cases where it must *not* fire — named service credentials, unknown roles, and a service name that isn't a host.

`cargo test --workspace` 825 passed, clippy and fmt clean.

## Honest scope

This fixes an **occasional** slip, not the dominant failure mode — the model got the key right in 4 of 5 trials. A rate measurement is running against a 2/5 baseline, but with n=5 on a non-deterministic model I would not read a 2/5 → 3/5 move as proof. The causal evidence is the twelve failed lookups and the one-character difference, not the rate.

Two known issues remain and are not addressed here: one trial timed out having never filled anything (a browser-level failure still under investigation), and `fill_credential` reported `status: "filled"` unconditionally — instrumentation for that is in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)