### PR TITLE
fix(browser): address tabs by Chrome target ID, not list position

### DIFF
--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -3,7 +3,7 @@
 //! Manages multiple isolated browser instances, each with its own CDP port,
 //! user-data directory, and lifecycle. The manager handles:
 //! - Launching/connecting to Chrome instances per profile
-//! - Tab management (list, open, close, focus) with targetId addressing
+//! - Tab management (list, open, close, focus) by stable Chrome target ID
 //! - Browser lifecycle (start, stop, status)
 //! - Chrome profile symlink setup for cookie/session persistence
 //! - Process tracking (Child handles) so spawned Chromes can be killed
@@ -64,6 +64,13 @@ pub struct BrowserManager {
     /// (synchronous) can kill them even while the async `instances` lock
     /// is held elsewhere.
     children: Arc<std::sync::Mutex<HashMap<String, std::process::Child>>>,
+    /// The tab each session last navigated, keyed by `(session, profile)`.
+    ///
+    /// Without this, an action that omits `targetId` re-resolves the page
+    /// from scratch every call, and one browser profile is shared by every
+    /// concurrent run. Pinning the navigated tab is what keeps a `navigate`
+    /// and the `snapshot` after it on the same page.
+    sticky: Arc<std::sync::Mutex<HashMap<(String, String), String>>>,
 }
 
 impl BrowserManager {
@@ -72,6 +79,7 @@ impl BrowserManager {
             config,
             instances: Arc::new(Mutex::new(HashMap::new())),
             children: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            sticky: Arc::new(std::sync::Mutex::new(HashMap::new())),
         };
         if std::env::var("RUSTYKRAB_BROWSER_SWEEP").as_deref() == Ok("1") {
             sweep_stale_processes();
@@ -258,19 +266,29 @@ impl BrowserManager {
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to list tabs: {e}").into()))?;
 
-        let mut tabs = Vec::new();
-        for (i, page) in pages.iter().enumerate() {
+        // Address tabs by Chrome's own target ID. `pages()` walks a
+        // `HashMap`, so position in that list is arbitrary and unstable
+        // between calls — a positional `tab_N` names a different page from
+        // one call to the next.
+        let mut rows = Vec::new();
+        for page in pages.iter() {
             let url = page.url().await.ok().flatten().unwrap_or_default();
             let title = page.get_title().await.ok().flatten().unwrap_or_default();
-            // Use the page's target ID for deterministic addressing
-            let target_id = format!("tab_{i}");
-            tabs.push(serde_json::json!({
-                "targetId": target_id,
-                "index": i,
-                "url": url,
-                "title": title,
-            }));
+            rows.push((page.target_id().inner().clone(), url, title));
         }
+        // Sort so the listing itself is stable across calls; `pages()` is not.
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let tabs: Vec<serde_json::Value> = rows
+            .into_iter()
+            .map(|(target_id, url, title)| {
+                serde_json::json!({
+                    "targetId": target_id,
+                    "url": url,
+                    "title": title,
+                })
+            })
+            .collect();
 
         Ok(serde_json::json!({
             "tabs": tabs,
@@ -301,13 +319,12 @@ impl BrowserManager {
         let _ = tokio::time::timeout(nav_timeout, page.wait_for_navigation()).await;
         let actual_url = page.url().await.ok().flatten().unwrap_or_default();
         let title = page.get_title().await.ok().flatten().unwrap_or_default();
-        let pages = inst.browser.pages().await.map(|p| p.len()).unwrap_or(0);
 
         Ok(serde_json::json!({
             "status": "opened",
             "url": actual_url,
             "title": title,
-            "targetId": format!("tab_{}", pages.saturating_sub(1)),
+            "targetId": page.target_id().inner().clone(),
             "profile": profile_name
         }))
     }
@@ -323,18 +340,13 @@ impl BrowserManager {
             Error::ToolExecution(format!("browser not running for profile '{profile_name}'").into())
         })?;
 
-        let idx = parse_tab_index(target_id)?;
         let mut pages = inst
             .browser
             .pages()
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to list tabs: {e}").into()))?;
 
-        if idx >= pages.len() {
-            return Err(Error::ToolExecution(
-                format!("tab index {idx} out of range (have {} tabs)", pages.len()).into(),
-            ));
-        }
+        let idx = find_target_index(&pages, target_id)?;
 
         // `Page::close` (the CDP `Target.closeTarget`) consumes self, so we
         // take the page by value out of the Vec. This avoids `window.close()`
@@ -362,20 +374,13 @@ impl BrowserManager {
             Error::ToolExecution(format!("browser not running for profile '{profile_name}'").into())
         })?;
 
-        let idx = parse_tab_index(target_id)?;
         let pages = inst
             .browser
             .pages()
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to list tabs: {e}").into()))?;
 
-        if idx >= pages.len() {
-            return Err(Error::ToolExecution(
-                format!("tab index {idx} out of range (have {} tabs)", pages.len()).into(),
-            ));
-        }
-
-        let page = &pages[idx];
+        let page = &pages[find_target_index(&pages, target_id)?];
         page.bring_to_front()
             .await
             .map_err(|e| Error::ToolExecution(format!("failed to focus tab: {e}").into()))?;
@@ -392,7 +397,52 @@ impl BrowserManager {
         }))
     }
 
-    /// Get a specific page by targetId, or the first active page.
+    /// Pin the tab this session is working in, so later actions that omit
+    /// `targetId` address the same page.
+    pub fn set_sticky_target(&self, session: &str, profile: &str, target_id: &str) {
+        let key = (session.to_string(), profile.to_string());
+        let mut sticky = match self.sticky.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        sticky.insert(key, target_id.to_string());
+    }
+
+    /// The tab this session last navigated, if any.
+    pub fn sticky_target(&self, session: &str, profile: &str) -> Option<String> {
+        let key = (session.to_string(), profile.to_string());
+        let sticky = match self.sticky.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        sticky.get(&key).cloned()
+    }
+
+    /// Forget this session's pinned tab — called when it turns out to be
+    /// gone, so the next action falls back to normal resolution instead of
+    /// failing forever on a closed target.
+    pub fn clear_sticky_target(&self, session: &str, profile: &str) {
+        let key = (session.to_string(), profile.to_string());
+        let mut sticky = match self.sticky.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        sticky.remove(&key);
+    }
+
+    /// Whether `target_id` still names a live tab in this profile.
+    pub async fn target_is_live(&self, profile_name: &str, target_id: &str) -> bool {
+        let instances = self.instances.lock().await;
+        let Some(inst) = instances.get(profile_name) else {
+            return false;
+        };
+        let Ok(pages) = inst.browser.pages().await else {
+            return false;
+        };
+        pages.iter().any(|p| p.target_id().inner() == target_id)
+    }
+
+    /// Get a specific page by targetId, or the session's current page.
     pub async fn get_page(
         &self,
         profile_name: &str,
@@ -415,23 +465,32 @@ impl BrowserManager {
             .map_err(|e| Error::ToolExecution(format!("failed to list pages: {e}").into()))?;
 
         if let Some(tid) = target_id {
-            let idx = parse_tab_index(tid)?;
-            if idx < pages.len() {
-                Ok(pages.into_iter().nth(idx).unwrap())
-            } else {
-                Err(Error::ToolExecution(
-                    format!("tab {tid} not found (have {} tabs)", pages.len()).into(),
-                ))
-            }
-        } else if let Some(page) = pages.into_iter().next() {
-            Ok(page)
-        } else {
-            // No pages — create one
-            inst.browser
-                .new_page("about:blank")
-                .await
-                .map_err(|e| Error::ToolExecution(format!("failed to create tab: {e}").into()))
+            let idx = find_target_index(&pages, tid)?;
+            return Ok(pages.into_iter().nth(idx).unwrap());
         }
+
+        // No explicit target. `pages()` walks a `HashMap`, so `pages[0]` is
+        // an arbitrary tab that can differ between two consecutive calls —
+        // that is how a `navigate` and the `snapshot` after it end up on
+        // different pages, one of them the permanent `about:blank` startup
+        // tab. Rank instead: real pages before blank ones, ties broken on
+        // target ID, so repeated calls agree on the same page.
+        let mut ranked: Vec<(bool, String, usize)> = Vec::with_capacity(pages.len());
+        for (i, page) in pages.iter().enumerate() {
+            let url = page.url().await.ok().flatten().unwrap_or_default();
+            ranked.push((is_blank_url(&url), page.target_id().inner().clone(), i));
+        }
+        ranked.sort();
+
+        if let Some((_, _, idx)) = ranked.into_iter().next() {
+            return Ok(pages.into_iter().nth(idx).unwrap());
+        }
+
+        // No pages — create one.
+        inst.browser
+            .new_page("about:blank")
+            .await
+            .map_err(|e| Error::ToolExecution(format!("failed to create tab: {e}").into()))
     }
 
     /// Connect to an existing browser or launch a new one for the given profile.
@@ -905,13 +964,188 @@ async fn probe_cdp(url: &str, timeout: Duration) -> bool {
     )
 }
 
-/// Parse a targetId like "tab_3" into an index.
-fn parse_tab_index(target_id: &str) -> Result<usize> {
-    let idx_str = target_id.strip_prefix("tab_").unwrap_or(target_id);
-    idx_str.parse::<usize>().map_err(|_| {
-        Error::ToolExecution(
-            format!("invalid targetId '{target_id}'. Expected format: 'tab_N' (e.g., 'tab_0')")
+/// True for URLs that carry no page content: Chrome's startup tab and the
+/// placeholder [`BrowserManager::get_page`] creates when a profile has none.
+pub(super) fn is_blank_url(url: &str) -> bool {
+    url.is_empty() || url == "about:blank" || url.starts_with("chrome://new-tab")
+}
+
+/// Resolve a CDP target ID to its index in `pages`.
+///
+/// Target IDs are Chrome's own opaque per-tab identifiers, stable for the
+/// life of the tab. They replaced positional `tab_N` ids, which indexed a
+/// `HashMap` iteration and so named a different page from call to call.
+fn find_target_index(pages: &[chromiumoxide::Page], target_id: &str) -> Result<usize> {
+    pages
+        .iter()
+        .position(|p| p.target_id().inner() == target_id)
+        .ok_or_else(|| {
+            Error::ToolExecution(
+                format!(
+                    "tab '{target_id}' not found (have {} open). It may have been closed — \
+                     call action 'tabs' for the current targetIds.",
+                    pages.len()
+                )
                 .into(),
-        )
-    })
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager() -> BrowserManager {
+        BrowserManager::new(BrowserConfig::default())
+    }
+
+    #[test]
+    fn blank_urls_are_recognized() {
+        assert!(is_blank_url(""));
+        assert!(is_blank_url("about:blank"));
+        assert!(is_blank_url("chrome://new-tab-page"));
+        assert!(!is_blank_url("https://www.instagram.com/cutty13/"));
+        // Not blank just because the host is unusual.
+        assert!(!is_blank_url("about:config"));
+    }
+
+    #[test]
+    fn sticky_target_round_trips() {
+        let mgr = manager();
+        assert_eq!(mgr.sticky_target("conv-a", "default"), None);
+
+        mgr.set_sticky_target("conv-a", "default", "TARGET-1");
+        assert_eq!(
+            mgr.sticky_target("conv-a", "default").as_deref(),
+            Some("TARGET-1")
+        );
+
+        mgr.clear_sticky_target("conv-a", "default");
+        assert_eq!(mgr.sticky_target("conv-a", "default"), None);
+    }
+
+    /// Live regression check for the bug this addressing scheme replaced.
+    ///
+    /// Chrome always has a blank startup tab, and `pages()` walks a
+    /// `HashMap`, so the old `pages()[0]` resolution could hand a read the
+    /// blank tab moments after a navigate loaded content into another one.
+    /// Launches a real headless Chrome; ignored by default:
+    ///
+    /// ```sh
+    /// cargo test -p rustykrab-tools --no-default-features \
+    ///   browser::manager::tests::live -- --ignored --nocapture
+    /// ```
+    #[tokio::test]
+    #[ignore = "launches a real Chrome"]
+    async fn live_resolution_never_lands_on_the_blank_tab() {
+        const CONTENT: &str = "data:text/html,<title>cutty13</title><h1>profile</h1>";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").expect("free port");
+            l.local_addr().unwrap().port()
+        };
+        let profile = "tab-resolution-test";
+
+        let mut config = BrowserConfig {
+            default_profile: profile.to_string(),
+            ..Default::default()
+        };
+        config.profiles.insert(
+            profile.to_string(),
+            super::super::config::BrowserProfile {
+                cdp_port: Some(port),
+                user_data_dir: Some(dir.path().display().to_string()),
+                headless: Some(true),
+                ..Default::default()
+            },
+        );
+
+        let mgr = BrowserManager::new(config);
+        mgr.start(profile).await.expect("launch chrome");
+
+        // The hazard has to actually be present, or the test proves nothing:
+        // a blank startup tab sitting alongside the page we care about.
+        let startup = mgr.get_page(profile, None).await.expect("startup page");
+        let startup_url = startup.url().await.ok().flatten().unwrap_or_default();
+        assert!(
+            is_blank_url(&startup_url),
+            "expected a blank startup tab, got {startup_url}"
+        );
+
+        let opened = mgr.open_tab(profile, CONTENT).await.expect("open content");
+        let content_id = opened["targetId"].as_str().expect("targetId").to_string();
+        assert!(
+            !content_id.starts_with("tab_"),
+            "targetId must be Chrome's own id, got {content_id}"
+        );
+
+        // Resolution must be stable: same page every call, never the blank
+        // tab. Meanwhile record what the old `pages()[0]` rule would have
+        // returned, so the run reports whether the hazard fired.
+        let mut raw_blank_hits = 0;
+        for i in 0..20 {
+            let page = mgr.get_page(profile, None).await.expect("resolve page");
+            let url = page.url().await.ok().flatten().unwrap_or_default();
+            assert!(!is_blank_url(&url), "iteration {i} resolved to a blank tab");
+            assert_eq!(
+                page.target_id().inner(),
+                &content_id,
+                "iteration {i} resolved to a different tab"
+            );
+
+            let instances = mgr.instances.lock().await;
+            let pages = instances[profile].browser.pages().await.expect("pages");
+            let first = pages.first().expect("at least one page");
+            let first_url = first.url().await.ok().flatten().unwrap_or_default();
+            if is_blank_url(&first_url) {
+                raw_blank_hits += 1;
+            }
+        }
+        eprintln!("old pages()[0] rule would have hit the blank tab {raw_blank_hits}/20 times");
+
+        // An id that no longer names a tab is an error, not a silent
+        // fallback to some other page.
+        let err = mgr
+            .get_page(profile, Some("NO-SUCH-TARGET"))
+            .await
+            .expect_err("stale target must fail");
+        assert!(err.to_string().contains("not found"), "{err}");
+
+        // The listing is stable across calls too.
+        let first_listing = mgr.tabs(profile).await.expect("tabs");
+        let second_listing = mgr.tabs(profile).await.expect("tabs");
+        assert_eq!(first_listing["tabs"], second_listing["tabs"]);
+
+        let _ = mgr.stop(profile).await;
+    }
+
+    #[test]
+    fn sticky_targets_are_scoped_per_session_and_profile() {
+        let mgr = manager();
+        mgr.set_sticky_target("conv-a", "default", "TARGET-A");
+        mgr.set_sticky_target("conv-b", "default", "TARGET-B");
+        mgr.set_sticky_target("conv-a", "work", "TARGET-C");
+
+        // Two conversations browsing the same profile must not steer each
+        // other's page.
+        assert_eq!(
+            mgr.sticky_target("conv-a", "default").as_deref(),
+            Some("TARGET-A")
+        );
+        assert_eq!(
+            mgr.sticky_target("conv-b", "default").as_deref(),
+            Some("TARGET-B")
+        );
+        assert_eq!(
+            mgr.sticky_target("conv-a", "work").as_deref(),
+            Some("TARGET-C")
+        );
+
+        mgr.clear_sticky_target("conv-a", "default");
+        assert_eq!(mgr.sticky_target("conv-a", "default"), None);
+        assert_eq!(
+            mgr.sticky_target("conv-b", "default").as_deref(),
+            Some("TARGET-B")
+        );
+    }
 }

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -3,7 +3,7 @@
 //! Provides a comprehensive browser control surface with:
 //! - Multi-profile browser management (isolated Chrome instances)
 //! - Browser lifecycle (status/start/stop)
-//! - Tab management (tabs/open/close/focus) with targetId addressing
+//! - Tab management (tabs/open/close/focus) addressed by Chrome target ID
 //! - Accessibility-tree snapshots with element refs
 //! - Ref-based actions (click/type/press/hover/select/drag via snapshot refs)
 //! - Screenshot, navigate, evaluate, console, PDF, scroll
@@ -38,7 +38,7 @@ const MAX_CONTENT_BYTES: usize = 50 * 1024; // 50KB cap for page content
 /// Modeled after OpenClaw's browser management architecture:
 /// - Multiple named browser profiles, each an isolated Chrome instance
 /// - Browser lifecycle management (status/start/stop)
-/// - Deterministic tab control (tabs/open/close/focus by targetId)
+/// - Tab control (tabs/open/close/focus) by stable Chrome target ID
 /// - Accessibility-tree snapshots with element refs for actions
 /// - Ref-based interactions (click ref 12, type ref 5 "hello")
 ///
@@ -70,6 +70,21 @@ impl BrowserTool {
         }
     }
 
+    /// Build a tool against an explicit config.
+    ///
+    /// [`Self::new`] loads `~/.rustykrab/browser.json`, which ties it to the
+    /// operator's real Chrome profile and its live sessions. Callers that
+    /// need an isolated browser — tests, embedders driving a throwaway
+    /// profile — supply their own config here.
+    pub fn with_config(config: config::BrowserConfig) -> Self {
+        Self {
+            manager: BrowserManager::new(config),
+            snapshot_store: SnapshotStore::new(),
+            adaptive_store: AdaptiveStore::new(),
+            secrets: None,
+        }
+    }
+
     /// Let the browser type a stored credential without the model ever
     /// holding it.
     pub fn with_secrets(mut self, secrets: rustykrab_store::GuardedSecrets) -> Self {
@@ -90,6 +105,106 @@ impl BrowserTool {
             Some(tid) => format!("{profile}:{tid}"),
             None => format!("{profile}:active"),
         }
+    }
+
+    /// Key for per-conversation browser state.
+    ///
+    /// One Chrome profile is shared by every concurrent run, so the pinned
+    /// tab has to be scoped per conversation or two agents browsing at once
+    /// would steer each other's page. Outside a runner scope (CLI, tests)
+    /// there is one caller and one browser, so a shared key is correct.
+    fn session_key() -> String {
+        rustykrab_core::active_tools::with_session_context(|ctx| ctx.conversation_id.to_string())
+            .unwrap_or_else(|| "global".to_string())
+    }
+
+    /// Actions that operate on a page, and so need one resolved.
+    const PAGE_ACTIONS: &'static [&'static str] = &[
+        "navigate",
+        "snapshot",
+        "act",
+        "fill_credential",
+        "screenshot",
+        "content",
+        "evaluate",
+        "scroll",
+        "console",
+        "cookies",
+        "pdf",
+        "select",
+        "wait_for",
+    ];
+
+    /// Read actions whose whole purpose is to observe page content. Landing
+    /// one of these on a blank tab is a failure, not an empty result.
+    const READ_ACTIONS: &'static [&'static str] =
+        &["snapshot", "content", "evaluate", "screenshot", "pdf"];
+
+    /// Resolve the target this call addresses: explicit `targetId`, else the
+    /// session's pinned tab if it is still live.
+    async fn resolve_target(
+        &self,
+        action: &str,
+        profile: &str,
+        session: &str,
+        args: &Value,
+    ) -> Option<String> {
+        if let Some(tid) = args["targetId"].as_str() {
+            return Some(tid.to_string());
+        }
+        if !Self::PAGE_ACTIONS.contains(&action) {
+            return None;
+        }
+        let pinned = self.manager.sticky_target(session, profile)?;
+        if self.manager.target_is_live(profile, &pinned).await {
+            Some(pinned)
+        } else {
+            // The tab was closed out from under us. Drop the pin rather than
+            // failing every subsequent action on a dead target.
+            self.manager.clear_sticky_target(session, profile);
+            None
+        }
+    }
+
+    /// Resolve the page for a read action, refusing to report a blank tab
+    /// as an empty page.
+    async fn page_for(
+        &self,
+        action: &str,
+        profile: &str,
+        session: &str,
+        target_id: Option<&str>,
+    ) -> Result<chromiumoxide::Page> {
+        let page = self.manager.get_page(profile, target_id).await?;
+        let url = page.url().await.ok().flatten().unwrap_or_default();
+        let navigated = self.manager.sticky_target(session, profile).is_some();
+        Self::reject_blank_read(action, &url, navigated)?;
+        Ok(page)
+    }
+
+    /// Reject a read action that resolved to a blank tab.
+    ///
+    /// Chrome is launched with an `about:blank` startup tab that never goes
+    /// away, so a read can land on it and return a perfectly well-formed
+    /// empty result. That reads to the model as "this page has nothing on
+    /// it" and it stops using the browser, rather than as "you are not
+    /// looking at the page you navigated".
+    fn reject_blank_read(action: &str, url: &str, navigated: bool) -> Result<()> {
+        if !Self::READ_ACTIONS.contains(&action) || !manager::is_blank_url(url) {
+            return Ok(());
+        }
+        let detail = if navigated {
+            "the tab you navigated is no longer available, so this resolved to a blank tab"
+        } else {
+            "no page has been navigated in this session yet"
+        };
+        Err(Error::ToolExecution(
+            format!(
+                "'{action}' resolved to a blank tab ('{url}') — {detail}. \
+                 Call action 'navigate' with the URL you want to read, then retry."
+            )
+            .into(),
+        ))
     }
 }
 
@@ -443,7 +558,16 @@ impl Tool for BrowserTool {
         }
 
         let profile = self.resolve_profile(&args).to_string();
-        let target_id = args["targetId"].as_str();
+        let session = Self::session_key();
+
+        // Decide which page this call addresses once, here: an explicit
+        // `targetId` wins, otherwise the tab this session last navigated,
+        // provided it is still open. Every page action below reads
+        // `target_id`, so this is the single place "which page?" is answered
+        // — previously each one re-resolved it and could land on a different
+        // tab than the call before.
+        let resolved_target = self.resolve_target(action, &profile, &session, &args).await;
+        let target_id = resolved_target.as_deref();
 
         match action {
             // ── Lifecycle ──────────────────────────────────────────
@@ -470,21 +594,33 @@ impl Tool for BrowserTool {
                     .await
                     .map_err(|e| Error::ToolExecution(e.into()))?;
                 let _ = self.manager.get_browser(&profile).await?;
-                self.manager.open_tab(&profile, url).await
+                let opened = self.manager.open_tab(&profile, url).await?;
+                // A freshly opened tab is where this session is now working.
+                if let Some(tid) = opened["targetId"].as_str() {
+                    self.manager.set_sticky_target(&session, &profile, tid);
+                }
+                Ok(opened)
             }
 
             "close" => {
                 let tid = target_id.ok_or_else(|| {
                     Error::ToolExecution("'close' requires 'targetId' parameter".into())
                 })?;
-                self.manager.close_tab(&profile, tid).await
+                let closed = self.manager.close_tab(&profile, tid).await?;
+                if self.manager.sticky_target(&session, &profile).as_deref() == Some(tid) {
+                    self.manager.clear_sticky_target(&session, &profile);
+                }
+                Ok(closed)
             }
 
             "focus" => {
                 let tid = target_id.ok_or_else(|| {
                     Error::ToolExecution("'focus' requires 'targetId' parameter".into())
                 })?;
-                self.manager.focus_tab(&profile, tid).await
+                let focused = self.manager.focus_tab(&profile, tid).await?;
+                // Focusing a tab is a statement about where to work next.
+                self.manager.set_sticky_target(&session, &profile, tid);
+                Ok(focused)
             }
 
             // ── Navigation ─────────────────────────────────────────
@@ -546,10 +682,17 @@ impl Tool for BrowserTool {
                 let title = page.get_title().await.ok().flatten().unwrap_or_default();
                 let current_url = page.url().await.ok().flatten().unwrap_or_default();
 
+                // Pin the tab we just loaded so the snapshot/content call
+                // that follows reads this page and not some other one.
+                let landed_on = page.target_id().inner().clone();
+                self.manager
+                    .set_sticky_target(&session, &profile, &landed_on);
+
                 Ok(json!({
                     "title": title,
                     "url": current_url,
                     "status": "loaded",
+                    "targetId": landed_on,
                     "waits": Value::Object(wait_results),
                     "profile": profile
                 }))
@@ -558,7 +701,7 @@ impl Tool for BrowserTool {
             // ── Snapshot ───────────────────────────────────────────
             "snapshot" => {
                 let _ = self.manager.get_browser(&profile).await?;
-                let page = self.manager.get_page(&profile, target_id).await?;
+                let page = self.page_for(action, &profile, &session, target_id).await?;
 
                 let mode = match args["format"].as_str() {
                     Some("aria") => SnapshotMode::Aria,
@@ -670,7 +813,7 @@ impl Tool for BrowserTool {
             // ── Screenshot ─────────────────────────────────────────
             "screenshot" => {
                 let _ = self.manager.get_browser(&profile).await?;
-                let page = self.manager.get_page(&profile, target_id).await?;
+                let page = self.page_for(action, &profile, &session, target_id).await?;
                 let full_page = args["full_page"].as_bool().unwrap_or(false);
                 let selector = args["selector"].as_str();
 
@@ -709,7 +852,7 @@ impl Tool for BrowserTool {
             // ── Content ────────────────────────────────────────────
             "content" => {
                 let _ = self.manager.get_browser(&profile).await?;
-                let page = self.manager.get_page(&profile, target_id).await?;
+                let page = self.page_for(action, &profile, &session, target_id).await?;
                 let format = args["format"].as_str().unwrap_or("text");
 
                 let content = match format {
@@ -938,7 +1081,7 @@ impl Tool for BrowserTool {
             // ── PDF ────────────────────────────────────────────────
             "pdf" => {
                 let _ = self.manager.get_browser(&profile).await?;
-                let page = self.manager.get_page(&profile, target_id).await?;
+                let page = self.page_for(action, &profile, &session, target_id).await?;
 
                 let pdf_bytes = page.pdf(Default::default()).await.map_err(|e| {
                     Error::ToolExecution(
@@ -1159,5 +1302,170 @@ impl Tool for BrowserTool {
                 .into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_on_a_blank_tab_is_an_error() {
+        // This is the regression: a snapshot that resolved to the startup
+        // tab used to return `count: 0` as a success, which reads as "the
+        // page is empty" rather than "you are on the wrong page".
+        let err = BrowserTool::reject_blank_read("snapshot", "about:blank", true)
+            .expect_err("blank read must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("blank tab"), "{msg}");
+        assert!(msg.contains("navigate"), "{msg}");
+    }
+
+    #[test]
+    fn blank_read_message_distinguishes_never_navigated() {
+        let never = BrowserTool::reject_blank_read("content", "", false)
+            .expect_err("blank read must fail")
+            .to_string();
+        assert!(never.contains("no page has been navigated"), "{never}");
+
+        let lost = BrowserTool::reject_blank_read("content", "", true)
+            .expect_err("blank read must fail")
+            .to_string();
+        assert!(lost.contains("no longer available"), "{lost}");
+    }
+
+    #[test]
+    fn reads_on_a_real_page_pass() {
+        BrowserTool::reject_blank_read("snapshot", "https://www.instagram.com/cutty13/", true)
+            .expect("a real page is readable");
+    }
+
+    #[test]
+    fn non_read_actions_are_not_guarded() {
+        // `navigate` legitimately starts from a blank tab — guarding it
+        // would make the browser unusable from a cold start.
+        BrowserTool::reject_blank_read("navigate", "about:blank", false)
+            .expect("navigate may start blank");
+        BrowserTool::reject_blank_read("act", "about:blank", true).expect("act is not a read");
+    }
+
+    /// End-to-end check of the whole fix against the page that exposed it:
+    /// a real Instagram profile, which serves a login wall to a logged-out
+    /// browser. The old resolution answered this with `about:blank` and an
+    /// empty element list, which read to the model as "this page has nothing
+    /// on it" — so it abandoned the browser and never came back.
+    ///
+    /// Needs the network and launches a real Chrome; ignored by default:
+    ///
+    /// ```sh
+    /// cargo test -p rustykrab-tools --no-default-features \
+    ///   browser::tests::live -- --ignored --nocapture
+    /// ```
+    #[tokio::test]
+    #[ignore = "needs the network and launches a real Chrome"]
+    async fn live_instagram_navigate_then_snapshot_sees_the_page() {
+        const PROFILE_URL: &str = "https://www.instagram.com/secret_sanfrancisco/";
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").expect("free port");
+            l.local_addr().unwrap().port()
+        };
+        let profile = "instagram-live-test";
+
+        let mut cfg = config::BrowserConfig {
+            default_profile: profile.to_string(),
+            ..Default::default()
+        };
+        cfg.profiles.insert(
+            profile.to_string(),
+            config::BrowserProfile {
+                cdp_port: Some(port),
+                user_data_dir: Some(dir.path().display().to_string()),
+                headless: Some(true),
+                ..Default::default()
+            },
+        );
+        let tool = BrowserTool::with_config(cfg);
+
+        let navigated = tool
+            .execute(json!({"action": "navigate", "url": PROFILE_URL, "timeout_ms": 30000}))
+            .await
+            .expect("navigate");
+        eprintln!("navigate -> {navigated}");
+
+        let landed = navigated["url"].as_str().unwrap_or_default();
+        assert!(
+            !manager::is_blank_url(landed),
+            "navigate landed on a blank tab: {navigated}"
+        );
+        let pinned = navigated["targetId"]
+            .as_str()
+            .expect("navigate must report the tab it used")
+            .to_string();
+
+        // The read that follows must observe the page that was navigated —
+        // this is the exact pair that broke.
+        let snapshot = tool
+            .execute(json!({"action": "snapshot"}))
+            .await
+            .expect("snapshot must not fail on a loaded page");
+        eprintln!(
+            "snapshot -> count={} url={}",
+            snapshot["count"], snapshot["url"]
+        );
+        for el in snapshot["elements"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .take(12)
+        {
+            eprintln!("  [{}] {} {}", el["ref"], el["role"], el["name"]);
+        }
+
+        assert!(
+            !manager::is_blank_url(snapshot["url"].as_str().unwrap_or_default()),
+            "snapshot resolved to a blank tab: {snapshot}"
+        );
+        assert!(
+            snapshot["count"].as_u64().unwrap_or(0) > 0,
+            "snapshot saw no elements: {snapshot}"
+        );
+
+        // And it stays on that page across further reads, without the model
+        // having to thread a targetId through.
+        let content = tool
+            .execute(json!({"action": "content", "format": "text"}))
+            .await
+            .expect("content");
+        assert!(
+            !manager::is_blank_url(content["url"].as_str().unwrap_or(landed)),
+            "content resolved to a blank tab: {content}"
+        );
+
+        let tabs = tool.execute(json!({"action": "tabs"})).await.expect("tabs");
+        assert!(
+            tabs["tabs"]
+                .as_array()
+                .expect("tabs array")
+                .iter()
+                .any(|t| t["targetId"].as_str() == Some(pinned.as_str())),
+            "the pinned tab should still be listed: {tabs}"
+        );
+
+        let _ = tool.execute(json!({"action": "stop"})).await;
+    }
+
+    #[test]
+    fn store_key_separates_tabs() {
+        assert_eq!(
+            BrowserTool::store_key("default", Some("TARGET-1")),
+            "default:TARGET-1"
+        );
+        assert_ne!(
+            BrowserTool::store_key("default", Some("TARGET-1")),
+            BrowserTool::store_key("default", Some("TARGET-2"))
+        );
+        assert_eq!(BrowserTool::store_key("default", None), "default:active");
     }
 }


### PR DESCRIPTION
## The bug

A `navigate` could load a page and the `snapshot` immediately after it could return:

```json
{"count":0,"elements":[],"title":"","url":"about:blank"}
```

`is_error: false`. A successful, empty observation. The model reads that as "this page has nothing on it", abandons the browser, and doesn't go back.

Seen in production on 2026-09-01: a Telegram run navigated to an Instagram profile at 01:50:32 (`status: loaded`, correct title), snapshotted 23 s later, got `about:blank`, and then issued 24 consecutive `web_search` calls instead. It had a usable profile URL in context the whole time and never opened it.

## Cause

`get_page` with no `targetId` took `pages().into_iter().next()`. `pages()` walks a `HashMap` (chromiumoxide `handler/mod.rs:549-557`), so index 0 is an arbitrary tab — never insertion order, and not stable across mutations of the target set, which the handler's poll loop performs continuously. Chrome is also launched with an `about:blank` startup tab (`manager.rs:706`) that is never closed, so there is always a blank page in the pool to land on.

Measured on a fresh two-tab profile, the old rule picked the blank tab **20/20 times**.

Passing `targetId` explicitly didn't help: the ids handed to callers were `tab_N`, a position in that same unordered walk, so `tab_2` could name a different page by the next call — despite the module advertising "deterministic tab control".

## Changes

**Address tabs by `page.target_id()`** — Chrome's own opaque id, stable for the life of the tab. `parse_tab_index` and the `tab_N` scheme are gone. The `tabs` listing is sorted by id so the listing itself is stable.

**Resolve the page once per call.** Explicit `targetId` wins; otherwise the tab this session last navigated, pinned per `(conversation, profile)` — one Chrome profile is shared by every concurrent run, so the pin has to be conversation-scoped or two agents browsing at once steer each other's page. A stale pin is dropped rather than failing forever. With nothing pinned, resolution ranks real pages ahead of blank ones with ties broken on target id, so repeated calls agree.

**Refuse to answer a read from a blank tab.** `snapshot`, `content`, `evaluate`, `screenshot` and `pdf` now error instead of returning an empty success:

```
'snapshot' resolved to a blank tab ('about:blank') — the tab you navigated is no
longer available, so this resolved to a blank tab. Call action 'navigate' with the
URL you want to read, then retry.
```

`navigate` and `act` are deliberately not guarded — navigate legitimately starts from a blank tab.

Also adds `BrowserTool::with_config`, so a test can drive an isolated browser instead of the operator's real Chrome profile and its live sessions.

## Verification

Two live tests, both `#[ignore]`d so CI stays hermetic.

`browser::manager::tests::live_resolution_never_lands_on_the_blank_tab` launches a headless Chrome, asserts the hazard is present (a blank startup tab), then resolves 20 times while recording what the old rule would have returned:

```
old pages()[0] rule would have hit the blank tab 20/20 times
test browser::manager::tests::live_resolution_never_lands_on_the_blank_tab ... ok
```

`browser::tests::live_instagram_navigate_then_snapshot_sees_the_page` drives the full tool path against a real profile:

```
navigate -> {"status":"loaded","targetId":"5CD6E9E67385A66A7CB379605773E354",
             "title":"Secret San Francisco (@secret_sanfrancisco) • Instagram photos and videos",
             "url":"https://www.instagram.com/secret_sanfrancisco/"}
snapshot -> count=129 url="https://www.instagram.com/secret_sanfrancisco/"
  ["7"] "main" "secret_sanfranciscoVerifiedOptions435K followers609 followingSecret San Francisc…"
```

Bio, follower and following counts — readable logged out. That is the content the old path reported as an empty page.

```sh
cargo test -p rustykrab-tools --no-default-features browser::tests::live -- --ignored --nocapture
cargo test -p rustykrab-tools --no-default-features browser::manager::tests::live -- --ignored --nocapture
```

Plus 8 new unit tests: blank-URL detection, per-session/per-profile pin isolation, and each branch of the read guard.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` (26 binaries) are clean.

## Note for reviewers

`targetId` values are now opaque Chrome ids rather than `tab_N`. Nothing in the repo, `docs/`, `README.md` or the installed skills referenced the old format, so there is nothing to migrate. A caller holding a stale `tab_0` now gets `tab 'tab_0' not found — call action 'tabs'` rather than silently landing on the wrong page.

Instagram races its signup interstitial against the page render: across six live runs, four returned the full profile (129 elements) and two the login modal (9). Both are non-blank, so the guarantee holds either way and the test asserts `count > 0` rather than specific content. `navigate` already accepts `wait_selector` / `delay_ms` if you want one state deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
