### PR TITLE
refactor(core): move MemoryBackend to core, delete the adapter it forced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ Workspace with 11 crates under `crates/`:
 ## Key patterns
 
 - **Tool trait** (`rustykrab-core/src/tool.rs`): All agent tools implement `Tool` with `name()`, `description()`, `schema()`, `execute()`.
-- **Backend traits** (`rustykrab-tools/src/*_backend.rs`): Abstract interfaces for pluggable backends (memory, cron, message, gateway). Concrete implementations live in the crate that owns the dependency (e.g. `JobStore` in `rustykrab-store`).
-- **Adapter structs** (`rustykrab-cli/src/main.rs`): Bridge concrete implementations to tool backend traits (e.g. `MemoryAdapter`, `CronAdapter`).
+- **Backend traits**: Abstract interfaces the tools call. A trait whose implementor sits *below* `rustykrab-tools` in the crate graph lives in `rustykrab-core` (`MemoryBackend`), so the crate owning the capability can implement it directly. The rest stay in `rustykrab-tools/src/*_backend.rs`, because their implementors (`rustykrab-cli`, `rustykrab-agent`) already sit above it and a move would buy nothing.
+- **Adapter structs** (`rustykrab-cli/src/main.rs`): Bridge concrete implementations to tool backend traits where the binary genuinely adds something — `CronAdapter` merges the calling conversation's channel context into cron args, `MessageAdapter` routes by channel name. A pure pass-through is a sign the trait is in the wrong crate.
 - **Background tasks**: `tokio::spawn` with handles stored in `infra_handles` for graceful shutdown.
 - **Database**: SQLite with WAL mode via `rusqlite`. Schema created idempotently in `Store::run_migrations()`.
 - **Config**: Environment variables only (no config files). See README.md for the full list.

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -53,50 +53,6 @@ use uuid::Uuid;
 /// Adapter bridging [HybridMemoryBackend] (rustykrab-memory) to the
 /// [MemoryBackend] trait (rustykrab-tools) so the memory tools can use
 /// the hybrid retrieval engine.
-struct MemoryAdapter {
-    inner: HybridMemoryBackend,
-}
-
-#[async_trait::async_trait]
-impl MemoryBackend for MemoryAdapter {
-    async fn search(
-        &self,
-        query: &str,
-        tags: &[String],
-        limit: usize,
-        session_id: Option<&str>,
-    ) -> rustykrab_core::Result<serde_json::Value> {
-        match session_id {
-            Some(raw) => match Uuid::parse_str(raw.trim()) {
-                Ok(sid) => self.inner.search(query, tags, limit, Some(sid)).await,
-                Err(_) => {
-                    // Degrade to a global search, but say so — a silently
-                    // widened scope would let the model attribute other
-                    // conversations' memories to this one.
-                    let mut result = self.inner.search(query, tags, limit, None).await?;
-                    result["session_scope"] = serde_json::json!(
-                        "session_id was not a valid conversation id; results are global"
-                    );
-                    Ok(result)
-                }
-            },
-            None => self.inner.search(query, tags, limit, None).await,
-        }
-    }
-    async fn get(&self, memory_id: &str) -> rustykrab_core::Result<serde_json::Value> {
-        self.inner.get(memory_id).await
-    }
-    async fn save(&self, fact: &str, tags: &[String]) -> rustykrab_core::Result<serde_json::Value> {
-        self.inner.save(fact, tags).await
-    }
-    async fn delete(&self, memory_id: &str) -> rustykrab_core::Result<serde_json::Value> {
-        self.inner.delete(memory_id).await
-    }
-    async fn list(&self) -> rustykrab_core::Result<serde_json::Value> {
-        self.inner.list().await
-    }
-}
-
 /// Adapter bridging [rustykrab_store::JobStore] to the [CronBackend] trait
 /// (rustykrab-tools) so the cron tool can manage scheduled jobs.
 struct CronAdapter {
@@ -753,14 +709,12 @@ async fn main() -> anyhow::Result<()> {
     let retrieval_log = rustykrab_core::retrieval_log::RetrievalLog::new();
     let activity_tracker = rustykrab_core::activity::ActivityTracker::new();
 
-    let memory_backend: Arc<dyn MemoryBackend> = Arc::new(MemoryAdapter {
-        inner: HybridMemoryBackend::new(
-            Arc::clone(&memory_system),
-            agent_id,
-            fallback_memory_scope,
-        )
-        .with_retrieval_log(retrieval_log.clone()),
-    });
+    // `HybridMemoryBackend` implements `MemoryBackend` itself now, so there is
+    // nothing left for the binary to bridge.
+    let memory_backend: Arc<dyn MemoryBackend> = Arc::new(
+        HybridMemoryBackend::new(Arc::clone(&memory_system), agent_id, fallback_memory_scope)
+            .with_retrieval_log(retrieval_log.clone()),
+    );
     tracing::info!(%agent_id, "memory system initialized");
 
     // --- Idle lifecycle sweep ---

--- a/crates/rustykrab-core/src/lib.rs
+++ b/crates/rustykrab-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod agent_def;
 pub mod capability;
 pub mod crypto;
 pub mod error;
+pub mod memory_backend;
 pub mod model;
 pub mod orchestration;
 pub mod outcome;
@@ -33,6 +34,7 @@ pub use activity::ActivityTracker;
 pub use agent_def::{AgentDefinition, AgentRegistry};
 pub use capability::{is_subagent_tool, Capability, CapabilitySet, SUBAGENT_TOOL_NAMES};
 pub use error::{Error, Result, ToolError, ToolErrorKind};
+pub use memory_backend::MemoryBackend;
 pub use model::ModelProvider;
 pub use orchestration::{OrchestrationConfig, RecursiveCall, TaskComplexity, VoteResult};
 pub use outcome::{

--- a/crates/rustykrab-core/src/memory_backend.rs
+++ b/crates/rustykrab-core/src/memory_backend.rs
@@ -1,0 +1,39 @@
+//! The memory surface the `memory_*` tools call.
+//!
+//! The trait lives here rather than beside the tools that consume it so the
+//! crate that *owns* agent memory can implement it. `rustykrab-memory` sits
+//! below `rustykrab-tools` in the graph, so while this trait was declared in
+//! the tool crate it was unimplementable there: the memory crate carried a
+//! structurally identical but unrelated method set, and the binary bridged
+//! the two with a pass-through adapter.
+//!
+//! Arguments arrive as they came off the wire — ids are `&str`, not `Uuid` —
+//! because parsing them is a judgement the implementation makes. An id that
+//! does not parse is a model mistake, and how to answer it (fail, or widen
+//! the search and say so) belongs with the thing that knows what widening
+//! costs.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::error::Result;
+
+#[async_trait]
+pub trait MemoryBackend: Send + Sync {
+    /// Search memories. `session_id` (a conversation id) restricts results to
+    /// memories recorded during that conversation.
+    async fn search(
+        &self,
+        query: &str,
+        tags: &[String],
+        limit: usize,
+        session_id: Option<&str>,
+    ) -> Result<Value>;
+    async fn get(&self, memory_id: &str) -> Result<Value>;
+    /// Save a fact with association tags. Returns the new memory ID.
+    async fn save(&self, fact: &str, tags: &[String]) -> Result<Value>;
+    /// Delete a memory by ID.
+    async fn delete(&self, memory_id: &str) -> Result<Value>;
+    /// List all memories for the current conversation.
+    async fn list(&self) -> Result<Value>;
+}

--- a/crates/rustykrab-memory/src/backend.rs
+++ b/crates/rustykrab-memory/src/backend.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use std::sync::Arc;
 
 use rustykrab_core::active_tools::with_session_context;
@@ -31,9 +32,11 @@ fn fact_to_json(fact: &ExtractedFact) -> Value {
 /// tool interface (memory_save, memory_search, memory_get, memory_delete)
 /// while transparently using vector search, FTS5, and lifecycle scoring.
 ///
-/// The trait itself is defined in `rustykrab-tools::memory_backend`.
-/// We re-implement it here structurally to avoid a circular dependency;
-/// the gateway wires this into the tool system via a thin wrapper.
+/// Implements `rustykrab_core::MemoryBackend`, so it can be handed to the
+/// `memory_*` tools directly. The trait used to live in `rustykrab-tools`,
+/// which sits above this crate, so it could not be implemented here at all —
+/// this type carried a structurally identical but unrelated method set and
+/// the binary bridged the two with a pass-through adapter.
 pub struct HybridMemoryBackend {
     system: Arc<MemorySystem>,
     agent_id: Uuid,
@@ -348,6 +351,54 @@ impl HybridMemoryBackend {
             "memories": items,
             "count": items.len(),
         }))
+    }
+}
+
+/// The tool-facing surface, implemented directly rather than through an
+/// adapter in the binary.
+///
+/// The trait takes `session_id` as a string because that is how it arrives
+/// from the model. Deciding what an unparseable one means is this crate's
+/// call, not the caller's: a conversation id the model garbled must not
+/// silently become a global search, because the model would then attribute
+/// another conversation's memories to this one. It widens, and says so.
+#[async_trait]
+impl rustykrab_core::MemoryBackend for HybridMemoryBackend {
+    async fn search(
+        &self,
+        query: &str,
+        tags: &[String],
+        limit: usize,
+        session_id: Option<&str>,
+    ) -> rustykrab_core::Result<Value> {
+        let Some(raw) = session_id else {
+            return self.search(query, tags, limit, None).await;
+        };
+        match Uuid::parse_str(raw.trim()) {
+            Ok(sid) => self.search(query, tags, limit, Some(sid)).await,
+            Err(_) => {
+                let mut result = self.search(query, tags, limit, None).await?;
+                result["session_scope"] =
+                    json!("session_id was not a valid conversation id; results are global");
+                Ok(result)
+            }
+        }
+    }
+
+    async fn get(&self, memory_id: &str) -> rustykrab_core::Result<Value> {
+        self.get(memory_id).await
+    }
+
+    async fn save(&self, fact: &str, tags: &[String]) -> rustykrab_core::Result<Value> {
+        self.save(fact, tags).await
+    }
+
+    async fn delete(&self, memory_id: &str) -> rustykrab_core::Result<Value> {
+        self.delete(memory_id).await
+    }
+
+    async fn list(&self) -> rustykrab_core::Result<Value> {
+        self.list().await
     }
 }
 

--- a/crates/rustykrab-tools/src/memory_backend.rs
+++ b/crates/rustykrab-tools/src/memory_backend.rs
@@ -1,23 +1,6 @@
-use async_trait::async_trait;
-use rustykrab_core::Result;
-use serde_json::Value;
-
-#[async_trait]
-pub trait MemoryBackend: Send + Sync {
-    /// Search memories. `session_id` (a conversation id) restricts results to
-    /// memories recorded during that conversation.
-    async fn search(
-        &self,
-        query: &str,
-        tags: &[String],
-        limit: usize,
-        session_id: Option<&str>,
-    ) -> Result<Value>;
-    async fn get(&self, memory_id: &str) -> Result<Value>;
-    /// Save a fact with association tags. Returns the new memory ID.
-    async fn save(&self, fact: &str, tags: &[String]) -> Result<Value>;
-    /// Delete a memory by ID.
-    async fn delete(&self, memory_id: &str) -> Result<Value>;
-    /// List all memories for the current conversation.
-    async fn list(&self) -> Result<Value>;
-}
+//! Re-export of the memory surface the `memory_*` tools call.
+//!
+//! The trait itself lives in `rustykrab-core` so `rustykrab-memory` — which
+//! sits below this crate — can implement it directly. Re-exported here so
+//! `rustykrab_tools::MemoryBackend` keeps resolving for existing callers.
+pub use rustykrab_core::memory_backend::MemoryBackend;


### PR DESCRIPTION
> Stacked on #591 → #590 → #589 → #588.

## What

`MemoryBackend` moves from `rustykrab-tools` to `rustykrab-core`.
`HybridMemoryBackend` implements it directly. `MemoryAdapter` (44 lines in
`cli/main.rs`) is deleted.

## Why

`rustykrab-memory` sits *below* `rustykrab-tools`, so while the trait lived
in the tool crate the memory crate could not implement it. It said so:

```rust
/// The trait itself is defined in `rustykrab-tools::memory_backend`.
/// We re-implement it here structurally to avoid a circular dependency;
/// the gateway wires this into the tool system via a thin wrapper.
```

The result was a type with a structurally identical but unrelated method
set, plus an adapter in the binary whose five methods were four straight
delegations and one argument parse.

The parse moves too, and that's the part I'd defend independently: deciding
what an unparseable conversation id means — fail, or widen the search and
label it — requires knowing what widening costs. That's the memory crate's
knowledge. The binary was making a memory-semantics decision because of a
graph constraint.

## Correcting the review

My review said *six* backend traits were in the wrong crate. Checking each
implementor, that was wrong:

| Trait | Real implementor | Lives in | Blocked? |
|---|---|---|---|
| `MemoryBackend` | `HybridMemoryBackend` | `rustykrab-memory` | **yes — below `tools`** |
| `SessionManager` | `SubagentRunner` | `rustykrab-agent` | no, above |
| `ComputerBackend` | `EnigoXcapBackend` | `rustykrab-cli` | no, above |
| `VideoBackend` | `VideoChannelAdapter` | `rustykrab-tools` | no, same crate |
| `CronBackend` | `CronAdapter` | `rustykrab-cli` | no, above |
| `MessageBackend` | `MessageAdapter` | `rustykrab-cli` | no, above |

Only `MemoryBackend` had a cycle to break, and it's the only one that had
produced a pass-through adapter — which is the tell. The other five are
left alone; moving them would be churn, and `ComputerBackend`/`VideoBackend`
would drag `CapturedImage`, `VideoProject` and `CompositionElement` into
`core` for no gain.

`CronAdapter` and `MessageAdapter` stay because they aren't pass-throughs:
`CronAdapter` merges the calling conversation's channel context into cron
args (the model routinely omits `channel`/`chat_id`, leaving jobs with no
delivery target), and `MessageAdapter` routes by channel name.

## Compatibility

`rustykrab_tools::MemoryBackend` still resolves — `tools/src/memory_backend.rs`
is now a re-export.

## Docs

`CLAUDE.md` described the backend-trait pattern as uniform, which is what
made the inconsistency easy to miss. It now states the rule that actually
applies, and notes that a pure pass-through adapter is the symptom of a
trait in the wrong crate.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` clean.

Found by the architecture review — see `docs/architecture/02-extension-seams.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)