### PR TITLE
fix(browser): accept fill_credential where the model reaches for it

### DIFF
--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -1423,7 +1423,8 @@ ENVIRONMENT:
     ANTHROPIC_API_KEY   Grades model-mode rubrics with claude-sonnet-5.
                         Without it the model under test grades itself, and
                         the report says so.
-    E2E_KEEP_TMP        Keep the throwaway data dir for post-mortems.
+    E2E_KEEP_TMP        Keep the throwaway data dir for post-mortems (logs
+                        only; the Chrome profile is shed to save disk).
 ";
 
 struct Args {
@@ -1747,10 +1748,88 @@ async fn shutdown_daemon(mut child: Child) {
 /// TempDir's Drop: this process exits via `std::process::exit` when the
 /// suite is red, which skips destructors, and going red is exactly when a
 /// run would otherwise leak its dir and logs.
+/// Keep the evidence, not the browser profile.
+///
+/// A retained trial is worth keeping for its logs, which are kilobytes.
+/// The Chrome user-data dir beside them is hundreds of megabytes, and
+/// nothing in a post-mortem reads it except `chrome-stderr.log`. Fifteen
+/// retained trials filled the disk and stopped the machine mid-run --
+/// including the suite that was still going -- so retention now keeps
+/// what gets read and sheds what does not.
+fn shed_browser_profile(root: &std::path::Path) -> String {
+    let mut freed = 0u64;
+    for user_data in find_user_data_dirs(root) {
+        // The one file worth rescuing before the profile goes.
+        let stderr_log = user_data.join("chrome-stderr.log");
+        let rescued = std::fs::read(&stderr_log).ok();
+        freed += dir_size(&user_data);
+        if std::fs::remove_dir_all(&user_data).is_ok() {
+            if let Some(bytes) = rescued {
+                let _ = std::fs::create_dir_all(&user_data);
+                let _ = std::fs::write(&stderr_log, bytes);
+            }
+        }
+    }
+    if freed == 0 {
+        String::new()
+    } else {
+        format!(
+            " (browser profile shed, {} MiB freed; chrome-stderr.log kept)",
+            freed / (1024 * 1024)
+        )
+    }
+}
+
+fn find_user_data_dirs(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if path.file_name().is_some_and(|n| n == "user-data") {
+                found.push(path);
+            } else {
+                stack.push(path);
+            }
+        }
+    }
+    found
+}
+
+fn dir_size(dir: &std::path::Path) -> u64 {
+    let mut total = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            match entry.metadata() {
+                Ok(m) if m.is_dir() => stack.push(path),
+                Ok(m) => total += m.len(),
+                Err(_) => {}
+            }
+        }
+    }
+    total
+}
+
 fn keep_or_drop(tmp: tempfile::TempDir) {
     if std::env::var("E2E_KEEP_TMP").is_ok() {
         let path = tmp.keep();
-        eprintln!("E2E_KEEP_TMP set — data dir kept at {}", path.display());
+        let freed = shed_browser_profile(&path);
+        eprintln!(
+            "E2E_KEEP_TMP set — data dir kept at {}{}",
+            path.display(),
+            freed
+        );
         return;
     }
     let path = tmp.path().to_path_buf();

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -60,6 +60,296 @@ pub struct BrowserTool {
     secrets: Option<rustykrab_store::GuardedSecrets>,
 }
 
+/// Resolve the action the caller meant.
+///
+/// `fill_credential` is the only ref-based operation that lives at the
+/// top level; every other one -- click, type, fill, press -- is an
+/// `actAction` under `act`. A model holding a ref from a snapshot
+/// reaches for `act` + `actAction: "fill_credential"`, which is where
+/// the pattern says it should be, and was told the sub-action was
+/// invalid.
+///
+/// Observed, not hypothesised: a trial did exactly this, was refused
+/// twice, and fell back to `fill` with the credential's *key name* as
+/// the text -- typing `web_..._username` and `web_..._password` into
+/// the login form and failing the sign-in. The tool's shape turned a
+/// correct intention into a wrong action, so accept the spelling the
+/// model already reaches for.
+/// The browser tool's parameter schema, as a free function so tests can
+/// assert on what the model is actually told without building a tool.
+fn schema_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "status", "start", "stop", "profiles",
+                    "tabs", "open", "close", "focus",
+                    "navigate", "snapshot", "act", "screenshot",
+                    "content", "evaluate", "scroll",
+                    "console", "cookies", "pdf",
+                    "fetch", "stealth_fetch", "select", "wait_for",
+                    "fill_credential"
+                ],
+                "description": "Action to perform"
+            },
+            "field": {
+                "type": "string",
+                "description": "Which part of the login to fill (fill_credential action): 'username' or 'password'. Defaults to 'password'."
+            },
+            "profile": {
+                "type": "string",
+                "description": "Browser profile name (default: configured default profile)"
+            },
+            "url": {
+                "type": "string",
+                "description": "URL to navigate to or open (navigate/open actions)"
+            },
+            "targetId": {
+                "type": "string",
+                "description": "Tab identifier from 'tabs' action (e.g., 'tab_0'). Used by close/focus/navigate/snapshot/act/screenshot/content/evaluate"
+            },
+            "ref": {
+                "type": "string",
+                "description": "Element ref from a snapshot (e.g., '12' or 'e12'). Used by 'act' action"
+            },
+            "actAction": {
+                "type": "string",
+                "enum": ["click", "type", "fill", "press", "hover", "select", "drag", "wait", "fill_credential"],
+                "description": "Sub-action for 'act' (e.g., click, type, press). Requires 'ref' from snapshot. 'fill_credential' fills a stored credential without its value passing through you — set 'field' to 'username' or 'password'; do not put the secret in 'text'"
+            },
+            "text": {
+                "type": "string",
+                "description": "Text to type (act type/fill action)"
+            },
+            "key": {
+                "type": "string",
+                "description": "Key to press (act press action, e.g., 'Enter', 'Tab', 'Escape')"
+            },
+            "value": {
+                "type": "string",
+                "description": "Value to select (act select action)"
+            },
+            "targetRef": {
+                "type": "string",
+                "description": "Target element ref for drag action"
+            },
+            "clear": {
+                "type": "boolean",
+                "description": "Clear field before typing (default: true for fill, false for type)"
+            },
+            "selector": {
+                "type": "string",
+                "description": "CSS selector — use 'ref' from snapshot instead when possible. For screenshot element targeting or snapshot scoping"
+            },
+            "expression": {
+                "type": "string",
+                "description": "JavaScript to evaluate (evaluate action)"
+            },
+            "format": {
+                "type": "string",
+                "enum": ["text", "html", "ai", "aria"],
+                "description": "Content format (text/html for content action; ai/aria for snapshot mode)"
+            },
+            "full_page": {
+                "type": "boolean",
+                "description": "Full page screenshot (default: false)"
+            },
+            "direction": {
+                "type": "string",
+                "enum": ["down", "up", "bottom", "top"],
+                "description": "Scroll direction"
+            },
+            "amount": {
+                "type": "integer",
+                "description": "Scroll amount in pixels (default: 500)"
+            },
+            "domain": {
+                "type": "string",
+                "description": "Cookie domain filter (cookies action)"
+            },
+            "timeout_ms": {
+                "type": "integer",
+                "description": "Timeout in milliseconds (wait/navigate, default: 10000)"
+            },
+            "interactive": {
+                "type": "boolean",
+                "description": "Snapshot: only include interactive elements (default: false)"
+            },
+            "compact": {
+                "type": "boolean",
+                "description": "Snapshot: compact output format (default: false)"
+            },
+            "depth": {
+                "type": "integer",
+                "description": "Snapshot: max tree depth (default: 50). Modern SPAs nest interactive elements 25-40 levels deep; raise this if a snapshot returns no/too few elements."
+            },
+            "highlight": {
+                "type": "boolean",
+                "description": "Snapshot: paint numbered overlay boxes on each ref so a subsequent screenshot shows the labels (default: false). Overlays auto-clear on the next snapshot."
+            },
+
+            "method": {
+                "type": "string",
+                "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
+                "description": "HTTP method for 'fetch' (default: GET)"
+            },
+            "body": {
+                "type": "string",
+                "description": "Raw request body for 'fetch'"
+            },
+            "json": {
+                "description": "JSON body for 'fetch' (object/array/value sent as application/json)"
+            },
+            "form": {
+                "type": "object",
+                "description": "Form-encoded body for 'fetch'",
+                "additionalProperties": {"type": "string"}
+            },
+            "extra_headers": {
+                "type": "object",
+                "description": "Extra headers for 'fetch'/'stealth_fetch'/'navigate'",
+                "additionalProperties": {"type": "string"}
+            },
+            "cookies": {
+                "type": "object",
+                "description": "Cookies map for 'fetch' (sent as Cookie header)",
+                "additionalProperties": {"type": "string"}
+            },
+            "user_agent": {
+                "type": "string",
+                "description": "Custom User-Agent for 'fetch' or 'stealth_fetch'"
+            },
+            "impersonate": {
+                "type": "string",
+                "description": "Browser pack to impersonate: chrome, firefox, safari, edge (also accepts versioned variants like 'chrome131')"
+            },
+            "stealthy_headers": {
+                "type": "boolean",
+                "description": "fetch: send a coordinated browser-like header pack (Sec-Ch-Ua, Sec-Fetch-*, Accept-Language, etc.)"
+            },
+            "follow_redirects": {
+                "type": "boolean",
+                "description": "fetch: follow redirects (default: true)"
+            },
+            "max_redirects": {
+                "type": "integer",
+                "description": "fetch: redirect limit (default: 10)"
+            },
+            "retries": {
+                "type": "integer",
+                "description": "fetch: retry count on transport failure (default: 0)"
+            },
+            "proxy": {
+                "type": "string",
+                "description": "fetch/stealth_fetch: proxy URL (e.g. http://user:pass@host:8080)"
+            },
+            "verify_tls": {
+                "type": "boolean",
+                "description": "fetch: verify TLS certificates (default: true)"
+            },
+
+            "wait_selector": {
+                "type": "string",
+                "description": "navigate/stealth_fetch/wait_for: CSS selector to wait for"
+            },
+            "wait_selector_state": {
+                "type": "string",
+                "enum": ["attached", "detached", "visible", "hidden"],
+                "description": "wait_selector state (default: visible)"
+            },
+            "network_idle": {
+                "type": "boolean",
+                "description": "navigate/stealth_fetch/wait_for: wait for the network to be idle (no new requests for ~500ms)"
+            },
+            "solve_cloudflare": {
+                "type": "boolean",
+                "description": "navigate/stealth_fetch: best-effort wait for Cloudflare challenge to clear"
+            },
+            "block_webrtc": {
+                "type": "boolean",
+                "description": "stealth_fetch/navigate: block WebRTC to prevent IP leaks"
+            },
+            "hide_canvas": {
+                "type": "boolean",
+                "description": "stealth_fetch/navigate: add noise to canvas/WebGL fingerprints"
+            },
+            "disable_resources": {
+                "type": "boolean",
+                "description": "stealth_fetch/navigate: don't load images/fonts/media (faster)"
+            },
+            "block_images": {
+                "type": "boolean",
+                "description": "stealth_fetch/navigate: block image loads only"
+            },
+            "hide_webdriver": {
+                "type": "boolean",
+                "description": "stealth_fetch/navigate: hide navigator.webdriver and other automation tells (default: true)"
+            },
+
+            "html": {
+                "type": "string",
+                "description": "select: parse this static HTML body instead of querying the live tab"
+            },
+            "css": {
+                "type": "string",
+                "description": "select: CSS selector. Supports Scrapling pseudo-selectors ::text and ::attr(name)"
+            },
+            "xpath": {
+                "type": "string",
+                "description": "select: XPath query (live mode only — requires an active tab)"
+            },
+            "find_by_text": {
+                "type": "string",
+                "description": "select: filter matches by text (substring or regex when 'regex' is true)"
+            },
+            "regex": {
+                "type": "boolean",
+                "description": "select: treat find_by_text as a regex (default: false)"
+            },
+            "limit": {
+                "type": "integer",
+                "description": "select: max number of matches to return (default 500, hard cap 500)"
+            },
+            "include_html": {
+                "type": "boolean",
+                "description": "select: include each match's outerHTML"
+            },
+            "auto_save": {
+                "type": "boolean",
+                "description": "select: store fingerprints of the matches under 'auto_save_id' for adaptive matching later"
+            },
+            "auto_match": {
+                "type": "boolean",
+                "description": "select: if the selector returns nothing, locate closest matches by similarity to fingerprints saved under 'auto_save_id'"
+            },
+            "auto_save_id": {
+                "type": "string",
+                "description": "select: identifier for the saved fingerprint set"
+            },
+            "auto_match_threshold": {
+                "type": "number",
+                "description": "select: minimum similarity (0-1) to accept an adaptive match (default 0.6)"
+            },
+
+            "delay_ms": {
+                "type": "integer",
+                "description": "wait_for/stealth_fetch: extra delay in ms after other waits resolve"
+            }
+        },
+        "required": ["action"]
+    })
+}
+
+fn effective_action<'a>(action: &'a str, args: &serde_json::Value) -> &'a str {
+    if action == "act" && args["actAction"] == "fill_credential" {
+        "fill_credential"
+    } else {
+        action
+    }
+}
+
 impl BrowserTool {
     pub fn new() -> Self {
         Self {
@@ -281,268 +571,7 @@ impl Tool for BrowserTool {
         ToolSchema {
             name: self.name().to_string(),
             description: self.description().to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": [
-                            "status", "start", "stop", "profiles",
-                            "tabs", "open", "close", "focus",
-                            "navigate", "snapshot", "act", "screenshot",
-                            "content", "evaluate", "scroll",
-                            "console", "cookies", "pdf",
-                            "fetch", "stealth_fetch", "select", "wait_for",
-                            "fill_credential"
-                        ],
-                        "description": "Action to perform"
-                    },
-                    "field": {
-                        "type": "string",
-                        "description": "Which part of the login to fill (fill_credential action): 'username' or 'password'. Defaults to 'password'."
-                    },
-                    "profile": {
-                        "type": "string",
-                        "description": "Browser profile name (default: configured default profile)"
-                    },
-                    "url": {
-                        "type": "string",
-                        "description": "URL to navigate to or open (navigate/open actions)"
-                    },
-                    "targetId": {
-                        "type": "string",
-                        "description": "Tab identifier from 'tabs' action (e.g., 'tab_0'). Used by close/focus/navigate/snapshot/act/screenshot/content/evaluate"
-                    },
-                    "ref": {
-                        "type": "string",
-                        "description": "Element ref from a snapshot (e.g., '12' or 'e12'). Used by 'act' action"
-                    },
-                    "actAction": {
-                        "type": "string",
-                        "enum": ["click", "type", "fill", "press", "hover", "select", "drag", "wait"],
-                        "description": "Sub-action for 'act' (e.g., click, type, press). Requires 'ref' from snapshot"
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "Text to type (act type/fill action)"
-                    },
-                    "key": {
-                        "type": "string",
-                        "description": "Key to press (act press action, e.g., 'Enter', 'Tab', 'Escape')"
-                    },
-                    "value": {
-                        "type": "string",
-                        "description": "Value to select (act select action)"
-                    },
-                    "targetRef": {
-                        "type": "string",
-                        "description": "Target element ref for drag action"
-                    },
-                    "clear": {
-                        "type": "boolean",
-                        "description": "Clear field before typing (default: true for fill, false for type)"
-                    },
-                    "selector": {
-                        "type": "string",
-                        "description": "CSS selector — use 'ref' from snapshot instead when possible. For screenshot element targeting or snapshot scoping"
-                    },
-                    "expression": {
-                        "type": "string",
-                        "description": "JavaScript to evaluate (evaluate action)"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["text", "html", "ai", "aria"],
-                        "description": "Content format (text/html for content action; ai/aria for snapshot mode)"
-                    },
-                    "full_page": {
-                        "type": "boolean",
-                        "description": "Full page screenshot (default: false)"
-                    },
-                    "direction": {
-                        "type": "string",
-                        "enum": ["down", "up", "bottom", "top"],
-                        "description": "Scroll direction"
-                    },
-                    "amount": {
-                        "type": "integer",
-                        "description": "Scroll amount in pixels (default: 500)"
-                    },
-                    "domain": {
-                        "type": "string",
-                        "description": "Cookie domain filter (cookies action)"
-                    },
-                    "timeout_ms": {
-                        "type": "integer",
-                        "description": "Timeout in milliseconds (wait/navigate, default: 10000)"
-                    },
-                    "interactive": {
-                        "type": "boolean",
-                        "description": "Snapshot: only include interactive elements (default: false)"
-                    },
-                    "compact": {
-                        "type": "boolean",
-                        "description": "Snapshot: compact output format (default: false)"
-                    },
-                    "depth": {
-                        "type": "integer",
-                        "description": "Snapshot: max tree depth (default: 50). Modern SPAs nest interactive elements 25-40 levels deep; raise this if a snapshot returns no/too few elements."
-                    },
-                    "highlight": {
-                        "type": "boolean",
-                        "description": "Snapshot: paint numbered overlay boxes on each ref so a subsequent screenshot shows the labels (default: false). Overlays auto-clear on the next snapshot."
-                    },
-
-                    "method": {
-                        "type": "string",
-                        "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
-                        "description": "HTTP method for 'fetch' (default: GET)"
-                    },
-                    "body": {
-                        "type": "string",
-                        "description": "Raw request body for 'fetch'"
-                    },
-                    "json": {
-                        "description": "JSON body for 'fetch' (object/array/value sent as application/json)"
-                    },
-                    "form": {
-                        "type": "object",
-                        "description": "Form-encoded body for 'fetch'",
-                        "additionalProperties": {"type": "string"}
-                    },
-                    "extra_headers": {
-                        "type": "object",
-                        "description": "Extra headers for 'fetch'/'stealth_fetch'/'navigate'",
-                        "additionalProperties": {"type": "string"}
-                    },
-                    "cookies": {
-                        "type": "object",
-                        "description": "Cookies map for 'fetch' (sent as Cookie header)",
-                        "additionalProperties": {"type": "string"}
-                    },
-                    "user_agent": {
-                        "type": "string",
-                        "description": "Custom User-Agent for 'fetch' or 'stealth_fetch'"
-                    },
-                    "impersonate": {
-                        "type": "string",
-                        "description": "Browser pack to impersonate: chrome, firefox, safari, edge (also accepts versioned variants like 'chrome131')"
-                    },
-                    "stealthy_headers": {
-                        "type": "boolean",
-                        "description": "fetch: send a coordinated browser-like header pack (Sec-Ch-Ua, Sec-Fetch-*, Accept-Language, etc.)"
-                    },
-                    "follow_redirects": {
-                        "type": "boolean",
-                        "description": "fetch: follow redirects (default: true)"
-                    },
-                    "max_redirects": {
-                        "type": "integer",
-                        "description": "fetch: redirect limit (default: 10)"
-                    },
-                    "retries": {
-                        "type": "integer",
-                        "description": "fetch: retry count on transport failure (default: 0)"
-                    },
-                    "proxy": {
-                        "type": "string",
-                        "description": "fetch/stealth_fetch: proxy URL (e.g. http://user:pass@host:8080)"
-                    },
-                    "verify_tls": {
-                        "type": "boolean",
-                        "description": "fetch: verify TLS certificates (default: true)"
-                    },
-
-                    "wait_selector": {
-                        "type": "string",
-                        "description": "navigate/stealth_fetch/wait_for: CSS selector to wait for"
-                    },
-                    "wait_selector_state": {
-                        "type": "string",
-                        "enum": ["attached", "detached", "visible", "hidden"],
-                        "description": "wait_selector state (default: visible)"
-                    },
-                    "network_idle": {
-                        "type": "boolean",
-                        "description": "navigate/stealth_fetch/wait_for: wait for the network to be idle (no new requests for ~500ms)"
-                    },
-                    "solve_cloudflare": {
-                        "type": "boolean",
-                        "description": "navigate/stealth_fetch: best-effort wait for Cloudflare challenge to clear"
-                    },
-                    "block_webrtc": {
-                        "type": "boolean",
-                        "description": "stealth_fetch/navigate: block WebRTC to prevent IP leaks"
-                    },
-                    "hide_canvas": {
-                        "type": "boolean",
-                        "description": "stealth_fetch/navigate: add noise to canvas/WebGL fingerprints"
-                    },
-                    "disable_resources": {
-                        "type": "boolean",
-                        "description": "stealth_fetch/navigate: don't load images/fonts/media (faster)"
-                    },
-                    "block_images": {
-                        "type": "boolean",
-                        "description": "stealth_fetch/navigate: block image loads only"
-                    },
-                    "hide_webdriver": {
-                        "type": "boolean",
-                        "description": "stealth_fetch/navigate: hide navigator.webdriver and other automation tells (default: true)"
-                    },
-
-                    "html": {
-                        "type": "string",
-                        "description": "select: parse this static HTML body instead of querying the live tab"
-                    },
-                    "css": {
-                        "type": "string",
-                        "description": "select: CSS selector. Supports Scrapling pseudo-selectors ::text and ::attr(name)"
-                    },
-                    "xpath": {
-                        "type": "string",
-                        "description": "select: XPath query (live mode only — requires an active tab)"
-                    },
-                    "find_by_text": {
-                        "type": "string",
-                        "description": "select: filter matches by text (substring or regex when 'regex' is true)"
-                    },
-                    "regex": {
-                        "type": "boolean",
-                        "description": "select: treat find_by_text as a regex (default: false)"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "select: max number of matches to return (default 500, hard cap 500)"
-                    },
-                    "include_html": {
-                        "type": "boolean",
-                        "description": "select: include each match's outerHTML"
-                    },
-                    "auto_save": {
-                        "type": "boolean",
-                        "description": "select: store fingerprints of the matches under 'auto_save_id' for adaptive matching later"
-                    },
-                    "auto_match": {
-                        "type": "boolean",
-                        "description": "select: if the selector returns nothing, locate closest matches by similarity to fingerprints saved under 'auto_save_id'"
-                    },
-                    "auto_save_id": {
-                        "type": "string",
-                        "description": "select: identifier for the saved fingerprint set"
-                    },
-                    "auto_match_threshold": {
-                        "type": "number",
-                        "description": "select: minimum similarity (0-1) to accept an adaptive match (default 0.6)"
-                    },
-
-                    "delay_ms": {
-                        "type": "integer",
-                        "description": "wait_for/stealth_fetch: extra delay in ms after other waits resolve"
-                    }
-                },
-                "required": ["action"]
-            }),
+            parameters: schema_parameters(),
         }
     }
 
@@ -550,6 +579,8 @@ impl Tool for BrowserTool {
         let action = args["action"]
             .as_str()
             .ok_or_else(|| Error::ToolExecution("missing 'action' parameter".into()))?;
+
+        let action = effective_action(action, &args);
 
         if !self.manager.config().enabled {
             return Err(Error::ToolExecution(
@@ -1541,5 +1572,67 @@ mod tests {
             BrowserTool::store_key("default", Some("TARGET-2"))
         );
         assert_eq!(BrowserTool::store_key("default", None), "default:active");
+    }
+}
+
+#[cfg(test)]
+mod act_action_tests {
+    use super::effective_action;
+    use serde_json::json;
+
+    #[test]
+    fn fill_credential_as_a_sub_action_is_accepted() {
+        // The spelling a model reaches for when it holds a snapshot ref.
+        let args = json!({"action": "act", "ref": "e12", "actAction": "fill_credential",
+                          "field": "password"});
+        assert_eq!(effective_action("act", &args), "fill_credential");
+    }
+
+    #[test]
+    fn top_level_spelling_still_works() {
+        let args = json!({"action": "fill_credential", "ref": "e12", "field": "password"});
+        assert_eq!(
+            effective_action("fill_credential", &args),
+            "fill_credential"
+        );
+    }
+
+    #[test]
+    fn other_sub_actions_are_untouched() {
+        for sub in [
+            "click", "type", "fill", "press", "hover", "select", "drag", "wait",
+        ] {
+            let args = json!({"action": "act", "ref": "e1", "actAction": sub});
+            assert_eq!(
+                effective_action("act", &args),
+                "act",
+                "{sub} should stay an act"
+            );
+        }
+    }
+
+    #[test]
+    fn act_without_a_sub_action_is_untouched() {
+        let args = json!({"action": "act", "ref": "e1"});
+        assert_eq!(effective_action("act", &args), "act");
+    }
+
+    #[test]
+    fn the_schema_advertises_it_so_the_model_need_not_guess() {
+        // The fallback that made this matter was the model typing the
+        // credential's key name into the form; it should not have to
+        // infer the spelling from a rejection.
+        let params = super::schema_parameters();
+        let sub = &params["properties"]["actAction"];
+        let variants: Vec<&str> = sub["enum"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(
+            variants.contains(&"fill_credential"),
+            "actAction enum: {variants:?}"
+        );
     }
 }


### PR DESCRIPTION
`fill_credential` is the only ref-based operation that lives at the top level. Every sibling — `click`, `type`, `fill`, `press`, `hover`, `select`, `drag`, `wait` — is an `actAction` under `act`. So an agent holding a ref from a snapshot asks for `act` + `actAction: "fill_credential"`, which is where the pattern says it should be, and was told the sub-action was invalid.

This is not hypothetical. A trial did exactly that, was refused twice, and fell back to `fill` with the credential's **key name** as the text. The portal recorded the result:

```
LOGIN FAILED user='web_m1_max_64gb_tail84017e_ts_net_username'
             user_len=42 pw_len=42
```

Both fields received a 42-character key name instead of a credential. The agent had the right intention, named the right credential, and held a valid ref; the tool's shape converted all of that into a failed sign-in and a password-shaped string in the transcript.

## The fix

Accept the spelling the model already reaches for, and advertise it in the `actAction` enum so it need not learn it from a rejection. The top-level spelling keeps working; every other sub-action is untouched. Five tests cover both spellings, the untouched siblings, `act` with no sub-action, and the schema advertising it.

## Also

Retained trial dirs now shed the Chrome profile and keep `chrome-stderr.log`. Logs are kilobytes and get read; a user-data dir is hundreds of megabytes and does not. Fifteen retained trials filled the disk and stopped the machine mid-run, taking the suite in flight with it.

Stacked on #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)