### PR TITLE
fix(browser): stop wedging Chrome by taking its HOME away

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4169,7 +4169,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4298,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.2.6"
+version = "5.2.7"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -284,7 +284,11 @@ impl Ctx {
             .args(args)
             .env_clear()
             .env("PATH", std::env::var("PATH").unwrap_or_default())
-            .env("HOME", sandboxed_home(&self.data_dir))
+            .env("HOME", std::env::var("HOME").unwrap_or_default())
+            .env(
+                "RUSTYKRAB_BROWSER_ISOLATED_ROOT",
+                isolated_browser_root(&self.data_dir),
+            )
             .env("RUSTYKRAB_DATA_DIR", &self.data_dir)
             .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
             .env("RUSTYKRAB_AUTH_TOKEN", AUTH_TOKEN)
@@ -1072,11 +1076,16 @@ fn spawn_daemon_with(
         // Start from an empty environment: the developer's shell may hold
         // real credentials (which would be written into this throwaway
         // store) and RUSTYKRAB_* settings that would change behaviour and
-        // break determinism. Only PATH is carried over; HOME is
-        // redirected into the trial dir -- see `sandboxed_home`.
+        // break determinism. PATH and HOME are carried over: Chrome
+        // needs a real HOME (see `isolated_browser_root`), so the browser
+        // is isolated by its own root instead.
         .env_clear()
         .env("PATH", std::env::var("PATH").unwrap_or_default())
-        .env("HOME", sandboxed_home(data_dir))
+        .env("HOME", std::env::var("HOME").unwrap_or_default())
+        .env(
+            "RUSTYKRAB_BROWSER_ISOLATED_ROOT",
+            isolated_browser_root(data_dir),
+        )
         .env("RUSTYKRAB_DATA_DIR", data_dir)
         .env("RUSTYKRAB_PORT", port.to_string())
         .env("RUSTYKRAB_MASTER_KEY", MASTER_KEY_HEX)
@@ -1097,7 +1106,13 @@ fn spawn_daemon_with(
         // explain why. E2E_DAEMON_LOG turns the detail back on.
         .env(
             "RUST_LOG",
-            std::env::var("E2E_DAEMON_LOG").unwrap_or_else(|_| "info".to_string()),
+            // The browser tool's diagnostics -- fill digests, tab timings --
+            // are `debug`, deliberately: a four-byte hash prefix of a secret
+            // is a partial fingerprint and does not belong in a production
+            // log by default. The harness wants them, so it asks for that
+            // one target rather than raising the level everywhere.
+            std::env::var("E2E_DAEMON_LOG")
+                .unwrap_or_else(|_| "info,rustykrab_tools::browser=debug".to_string()),
         )
         // The suite drives far more than the shipping 20 req/min from one
         // IP; raise the limit for this throwaway boot only.
@@ -1331,10 +1346,19 @@ fn kill_browser_for(data_dir: &std::path::Path) {
     }
 }
 
-fn sandboxed_home(data_dir: &std::path::Path) -> std::ffi::OsString {
-    let home = data_dir.join("home");
-    let _ = std::fs::create_dir_all(&home);
-    home.into_os_string()
+/// A browser root of this trial's own, so no trial inherits another's
+/// cookies or borrows the developer's signed-in Chrome profile.
+///
+/// This used to be done by pointing HOME at the trial directory, which
+/// isolated the browser and broke it: Chrome wedges its renderer when
+/// HOME is an empty directory -- the page commits its URL and the
+/// document never arrives. Every browser call then burns its full
+/// timeout, which reads as a slow site or a hung agent and is neither.
+/// Isolate the browser root; leave HOME alone.
+fn isolated_browser_root(data_dir: &std::path::Path) -> std::ffi::OsString {
+    let root = data_dir.join("browser");
+    let _ = std::fs::create_dir_all(&root);
+    root.into_os_string()
 }
 
 const PREFLIGHT_BUDGET_SECS: u64 = 120;

--- a/crates/rustykrab-tools/src/browser/config.rs
+++ b/crates/rustykrab-tools/src/browser/config.rs
@@ -254,6 +254,22 @@ impl BrowserConfig {
                 return PathBuf::from(dir);
             }
         }
+        // An explicit isolated root, for callers that need a browser of
+        // their own without borrowing anything from the real account.
+        //
+        // The obvious way to get that is to point HOME at a scratch dir,
+        // and it does not work: Chrome wedges its renderer when HOME is
+        // an empty directory. The page commits its URL and the document
+        // never arrives, which is indistinguishable from a hung site. A
+        // 2x2 over (stealth flags, sandboxed HOME) put it beyond doubt --
+        // every run with a redirected HOME wedged, every run without it
+        // loaded in ~2s. So isolate the one directory that needs
+        // isolating and leave HOME alone.
+        if let Ok(root) = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT") {
+            if !root.is_empty() {
+                return PathBuf::from(root).join(profile_name).join("user-data");
+            }
+        }
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .unwrap_or_else(|_| ".".to_string());

--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -1032,7 +1032,16 @@ fn detect_profile_name(chrome_dir: &std::path::Path) -> String {
 /// Set up a wrapper data directory that symlinks back to the user's real
 /// Chrome profile, preserving cookies and sessions.
 fn setup_profile_link(user_data_dir: &std::path::Path) -> String {
-    let Some(chrome_dir) = chrome_data_dir() else {
+    // Borrowing the real profile is the point in normal use -- it carries
+    // the logins. Under an isolated root it is precisely what the caller
+    // asked to avoid, and in an eval it silently invalidates the result:
+    // a trial that inherits a signed-in cookie looks like a successful
+    // sign-in without ever signing in.
+    let isolated = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let Some(chrome_dir) = chrome_data_dir().filter(|_| !isolated) else {
+        write_local_state(user_data_dir, "Default");
         return "Default".to_string();
     };
 
@@ -1049,20 +1058,25 @@ fn setup_profile_link(user_data_dir: &std::path::Path) -> String {
         }
     }
 
-    // Write minimal Local State to disable profile picker
-    let local_state_dest = user_data_dir.join("Local State");
+    write_local_state(user_data_dir, &profile_name);
+
+    profile_name
+}
+
+/// Minimal `Local State`, which keeps Chrome's profile picker from
+/// appearing. A picker means no page, and no page means every action
+/// times out with nothing to say why.
+fn write_local_state(user_data_dir: &std::path::Path, profile_name: &str) {
     let local_state = serde_json::json!({
         "profile": {
-            "last_used": &profile_name,
-            "last_active_profiles": [&profile_name],
+            "last_used": profile_name,
+            "last_active_profiles": [profile_name],
             "picker_shown": false
         }
     });
-    if let Err(e) = std::fs::write(&local_state_dest, local_state.to_string()) {
+    if let Err(e) = std::fs::write(user_data_dir.join("Local State"), local_state.to_string()) {
         tracing::warn!("could not write Chrome Local State: {e}");
     }
-
-    profile_name
 }
 
 /// Detect the Chrome/Chromium executable path for the current platform.

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -645,11 +645,35 @@ impl Tool for BrowserTool {
                 // `navigator.webdriver` from frameworks that read it on load.
                 let _ = stealth::install_stealth_on_new_document(&page, &stealth_opts).await;
 
-                page.goto(url)
-                    .await
-                    .map_err(|e| Error::ToolExecution(format!("navigation failed: {e}").into()))?;
-
+                // `goto` gets the caller's budget too, not just the settle
+                // wait below. Unbounded, it falls through to the CDP client's
+                // own request timeout, so `timeout_ms` silently did not bound
+                // the navigation it names -- a server that accepts the
+                // connection and never answers cost 30s per attempt, and the
+                // runner then retried it.
                 let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(10_000);
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(timeout_ms),
+                    page.goto(url),
+                )
+                .await
+                {
+                    Ok(r) => r.map_err(|e| {
+                        Error::ToolExecution(format!("navigation failed: {e}").into())
+                    })?,
+                    Err(_) => {
+                        return Err(Error::ToolExecution(
+                            format!(
+                                "navigation to '{url}' did not complete within {timeout_ms}ms. \
+                                 The browser is alive and accepted the request, so this is the \
+                                 page or the server it talks to, not the browser: a server that \
+                                 accepts the connection and never responds looks exactly like \
+                                 this. Retrying the same URL will usually fail the same way."
+                            )
+                            .into(),
+                        ));
+                    }
+                };
                 let _ = tokio::time::timeout(
                     std::time::Duration::from_millis(timeout_ms),
                     page.wait_for_navigation(),
@@ -1154,11 +1178,35 @@ impl Tool for BrowserTool {
                 let _ = stealth::apply_network_overrides(&page, &stealth_opts).await;
                 let _ = stealth::install_stealth_on_new_document(&page, &stealth_opts).await;
 
-                page.goto(url)
-                    .await
-                    .map_err(|e| Error::ToolExecution(format!("navigation failed: {e}").into()))?;
-
+                // `goto` gets the caller's budget too, not just the settle
+                // wait below. Unbounded, it falls through to the CDP client's
+                // own request timeout, so `timeout_ms` silently did not bound
+                // the navigation it names -- a server that accepts the
+                // connection and never answers cost 30s per attempt, and the
+                // runner then retried it.
                 let timeout_ms = args["timeout_ms"].as_u64().unwrap_or(30_000);
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(timeout_ms),
+                    page.goto(url),
+                )
+                .await
+                {
+                    Ok(r) => r.map_err(|e| {
+                        Error::ToolExecution(format!("navigation failed: {e}").into())
+                    })?,
+                    Err(_) => {
+                        return Err(Error::ToolExecution(
+                            format!(
+                                "navigation to '{url}' did not complete within {timeout_ms}ms. \
+                                 The browser is alive and accepted the request, so this is the \
+                                 page or the server it talks to, not the browser: a server that \
+                                 accepts the connection and never responds looks exactly like \
+                                 this. Retrying the same URL will usually fail the same way."
+                            )
+                            .into(),
+                        ));
+                    }
+                };
                 let _ = tokio::time::timeout(
                     std::time::Duration::from_millis(timeout_ms),
                     page.wait_for_navigation(),


### PR DESCRIPTION
Trials were isolated by pointing `HOME` at the trial directory. That does isolate the browser, and it also breaks it: **Chrome wedges its renderer when `HOME` is an empty directory.** The page commits its URL and the document never arrives, so every later action burns its full timeout with nothing in any log explaining why. It reads as a slow site, a hung agent, or a flaky browser, and is none of them.

A 2×2, run outside the agent against a plain HTTP server:

| stealth flags | HOME | result |
|---|---|---|
| off | real | OK — title `'Sign in'` in 2.1s |
| on | real | OK — title `'Sign in'` in 2.1s |
| off | **sandboxed** | **WEDGED** |
| on | **sandboxed** | **WEDGED** |

The launch flags are irrelevant; `HOME` is the whole effect. It cost six 60s browser timeouts in a single 600s trial — 60% of that trial's budget — and was the largest single cause of the login suite's timeouts. It was also self-inflicted, introduced by #577.

## The fix

`RUSTYKRAB_BROWSER_ISOLATED_ROOT` roots the browser's user-data dir where the caller says and suppresses the symlink to the real Chrome profile. Both goals survive — no trial inherits another's cookies or borrows the developer's signed-in profile — and Chrome keeps the home it needs. Unset, nothing changes: normal use still borrows the real profile, which is where the logins are.

Also bounds `page.goto` by the caller's `timeout_ms` at both call sites. It was unbounded, falling through to the CDP client's own request timeout, so `timeout_ms` did not bound the navigation it names: a server that accepts a connection and never answers cost 30s per attempt, and the runner then retried it.

## Measured effect

Sign-in rate over 5 trials went from 2/5 to **5/5**.

Stacked on #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)