### PR TITLE
fix(cli,store): recover from a dead conversation instead of failing forever

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -1568,6 +1568,55 @@ const HEARTBEAT_TIMEOUT_SECS: u64 = 1800; // 30 minutes
 /// Telegram's typing indicator expires after ~5 seconds.
 const TYPING_INTERVAL_SECS: u64 = 4;
 
+/// Load the conversation bound to a channel address, minting a fresh one if
+/// the binding has outlived it.
+///
+/// Deleting a conversation through the API takes its binding with it
+/// (`channel_bindings` cascades), but a channel loop that has already
+/// resolved the id keeps it in an in-process cache and never consults the
+/// binding again. Loading it then fails, and — because the cache is not
+/// invalidated either — it fails identically for every message after this
+/// one, until the user happens to send /reset.
+///
+/// So a conversation that no longer loads is treated as an instruction to
+/// start a new one rather than as an error. Returns the conversation and
+/// whether it replaced a dead id, so the caller can refresh its cache.
+///
+/// Only `NotFound` is healed. A storage failure is a real error and is
+/// propagated: minting a replacement conversation because the disk is
+/// unhappy would silently discard history that is still there.
+async fn load_or_rebind(
+    state: &AppState,
+    address: &rustykrab_store::ChannelAddress,
+    conv_id: Uuid,
+    channel_source: &str,
+    channel_id: Option<String>,
+    channel_thread_id: Option<String>,
+) -> Result<(rustykrab_core::types::Conversation, bool), rustykrab_core::Error> {
+    match state.store.conversations().get(conv_id).await {
+        Ok(conv) => Ok((conv, false)),
+        Err(rustykrab_core::Error::NotFound(_)) => {
+            tracing::warn!(
+                channel = address.channel(),
+                stale_conv_id = %conv_id,
+                "bound conversation no longer exists — starting a new one"
+            );
+            let mut conv = state.store.conversations().create().await?;
+            conv.channel_source = Some(channel_source.to_string());
+            conv.channel_id = channel_id;
+            conv.channel_thread_id = channel_thread_id;
+            state.store.conversations().save_meta(&conv).await?;
+            state
+                .store
+                .channel_bindings()
+                .bind(address, conv.id)
+                .await?;
+            Ok((conv, true))
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Address of a Telegram chat (or forum topic) for
 /// [`rustykrab_store::ChannelBindingStore`].
 fn telegram_address(chat_id: i64, thread_id: i64) -> rustykrab_store::ChannelAddress {
@@ -1839,13 +1888,32 @@ async fn process_telegram_message(
     // Load the conversation. `persisted_ids` lets the post-run save
     // append only this turn's messages (full rewrite if the agent
     // compacted history mid-run).
-    let mut conv = match state.store.conversations().get(conv_id).await {
-        Ok(c) => c,
+    let address = telegram_address(chat_id, thread_id);
+    let (mut conv, rebound) = match load_or_rebind(
+        state,
+        &address,
+        conv_id,
+        "telegram",
+        Some(chat_id.to_string()),
+        (thread_id != 0).then(|| thread_id.to_string()),
+    )
+    .await
+    {
+        Ok(pair) => pair,
         Err(e) => {
             tracing::error!(chat_id, thread_id, %conv_id, "failed to load conversation: {e}");
             return "Internal error — please try again.".to_string();
         }
     };
+    // The cached id is the one that just failed to load; leaving it in place
+    // would send the next message down the same dead path.
+    let conv_id = conv.id;
+    if rebound {
+        let mut states = chat_states.lock().await;
+        if let Some(cs) = states.get_mut(&key) {
+            cs.conv_id = conv_id;
+        }
+    }
     let persisted_ids: Vec<Uuid> = conv.messages.iter().map(|m| m.id).collect();
 
     // Ensure channel metadata is present (backfills conversations created
@@ -2201,9 +2269,10 @@ async fn slack_agent_loop(
                 }
             }
 
-            let reply = process_slack_message(
+            let (used_conv_id, reply) = process_slack_message(
                 &state,
                 conv_id,
+                &inbound.team_id,
                 &inbound.channel_id,
                 &effective_thread_ts,
                 inbound.message,
@@ -2211,11 +2280,15 @@ async fn slack_agent_loop(
             )
             .await;
 
-            // Clear busy.
+            // Clear busy, and adopt the conversation actually used: it
+            // differs when the cached id had outlived its conversation and
+            // a new one was started. Leaving the dead id cached would send
+            // the next message down the same path.
             {
                 let mut states = chat_states.lock().await;
                 if let Some(cs) = states.get_mut(&key) {
                     cs.busy = false;
+                    cs.conv_id = used_conv_id;
                 }
             }
 
@@ -2236,21 +2309,36 @@ async fn slack_agent_loop(
 }
 
 /// Process a single Slack message: load conversation, run agent, persist.
+/// Returns the conversation id actually used alongside the reply: it differs
+/// from the one passed in when the binding had outlived its conversation and
+/// [`load_or_rebind`] started a new one.
 async fn process_slack_message(
     state: &AppState,
     conv_id: Uuid,
+    team_id: &str,
     channel_id: &str,
     thread_ts: &str,
     message: rustykrab_core::types::Message,
     user_text: &str,
-) -> String {
-    let mut conv = match state.store.conversations().get(conv_id).await {
-        Ok(c) => c,
+) -> (Uuid, String) {
+    let address = slack_address(team_id, channel_id, thread_ts);
+    let (mut conv, _rebound) = match load_or_rebind(
+        state,
+        &address,
+        conv_id,
+        "slack",
+        Some(channel_id.to_string()),
+        Some(thread_ts.to_string()),
+    )
+    .await
+    {
+        Ok(pair) => pair,
         Err(e) => {
             tracing::error!(channel_id, thread_ts, %conv_id, "failed to load Slack conversation: {e}");
-            return "Internal error — please try again.".to_string();
+            return (conv_id, "Internal error — please try again.".to_string());
         }
     };
+    let conv_id = conv.id;
     // Ids of the already-persisted messages: the post-run save appends
     // only this turn's tail (full rewrite if the agent compacted
     // history mid-run).
@@ -2322,7 +2410,7 @@ async fn process_slack_message(
         tracing::error!(channel_id, %conv_id, "failed to persist Slack conversation: {e}");
     }
 
-    reply
+    (conv_id, reply)
 }
 
 async fn shutdown_signal() {

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -608,8 +608,52 @@ where
 {
     let conn = Arc::clone(conn);
     run_blocking(move || {
-        let conn = conn.lock().unwrap();
+        // Recover a poisoned lock rather than propagating the panic.
+        //
+        // Every database call in the process goes through here, so
+        // `unwrap()` turned one panic while holding the lock into a
+        // permanent outage: the mutex stayed poisoned and every subsequent
+        // call panicked with it. The data is not damaged by a panic — the
+        // connection is unchanged, and any transaction that was open is
+        // rolled back when its guard drops — so continuing is both safe and
+        // the only option that recovers.
+        //
+        // `RetrievalLog` and `AppState::rotate_token` already do this.
+        let conn = conn.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         f(&conn)
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A panic while holding the connection lock used to end the process's
+    /// ability to touch the database at all: the mutex stayed poisoned and
+    /// every later call panicked with it. A recoverable fault must not
+    /// become a permanent outage.
+    #[tokio::test]
+    async fn a_poisoned_connection_lock_does_not_end_the_process() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        Store::run_migrations(&conn).unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+
+        // Poison it the only way it can be poisoned: panic while holding it.
+        let poisoner = Arc::clone(&conn);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.lock().unwrap();
+            panic!("simulated panic while holding the connection");
+        })
+        .join();
+        assert!(conn.is_poisoned(), "the test must actually poison the lock");
+
+        let count: i64 = with_conn(&conn, |conn| {
+            conn.query_row("SELECT COUNT(*) FROM conversations", [], |row| row.get(0))
+                .map_err(|e| Error::Storage(e.to_string()))
+        })
+        .await
+        .expect("the store must still serve queries after a poisoned lock");
+        assert_eq!(count, 0);
+    }
 }


### PR DESCRIPTION
> Stacked on #588. Review that one first; this diff is against it.

## What

Two independent recovery fixes that share a shape — something recoverable
had been made permanent.

### 1. A stale conversation id no longer bricks the channel

#588 makes `channel_bindings` cascade, so deleting a conversation drops its
binding. That fixes the durable half. It does not fix the in-process half:
`telegram_agent_loop` and `slack_agent_loop` cache the resolved id in
`chat_states` and never consult the binding again, so the cached id
outlives the conversation, the load fails, and — because nothing
invalidates the cache — it fails identically for every message after it.

`load_or_rebind` treats a conversation that no longer loads as an
instruction to start a new one: mint, set the channel metadata, rebind,
and report back so the caller refreshes its cache.

Only `NotFound` is healed. A storage failure is propagated — minting a
replacement conversation because the disk is unhappy would silently discard
history that is still there.

`process_slack_message` now returns `(Uuid, String)`. The Slack loop, unlike
the Telegram one, owns the cache that needs updating, so the id actually
used has to travel back to it.

### 2. A poisoned lock no longer ends the process's database access

Every database call funnels through `with_conn`, which did
`lock().unwrap()`. One panic while holding that lock poisoned the mutex and
every subsequent database call in the process panicked with it. One
recoverable fault, then no database until restart.

A panic does not damage the connection, and any open transaction is rolled
back when its guard drops, so continuing is safe. `core::RetrievalLog::lock`
and `AppState::rotate_token` already recover this way and say why; the
database is more important than an attribution hint, not less.

## Tests

`a_poisoned_connection_lock_does_not_end_the_process` poisons the mutex the
only way it can be poisoned — panicking while holding it — asserts
`is_poisoned()` so the test cannot silently stop testing anything, and then
requires the store to still serve a query.

The healing path is covered end-to-end by #588's
`deleting_a_conversation_drops_its_bindings` plus this change; a direct test
needs the CLI's channel loop harness, which the turn-call-site collapse
later in this stack introduces.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` all clean.

Found by the architecture review — see `docs/architecture/OPINION.md` §1, §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)