### PR TITLE
feat(browser): record how much of a page a snapshot actually held

### DIFF
--- a/crates/rustykrab-e2e/src/main.rs
+++ b/crates/rustykrab-e2e/src/main.rs
@@ -1327,10 +1327,30 @@ async fn preflight_model(ollama_url: &str, model: &str) -> Result<()> {
             resp.status()
         );
     }
+    let elapsed = started.elapsed();
     eprintln!(
         "preflight: {model} answered in {:.1}s",
-        started.elapsed().as_secs_f64()
+        elapsed.as_secs_f64()
     );
+
+    // A one-word prompt that takes this long is not a fast model having a
+    // slow day. Ollama serves one request at a time per model, so the
+    // usual cause is something else holding the slot -- a running
+    // RustyKrab daemon is the usual culprit -- and the run that follows
+    // will produce trials that look like agent failures and are not.
+    //
+    // This is a warning rather than an error because a cold load of a
+    // large model legitimately takes tens of seconds. It is loud because
+    // the timing was already printed, and was read past.
+    if elapsed > Duration::from_secs(PREFLIGHT_SLOW_SECS) {
+        eprintln!(
+            "preflight: WARNING — {:.0}s for a one-word prompt suggests something \
+             else is holding {model}'s slot (a running RustyKrab daemon is the \
+             usual culprit). Trials will time out and look like agent failures. \
+             Stop it, or expect to throw this run away.",
+            elapsed.as_secs_f64()
+        );
+    }
     Ok(())
 }
 
@@ -1362,6 +1382,9 @@ fn isolated_browser_root(data_dir: &std::path::Path) -> std::ffi::OsString {
 }
 
 const PREFLIGHT_BUDGET_SECS: u64 = 120;
+
+/// Above this, a trivial generation means contention, not model speed.
+const PREFLIGHT_SLOW_SECS: u64 = 20;
 
 async fn wait_for_health(base: &str, client: &reqwest::Client, child: &mut Child) -> Result<()> {
     for _ in 0..240 {

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -773,7 +773,29 @@ impl Tool for BrowserTool {
                 };
 
                 let key = Self::store_key(&profile, target_id);
-                snapshot::take_snapshot(&page, &options, &self.snapshot_store, &key).await
+                let snap =
+                    snapshot::take_snapshot(&page, &options, &self.snapshot_store, &key).await;
+
+                // How much of the page the agent actually received.
+                //
+                // When an agent reports only a page's heading, two very
+                // different things could have happened: the snapshot held
+                // one node because the document was still arriving, or it
+                // held the whole page and the model quoted the first line.
+                // Those need opposite fixes and the reply cannot tell them
+                // apart. Sizes settle it; the page's text is deliberately
+                // not logged, because a snapshot can contain anything the
+                // page contains.
+                if let Ok(ref v) = snap {
+                    let url = page.url().await.ok().flatten().unwrap_or_default();
+                    tracing::debug!(
+                        url = %url,
+                        chars = v.to_string().len(),
+                        nodes = v["elements"].as_array().map(|a| a.len()).unwrap_or(0),
+                        "took page snapshot"
+                    );
+                }
+                snap
             }
 
             // ── Act (ref-based actions) ────────────────────────────


### PR DESCRIPTION
An agent that signs in and then reports only the page's heading could have received one node because the document was still arriving, or the whole page and quoted the first line of it. Those need opposite fixes, and the reply cannot tell them apart.

Snapshots now record their own size — the URL, the JSON length, and the node count. The page's **text is deliberately not logged**: a snapshot contains whatever the page contains, which on a signed-in page is exactly the material that should not land in a log.

It answered the question immediately. Across four instrumented trials:

| trial | outcome | post-login snapshot |
|---|---|---|
| #1 | Succeeded | `chars=362 nodes=1` |
| #2 | Timeout | none — never left the login page |
| #3 | Succeeded | `chars=362 nodes=1` |
| #4 | Succeeded | `chars=362 nodes=1` |

The trials that **succeeded** — reporting the invoice in full — got `nodes=1`. So a single node holding 362 characters contains the whole account page; "1 node" is what that page produces, not truncation. That refutes the render-race theory and means a navigation wait after `act_click` would have been work against a correct component.

## Also: a loud slow-preflight warning

Ollama serves one request at a time per model, so a one-word generation taking >20s means something else holds the slot — a running RustyKrab daemon is the usual culprit — and every trial after it times out and looks like an agent failure.

The timing was already printed. A run was started anyway with `14.9s` on screen against a healthy `0.8s`, and produced exactly that worthless result. A warning is louder than a number. It stays a warning rather than an error because a cold load of a large model legitimately takes tens of seconds.

Stacked on #579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)