### PR TITLE
refactor(browser): make the isolated root a config field, read once

### DIFF
--- a/crates/rustykrab-tools/src/browser/config.rs
+++ b/crates/rustykrab-tools/src/browser/config.rs
@@ -26,6 +26,22 @@ pub struct BrowserConfig {
     #[serde(default = "default_profile_name")]
     pub default_profile: String,
 
+    /// Root for browser profile data, when the caller wants a browser of
+    /// its own rather than the account's.
+    ///
+    /// Set it and two things follow: profile data lives under this root
+    /// instead of `~/.rustykrab/browser`, and the symlink to the real
+    /// Chrome profile is suppressed. Unset -- the normal case -- nothing
+    /// changes, and the real profile is borrowed because that is where
+    /// the logins are.
+    ///
+    /// The obvious way to get an isolated browser is to point HOME at a
+    /// scratch directory. That does not work: Chrome wedges its renderer
+    /// when HOME is an empty directory, committing a page's URL while the
+    /// document never arrives. Isolate this one directory instead.
+    #[serde(default)]
+    pub isolated_root: Option<PathBuf>,
+
     /// Run browsers in headless mode.
     #[serde(default)]
     pub headless: bool,
@@ -152,6 +168,9 @@ impl Default for BrowserConfig {
             enabled: true,
             evaluate_enabled: false,
             default_profile: "rustykrab".to_string(),
+            // Unset by default: normal use borrows the real Chrome
+            // profile, which is where the logins are.
+            isolated_root: None,
             headless: false,
             no_sandbox: false,
             attach_only: false,
@@ -209,6 +228,11 @@ impl BrowserConfig {
         if let Ok(path) = std::env::var("CHROME_EXECUTABLE") {
             config.executable_path = Some(path);
         }
+        if let Ok(root) = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT") {
+            if !root.is_empty() {
+                config.isolated_root = Some(PathBuf::from(root));
+            }
+        }
         if std::env::var("BROWSER_HEADLESS").as_deref() == Ok("1") {
             config.headless = true;
         }
@@ -254,21 +278,8 @@ impl BrowserConfig {
                 return PathBuf::from(dir);
             }
         }
-        // An explicit isolated root, for callers that need a browser of
-        // their own without borrowing anything from the real account.
-        //
-        // The obvious way to get that is to point HOME at a scratch dir,
-        // and it does not work: Chrome wedges its renderer when HOME is
-        // an empty directory. The page commits its URL and the document
-        // never arrives, which is indistinguishable from a hung site. A
-        // 2x2 over (stealth flags, sandboxed HOME) put it beyond doubt --
-        // every run with a redirected HOME wedged, every run without it
-        // loaded in ~2s. So isolate the one directory that needs
-        // isolating and leave HOME alone.
-        if let Ok(root) = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT") {
-            if !root.is_empty() {
-                return PathBuf::from(root).join(profile_name).join("user-data");
-            }
+        if let Some(root) = &self.isolated_root {
+            return root.join(profile_name).join("user-data");
         }
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
@@ -331,4 +342,56 @@ fn default_remote_cdp_timeout() -> u64 {
 
 fn default_color() -> String {
     "#FF6B00".to_string()
+}
+
+#[cfg(test)]
+mod isolated_root_tests {
+    use super::*;
+
+    /// The point of holding this as config rather than reading the
+    /// environment where it is used: it can be exercised without mutating
+    /// process-global state, which every other test in this binary shares.
+    #[test]
+    fn an_isolated_root_places_profile_data_under_it() {
+        let config = BrowserConfig {
+            isolated_root: Some(PathBuf::from("/tmp/trial-7/browser")),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.resolve_user_data_dir("rustykrab"),
+            PathBuf::from("/tmp/trial-7/browser/rustykrab/user-data")
+        );
+    }
+
+    #[test]
+    fn without_one_the_account_directory_is_used() {
+        let dir = BrowserConfig::default().resolve_user_data_dir("rustykrab");
+        let shown = dir.display().to_string();
+        assert!(shown.contains(".rustykrab/browser/rustykrab"), "{shown}");
+    }
+
+    /// Normal use must keep borrowing the real Chrome profile; that is
+    /// where the logins are.
+    #[test]
+    fn isolation_is_off_by_default() {
+        assert!(BrowserConfig::default().isolated_root.is_none());
+    }
+
+    /// A per-profile override still wins, as it did before.
+    #[test]
+    fn an_explicit_profile_directory_outranks_the_isolated_root() {
+        let mut config = BrowserConfig {
+            isolated_root: Some(PathBuf::from("/tmp/trial-7/browser")),
+            ..Default::default()
+        };
+        config
+            .profiles
+            .entry("rustykrab".to_string())
+            .or_default()
+            .user_data_dir = Some("/explicit/path".to_string());
+        assert_eq!(
+            config.resolve_user_data_dir("rustykrab"),
+            PathBuf::from("/explicit/path")
+        );
+    }
 }

--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -864,7 +864,7 @@ fn launch_browser_blocking(
     let profile = config.profiles.get(profile_name);
     let driver = profile.map(|p| &p.driver).unwrap_or(&DriverType::Rustykrab);
     let profile_dir_name = if *driver == DriverType::Rustykrab {
-        setup_profile_link(&user_data_dir)
+        setup_profile_link(&user_data_dir, config.isolated_root.is_some())
     } else {
         "Default".to_string()
     };
@@ -1031,15 +1031,21 @@ fn detect_profile_name(chrome_dir: &std::path::Path) -> String {
 
 /// Set up a wrapper data directory that symlinks back to the user's real
 /// Chrome profile, preserving cookies and sessions.
-fn setup_profile_link(user_data_dir: &std::path::Path) -> String {
-    // Borrowing the real profile is the point in normal use -- it carries
-    // the logins. Under an isolated root it is precisely what the caller
-    // asked to avoid, and in an eval it silently invalidates the result:
-    // a trial that inherits a signed-in cookie looks like a successful
-    // sign-in without ever signing in.
-    let isolated = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT")
-        .map(|v| !v.is_empty())
-        .unwrap_or(false);
+/// Link the account's real Chrome profile into `user_data_dir`, unless
+/// the caller asked for an isolated browser.
+///
+/// Borrowing the real profile is the point in normal use -- it carries
+/// the logins. Under an isolated root it is precisely what the caller
+/// asked to avoid, and in an eval it silently invalidates the result: a
+/// trial that inherits a signed-in cookie looks like a successful
+/// sign-in without ever having signed in.
+///
+/// `isolated` is passed in rather than read from the environment here.
+/// One setting read in one place is easier to reason about than the same
+/// `env::var` in two functions, and it makes this decision testable
+/// without mutating process-global state -- which in this workspace is
+/// shared with every other test in the binary.
+fn setup_profile_link(user_data_dir: &std::path::Path, isolated: bool) -> String {
     let Some(chrome_dir) = chrome_data_dir().filter(|_| !isolated) else {
         write_local_state(user_data_dir, "Default");
         return "Default".to_string();


### PR DESCRIPTION
Review feedback on the stack that just merged: the setting was integrated in too many places. It was.

`RUSTYKRAB_BROWSER_ISOLATED_ROOT` arrived as `env::var` in two spots — inside `resolve_user_data_dir`, evaluated on **every call**, and inside `setup_profile_link` to decide whether to borrow the account's Chrome profile. Neither is where this workspace keeps configuration. `BrowserConfig::load` already reads `CHROME_CDP_URL`, `CHROME_EXECUTABLE`, `BROWSER_HEADLESS` and the rest exactly once into fields; this setting just didn't follow the pattern it was sitting next to.

## Now

`BrowserConfig::isolated_root: Option<PathBuf>`, read once at load beside its peers. `resolve_user_data_dir` consults the field; `setup_profile_link` takes the decision as an argument rather than asking the environment itself.

Every mention of the variable in the product is now one line:

```
rustykrab-tools/src/browser/config.rs:231:  if let Ok(root) = std::env::var("RUSTYKRAB_BROWSER_ISOLATED_ROOT")
```

(the other two are the e2e harness *setting* it)

## Three gains, one that matters most

**Settable in `browser.json`** like every other browser setting, instead of being environment-only for no reason.

**Read once**, and one source of truth cannot disagree with itself.

**Testable without touching process-global environment.** Tests in this binary share one environment, so a test that sets a variable races every other test in it — a lesson this workspace has already paid for once. The four new tests build a `BrowserConfig` and assert on it, touching nothing global. That wasn't possible with the old shape, which is the real argument for the change.

Behaviour unchanged: unset still means the real Chrome profile is borrowed, which is where the logins are. A per-profile `user_data_dir` still outranks the isolated root — covered by a test.

Verified against the merged main: 26 suites, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)