### PR TITLE
fix(browser): bound the renderer round trips that decorate a result

### DIFF
--- a/crates/rustykrab-tools/src/browser/actions.rs
+++ b/crates/rustykrab-tools/src/browser/actions.rs
@@ -294,7 +294,10 @@ const ELEMENT_OP_BUDGET: std::time::Duration = std::time::Duration::from_secs(10
 /// "Request timed out" told the agent nothing, so it reissued the same
 /// call until the trial ended. A fresh snapshot re-reads the document and
 /// yields refs that work, so say that.
-async fn find_element_bounded(page: &Page, selector: &str) -> Result<chromiumoxide::Element> {
+pub(super) async fn find_element_bounded(
+    page: &Page,
+    selector: &str,
+) -> Result<chromiumoxide::Element> {
     match tokio::time::timeout(ELEMENT_OP_BUDGET, page.find_element(selector)).await {
         Ok(Ok(elem)) => Ok(elem),
         Ok(Err(e)) => Err(Error::ToolExecution(ToolError::not_found(format!(

--- a/crates/rustykrab-tools/src/browser/manager.rs
+++ b/crates/rustykrab-tools/src/browser/manager.rs
@@ -27,6 +27,17 @@ const POST_LAUNCH_TIMEOUT_MS: u64 = 15_000;
 /// Cap on the per-probe HTTP timeout when polling `/json/version`.
 const HEALTH_PROBE_TIMEOUT_MS: u64 = 3_000;
 
+/// Cap on a single `Page::url()` probe. `url()` is a CDP round trip, and an
+/// unbounded one inherits the client's own 30s fallback — long enough that a
+/// tool call is killed by its budget and retried, three times over, before
+/// the browser ever answers.
+const PAGE_PROBE_TIMEOUT_MS: u64 = 2_000;
+
+/// Cap on the *total* spent probing pages while resolving which tab to use.
+/// Bounds the whole loop, not each call, so a profile at its tab cap cannot
+/// multiply the per-probe budget by the number of tabs.
+const RESOLVE_PROBE_BUDGET_MS: u64 = 5_000;
+
 /// Stealth-oriented Chrome launch flags. These reduce the most obvious
 /// "this is a headed automation browser" signals — automation banner,
 /// `navigator.webdriver`, and the timer throttling that causes the macOS
@@ -302,10 +313,13 @@ impl BrowserManager {
         // `HashMap`, so position in that list is arbitrary and unstable
         // between calls — a positional `tab_N` names a different page from
         // one call to the next.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(RESOLVE_PROBE_BUDGET_MS);
         let mut rows = Vec::new();
         for page in pages.iter() {
-            let url = page.url().await.ok().flatten().unwrap_or_default();
-            let title = page.get_title().await.ok().flatten().unwrap_or_default();
+            // One unresponsive tab should still leave the listing usable, so
+            // it is reported with what could be read rather than blocking it.
+            let url = probe_page_url(page, deadline).await.unwrap_or_default();
+            let title = probe_page_title(page, deadline).await.unwrap_or_default();
             rows.push((page.target_id().inner().clone(), url, title));
         }
         // Sort so the listing itself is stable across calls; `pages()` is not.
@@ -356,12 +370,23 @@ impl BrowserManager {
                 // unpinned tabs. Pinned tabs are never candidates.
                 let mut blank = Vec::new();
                 let mut other = Vec::new();
+                let deadline =
+                    tokio::time::Instant::now() + Duration::from_millis(RESOLVE_PROBE_BUDGET_MS);
                 for page in existing {
                     if pinned.contains(page.target_id().inner()) {
                         continue;
                     }
-                    let url = page.url().await.ok().flatten().unwrap_or_default();
-                    if is_blank_url(&url) {
+                    // Bounded, and deliberately the opposite polarity to
+                    // `get_page`: there an unreadable tab is ranked with the
+                    // blank ones so it cannot win, here it is ranked away
+                    // from them so it does not get closed. Both directions
+                    // are "when in doubt, leave it alone".
+                    let blank_page = probe_page_url(&page, deadline)
+                        .await
+                        .as_deref()
+                        .map(is_blank_url)
+                        .unwrap_or(false);
+                    if blank_page {
                         blank.push(page);
                     } else {
                         other.push(page);
@@ -432,7 +457,7 @@ impl BrowserManager {
             "opened tab"
         );
         let actual_url = page.url().await.ok().flatten().unwrap_or_default();
-        let title = page.get_title().await.ok().flatten().unwrap_or_default();
+        let title = probe_page_title_once(&page).await.unwrap_or_default();
 
         Ok(serde_json::json!({
             "status": "opened",
@@ -500,7 +525,7 @@ impl BrowserManager {
             .map_err(|e| Error::ToolExecution(format!("failed to focus tab: {e}").into()))?;
 
         let url = page.url().await.ok().flatten().unwrap_or_default();
-        let title = page.get_title().await.ok().flatten().unwrap_or_default();
+        let title = probe_page_title_once(page).await.unwrap_or_default();
 
         Ok(serde_json::json!({
             "status": "focused",
@@ -562,15 +587,29 @@ impl BrowserManager {
     }
 
     /// Whether `target_id` still names a live tab in this profile.
-    pub async fn target_is_live(&self, profile_name: &str, target_id: &str) -> bool {
+    ///
+    /// `Some(false)` only when the browser answered and the tab was absent.
+    /// `None` means the probe could not tell — a browser that is merely slow
+    /// must not cost a session the tab it is working in, so callers keep the
+    /// pin on `None` and only drop it on a definite answer.
+    pub async fn target_is_live(&self, profile_name: &str, target_id: &str) -> Option<bool> {
         let instances = self.instances.lock().await;
+        // No instance is a definite answer, not an inconclusive one: a
+        // profile with no browser has no tabs, so a pin naming one is dead.
+        // This is the path a pin takes across a Chrome relaunch.
         let Some(inst) = instances.get(profile_name) else {
-            return false;
+            return Some(false);
         };
-        let Ok(pages) = inst.browser.pages().await else {
-            return false;
-        };
-        pages.iter().any(|p| p.target_id().inner() == target_id)
+        let listing = tokio::time::timeout(
+            Duration::from_millis(HEALTH_PROBE_TIMEOUT_MS),
+            inst.browser.pages(),
+        )
+        .await;
+        match listing {
+            Ok(Ok(pages)) => Some(pages.iter().any(|p| p.target_id().inner() == target_id)),
+            // Timed out, or the handler is gone: inconclusive.
+            _ => None,
+        }
     }
 
     /// Get a specific page by targetId, or the session's current page.
@@ -606,10 +645,19 @@ impl BrowserManager {
         // different pages, one of them the permanent `about:blank` startup
         // tab. Rank instead: real pages before blank ones, ties broken on
         // target ID, so repeated calls agree on the same page.
+        //
+        // Probing costs a CDP round trip per tab, so it runs under a shared
+        // deadline: a tab that will not answer ranks alongside the blank ones
+        // rather than stalling resolution or winning by default.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(RESOLVE_PROBE_BUDGET_MS);
         let mut ranked: Vec<(bool, String, usize)> = Vec::with_capacity(pages.len());
         for (i, page) in pages.iter().enumerate() {
-            let url = page.url().await.ok().flatten().unwrap_or_default();
-            ranked.push((is_blank_url(&url), page.target_id().inner().clone(), i));
+            let blank = probe_page_url(page, deadline)
+                .await
+                .as_deref()
+                .map(is_blank_url)
+                .unwrap_or(true);
+            ranked.push((blank, page.target_id().inner().clone(), i));
         }
         ranked.sort();
 
@@ -1139,6 +1187,62 @@ async fn probe_cdp(url: &str, timeout: Duration) -> bool {
     )
 }
 
+/// Read a page's URL under a bound, returning `None` when it will not answer.
+///
+/// Measured: `url()` is served from the handler's cached target info, so it
+/// returns in microseconds even against a spinning renderer. The bound is
+/// insurance for the case the handler itself is saturated, not a fix for a
+/// hang — [`probe_page_title`] is where the real exposure is.
+///
+/// Callers treat `None` as "cannot tell", never as a fact about the page.
+pub(super) async fn probe_page_url(
+    page: &chromiumoxide::Page,
+    deadline: tokio::time::Instant,
+) -> Option<String> {
+    let now = tokio::time::Instant::now();
+    if now >= deadline {
+        return None;
+    }
+    let budget = Duration::from_millis(PAGE_PROBE_TIMEOUT_MS).min(deadline - now);
+    match tokio::time::timeout(budget, page.url()).await {
+        Ok(Ok(url)) => url,
+        _ => None,
+    }
+}
+
+/// Read a page's title under a bound, returning `None` when it will not answer.
+///
+/// Unlike [`probe_page_url`], this is a real round trip to the renderer, so a
+/// page spinning in JavaScript never answers it. Measured against a tab in a
+/// `while(true)` loop, an unbounded call had still not returned after 40s —
+/// long enough to blow a tool-call budget and be retried on top.
+pub(super) async fn probe_page_title(
+    page: &chromiumoxide::Page,
+    deadline: tokio::time::Instant,
+) -> Option<String> {
+    let now = tokio::time::Instant::now();
+    if now >= deadline {
+        return None;
+    }
+    let budget = Duration::from_millis(PAGE_PROBE_TIMEOUT_MS).min(deadline - now);
+    match tokio::time::timeout(budget, page.get_title()).await {
+        Ok(Ok(title)) => title,
+        _ => None,
+    }
+}
+
+/// [`probe_page_title`] with a fresh single-probe deadline.
+pub(super) async fn probe_page_title_once(page: &chromiumoxide::Page) -> Option<String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(PAGE_PROBE_TIMEOUT_MS);
+    probe_page_title(page, deadline).await
+}
+
+/// [`probe_page_url`] with a fresh single-probe deadline.
+pub(super) async fn probe_page_url_once(page: &chromiumoxide::Page) -> Option<String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(PAGE_PROBE_TIMEOUT_MS);
+    probe_page_url(page, deadline).await
+}
+
 /// True for URLs that carry no page content: Chrome's startup tab and the
 /// placeholder [`BrowserManager::get_page`] creates when a profile has none.
 pub(super) fn is_blank_url(url: &str) -> bool {
@@ -1197,6 +1301,95 @@ mod tests {
 
         mgr.clear_sticky_target("conv-a", "default");
         assert_eq!(mgr.sticky_target("conv-a", "default"), None);
+    }
+
+    #[tokio::test]
+    async fn a_pin_with_no_browser_is_definitely_dead() {
+        // The relaunch path: Chrome went away, so a pin naming one of its
+        // tabs cannot survive. This must be a definite answer, or the pin
+        // would be kept forever against a browser that no longer exists.
+        let mgr = manager();
+        assert_eq!(
+            mgr.target_is_live("nonexistent", "SOME-TARGET").await,
+            Some(false)
+        );
+    }
+
+    /// A tab spinning in JavaScript must not stall work on the others.
+    ///
+    /// `get_title()` is a real round trip to the renderer, so a page in a
+    /// `while(true)` loop never answers it; measured unbounded, it had still
+    /// not returned after 40s. `tabs` reads a title per tab, so one wedged
+    /// page used to hang the whole listing well past any tool-call budget.
+    /// (`url()` is served from the handler's cache and returns in
+    /// microseconds even then — it is not the exposure.)
+    ///
+    /// Launches a real headless Chrome; ignored by default.
+    #[tokio::test]
+    #[ignore = "launches a real Chrome"]
+    async fn live_a_wedged_tab_cannot_stall_the_others() {
+        const WEDGE: &str = "data:text/html,<title>wedge</title>\
+<script>setTimeout(()=>{while(true){}},1500)</script>";
+        const NORMAL: &str = "data:text/html,<title>normal</title><h1>ok</h1>";
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").expect("free port");
+            l.local_addr().unwrap().port()
+        };
+        let profile = "wedged-tab-test";
+        let mut config = BrowserConfig {
+            default_profile: profile.to_string(),
+            ..Default::default()
+        };
+        config.profiles.insert(
+            profile.to_string(),
+            super::super::config::BrowserProfile {
+                cdp_port: Some(port),
+                user_data_dir: Some(dir.path().display().to_string()),
+                headless: Some(true),
+                ..Default::default()
+            },
+        );
+        let mgr = BrowserManager::new(config);
+        mgr.start(profile).await.expect("launch chrome");
+
+        mgr.open_tab(profile, NORMAL).await.expect("open normal");
+        mgr.open_tab(profile, WEDGE).await.expect("open wedge");
+        // Let the wedge tab enter its loop.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Every probe shares one budget, so the listing is bounded by
+        // RESOLVE_PROBE_BUDGET_MS however many tabs are stuck.
+        let started = std::time::Instant::now();
+        let tabs = mgr.tabs(profile).await.expect("tabs must not hang");
+        let elapsed = started.elapsed();
+        eprintln!("tabs() with a wedged tab -> {:?}", elapsed);
+        assert!(
+            elapsed < Duration::from_millis(RESOLVE_PROBE_BUDGET_MS + 2_000),
+            "tabs() took {elapsed:?}"
+        );
+
+        // The healthy tab is still fully described; only the wedged one
+        // loses its title.
+        let listed = tabs["tabs"].as_array().expect("tabs array");
+        assert!(
+            listed.iter().any(|t| t["title"] == "normal"),
+            "the healthy tab should still report its title: {tabs}"
+        );
+
+        // Resolution stays fast, and must not pick the wedged tab over the
+        // healthy one just because it could not be read.
+        let started = std::time::Instant::now();
+        let page = mgr.get_page(profile, None).await.expect("resolve");
+        eprintln!(
+            "get_page(None) with a wedged tab -> {:?}",
+            started.elapsed()
+        );
+        assert!(started.elapsed() < Duration::from_secs(6));
+        assert!(!page.target_id().inner().is_empty());
+
+        let _ = mgr.stop(profile).await;
     }
 
     /// Live regression check for the bug this addressing scheme replaced.

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -446,13 +446,16 @@ impl BrowserTool {
             return None;
         }
         let pinned = self.manager.sticky_target(session, profile)?;
-        if self.manager.target_is_live(profile, &pinned).await {
-            Some(pinned)
-        } else {
-            // The tab was closed out from under us. Drop the pin rather than
-            // failing every subsequent action on a dead target.
-            self.manager.clear_sticky_target(session, profile);
-            None
+        match self.manager.target_is_live(profile, &pinned).await {
+            // Definitely gone: the tab was closed out from under us. Drop the
+            // pin rather than failing every subsequent action on it.
+            Some(false) => {
+                self.manager.clear_sticky_target(session, profile);
+                None
+            }
+            // Live, or the browser could not answer in time. Keep the pin —
+            // a slow Chrome is not a reason to lose the page mid-task.
+            _ => Some(pinned),
         }
     }
 
@@ -466,9 +469,13 @@ impl BrowserTool {
         target_id: Option<&str>,
     ) -> Result<chromiumoxide::Page> {
         let page = self.manager.get_page(profile, target_id).await?;
-        let url = page.url().await.ok().flatten().unwrap_or_default();
-        let navigated = self.manager.sticky_target(session, profile).is_some();
-        Self::reject_blank_read(action, &url, navigated)?;
+        // Bounded: a page that will not answer is not evidence of a blank
+        // tab, so an inconclusive probe skips the guard rather than
+        // rejecting a read the model may well be able to complete.
+        if let Some(url) = manager::probe_page_url_once(&page).await {
+            let navigated = self.manager.sticky_target(session, profile).is_some();
+            Self::reject_blank_read(action, &url, navigated)?;
+        }
         Ok(page)
     }
 
@@ -734,7 +741,9 @@ impl Tool for BrowserTool {
                     tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
                 }
 
-                let title = page.get_title().await.ok().flatten().unwrap_or_default();
+                let title = manager::probe_page_title_once(&page)
+                    .await
+                    .unwrap_or_default();
                 let current_url = page.url().await.ok().flatten().unwrap_or_default();
 
                 // Pin the tab we just loaded so the snapshot/content call
@@ -921,11 +930,9 @@ impl Tool for BrowserTool {
                 let selector = args["selector"].as_str();
 
                 let png_bytes = if let Some(sel) = selector {
-                    let elem = page.find_element(sel).await.map_err(|e| {
-                        Error::ToolExecution(
-                            format!("element not found for selector '{sel}': {e}").into(),
-                        )
-                    })?;
+                    // Same bound the `act` path got: an element lookup
+                    // against a wedged document never returns on its own.
+                    let elem = actions::find_element_bounded(&page, sel).await?;
                     elem.screenshot(
                         chromiumoxide::cdp::browser_protocol::page::CaptureScreenshotFormat::Png,
                     )
@@ -976,7 +983,9 @@ impl Tool for BrowserTool {
                 };
 
                 let (truncated_content, was_truncated) = truncate_utf8(&content, MAX_CONTENT_BYTES);
-                let title = page.get_title().await.ok().flatten().unwrap_or_default();
+                let title = manager::probe_page_title_once(&page)
+                    .await
+                    .unwrap_or_default();
                 let current_url = page.url().await.ok().flatten().unwrap_or_default();
 
                 Ok(json!({
@@ -1197,7 +1206,9 @@ impl Tool for BrowserTool {
                 let b64 = base64::engine::general_purpose::STANDARD.encode(&pdf_bytes);
 
                 let url = page.url().await.ok().flatten().unwrap_or_default();
-                let title = page.get_title().await.ok().flatten().unwrap_or_default();
+                let title = manager::probe_page_title_once(&page)
+                    .await
+                    .unwrap_or_default();
 
                 Ok(json!({
                     "pdf": b64,
@@ -1289,7 +1300,9 @@ impl Tool for BrowserTool {
                 }
 
                 let final_url = page.url().await.ok().flatten().unwrap_or_default();
-                let title = page.get_title().await.ok().flatten().unwrap_or_default();
+                let title = manager::probe_page_title_once(&page)
+                    .await
+                    .unwrap_or_default();
                 let html = page.content().await.unwrap_or_default();
                 let text = page
                     .evaluate("document.body ? document.body.innerText : ''")


### PR DESCRIPTION
## The problem, measured against the running daemon

A tab spinning in JavaScript answers no CDP command that reaches its renderer. `get_title()` is one of those, and `tabs` reads a title per tab — so one wedged page hung the entire listing.

Booting the real daemon with the scripted provider, against a page that starts a `while(true)` loop 1.5s after load, its own log:

```
BEFORE (main @ 608ae4d)
  tool call started   tool=browser  07:04:51.673173Z
  tool call succeeded tool=browser  07:05:49.072342Z     <- 57.4s
  turn wall-clock: 60.6s

AFTER (this branch)
  tool call started   tool=browser  07:04:31.922428Z
  tool call succeeded tool=browser  07:04:33.927111Z     <- 2.0s
  turn wall-clock: 5.2s
```

57.4s for one `browser tabs` call against a 60s tool budget. The first three tool calls in the scenario — two `open`s and a `navigate` — are unaffected in both runs; the entire difference is the listing.

## What was blocking

`get_title()`, and only ever as garnish. In every one of these the result was already computed and the title was decoration on top:

- `tabs` — a title per tab, so cost scaled with tab count
- `open` and `focus` — the title reported back
- `navigate`, `content`, `pdf`, `wait_for` — the title in the returned payload

Bounded at 2s per probe against a 5s budget shared across a profile's tabs, so it cannot scale with tab count. A tab that will not answer loses its title; every other tab is still fully described.

`find_element` in the `screenshot` selector path gets the same bound #581 gave the `act` path — it was the one element lookup still unbounded.

## What was *not* the problem

I assumed `get_page`'s tab ranking was exposed too, and it isn't. Measured against the same spinning renderer:

| call | elapsed |
|---|---|
| `page.url()` | **46µs** — served from the handler's cached target info |
| `page.get_title()` | **>40s** — real renderer round trip, never returned |
| `get_page(None)` | 257µs |

`url()` never reaches the renderer, so the ranking loop was fine. It is bounded here anyway — same helper, no cost — but as insurance against a saturated handler, not as a fix for a hang. The doc comments say exactly that rather than implying a hazard that isn't there.

## Two pieces of hygiene in the same area

`get_page`'s ranking and `open_tab`'s reap both run under the shared budget, with deliberately opposite polarity: a tab that cannot be read is ranked **with** the blank ones in `get_page` so it cannot be selected, and **away** from them in the reap so it cannot be closed. Both are "when in doubt, leave it alone."

`target_is_live` now returns `Option<bool>`. Only a definite answer drops a session's pinned tab; an inconclusive probe keeps it, so a slow browser cannot cost a session the page it is working in. A profile with no browser stays definite — that is the Chrome-relaunch path.

## Verification

New live regression test, `browser::manager::tests::live_a_wedged_tab_cannot_stall_the_others`, launches a real headless Chrome, wedges one tab and asserts the listing stays bounded and still describes the healthy tab:

```
tabs() with a wedged tab -> 2.00494875s
get_page(None) with a wedged tab -> 181.792µs
```

Ignored by default, like the other live tests:

```sh
cargo test -p rustykrab-tools --no-default-features live_a_wedged_tab -- --ignored --nocapture
```

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` (26 binaries) all clean. The existing live tests from #583 still pass unchanged.

## Note for reviewers

Thanks to whoever wrote #581 — the "unbounded call falls through to the CDP client's 30s, then the runner retries it" framing there is what sent me looking, and this is the same class of exposure in the metadata reads rather than the element lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
