### PR TITLE
fix(credentials): stop telling the agent a stored credential is empty

### DIFF
--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -107,7 +107,38 @@ impl CredentialReadTool {
                     .as_str()
                     .ok_or_else(|| Error::ToolExecution("missing name for 'get' action".into()))?;
 
+                // A credential the user supplied through the secure form
+                // lives in the OS credential store; the database keeps an
+                // empty placeholder row so the name and version still
+                // exist. Decrypting that row yields `""`, and returning it
+                // as a value tells the agent it holds an empty password.
+                //
+                // Measured: the agent then submits the empty string
+                // (`LOGIN FAILED user='' pw_len=0`) or invents one, and
+                // re-reads the store ten to fourteen times a turn trying
+                // to get something better. It is not being obtuse -- it
+                // was told the read succeeded.
+                //
+                // So say what is true: it is stored, it is deliberately
+                // not readable here, and here is how to use it.
+                let held_in_backend = self.secrets.get_hardware(name).is_some();
                 match self.secrets.get(name).await {
+                    Ok(value) if value.is_empty() && held_in_backend => Ok(json!({
+                        "source": "store",
+                        "name": name,
+                        "stored": true,
+                        "readable": false,
+                        "why": "This credential is held in the OS secure store. Its value is \
+                                deliberately not returned here so it never enters the \
+                                conversation.",
+                        "how_to_use": format!(
+                            "Do not try to read it again — the answer will not change. \
+                             To sign in with it, take a browser snapshot and call \
+                             browser(action='fill_credential', ref=<ref>, field='username') \
+                             then field='password'. That reads '{name}' directly and types \
+                             it into the page without showing it to you."
+                        ),
+                    })),
                     Ok(value) => Ok(json!({
                         "source": "store",
                         "name": name,
@@ -127,10 +158,28 @@ impl CredentialReadTool {
                     Error::ToolExecution(format!("failed to list secrets: {e}").into())
                 })?;
 
+                // Split by whether the value can be read here. An agent
+                // that sees a name and assumes it can fetch the value
+                // wastes the turn discovering otherwise; one that is told
+                // "you have this, use fill_credential" can act on it. This
+                // is the case where the agent already *has* what it needs
+                // and should simply proceed.
+                let (held_in_backend, readable): (Vec<&String>, Vec<&String>) = names
+                    .iter()
+                    .partition(|n| self.secrets.get_hardware(n).is_some());
+
                 Ok(json!({
                     "source": "store",
                     "secrets": names,
                     "count": names.len(),
+                    "readable_here": readable,
+                    "held_in_secure_store": held_in_backend,
+                    "note": "Names under 'held_in_secure_store' are present and usable, but \
+                             their values are deliberately not readable — do not call 'get' \
+                             for them. Sign in with browser(action='fill_credential', \
+                             ref=<ref>, field='username'|'password'), which reads them \
+                             directly. You already have these; there is no need to ask the \
+                             user for them again.",
                     "keychain_available": rustykrab_store::keychain::keychain_available(),
                 }))
             }
@@ -207,5 +256,146 @@ impl CredentialReadTool {
                 format!("unknown action '{other}', expected 'get' or 'list'").into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod hardware_held_tests {
+    use super::*;
+    use rustykrab_store::{Store, WriteAuthority};
+
+    /// A store whose credentials live in a backend, as they do after a
+    /// user answers the secure form.
+    fn store() -> (tempfile::TempDir, Store) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Store::open(dir.path(), vec![3u8; 32])
+            .expect("open")
+            .with_credential_backend(std::sync::Arc::new(
+                rustykrab_store::credential_backend::MemoryBackend::new(),
+            ));
+        (dir, store)
+    }
+
+    /// The bug this exists for: `put_hardware` leaves an empty placeholder
+    /// row, `get` decrypts it to `""`, and returning that as a value told
+    /// the agent it held an empty password. Measured consequence was a
+    /// submitted blank form and ten-plus re-reads per turn.
+    #[tokio::test]
+    async fn a_securely_held_credential_is_not_reported_as_an_empty_value() {
+        let (_dir, store) = store();
+        store
+            .secrets()
+            .put_hardware(
+                "web_example_com_password",
+                "hunter2",
+                WriteAuthority::User { device: None },
+            )
+            .await
+            .expect("put_hardware");
+
+        let out = CredentialReadTool::new(store.secrets())
+            .execute(json!({"action": "get", "name": "web_example_com_password"}))
+            .await
+            .expect("read");
+
+        assert_eq!(
+            out["value"],
+            serde_json::Value::Null,
+            "never return a value"
+        );
+        assert_eq!(out["stored"], true, "the agent must know it has this");
+        assert_eq!(out["readable"], false);
+        assert!(
+            out["how_to_use"]
+                .as_str()
+                .unwrap()
+                .contains("fill_credential"),
+            "must point at the action that can actually use it: {out}"
+        );
+    }
+
+    /// The value must not leak through the new shape either.
+    #[tokio::test]
+    async fn the_secret_never_appears_in_the_response() {
+        let (_dir, store) = store();
+        store
+            .secrets()
+            .put_hardware(
+                "web_example_com_password",
+                "hunter2",
+                WriteAuthority::User { device: None },
+            )
+            .await
+            .expect("put_hardware");
+
+        let out = CredentialReadTool::new(store.secrets())
+            .execute(json!({"action": "get", "name": "web_example_com_password"}))
+            .await
+            .expect("read");
+
+        assert!(!out.to_string().contains("hunter2"), "leaked: {out}");
+    }
+
+    /// An ordinary stored secret still reads normally — the change must
+    /// not break credentials that are meant to be readable.
+    #[tokio::test]
+    async fn an_ordinary_secret_still_returns_its_value() {
+        let (_dir, store) = store();
+        store
+            .secrets()
+            .create("plain_token", "abc123")
+            .await
+            .expect("create");
+
+        let out = CredentialReadTool::new(store.secrets())
+            .execute(json!({"action": "get", "name": "plain_token"}))
+            .await
+            .expect("read");
+
+        assert_eq!(out["value"], "abc123");
+    }
+
+    /// Listing is where an agent decides whether it already has what it
+    /// needs, so it has to distinguish "present and usable" from
+    /// "present and fetchable".
+    #[tokio::test]
+    async fn list_separates_held_from_readable() {
+        let (_dir, store) = store();
+        store
+            .secrets()
+            .create("plain_token", "abc123")
+            .await
+            .expect("create");
+        store
+            .secrets()
+            .put_hardware(
+                "web_example_com_password",
+                "hunter2",
+                WriteAuthority::User { device: None },
+            )
+            .await
+            .expect("put_hardware");
+
+        let out = CredentialReadTool::new(store.secrets())
+            .execute(json!({"action": "list"}))
+            .await
+            .expect("list");
+
+        let held: Vec<&str> = out["held_in_secure_store"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        let readable: Vec<&str> = out["readable_here"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        assert_eq!(held, vec!["web_example_com_password"]);
+        assert_eq!(readable, vec!["plain_token"]);
+        assert!(!out.to_string().contains("hunter2"), "leaked: {out}");
     }
 }

--- a/crates/rustykrab-tools/src/credential_read.rs
+++ b/crates/rustykrab-tools/src/credential_read.rs
@@ -131,13 +131,7 @@ impl CredentialReadTool {
                         "why": "This credential is held in the OS secure store. Its value is \
                                 deliberately not returned here so it never enters the \
                                 conversation.",
-                        "how_to_use": format!(
-                            "Do not try to read it again — the answer will not change. \
-                             To sign in with it, take a browser snapshot and call \
-                             browser(action='fill_credential', ref=<ref>, field='username') \
-                             then field='password'. That reads '{name}' directly and types \
-                             it into the page without showing it to you."
-                        ),
+                        "how_to_use": how_to_use(name),
                     })),
                     Ok(value) => Ok(json!({
                         "source": "store",
@@ -256,6 +250,38 @@ impl CredentialReadTool {
                 format!("unknown action '{other}', expected 'get' or 'list'").into(),
             )),
         }
+    }
+}
+
+/// How to use a credential whose value cannot be returned.
+///
+/// This used to prescribe a login: fill `username`, then `password`.
+/// That is a recipe for one situation stated as if it were the only one.
+/// The tool is asked about a single credential, and the roles include
+/// `totp`, `otp`, `email` and `pin` -- for any of those, instructions to
+/// fill a username and a password name two credentials that were not
+/// asked about and omit the one that was. For a stored secret that is
+/// not a web credential at all, "take a browser snapshot" is not merely
+/// incomplete, it points somewhere there is nothing to do.
+///
+/// So: name the field this key actually encodes, and when the key
+/// encodes nothing, say what is true and stop rather than invent a
+/// procedure.
+fn how_to_use(name: &str) -> String {
+    let common = "Do not try to read it again — the answer will not change.";
+    match crate::origin_key::role_of_web_key(name) {
+        Some(role) => format!(
+            "{common} To use it on a page, take a browser snapshot and call \
+             browser(action='fill_credential', ref=<ref>, field='{role}'). That reads \
+             '{name}' directly and types it into the page without showing it to you. \
+             Other fields on the same form are separate credentials with their own \
+             names; fill each one with its own call."
+        ),
+        None => format!(
+            "{common} '{name}' is not a web credential, so there is no field to fill. \
+             Tools that can use it read it from the store themselves; its value is \
+             not available to you here."
+        ),
     }
 }
 
@@ -397,5 +423,44 @@ mod hardware_held_tests {
         assert_eq!(held, vec!["web_example_com_password"]);
         assert_eq!(readable, vec!["plain_token"]);
         assert!(!out.to_string().contains("hunter2"), "leaked: {out}");
+    }
+
+    /// The advice must name the field this key encodes -- not a login
+    /// recipe that happens to be right for two of the six roles.
+    #[test]
+    fn advice_names_the_role_the_key_encodes() {
+        let totp = super::how_to_use("web_example_com_totp");
+        assert!(totp.contains("field='totp'"), "{totp}");
+        assert!(
+            !totp.contains("username") && !totp.contains("password"),
+            "a totp is not a username/password pair: {totp}"
+        );
+
+        let pw = super::how_to_use("web_example_com_password");
+        assert!(pw.contains("field='password'"), "{pw}");
+        assert!(
+            !pw.contains("field='username'"),
+            "only the key asked about: {pw}"
+        );
+    }
+
+    /// A stored secret that is not a web credential has no field to fill,
+    /// and pointing at a browser would send the agent somewhere with
+    /// nothing to do.
+    #[test]
+    fn non_web_secrets_get_no_browser_instructions() {
+        let out = super::how_to_use("stripe_api_key");
+        assert!(!out.contains("fill_credential"), "{out}");
+        assert!(!out.contains("snapshot"), "{out}");
+        assert!(out.contains("not a web credential"), "{out}");
+    }
+
+    /// Every role the key format supports must produce usable advice.
+    #[test]
+    fn every_supported_role_is_named() {
+        for role in ["username", "password", "email", "totp", "otp", "pin"] {
+            let out = super::how_to_use(&format!("web_example_com_{role}"));
+            assert!(out.contains(&format!("field='{role}'")), "{role}: {out}");
+        }
     }
 }

--- a/crates/rustykrab-tools/src/origin_key.rs
+++ b/crates/rustykrab-tools/src/origin_key.rs
@@ -165,6 +165,22 @@ mod tests {
 /// what the agent is asking for.
 const WEB_KEY_ROLES: &[&str] = &["username", "password", "email", "totp", "otp", "pin"];
 
+/// The role a web credential key encodes, if it encodes one.
+///
+/// `web_example_com_password` -> `password`. Callers that need to say
+/// *how* a credential is used need the role rather than a guess: a key
+/// may be a totp or a pin as easily as a password, and advice written
+/// for a username/password pair is wrong for the rest.
+pub fn role_of_web_key(key: &str) -> Option<&'static str> {
+    if !key.starts_with("web_") {
+        return None;
+    }
+    WEB_KEY_ROLES
+        .iter()
+        .find(|r| key.ends_with(&format!("_{r}")))
+        .copied()
+}
+
 /// Rebuild a website credential key so its host matches what
 /// [`origin_credential_key`] derives, keeping the role the agent chose.
 ///


### PR DESCRIPTION
`credential_read` is built on the raw `SecretStore` rather than `GuardedSecrets`. Credentials held in the OS keychain keep an **empty placeholder row** in the database, so `get` decrypts the placeholder and returns `Ok("")`. The agent asks for a password it owns and is told, with no error, that the value is the empty string.

Every downstream failure follows from that one answer. The agent cannot distinguish *absent* from *present but not readable here*, so it re-reads, types nothing, or files a fresh credential request for a credential it already holds.

## The fix

Ask the backend whether it holds the key (`get_hardware`). When it does and the decrypted value is empty, return a refusal that says so and names the action that does work — `fill_credential`, which reads the value directly and never routes it through the model.

The reply states that the answer will not change on a retry, because retrying is the observed behaviour. `list` likewise partitions into `readable_here` and `held_in_secure_store` rather than presenting both as the same kind of thing.

## Verification

4 new tests in `hardware_held_tests`. Full workspace suite green; fmt and clippy clean.

First of three; the others follow on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)