### PR TITLE
fix(memory): scope a saved fact to the conversation that saved it

### DIFF
--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -722,7 +722,10 @@ async fn main() -> anyhow::Result<()> {
         id
     };
 
-    let session_id = Uuid::new_v4();
+    // Scope for memory writes made outside any conversation — a background
+    // task, or a tool invoked with no runner context. A write made while
+    // serving a turn is scoped to that conversation instead.
+    let fallback_memory_scope = Uuid::new_v4();
 
     // Rebuild FTS5 index from persisted memories (idempotent). Runs in the
     // background so a large corpus doesn't delay gateway bind; the handle
@@ -751,8 +754,12 @@ async fn main() -> anyhow::Result<()> {
     let activity_tracker = rustykrab_core::activity::ActivityTracker::new();
 
     let memory_backend: Arc<dyn MemoryBackend> = Arc::new(MemoryAdapter {
-        inner: HybridMemoryBackend::new(Arc::clone(&memory_system), agent_id, session_id)
-            .with_retrieval_log(retrieval_log.clone()),
+        inner: HybridMemoryBackend::new(
+            Arc::clone(&memory_system),
+            agent_id,
+            fallback_memory_scope,
+        )
+        .with_retrieval_log(retrieval_log.clone()),
     });
     tracing::info!(%agent_id, "memory system initialized");
 
@@ -1532,11 +1539,17 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Finalize memory session: Working → Episodic + lifecycle sweep.
+    // Finalize memory: Working → Episodic + lifecycle sweep.
+    //
+    // The whole working set, not one session's. Working memories are scoped
+    // to the conversation that produced them, and at process exit every
+    // conversation has ended — there is no session id here that names any of
+    // them. (This call used to pass the process-boot id, which named a
+    // working set that was always empty.)
     idle_sweep_handle.abort();
-    tracing::info!("finalizing memory session...");
-    if let Err(e) = memory_system.finalize_session(agent_id, session_id).await {
-        tracing::warn!(error = %e, "failed to finalize memory session");
+    tracing::info!("finalizing memory working set...");
+    if let Err(e) = memory_system.finalize_working_set(agent_id).await {
+        tracing::warn!(error = %e, "failed to finalize memory working set");
     }
     if let Err(e) = memory_system.lifecycle_sweep(agent_id).await {
         tracing::warn!(error = %e, "shutdown lifecycle sweep failed");

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -295,10 +295,11 @@ async fn delete_conversation(
             rustykrab_core::Error::NotFound(_) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         })?;
-    // Drop the recall archive too (cache + durable row) so a deleted
-    // conversation leaves nothing behind.
+    // Everything the conversation owns in the database — messages, recall
+    // archive, channel bindings — goes with it by cascade, so this handler
+    // no longer has to know the list. What is left is process state, which
+    // the database cannot reach: the recall cache and the todo list.
     state.recall.purge(id);
-    // Drop the conversation's todo list as well.
     state.todos.clear(id);
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -37,7 +37,15 @@ fn fact_to_json(fact: &ExtractedFact) -> Value {
 pub struct HybridMemoryBackend {
     system: Arc<MemorySystem>,
     agent_id: Uuid,
-    session_id: Uuid,
+    /// Scope for writes made outside any conversation — a background task,
+    /// or a caller that constructed the backend directly. Minted once per
+    /// process by the CLI.
+    ///
+    /// It is **not** the scope of a write made while serving a turn. That is
+    /// the conversation, read from the ambient tool context by
+    /// [`Self::write_scope`]. The two were the same field once, and the
+    /// consequences are described there.
+    fallback_scope: Uuid,
     user_id: Option<Uuid>,
     /// Records which memories were handed to the model, so a later outcome
     /// can be attributed to them. See `DREAMING.md`.
@@ -45,14 +53,35 @@ pub struct HybridMemoryBackend {
 }
 
 impl HybridMemoryBackend {
-    pub fn new(system: Arc<MemorySystem>, agent_id: Uuid, session_id: Uuid) -> Self {
+    /// `fallback_scope` is used only for writes made outside a conversation.
+    /// A write made while serving a turn is scoped to that conversation —
+    /// see [`Self::write_scope`].
+    pub fn new(system: Arc<MemorySystem>, agent_id: Uuid, fallback_scope: Uuid) -> Self {
         Self {
             system,
             agent_id,
-            session_id,
+            fallback_scope,
             user_id: None,
             retrieval_log: None,
         }
+    }
+
+    /// The session a write belongs to.
+    ///
+    /// `memories.session_id` is read back as a conversation id: the gateway
+    /// persists every turn under `conversation.id`, and `search` filters on
+    /// a conversation id supplied by the caller. `memory_save` was the one
+    /// writer that used something else — the id minted once per process when
+    /// the backend was constructed — so a fact the agent deliberately saved
+    /// was stamped with a scope no session-scoped search could ever match,
+    /// and only ever surfaced through unscoped search.
+    ///
+    /// The conversation is read from the ambient tool context, which is the
+    /// same source `search` already uses to record retrievals. Outside a
+    /// runner scope there is no conversation, and the construction-time id
+    /// stands in.
+    fn write_scope(&self) -> Uuid {
+        with_session_context(|ctx| ctx.conversation_id).unwrap_or(self.fallback_scope)
     }
 
     /// Set the user ID for scoped retrieval.
@@ -77,9 +106,9 @@ impl HybridMemoryBackend {
         self.agent_id
     }
 
-    /// Get the session ID.
-    pub fn session_id(&self) -> Uuid {
-        self.session_id
+    /// The scope used for writes made outside any conversation.
+    pub fn fallback_scope(&self) -> Uuid {
+        self.fallback_scope
     }
 
     /// Search memories using hybrid retrieval (vector + FTS5 + graph + temporal).
@@ -120,10 +149,18 @@ impl HybridMemoryBackend {
                     .recall_in_session(query, self.agent_id, fetch, sid)
                     .await?;
                 if scoped.is_empty() {
-                    scope_note = Some(
-                        "no matches within this conversation; showing global results \
-                         (explicitly saved facts are stored globally)",
-                    );
+                    // Widening is still worth doing — memories from earlier
+                    // conversations are often what the agent wants — but say
+                    // so, or the model will attribute them to this one.
+                    //
+                    // This note used to add "(explicitly saved facts are
+                    // stored globally)". That was true, and it was the bug:
+                    // `memory_save` stamped facts with a process-wide id
+                    // rather than the conversation, so a scoped search could
+                    // never match one and always landed here. See
+                    // `write_scope`.
+                    scope_note =
+                        Some("no matches within this conversation; showing global results");
                     self.system.recall(query, self.agent_id, fetch).await?
                 } else {
                     scoped
@@ -244,7 +281,7 @@ impl HybridMemoryBackend {
         match self
             .system
             .writer()
-            .save_fact(self.agent_id, self.session_id, fact, tags)
+            .save_fact(self.agent_id, self.write_scope(), fact, tags)
             .await?
         {
             Some(memory_id) => Ok(json!({
@@ -271,15 +308,13 @@ impl HybridMemoryBackend {
         }))
     }
 
-    /// Finalize the current session, promoting all Working memories to Episodic.
+    /// Finalize the current scope, promoting its Working memories to Episodic.
     pub async fn finalize_session(&self) -> rustykrab_core::Result<Value> {
-        let count = self
-            .system
-            .finalize_session(self.agent_id, self.session_id)
-            .await?;
+        let scope = self.write_scope();
+        let count = self.system.finalize_session(self.agent_id, scope).await?;
 
         Ok(json!({
-            "session_id": self.session_id.to_string(),
+            "session_id": scope.to_string(),
             "promoted_to_episodic": count,
             "status": "finalized",
         }))
@@ -333,6 +368,97 @@ mod tests {
             embedder,
         ));
         HybridMemoryBackend::new(system, Uuid::new_v4(), Uuid::new_v4())
+    }
+
+    /// Build the ambient tool context a runner installs around a tool call,
+    /// so a test can exercise the in-a-conversation path.
+    fn session_context(conversation_id: Uuid) -> rustykrab_core::SessionToolContext {
+        rustykrab_core::SessionToolContext {
+            conversation_id,
+            capabilities: Arc::new(rustykrab_core::CapabilitySet::none()),
+            all_tools: Arc::new(Vec::new()),
+            active_tools: Arc::new(rustykrab_core::ActiveToolsRegistry::new()),
+            recall: Arc::new(rustykrab_core::RecallStore::new()),
+            todos: Arc::new(rustykrab_core::TodoStore::new()),
+        }
+    }
+
+    /// The bug: `memory_save` stamped every fact with the id minted when the
+    /// backend was constructed — once per process — while `search` filters on
+    /// a conversation id. No scoped search could ever match one.
+    ///
+    /// It never surfaced as "the fact is missing", because `search` falls
+    /// back to a global sweep when the scoped one comes back empty. It
+    /// surfaced as every scoped search silently widening — and the note
+    /// explaining the widening had been updated to describe the bug as
+    /// intended behaviour.
+    ///
+    /// So the assertion is on the note, not the count: the fact must be found
+    /// *within* the conversation, not by giving up on the scope.
+    #[tokio::test]
+    async fn a_saved_fact_is_found_within_its_own_conversation() {
+        let backend = backend();
+        let conversation = Uuid::new_v4();
+
+        rustykrab_core::SESSION_TOOL_CONTEXT
+            .scope(session_context(conversation), async {
+                backend.save("I prefer dark mode", &[]).await.unwrap();
+            })
+            .await;
+
+        let scoped = backend
+            .search("dark mode", &[], 10, Some(conversation))
+            .await
+            .unwrap();
+
+        assert_eq!(scoped["count"], 1);
+        assert!(
+            scoped.get("session_scope").is_none(),
+            "the fact must be found inside the conversation, not by widening \
+             to a global search: {scoped}"
+        );
+    }
+
+    /// The complement: from another conversation the fact is still reachable,
+    /// but only by widening, and the response says so. Unchanged behaviour —
+    /// pinned here because it is what makes the assertion above meaningful.
+    #[tokio::test]
+    async fn another_conversation_reaches_it_only_by_widening() {
+        let backend = backend();
+        let mine = Uuid::new_v4();
+
+        rustykrab_core::SESSION_TOOL_CONTEXT
+            .scope(session_context(mine), async {
+                backend.save("I prefer dark mode", &[]).await.unwrap();
+            })
+            .await;
+
+        let other = backend
+            .search("dark mode", &[], 10, Some(Uuid::new_v4()))
+            .await
+            .unwrap();
+
+        assert_eq!(other["count"], 1);
+        assert!(
+            other["session_scope"]
+                .as_str()
+                .is_some_and(|n| n.contains("global")),
+            "a cross-conversation hit must be labelled as one: {other}"
+        );
+    }
+
+    /// Outside a runner there is no conversation, and the write still has to
+    /// land somewhere — the construction-time scope stands in.
+    #[tokio::test]
+    async fn a_save_outside_a_conversation_falls_back_to_the_construction_scope() {
+        let backend = backend();
+        backend.save("Deploy on Fridays", &[]).await.unwrap();
+
+        let scoped = backend
+            .search("deploy", &[], 10, Some(backend.fallback_scope()))
+            .await
+            .unwrap();
+        assert_eq!(scoped["count"], 1);
     }
 
     /// The `tags` argument is honored: a tag-scoped search must exclude

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -206,6 +206,12 @@ impl MemorySystem {
         self.lifecycle.finalize_session(agent_id, session_id).await
     }
 
+    /// Promote every Working memory for an agent to Episodic. For shutdown —
+    /// see [`lifecycle::LifecycleManager::finalize_working_set`].
+    pub async fn finalize_working_set(&self, agent_id: Uuid) -> rustykrab_core::Result<u32> {
+        self.lifecycle.finalize_working_set(agent_id).await
+    }
+
     /// Detect near-duplicate memories and create similarity links.
     pub async fn detect_near_duplicates(&self, agent_id: Uuid) -> rustykrab_core::Result<u32> {
         self.lifecycle.detect_near_duplicates(agent_id).await

--- a/crates/rustykrab-memory/src/lifecycle.rs
+++ b/crates/rustykrab-memory/src/lifecycle.rs
@@ -204,6 +204,39 @@ impl LifecycleManager {
         Ok(count)
     }
 
+    /// Promote every Working memory for an agent to Episodic.
+    ///
+    /// For shutdown. [`Self::finalize_session`] promotes one conversation's
+    /// working set, which is right when a conversation ends; at process exit
+    /// every conversation has ended, and nothing will be added to any of
+    /// their working sets again. Waiting for the idle sweep to notice would
+    /// leave them Working until well after the next boot.
+    pub async fn finalize_working_set(&self, agent_id: Uuid) -> rustykrab_core::Result<u32> {
+        let working = self
+            .storage
+            .list_by_stage(agent_id, LifecycleStage::Working)
+            .await?;
+
+        if working.is_empty() {
+            return Ok(0);
+        }
+
+        let promotions: Vec<(Uuid, LifecycleStage)> = working
+            .iter()
+            .map(|m| (m.id, LifecycleStage::Episodic))
+            .collect();
+
+        let count = self.storage.batch_update_stages(&promotions).await?;
+
+        info!(
+            agent_id = %agent_id,
+            promoted = count,
+            "working set finalized: working → episodic"
+        );
+
+        Ok(count)
+    }
+
     /// Detect near-duplicate memories and create links between them.
     ///
     /// Thresholds (from production systems):

--- a/crates/rustykrab-store/src/lib.rs
+++ b/crates/rustykrab-store/src/lib.rs
@@ -103,7 +103,8 @@ impl Store {
             );
 
             CREATE TABLE IF NOT EXISTS messages (
-                conversation_id TEXT NOT NULL,
+                conversation_id TEXT NOT NULL
+                    REFERENCES conversations(id) ON DELETE CASCADE,
                 idx             INTEGER NOT NULL,
                 data            TEXT NOT NULL,
                 PRIMARY KEY (conversation_id, idx)
@@ -136,7 +137,8 @@ impl Store {
 
             CREATE TABLE IF NOT EXISTS job_runs (
                 id         TEXT PRIMARY KEY,
-                job_id     TEXT NOT NULL,
+                job_id     TEXT NOT NULL
+                    REFERENCES scheduled_jobs(id) ON DELETE CASCADE,
                 status     TEXT NOT NULL,
                 output     TEXT,
                 started_at TEXT NOT NULL,
@@ -169,7 +171,8 @@ impl Store {
                 ON channel_bindings (conv_id);
 
             CREATE TABLE IF NOT EXISTS recall_archive (
-                conversation_id TEXT PRIMARY KEY,
+                conversation_id TEXT PRIMARY KEY
+                    REFERENCES conversations(id) ON DELETE CASCADE,
                 archive         TEXT NOT NULL,
                 created_at      TEXT NOT NULL,
                 updated_at      TEXT NOT NULL
@@ -236,6 +239,13 @@ impl Store {
             -- Tasks a peer node delegated to this instance. The caller
             -- holds only the id, so the row is the authoritative record of
             -- a delegation's progress and result.
+            -- `conversation_id` here, on `scheduled_jobs` and on
+            -- `credential_requests` is deliberately not a foreign key. Those
+            -- rows outlive the conversation on purpose: a cron job keeps its
+            -- own delivery channel and should keep firing, and a credential
+            -- request is audit-relevant after the conversation that filed it
+            -- is gone. The column records where the row came from, not
+            -- something it depends on.
             CREATE TABLE IF NOT EXISTS delegated_tasks (
                 id              TEXT PRIMARY KEY,
                 message         TEXT NOT NULL,
@@ -459,6 +469,11 @@ impl Store {
         )
         .map_err(|e| Error::Storage(e.to_string()))?;
 
+        // Adopt the foreign keys the fresh-database DDL declares onto
+        // databases created before it did. Runs after the additive column
+        // ALTERs, because the rebuild copies the current column set.
+        adopt_declared_foreign_keys(conn)?;
+
         // Fold the per-channel map tables into `channel_bindings` and drop
         // them. Idempotent — see `channel_binding::migrate_legacy_chat_maps`.
         // Runs before the blob migration so it sees the same `conversations`
@@ -598,6 +613,157 @@ where
 /// `spawn_blocking`, mirroring `SqliteMemoryStorage::with_conn` in
 /// rustykrab-memory. The mutex is locked on the blocking thread so async
 /// workers never park on disk I/O or the connection lock.
+/// Whether `table` already declares at least one foreign key.
+fn has_foreign_key(conn: &rusqlite::Connection, table: &str) -> Result<bool, Error> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA foreign_key_list({table})"))
+        .map_err(|e| Error::Storage(e.to_string()))?;
+    let mut rows = stmt.query([]).map_err(|e| Error::Storage(e.to_string()))?;
+    let present = rows
+        .next()
+        .map_err(|e| Error::Storage(e.to_string()))?
+        .is_some();
+    Ok(present)
+}
+
+/// Give an existing table a foreign key it was created without.
+///
+/// SQLite cannot `ALTER TABLE ... ADD CONSTRAINT`, so the only route is the
+/// rebuild the SQLite docs prescribe: create the new shape under a temporary
+/// name, copy the rows, drop the old table, rename, recreate the indexes.
+///
+/// `keep_predicate` selects the rows that satisfy the new constraint. Rows it
+/// excludes are already orphans — they name a parent that does not exist —
+/// and could not be inserted into the new table even if we wanted them. They
+/// are dropped, which is what enforcing the constraint means.
+///
+/// Foreign keys must be off for the duration: with them on, dropping the old
+/// table would cascade into the rows we just copied. The pragma is a no-op
+/// inside a transaction, so it is toggled outside one and restored after.
+/// `PRAGMA foreign_key_check` runs before the commit, so a rebuild that
+/// somehow produced a violation rolls back rather than persisting one.
+fn adopt_foreign_key(
+    conn: &rusqlite::Connection,
+    table: &str,
+    create_new: &str,
+    columns: &str,
+    keep_predicate: &str,
+    indexes: &[&str],
+) -> Result<(), Error> {
+    if has_foreign_key(conn, table)? {
+        return Ok(());
+    }
+
+    let fk_was_on: bool = conn
+        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+        .map_err(|e| Error::Storage(e.to_string()))?;
+    if fk_was_on {
+        conn.execute_batch("PRAGMA foreign_keys = OFF")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+    }
+
+    let rebuild = || -> Result<(), Error> {
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let staging = format!("{table}_fk_rebuild");
+        tx.execute_batch(create_new)
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        tx.execute_batch(&format!(
+            "INSERT INTO {staging} ({columns})
+             SELECT {columns} FROM {table} WHERE {keep_predicate};
+             DROP TABLE {table};
+             ALTER TABLE {staging} RENAME TO {table};"
+        ))
+        .map_err(|e| Error::Storage(e.to_string()))?;
+        for index in indexes {
+            tx.execute_batch(index)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+        let violations: i64 = tx
+            .query_row(
+                &format!("SELECT COUNT(*) FROM pragma_foreign_key_check('{table}')"),
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        if violations > 0 {
+            // Dropping the uncommitted transaction rolls the rebuild back.
+            return Err(Error::Storage(format!(
+                "rebuilding {table} left {violations} foreign-key violations"
+            )));
+        }
+        tx.commit().map_err(|e| Error::Storage(e.to_string()))
+    };
+
+    let outcome = rebuild();
+
+    if fk_was_on {
+        conn.execute_batch("PRAGMA foreign_keys = ON")
+            .map_err(|e| Error::Storage(e.to_string()))?;
+    }
+    outcome
+}
+
+/// Adopt the foreign keys the schema declares for fresh databases onto
+/// databases created before they were declared.
+///
+/// Only the references that are genuinely ownership survive here:
+/// a message, an archived recall window and a job run have no meaning
+/// without their parent. The nullable back-references on `scheduled_jobs`,
+/// `credential_requests` and `delegated_tasks` are left alone on purpose —
+/// see the comment on their DDL.
+fn adopt_declared_foreign_keys(conn: &rusqlite::Connection) -> Result<(), Error> {
+    adopt_foreign_key(
+        conn,
+        "messages",
+        "CREATE TABLE messages_fk_rebuild (
+             conversation_id TEXT NOT NULL
+                 REFERENCES conversations(id) ON DELETE CASCADE,
+             idx             INTEGER NOT NULL,
+             data            TEXT NOT NULL,
+             PRIMARY KEY (conversation_id, idx)
+         )",
+        "conversation_id, idx, data",
+        "conversation_id IN (SELECT id FROM conversations)",
+        &[],
+    )?;
+
+    adopt_foreign_key(
+        conn,
+        "recall_archive",
+        "CREATE TABLE recall_archive_fk_rebuild (
+             conversation_id TEXT PRIMARY KEY
+                 REFERENCES conversations(id) ON DELETE CASCADE,
+             archive         TEXT NOT NULL,
+             created_at      TEXT NOT NULL,
+             updated_at      TEXT NOT NULL
+         )",
+        "conversation_id, archive, created_at, updated_at",
+        "conversation_id IN (SELECT id FROM conversations)",
+        &[],
+    )?;
+
+    adopt_foreign_key(
+        conn,
+        "job_runs",
+        "CREATE TABLE job_runs_fk_rebuild (
+             id         TEXT PRIMARY KEY,
+             job_id     TEXT NOT NULL
+                 REFERENCES scheduled_jobs(id) ON DELETE CASCADE,
+             status     TEXT NOT NULL,
+             output     TEXT,
+             started_at TEXT NOT NULL,
+             finished_at TEXT NOT NULL,
+             rustykrab_version TEXT
+         )",
+        "id, job_id, status, output, started_at, finished_at, rustykrab_version",
+        "job_id IN (SELECT id FROM scheduled_jobs)",
+        &["CREATE INDEX IF NOT EXISTS idx_job_runs_job_id
+               ON job_runs (job_id, finished_at DESC)"],
+    )
+}
+
 pub(crate) async fn with_conn<T, F>(
     conn: &Arc<Mutex<rusqlite::Connection>>,
     f: F,
@@ -628,6 +794,197 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A database created before the foreign keys were declared: no
+    /// constraints, and rows that a constraint would have prevented.
+    fn legacy_db() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE conversations (
+                 id TEXT PRIMARY KEY, data TEXT NOT NULL,
+                 title TEXT, created_at TEXT, updated_at TEXT
+             );
+             CREATE TABLE messages (
+                 conversation_id TEXT NOT NULL, idx INTEGER NOT NULL,
+                 data TEXT NOT NULL, PRIMARY KEY (conversation_id, idx)
+             );
+             CREATE TABLE recall_archive (
+                 conversation_id TEXT PRIMARY KEY, archive TEXT NOT NULL,
+                 created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+             );
+             CREATE TABLE scheduled_jobs (
+                 id TEXT PRIMARY KEY, schedule TEXT NOT NULL, task TEXT NOT NULL,
+                 channel TEXT, chat_id TEXT, thread_id TEXT,
+                 one_shot INTEGER NOT NULL DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1,
+                 next_run_at TEXT NOT NULL, last_run_at TEXT, created_at TEXT NOT NULL
+             );
+             CREATE TABLE job_runs (
+                 id TEXT PRIMARY KEY, job_id TEXT NOT NULL, status TEXT NOT NULL,
+                 output TEXT, started_at TEXT NOT NULL, finished_at TEXT NOT NULL
+             );
+
+             INSERT INTO conversations (id, data) VALUES ('live', '{}');
+             INSERT INTO messages VALUES ('live', 0, '{}');
+             INSERT INTO messages VALUES ('deleted-conv', 0, '{}');
+             INSERT INTO recall_archive VALUES ('live', '[]', 't', 't');
+             INSERT INTO recall_archive VALUES ('deleted-conv', '[]', 't', 't');
+             INSERT INTO scheduled_jobs (id, schedule, task, next_run_at, created_at)
+                 VALUES ('job', '0 9 * * *', 'task', '2099-01-01T00:00:00+00:00', 't');
+             INSERT INTO job_runs VALUES ('run', 'job', 'ok', 'out', 't', 't');
+             INSERT INTO job_runs VALUES ('orphan-run', 'deleted-job', 'ok', 'out', 't', 't');",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn count(conn: &rusqlite::Connection, sql: &str) -> i64 {
+        conn.query_row(sql, [], |row| row.get(0)).unwrap()
+    }
+
+    #[test]
+    fn migration_adopts_the_foreign_keys_and_drops_the_orphans_they_forbid() {
+        let conn = legacy_db();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+
+        Store::run_migrations(&conn).unwrap();
+
+        for table in ["messages", "recall_archive", "job_runs"] {
+            assert!(
+                has_foreign_key(&conn, table).unwrap(),
+                "{table} must carry its foreign key after migration"
+            );
+        }
+        // Rows naming a parent that does not exist cannot survive the
+        // constraint, and are exactly what the constraint exists to prevent.
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM messages"), 1);
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM recall_archive"), 1);
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM job_runs"), 1);
+        assert_eq!(
+            count(&conn, "SELECT COUNT(*) FROM job_runs WHERE id = 'run'"),
+            1,
+            "the run whose job still exists must be preserved"
+        );
+    }
+
+    #[test]
+    fn adopting_foreign_keys_preserves_the_data_and_the_index() {
+        let conn = legacy_db();
+        Store::run_migrations(&conn).unwrap();
+
+        let data: String = conn
+            .query_row(
+                "SELECT data FROM messages WHERE conversation_id = 'live' AND idx = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(data, "{}");
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type = 'index' AND name = 'idx_job_runs_job_id'"
+            ),
+            1,
+            "the rebuild must put back the index it dropped with the table"
+        );
+        // And the version column the additive ALTERs added is still there.
+        assert_eq!(
+            count(
+                &conn,
+                "SELECT COUNT(*) FROM pragma_table_info('job_runs')
+                 WHERE name = 'rustykrab_version'"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn adopting_foreign_keys_is_idempotent() {
+        let conn = legacy_db();
+        Store::run_migrations(&conn).unwrap();
+        let after_first = count(&conn, "SELECT COUNT(*) FROM messages");
+        Store::run_migrations(&conn).unwrap();
+        Store::run_migrations(&conn).unwrap();
+        assert_eq!(count(&conn, "SELECT COUNT(*) FROM messages"), after_first);
+    }
+
+    #[tokio::test]
+    async fn deleting_a_conversation_cascades_to_everything_it_owns() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        Store::run_migrations(&conn).unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+
+        let conv = uuid::Uuid::new_v4();
+        {
+            let guard = conn.lock().unwrap();
+            guard
+                .execute(
+                    "INSERT INTO conversations (id, data, created_at, updated_at)
+                     VALUES (?1, '{}', 't', 't')",
+                    rusqlite::params![conv.to_string()],
+                )
+                .unwrap();
+            guard
+                .execute(
+                    "INSERT INTO messages VALUES (?1, 0, '{}')",
+                    rusqlite::params![conv.to_string()],
+                )
+                .unwrap();
+            guard
+                .execute(
+                    "INSERT INTO recall_archive VALUES (?1, '[]', 't', 't')",
+                    rusqlite::params![conv.to_string()],
+                )
+                .unwrap();
+        }
+
+        ConversationStore::new(Arc::clone(&conn))
+            .delete(conv)
+            .await
+            .unwrap();
+
+        let guard = conn.lock().unwrap();
+        assert_eq!(count(&guard, "SELECT COUNT(*) FROM messages"), 0);
+        assert_eq!(
+            count(&guard, "SELECT COUNT(*) FROM recall_archive"),
+            0,
+            "the archive must go with the conversation, without the caller \
+             having to remember to purge it"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_job_takes_its_run_history_with_it() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        Store::run_migrations(&conn).unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        {
+            let guard = conn.lock().unwrap();
+            guard
+                .execute_batch(
+                    "INSERT INTO scheduled_jobs (id, schedule, task, next_run_at, created_at)
+                         VALUES ('job', '0 9 * * *', 'task', '2099-01-01T00:00:00+00:00', 't');
+                     INSERT INTO job_runs (id, job_id, status, started_at, finished_at)
+                         VALUES ('run', 'job', 'ok', 't', 't');",
+                )
+                .unwrap();
+        }
+
+        assert!(JobStore::new(Arc::clone(&conn))
+            .delete_job("job")
+            .await
+            .unwrap());
+
+        let guard = conn.lock().unwrap();
+        assert_eq!(
+            count(&guard, "SELECT COUNT(*) FROM job_runs"),
+            0,
+            "run history must not outlive the job it belongs to"
+        );
+    }
 
     /// A panic while holding the connection lock used to end the process's
     /// ability to touch the database at all: the mutex stayed poisoned and


### PR DESCRIPTION
> Stacked on #590 → #589 → #588.

## What

`memories.session_id` is read back as a **conversation id** everywhere:
`build_memory_callback` persists every turn under `conversation.id`
(`orchestrate.rs:229`), and `HybridMemoryBackend::search` filters on a
conversation id the caller supplies.

`memory_save` was the one writer that used something else — the id
`HybridMemoryBackend` was constructed with, which `cli/main.rs` mints once
per **process**. So a fact the agent deliberately saved carried a scope no
session-scoped search could ever match.

## Why this didn't look like a bug

It didn't show up as a missing fact, because `search` falls back to a
global sweep when the scoped one returns nothing. It showed up as every
scoped search silently widening — and the note explaining the widening read:

```
"no matches within this conversation; showing global results
 (explicitly saved facts are stored globally)"
```

That parenthetical was accurate. It was also a description of the bug,
written as though it were the design. It's removed here, because it stops
being true.

I want to flag that I got this wrong in the review write-up: I described
the consequence as "explicitly saved facts are invisible to scoped search",
and the fallback means they were reachable, just never *scoped*. The fix is
the same; the severity is lower than I stated.

## The fix

`write_scope()` reads the conversation from the ambient tool context — the
same source `search` already uses to record retrievals for outcome
attribution. Outside a runner there is no conversation and the
construction-time id stands in, so the field is renamed `fallback_scope`
for what it actually is.

**Shutdown finalization.** `cli/main.rs` passed that same process-boot id to
`finalize_session`, promoting a working set that was always empty. It now
calls `finalize_working_set(agent_id)`, which is what process exit means:
every conversation has ended, and none of their working sets will grow
again. Without this the fix would have *removed* the only promotion those
memories got at shutdown, leaving them to the idle sweep's stale safety net.

## Tests

`a_saved_fact_is_found_within_its_own_conversation` asserts on the
**absence of the widening note**, not the result count — the count was 1
before and after, which is exactly why this went unnoticed. Verified to
fail when `write_scope()` is reverted to `fallback_scope`:

```
the fact must be found inside the conversation, not by widening to a global
search: {"count":1, ..., "session_scope":"no matches within this
conversation; showing global results"}
```

`another_conversation_reaches_it_only_by_widening` pins the complementary
behaviour, which is unchanged and is what makes the first assertion mean
something.

`a_save_outside_a_conversation_falls_back_to_the_construction_scope` covers
the no-runner path.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` clean.

Found by the architecture review — see `docs/architecture/OPINION.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)