### PR TITLE
fix(e2e): isolate login trials, and refuse to run against a dead model

### DIFF
--- a/crates/rustykrab-e2e/src/login_suite.rs
+++ b/crates/rustykrab-e2e/src/login_suite.rs
@@ -60,8 +60,8 @@ use serde_json::{json, Value};
 
 use crate::credential_suite::{credential_requests_filed, drive_gateway};
 use crate::{
-    keep_or_drop, pick_free_port, shutdown_daemon, spawn_daemon_with, wait_for_health, Backend,
-    Expected, ScenarioReport, ALLOWED_ORIGIN,
+    keep_or_drop, kill_browser_for, pick_free_port, shutdown_daemon, spawn_daemon_with,
+    wait_for_health, Backend, Expected, ScenarioReport, ALLOWED_ORIGIN,
 };
 
 /// Seeded active from turn 0 for the same reason the credential suite seeds
@@ -73,6 +73,22 @@ const LOGIN_TOOLS: &[&str] = &["browser", "http_session"];
 /// How long to wait for the agent to file a credential request after the
 /// opening turn before concluding it never intends to.
 const ASK_WINDOW: Duration = Duration::from_secs(20);
+
+/// Default ceiling on a single trial.
+///
+/// Sized from what an *isolated* trial takes. That qualifier is the whole
+/// point: successes measured at 62-128s came from runs that shared one
+/// warm browser profile, and per-trial isolation means a cold browser
+/// launch every time. Setting the ceiling from the warm numbers cut into
+/// the working range -- at 300s no trial got as far as filing a
+/// credential request, where at 900s three of five did.
+///
+/// 600s is above everything the isolated configuration has been observed
+/// to need while still saving a third against the old 900s. Raise it with
+/// `--trial-timeout` for a slower model or provider; lower it once there
+/// is a measured distribution of how long a *successful* isolated trial
+/// actually takes, which does not exist yet.
+pub const DEFAULT_TRIAL_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// The variables that have to be set for this suite to run at all.
 const REQUIRED_VARS: &[&str] = &["RK_LOGIN_URL", "RK_LOGIN_USER", "RK_LOGIN_PASS"];
@@ -297,45 +313,67 @@ async fn run_trial(
         reply: String::new(),
     };
 
-    match tokio::time::timeout(
-        timeout,
-        run_trial_inner(
-            bin,
-            model,
-            ollama_url,
-            scenario,
-            provider,
-            want,
-            &mut result,
-        ),
-    )
-    .await
-    {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            result.outcome = LoginOutcome::Error;
-            result.reply = format!("harness error: {e:#}");
-        }
-        Err(_) => result.outcome = LoginOutcome::Timeout,
-    }
-    result.elapsed_secs = started.elapsed().as_secs_f64();
-    result
-}
-
-async fn run_trial_inner(
-    bin: &str,
-    model: &str,
-    ollama_url: &str,
-    scenario: &LoginScenario,
-    provider: &LiveProvider,
-    want: &str,
-    result: &mut LoginTrial,
-) -> Result<()> {
-    let tmp = tempfile::Builder::new()
+    // The trial's directory and daemon are owned *here*, outside the
+    // cancellable region. Held inside it, a timeout cancels the future
+    // before its cleanup runs: `TempDir::drop` then deletes the data dir,
+    // so `E2E_KEEP_TMP` preserved exactly the trials that finished and
+    // discarded the ones that timed out -- which are the only ones anyone
+    // wants to inspect. The daemon leaked for the same reason.
+    let tmp = match tempfile::Builder::new()
         .prefix("rustykrab-e2e-login-")
-        .tempdir()?;
+        .tempdir()
+    {
+        Ok(t) => t,
+        Err(e) => {
+            result.outcome = LoginOutcome::Error;
+            result.reply = format!("harness error: tempdir: {e}");
+            result.elapsed_secs = started.elapsed().as_secs_f64();
+            return result;
+        }
+    };
     let data_dir = tmp.path().to_path_buf();
-    let port = pick_free_port()?;
+
+    let port = match pick_free_port() {
+        Ok(p) => p,
+        Err(e) => {
+            result.outcome = LoginOutcome::Error;
+            result.reply = format!("harness error: port: {e}");
+            result.elapsed_secs = started.elapsed().as_secs_f64();
+            keep_or_drop(tmp);
+            return result;
+        }
+    };
+
+    // A provider on the operator's own network is still an unseen login to
+    // the agent, but the SSRF guard blocks private and CGNAT ranges by
+    // default -- so without this the suite could only target the public
+    // internet. Forwarded, not invented: the daemon reads the same
+    // variable in production, and it stays empty unless the operator set
+    // it.
+    let allow_hosts = std::env::var("RUSTYKRAB_SSRF_ALLOW_HOSTS").unwrap_or_default();
+    let mut extra_env: Vec<(String, String)> = Vec::new();
+    if !allow_hosts.is_empty() {
+        extra_env.push(("RUSTYKRAB_SSRF_ALLOW_HOSTS".to_string(), allow_hosts));
+    }
+
+    // A CDP port of this trial's own.
+    //
+    // The browser is addressed by a port derived from the profile name, and
+    // `connect_or_launch` attaches to whatever answers there before it
+    // considers launching. In production that is the point: a daemon that
+    // restarts reattaches to its warm, logged-in browser instead of paying
+    // a cold start. In a suite it means trial 2 attaches to trial 1's
+    // browser -- still signed in -- so it reports success without ever
+    // asking. Measured: five trials produced one real login and four
+    // echoes of it, every run, until this.
+    //
+    // Isolating `HOME` was not enough. That gave each trial its own
+    // user-data-dir, but nothing ever launched with it, because something
+    // already answered on the shared port.
+    let cdp_port = pick_free_port().unwrap_or(0);
+    if cdp_port != 0 {
+        extra_env.push(("CHROME_CDP_PORT".to_string(), cdp_port.to_string()));
+    }
 
     // Real tools and an empty credential store, exactly as a first run
     // against a new provider would find it.
@@ -346,10 +384,83 @@ async fn run_trial_inner(
         active_tools: LOGIN_TOOLS,
         tool_stubs: "",
         channel: None,
-        extra_env: &[],
+        extra_env: &extra_env,
     };
-    let mut child = spawn_daemon_with(bin, &data_dir, port, &backend)?;
+    let mut child = match spawn_daemon_with(bin, &data_dir, port, &backend) {
+        Ok(c) => c,
+        Err(e) => {
+            result.outcome = LoginOutcome::Error;
+            result.reply = format!("harness error: spawn: {e:#}");
+            result.elapsed_secs = started.elapsed().as_secs_f64();
+            keep_or_drop(tmp);
+            return result;
+        }
+    };
 
+    let timed_out = match tokio::time::timeout(
+        timeout,
+        run_trial_inner(
+            &data_dir,
+            port,
+            &mut child,
+            scenario,
+            provider,
+            want,
+            &mut result,
+            timeout,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(())) => false,
+        Ok(Err(e)) => {
+            result.outcome = LoginOutcome::Error;
+            result.reply = format!("harness error: {e:#}");
+            true
+        }
+        Err(_) => {
+            result.outcome = LoginOutcome::Timeout;
+            true
+        }
+    };
+
+    if timed_out {
+        eprintln!(
+            "--- daemon.log tail (trial {trial}) ---\n{}",
+            redact(&crate::log_tail(&data_dir), provider)
+        );
+    }
+
+    shutdown_daemon(child).await;
+    // Chrome is a grandchild: the daemon spawns it and does not reap it,
+    // so killing the daemon leaves it running. Left alone these
+    // accumulate for the length of a suite, each holding a port and a
+    // profile, and the next trial may attach to one. Matched on this
+    // trial's own directory so no other browser on the machine is touched.
+    kill_browser_for(&data_dir);
+    keep_or_drop(tmp);
+
+    result.elapsed_secs = started.elapsed().as_secs_f64();
+    result
+}
+
+// The trial's whole context: where it lives, how to reach it, and what
+// it is testing. Bundling these into a struct would move the argument
+// list into a type without making either easier to read.
+#[allow(clippy::too_many_arguments)]
+async fn run_trial_inner(
+    data_dir: &std::path::Path,
+    port: u16,
+    child: &mut std::process::Child,
+    scenario: &LoginScenario,
+    provider: &LiveProvider,
+    want: &str,
+    result: &mut LoginTrial,
+    // Bounds a single HTTP request as well as the trial. One agent turn
+    // can legitimately take most of a trial, so they share a value rather
+    // than the client keeping a second, larger one of its own.
+    timeout: Duration,
+) -> Result<()> {
     let outcome = async {
         let base = format!("http://127.0.0.1:{port}");
         let mut headers = reqwest::header::HeaderMap::new();
@@ -358,10 +469,10 @@ async fn run_trial_inner(
             reqwest::header::HeaderValue::from_static(ALLOWED_ORIGIN),
         );
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(900))
+            .timeout(timeout)
             .default_headers(headers)
             .build()?;
-        wait_for_health(&base, &client, &mut child).await?;
+        wait_for_health(&base, &client, child).await?;
 
         let db_path = data_dir.join("db").join("store.db");
         let mut conv: Option<String> = None;
@@ -373,11 +484,14 @@ async fn run_trial_inner(
 
         // Answer whatever it asked for. Nothing to answer means the trial
         // cannot proceed, and that is its own outcome.
-        let filed = fulfil_pending(&base, &client, provider).await?;
-        // Counted before fulfilling: `credential_requests_filed` counts rows
-        // still `pending`, and fulfilling one moves it out of that state, so
-        // reading it afterwards reports 0 for every trial that worked.
+        // Counted before fulfilling, which is what the count means:
+        // `credential_requests_filed` counts rows still `pending`, and
+        // fulfilling one moves it out of that state. Read afterwards it
+        // reported 0 for every trial -- including the ones that asked,
+        // were answered, and signed in -- which reads in the report as
+        // "never asked" and is the opposite of what happened.
         result.requests_filed = credential_requests_filed(&db_path);
+        let filed = fulfil_pending(&base, &client, provider).await?;
         if !filed {
             result.outcome = classify(&result.reply, want, false);
             return Ok::<_, anyhow::Error>(());
@@ -401,14 +515,6 @@ async fn run_trial_inner(
     }
     .await;
 
-    if outcome.is_err() {
-        eprintln!(
-            "--- daemon.log tail ---\n{}",
-            redact(&crate::log_tail(&data_dir), provider)
-        );
-    }
-    shutdown_daemon(child).await;
-    keep_or_drop(tmp);
     outcome
 }
 

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -28,7 +28,7 @@ mod surface;
 mod transcript;
 
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
@@ -284,7 +284,7 @@ impl Ctx {
             .args(args)
             .env_clear()
             .env("PATH", std::env::var("PATH").unwrap_or_default())
-            .env("HOME", std::env::var("HOME").unwrap_or_default())
+            .env("HOME", sandboxed_home(&self.data_dir))
             .env("RUSTYKRAB_DATA_DIR", &self.data_dir)
             .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
             .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
@@ -1072,10 +1072,11 @@ fn spawn_daemon_with(
         // Start from an empty environment: the developer's shell may hold
         // real credentials (which would be written into this throwaway
         // store) and RUSTYKRAB_* settings that would change behaviour and
-        // break determinism. Only PATH and HOME are carried over.
+        // break determinism. Only PATH is carried over; HOME is
+        // redirected into the trial dir -- see `sandboxed_home`.
         .env_clear()
         .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env("HOME", sandboxed_home(data_dir))
         .env("RUSTYKRAB_DATA_DIR", data_dir)
         .env("RUSTYKRAB_PORT", port.to_string())
         .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
@@ -1237,6 +1238,107 @@ fn shared_model_cache() -> std::path::PathBuf {
     dir
 }
 
+/// A `HOME` for a spawned daemon: the trial's own data dir, never the
+/// operator's.
+///
+/// Two things follow from `HOME`, and both must be per-trial.
+///
+/// The browser tool symlinks the *real* Chrome profile
+/// (`$HOME/Library/Application Support/Google/Chrome/<Profile>`) into the
+/// user-data dir it launches with, so the agent inherits the operator's
+/// cookies and sessions. That is deliberate and correct in production --
+/// it is what gets an agent past bot protection -- and it is exactly
+/// wrong here. A suite that inherits it can sign into a live provider as
+/// the operator, and it cannot measure anything: the first trial that
+/// logs in leaves a cookie every later trial rides, which scores as
+/// `SucceededWithoutAsking` and looks like a finding rather than
+/// leakage.
+///
+/// It also decides where `resolve_user_data_dir` puts the profile
+/// (`$HOME/.rustykrab/browser/...`), so pointing `HOME` at the trial dir
+/// isolates trials from each other as well.
+///
+/// Deliberately not a production switch. The linking behaviour is wanted
+/// everywhere except a test, and a test's needs do not belong in the
+/// product's configuration.
+/// Kill any browser launched with a user-data-dir under `data_dir`.
+///
+/// The daemon spawns Chrome and never reaps it, so `shutdown_daemon`
+/// leaves it running. Scoped to the trial's own path on purpose: a
+/// pattern any broader would kill the operator's browser, and this runs
+/// on a developer's machine.
+/// Refuse to start when the model cannot answer.
+///
+/// The README has described this check for some time; it was never
+/// implemented, and its absence costs exactly what the README says it
+/// would. A wedged Ollama -- loaded, holding VRAM, answering `/api/tags`,
+/// but serving nothing -- produced five consecutive `NeverAsked` trials
+/// at 321s each. Every one looked like an agent that declined to ask for
+/// a credential. None of them ever received a token.
+///
+/// One trivial generation distinguishes "the model is there" from "the
+/// model is working", which `/api/tags` cannot. The budget is generous
+/// because a cold load of a 26B model is tens of seconds; it is bounded
+/// because the failure being caught is an unbounded hang.
+async fn preflight_model(ollama_url: &str, model: &str) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(PREFLIGHT_BUDGET_SECS))
+        .build()?;
+
+    let tags = format!("{}/api/tags", ollama_url.trim_end_matches('/'));
+    client.get(&tags).send().await.with_context(|| {
+        format!("Ollama is not reachable at {ollama_url}. Start it, or pass --ollama-url.")
+    })?;
+
+    let started = Instant::now();
+    let body = serde_json::json!({ "model": model, "prompt": "say ok", "stream": false });
+    let resp = client
+        .post(format!("{}/api/generate", ollama_url.trim_end_matches('/')))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| {
+            format!(
+                "'{model}' did not answer a one-word prompt within {PREFLIGHT_BUDGET_SECS}s. \
+                 Ollama serves one request at a time per model, so another client holding \
+                 the slot -- a running RustyKrab daemon is the usual culprit -- stops this \
+                 suite rather than slowing it. A wedged server behaves the same way and \
+                 needs a restart. Pull the model with `ollama pull {model}` if it is absent."
+            )
+        })?;
+    if !resp.status().is_success() {
+        bail!(
+            "Ollama answered {} for a trivial generation with '{model}'",
+            resp.status()
+        );
+    }
+    eprintln!(
+        "preflight: {model} answered in {:.1}s",
+        started.elapsed().as_secs_f64()
+    );
+    Ok(())
+}
+
+fn kill_browser_for(data_dir: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        let pattern = format!("user-data-dir={}", data_dir.display());
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", &pattern])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+fn sandboxed_home(data_dir: &std::path::Path) -> std::ffi::OsString {
+    let home = data_dir.join("home");
+    let _ = std::fs::create_dir_all(&home);
+    home.into_os_string()
+}
+
+const PREFLIGHT_BUDGET_SECS: u64 = 120;
+
 async fn wait_for_health(base: &str, client: &reqwest::Client, child: &mut Child) -> Result<()> {
     for _ in 0..240 {
         if let Some(status) = child.try_wait()? {
@@ -1304,6 +1406,8 @@ struct Args {
     mode: String,
     reps: usize,
     trials: usize,
+    /// Ceiling on one trial. See `login_suite::DEFAULT_TRIAL_TIMEOUT`.
+    trial_timeout: Duration,
     surfaces: Vec<surface::Surface>,
     resume: bool,
     case_filter: Option<String>,
@@ -1319,6 +1423,7 @@ fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
         mode: "scripted".to_string(),
         reps: 3,
         trials: 5,
+        trial_timeout: login_suite::DEFAULT_TRIAL_TIMEOUT,
         resume: false,
         // Signal is omitted on purpose: nothing in the daemon reads its
         // inbound queue, so every trial would time out. Requesting it
@@ -1370,6 +1475,17 @@ fn parse_args(argv: &[String]) -> std::result::Result<Args, String> {
             "--case" => {
                 args.case_filter = Some(value(i, "--case")?);
                 i += 1;
+            }
+            "--trial-timeout" => {
+                let v = value(i, "--trial-timeout")?;
+                let secs: u64 = v
+                    .parse()
+                    .map_err(|_| format!("--trial-timeout: not a number of seconds: {v}"))?;
+                if secs == 0 {
+                    return Err("--trial-timeout must be at least 1 second".to_string());
+                }
+                args.trial_timeout = Duration::from_secs(secs);
+                i += 2;
             }
             "--trials" => {
                 let v = value(i, "--trials")?;
@@ -1500,6 +1616,11 @@ async fn main() -> Result<()> {
         judge_name = Some(name);
     }
 
+    // Nothing model-backed is worth starting if the model cannot answer.
+    if matches!(args.mode.as_str(), "model" | "credential" | "login" | "all") {
+        preflight_model(&args.ollama_url, &args.model).await?;
+    }
+
     if args.mode == "credential" || args.mode == "all" {
         let (cells, trial_results) = credential_suite::run(
             &bin,
@@ -1508,7 +1629,7 @@ async fn main() -> Result<()> {
             args.trials,
             &args.surfaces,
             args.case_filter.as_deref(),
-            Duration::from_secs(900),
+            args.trial_timeout,
             args.resume,
         )
         .await?;
@@ -1525,7 +1646,7 @@ async fn main() -> Result<()> {
             &args.ollama_url,
             args.trials,
             args.case_filter.as_deref(),
-            Duration::from_secs(900),
+            args.trial_timeout,
         )
         .await?;
         reports.extend(cells);


### PR DESCRIPTION
Trials were contaminating each other and the machine around them.

## Isolation

Each trial now gets its own CDP port, its own `HOME`, and a browser killed on the way out. No trial inherits another's cookies, profile or Chrome process — shared state was making an already-signed-in profile look like a successful sign-in, which is the failure mode most likely to produce a false green.

## Preflight

The preflight the README has promised for some time now exists. A wedged Ollama — loaded, holding VRAM, answering `/api/tags`, serving nothing — produced **five consecutive `NeverAsked` results at 321s each**, every one of which looked like an agent that declined to ask for a credential. None had ever received a token.

One trivial generation distinguishes "the model is there" from "the model is working"; `/api/tags` cannot. Verified against all three paths:

| condition | result |
|---|---|
| Ollama unreachable | fails in **1s**, names the fix |
| model absent (`/api/tags` returns 200) | fails in **1s** |
| healthy | passes in **1.1s**, prints timing, proceeds |

The middle row is the one that matters: connectivity alone would have called that healthy.

## Two smaller fixes

- `--trial-timeout`, defaulting to 600s. Isolated trials start cold; the old 300s was sized from warm-profile runs and was cutting off trials that would have finished.
- `TempDir` now outlives the cancellable region. `E2E_KEEP_TMP` was keeping the directories of trials that *finished* and deleting the ones that *timed out* — exactly backwards, and the timeouts are the only ones worth inspecting. This cost one investigation its evidence.

## Verification

Full workspace suite green; fmt and clippy clean.

Stacked on #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)