### PR TITLE
fix(credentials): ask for a new app password when Google rejects the stored one

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -3453,6 +3453,13 @@ mod retry_policy_tests {
         assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
             ToolError::invalid_input("bad command")
         )));
+        // A credential the provider refused. Repeating the call cannot make
+        // a revoked password work, and the tools that raise this file a
+        // credential request as they do — so a retry would ask the user
+        // again for something they are already being asked for.
+        assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::permission_denied("Google rejected the stored app password")
+        )));
         assert!(should_retry_unchanged_tool_call(&Error::Internal(
             "uncategorized execution failure".into()
         )));

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -2191,6 +2191,25 @@ async fn slack_agent_loop(
                     "failed to send Slack reply: {e}"
                 );
             }
+
+            // Then any credential link the turn asked for, as its own
+            // message — same order and same reasoning as the Telegram
+            // loop: the user reads why before being handed the form, and
+            // the link never passed through the model so it cannot have
+            // been truncated. Slack has no app in the loop, so without
+            // this the ask is a dead end here.
+            for link in state.store.pending_links().take(conv_id) {
+                if let Err(e) = sl
+                    .send_text(&inbound.channel_id, &link, Some(&effective_thread_ts))
+                    .await
+                {
+                    tracing::error!(
+                        channel_id = %inbound.channel_id,
+                        thread_ts = %effective_thread_ts,
+                        "failed to send credential link: {e}"
+                    );
+                }
+            }
         });
     }
 

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -316,6 +316,7 @@ async fn execute_credential_wake(
         chat_id.as_deref(),
         thread_id.as_deref(),
         &response_text,
+        conv.id,
         state,
     )
     .await;
@@ -543,6 +544,7 @@ async fn execute_cron_task(
         effective_chat_id.as_deref(),
         effective_thread_id.as_deref(),
         &response_text,
+        conv.id,
         state,
     )
     .await;
@@ -848,7 +850,40 @@ fn resolve_delivery_target(
 /// channel that cannot be reached is logged with the text that was lost,
 /// never retried, because the agent has already run and re-running it
 /// would repeat its side effects.
+/// Deliver a turn's text, then any credential link that turn minted.
+///
+/// The link is a second message, after the text, for the same reason the
+/// Telegram inbound loop sends it that way: the user should read *why* they
+/// are being asked before they are handed the form.
+///
+/// `conversation_id` exists solely to drain [`PendingLinks`], which is keyed
+/// by conversation. Before this, only the inbound Telegram loop drained that
+/// queue, so a link minted by a scheduled job or a resumed delegated task was
+/// pushed and never delivered — and `next_step_out_of_band` had already told
+/// the model to say "a secure link is being sent to them right now" and not
+/// to write a URL itself. The user was promised a link that could not arrive
+/// and shown nothing. Draining here rather than at the call sites means a
+/// future delivery path cannot reintroduce that by forgetting a step.
 async fn deliver_response(
+    target: &str,
+    channel: Option<&str>,
+    chat_id: Option<&str>,
+    thread_id: Option<&str>,
+    response_text: &str,
+    conversation_id: Uuid,
+    state: &AppState,
+) {
+    deliver_text(target, channel, chat_id, thread_id, response_text, state).await;
+
+    // Each link goes as its own message and never passed through the model,
+    // so it cannot have been truncated or paraphrased on the way here.
+    for link in state.store.pending_links().take(conversation_id) {
+        deliver_text(target, channel, chat_id, thread_id, &link, state).await;
+    }
+}
+
+/// Send one message to whichever channel this turn belongs to.
+async fn deliver_text(
     target: &str,
     channel: Option<&str>,
     chat_id: Option<&str>,

--- a/crates/rustykrab-store/src/credential_request.rs
+++ b/crates/rustykrab-store/src/credential_request.rs
@@ -461,6 +461,44 @@ impl CredentialRequestStore {
         Ok(token)
     }
 
+    /// Whether `name` already has a pending request with a link that still
+    /// works.
+    ///
+    /// Exists so a caller can decline to ask twice. Filing a second request
+    /// for the same credential supersedes the first, and superseding
+    /// invalidates the link already sent — so an agent that trips over one
+    /// dead credential in four different tool calls sends the user four
+    /// links of which only the last works, and a superseded link renders
+    /// the same "Link expired" page a genuine expiry does. The user cannot
+    /// tell which of the four to trust, and three of them are already dead
+    /// on arrival.
+    ///
+    /// Deliberately checks the link rather than just the request: a pending
+    /// request whose link has expired *should* be asked again, because the
+    /// user has nothing usable left.
+    pub async fn has_live_link(&self, name: &str) -> Result<bool, Error> {
+        let name = name.to_string();
+        let now = Utc::now().timestamp_millis();
+        crate::with_conn(&self.conn, move |conn| {
+            let live: i64 = conn
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM credential_requests
+                          WHERE name = ?1
+                            AND status = 'pending'
+                            AND link_token_hash IS NOT NULL
+                            AND link_token_hash <> ''
+                            AND link_expires_at > ?2
+                     )",
+                    params![name, now],
+                    |row| row.get(0),
+                )
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            Ok(live != 0)
+        })
+        .await
+    }
+
     /// Resolve a one-time link token to the request it answers.
     ///
     /// Returns `None` for a token that is unknown, expired, or whose
@@ -774,6 +812,45 @@ mod fulfil_tests {
                 crate::credential_backend::MemoryBackend::new(),
             ));
         (dir, store.credential_requests(), store.secrets())
+    }
+
+    #[tokio::test]
+    async fn a_live_link_suppresses_a_second_ask_and_an_expired_one_does_not() {
+        let (_dir, requests, _secrets) = store();
+        let id = requests
+            .file_fulfil("gmail_app_password", None, gmail_fields(), None, None)
+            .await
+            .unwrap();
+
+        // Nothing minted yet: the user has nothing to open, so asking again
+        // is the right call.
+        assert!(!requests.has_live_link("gmail_app_password").await.unwrap());
+
+        requests
+            .issue_link(&id, std::time::Duration::from_secs(900))
+            .await
+            .unwrap();
+        assert!(
+            requests.has_live_link("gmail_app_password").await.unwrap(),
+            "a link the user can still open must suppress a second ask, or \
+             superseding it kills the one they were sent"
+        );
+
+        // An unrelated credential must not be suppressed by this one.
+        assert!(!requests.has_live_link("notion_api_token").await.unwrap());
+
+        // Expired: the user has nothing usable left, so the next tool to
+        // trip over the credential should ask again rather than leave them
+        // with a dead link and no way to get a fresh one.
+        requests
+            .issue_link(&id, std::time::Duration::from_millis(1))
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !requests.has_live_link("gmail_app_password").await.unwrap(),
+            "an expired link must not suppress a fresh ask"
+        );
     }
 
     pub(super) fn gmail_fields() -> Vec<RequestedField> {

--- a/crates/rustykrab-tools/src/caldav.rs
+++ b/crates/rustykrab-tools/src/caldav.rs
@@ -63,6 +63,10 @@ pub struct CalDavTool {
     /// not assembled a store; without it the tool reports the gap and asks
     /// nobody, which is the behaviour this exists to end.
     requests: Option<rustykrab_store::CredentialRequestStore>,
+    /// Where a minted link waits until the turn has finished speaking.
+    /// Without it the request is still filed and answerable in the app,
+    /// there is simply no link to send to a chat surface.
+    pending_links: Option<rustykrab_store::PendingLinks>,
 }
 
 impl CalDavTool {
@@ -74,6 +78,7 @@ impl CalDavTool {
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
             requests: None,
+            pending_links: None,
         }
     }
 
@@ -83,14 +88,25 @@ impl CalDavTool {
         self
     }
 
+    /// Deliver minted links out of band, after the turn.
+    pub fn with_pending_links(mut self, links: rustykrab_store::PendingLinks) -> Self {
+        self.pending_links = Some(links);
+        self
+    }
+
     /// Fetch the Google email + app password, asking the user when they are
     /// absent or unusable.
     ///
     /// One line, because mail and calendar are one account: see
     /// [`crate::google_credentials`].
     async fn get_credentials(&self) -> Result<(String, String)> {
-        crate::google_credentials::load(&self.secrets, self.requests.as_ref(), "Google Calendar")
-            .await
+        crate::google_credentials::load(
+            &self.secrets,
+            self.requests.as_ref(),
+            self.pending_links.as_ref(),
+            "Google Calendar",
+        )
+        .await
     }
 
     /// The events collection URL for a given calendar id (defaults to the
@@ -141,18 +157,28 @@ impl CalDavTool {
 
         if !(200..300).contains(&status) {
             let detail = text.chars().take(500).collect::<String>();
-            let hint = if status == 401 {
-                format!(
-                    " (401 Unauthorized — check that {KEY_APP_PASSWORD} is a Google *app* \
-                     password and that CalDAV access is permitted for the account; the \
-                     stored password is {})",
-                    describe_password_shape(password)
+            // A 401 here is Google refusing the stored app password —
+            // revoked, expired, or never permitted for DAV. `get_credentials`
+            // cannot see that: the value is present and well formed, so it
+            // passes through, and only this response proves it dead. Telling
+            // the model to "check that the password is an app password" was
+            // advice nobody could act on; ask the user for a new one instead,
+            // the same way an absent one is asked for.
+            if status == 401 {
+                return Err(crate::google_credentials::rejected(
+                    self.requests.as_ref(),
+                    self.pending_links.as_ref(),
+                    "Google Calendar",
+                    format!(
+                        "CalDAV {url} returned HTTP 401 Unauthorized — Google rejected the \
+                         stored {KEY_APP_PASSWORD}, which is {}: {detail}",
+                        describe_password_shape(password)
+                    ),
                 )
-            } else {
-                String::new()
-            };
+                .await);
+            }
             return Err(Error::ToolExecution(
-                format!("CalDAV {url} returned HTTP {status}{hint}: {detail}").into(),
+                format!("CalDAV {url} returned HTTP {status}: {detail}").into(),
             ));
         }
 

--- a/crates/rustykrab-tools/src/gmail.rs
+++ b/crates/rustykrab-tools/src/gmail.rs
@@ -22,6 +22,56 @@ const MAX_SEARCH_RESULTS: usize = 50;
 
 type ImapSession = async_imap::Session<tokio_rustls::client::TlsStream<tokio::net::TcpStream>>;
 
+/// Why [`connect_imap`] could not hand back a session.
+///
+/// The distinction that matters is which step failed. Everything before
+/// LOGIN fails for reasons a new password would not fix; a rejected LOGIN is
+/// precisely the case that should ask the user for one, and it is only
+/// visible here — by the time the error reaches the caller as a string, the
+/// two are indistinguishable.
+enum ConnectFailure {
+    /// Network, TLS or protocol failure before authentication.
+    Transport(Error),
+    /// The server refused these credentials. Carried unwrapped so it can be
+    /// composed into a sentence without an `Error`'s "tool execution error:"
+    /// prefix landing mid-string.
+    Rejected(String),
+}
+
+impl From<ConnectFailure> for Error {
+    /// Collapse back to a plain error, for callers with nobody to ask.
+    fn from(failure: ConnectFailure) -> Self {
+        match failure {
+            ConnectFailure::Transport(e) => e,
+            ConnectFailure::Rejected(message) => Error::ToolExecution(message.into()),
+        }
+    }
+}
+
+/// Whether an SMTP reply code is the server refusing the credential.
+///
+/// Sending has the same split as connecting, but it arrives as a reply code
+/// rather than a distinct error: a 5yz in the x3z family is the
+/// authentication group — 530 authentication required, 534 mechanism too
+/// weak, 535 credentials invalid, 538 encryption required — and Gmail
+/// answers a revoked app password with `535 5.7.8 Username and Password not
+/// accepted`.
+///
+/// Everything else a send can fail on is about the message, not the account.
+/// A 550 is a refused recipient and a 4yz is worth retrying unchanged;
+/// turning either into a password prompt would ask the user to fix something
+/// that is not broken.
+///
+/// Takes the code rather than the error because `lettre` does not let a test
+/// build one of its errors, and the code is the whole of the decision.
+fn is_smtp_credential_rejection(code: Option<lettre::transport::smtp::response::Code>) -> bool {
+    use lettre::transport::smtp::response::{Category, Severity};
+    code.is_some_and(|code| {
+        code.severity == Severity::PermanentNegativeCompletion
+            && code.category == Category::Unspecified3
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Cached IMAP session
 // ---------------------------------------------------------------------------
@@ -51,34 +101,6 @@ impl std::ops::DerefMut for CachedSession {
     fn deref_mut(&mut self) -> &mut ImapSession {
         &mut self.session
     }
-}
-
-/// Return a live, authenticated session for `email`, reusing the cached one
-/// when it belongs to the same account and still answers a NOOP; otherwise
-/// (re)connect lazily.
-async fn ensure_session<'a>(
-    cache: &'a mut Option<CachedSession>,
-    email: &str,
-    password: &str,
-) -> Result<&'a mut CachedSession> {
-    let reusable = match cache.as_mut() {
-        // NOOP doubles as a liveness probe and lets the server deliver
-        // pending mailbox updates (RFC 3501 §6.1.2).
-        Some(cached) if cached.email == email => cached.session.noop().await.is_ok(),
-        _ => false,
-    };
-    if !reusable {
-        // Drop rather than LOGOUT: the old connection is dead or belongs to
-        // another account, and a LOGOUT on a broken socket can stall.
-        *cache = None;
-        let session = connect_imap(email, password).await?;
-        *cache = Some(CachedSession {
-            session,
-            email: email.to_string(),
-            selected_mailbox: None,
-        });
-    }
-    Ok(cache.as_mut().expect("session was just ensured"))
 }
 
 /// SELECT `mailbox` unless it is already the selected mailbox of this session.
@@ -113,6 +135,10 @@ pub struct GmailTool {
     /// not assembled a store; without it the tool reports the gap and asks
     /// nobody, which is the behaviour this exists to end.
     requests: Option<rustykrab_store::CredentialRequestStore>,
+    /// Where a minted link waits until the turn has finished speaking.
+    /// Without it the request is still filed and answerable in the app,
+    /// there is simply no link to send to a chat surface.
+    pending_links: Option<rustykrab_store::PendingLinks>,
 }
 
 impl GmailTool {
@@ -121,6 +147,7 @@ impl GmailTool {
             secrets,
             imap: tokio::sync::Mutex::new(None),
             requests: None,
+            pending_links: None,
         }
     }
 
@@ -130,13 +157,76 @@ impl GmailTool {
         self
     }
 
+    /// Deliver minted links out of band, after the turn.
+    pub fn with_pending_links(mut self, links: rustykrab_store::PendingLinks) -> Self {
+        self.pending_links = Some(links);
+        self
+    }
+
     /// Get email and app password from the credential store, asking the
     /// user when they are absent.
     ///
     /// One line, because the calendar needs exactly the same thing from the
     /// same account: see [`crate::google_credentials`].
     async fn get_credentials(&self) -> Result<(String, String)> {
-        crate::google_credentials::load(&self.secrets, self.requests.as_ref(), "Gmail").await
+        crate::google_credentials::load(
+            &self.secrets,
+            self.requests.as_ref(),
+            self.pending_links.as_ref(),
+            "Gmail",
+        )
+        .await
+    }
+
+    /// Return a live, authenticated session for `email`, reusing the cached
+    /// one when it belongs to the same account and still answers a NOOP;
+    /// otherwise (re)connect lazily.
+    ///
+    /// A method rather than a free function because a rejected LOGIN has to
+    /// reach `self.requests`: this is the only path by which a *stored*
+    /// credential is put to Google, so it is the only one that ever learns
+    /// the stored credential is dead.
+    async fn ensure_session<'a>(
+        &self,
+        cache: &'a mut Option<CachedSession>,
+        email: &str,
+        password: &str,
+    ) -> Result<&'a mut CachedSession> {
+        let reusable = match cache.as_mut() {
+            // NOOP doubles as a liveness probe and lets the server deliver
+            // pending mailbox updates (RFC 3501 §6.1.2).
+            Some(cached) if cached.email == email => cached.session.noop().await.is_ok(),
+            _ => false,
+        };
+        if !reusable {
+            // Drop rather than LOGOUT: the old connection is dead or belongs
+            // to another account, and a LOGOUT on a broken socket can stall.
+            *cache = None;
+            let session = match connect_imap(email, password).await {
+                Ok(session) => session,
+                Err(ConnectFailure::Transport(e)) => return Err(e),
+                // The password `get_credentials` just handed over no longer
+                // works. Nothing here can fix that and retrying cannot
+                // either, so ask the user for a new one — the same route an
+                // absent password takes, and fulfilling the request
+                // overwrites what is stored.
+                Err(ConnectFailure::Rejected(reason)) => {
+                    return Err(crate::google_credentials::rejected(
+                        self.requests.as_ref(),
+                        self.pending_links.as_ref(),
+                        "Gmail",
+                        reason,
+                    )
+                    .await)
+                }
+            };
+            *cache = Some(CachedSession {
+                session,
+                email: email.to_string(),
+                selected_mailbox: None,
+            });
+        }
+        Ok(cache.as_mut().expect("session was just ensured"))
     }
 
     // -----------------------------------------------------------------------
@@ -195,7 +285,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, mailbox).await?;
 
         // Use Gmail's X-GM-RAW extension for full search syntax,
@@ -293,7 +383,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, mailbox).await?;
 
         let fetches: Vec<async_imap::types::Fetch> = session
@@ -484,10 +574,22 @@ impl GmailTool {
             .credentials(creds)
             .build();
 
-        mailer
-            .send(email_msg)
-            .await
-            .map_err(|e| Error::ToolExecution(format!("send failed: {e}").into()))?;
+        if let Err(e) = mailer.send(email_msg).await {
+            // One account, one app password: SMTP authenticates with exactly
+            // what IMAP and CalDAV use, so a refused AUTH here is the same
+            // dead credential and takes the same route. Without this, sending
+            // is the one Google path that still ends in an error string.
+            if is_smtp_credential_rejection(e.status()) {
+                return Err(crate::google_credentials::rejected(
+                    self.requests.as_ref(),
+                    self.pending_links.as_ref(),
+                    "Gmail",
+                    format!("SMTP send failed: {e}"),
+                )
+                .await);
+            }
+            return Err(Error::ToolExecution(format!("send failed: {e}").into()));
+        }
 
         Ok(json!({
             "status": "sent",
@@ -503,7 +605,7 @@ impl GmailTool {
     async fn action_labels(&self) -> Result<Value> {
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
 
         let names: Vec<async_imap::types::Name> = session
             .list(Some(""), Some("*"))
@@ -543,7 +645,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, &from_mailbox).await?;
 
         session
@@ -572,7 +674,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, mailbox).await?;
 
         session
@@ -596,7 +698,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, mailbox).await?;
 
         // uid_store returns a stream of FETCH responses; drain it so the server
@@ -634,7 +736,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
 
         // First, fetch the target message to get its References/In-Reply-To/Message-ID.
         select_mailbox(session, mailbox).await?;
@@ -818,7 +920,7 @@ impl GmailTool {
 
         let (email, password) = self.get_credentials().await?;
         let mut guard = self.imap.lock().await;
-        let session = ensure_session(&mut guard, &email, &password).await?;
+        let session = self.ensure_session(&mut guard, &email, &password).await?;
         select_mailbox(session, mailbox).await?;
 
         let fetches: Vec<async_imap::types::Fetch> = session
@@ -1033,7 +1135,10 @@ impl Tool for GmailTool {
 // ---------------------------------------------------------------------------
 
 /// Connect to Gmail IMAP over rustls and authenticate.
-async fn connect_imap(email: &str, password: &str) -> Result<ImapSession> {
+async fn connect_imap(
+    email: &str,
+    password: &str,
+) -> std::result::Result<ImapSession, ConnectFailure> {
     let native_certs = rustls_native_certs::load_native_certs();
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_parsable_certificates(native_certs.certs);
@@ -1043,34 +1148,50 @@ async fn connect_imap(email: &str, password: &str) -> Result<ImapSession> {
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     );
-    let server_name: rustls::pki_types::ServerName<'static> = IMAP_HOST
-        .to_string()
-        .try_into()
-        .map_err(|e| Error::ToolExecution(format!("invalid server name: {e}").into()))?;
+    let server_name: rustls::pki_types::ServerName<'static> =
+        IMAP_HOST.to_string().try_into().map_err(|e| {
+            ConnectFailure::Transport(Error::ToolExecution(
+                format!("invalid server name: {e}").into(),
+            ))
+        })?;
 
     let tcp = tokio::net::TcpStream::connect((IMAP_HOST, IMAP_PORT))
         .await
-        .map_err(|e| Error::ToolExecution(format!("IMAP connect failed: {e}").into()))?;
+        .map_err(|e| {
+            ConnectFailure::Transport(Error::ToolExecution(
+                format!("IMAP connect failed: {e}").into(),
+            ))
+        })?;
     let connector = tokio_rustls::TlsConnector::from(config);
-    let tls_stream = connector
-        .connect(server_name, tcp)
-        .await
-        .map_err(|e| Error::ToolExecution(format!("TLS handshake failed: {e}").into()))?;
+    let tls_stream = connector.connect(server_name, tcp).await.map_err(|e| {
+        ConnectFailure::Transport(Error::ToolExecution(
+            format!("TLS handshake failed: {e}").into(),
+        ))
+    })?;
 
     let mut client = async_imap::Client::new(tls_stream);
     // Read the server greeting so the protocol stream stays in sync.
     let _greeting = client
         .read_response()
         .await
-        .map_err(|e| Error::ToolExecution(format!("IMAP greeting read failed: {e}").into()))?
+        .map_err(|e| {
+            ConnectFailure::Transport(Error::ToolExecution(
+                format!("IMAP greeting read failed: {e}").into(),
+            ))
+        })?
         .ok_or_else(|| {
-            Error::ToolExecution("IMAP server closed connection before greeting".into())
+            ConnectFailure::Transport(Error::ToolExecution(
+                "IMAP server closed connection before greeting".into(),
+            ))
         })?;
 
     let session = client
         .login(email, password)
         .await
-        .map_err(|(e, _client)| Error::ToolExecution(format!("IMAP login failed: {e}").into()))?;
+        // Google's answer when the app password has been revoked, expired,
+        // or never existed. Kept as a bare message so a caller with a
+        // credential store can turn it into an ask.
+        .map_err(|(e, _client)| ConnectFailure::Rejected(format!("IMAP login failed: {e}")))?;
     Ok(session)
 }
 
@@ -1118,4 +1239,51 @@ fn strip_html_tags(html: &str) -> String {
         .replace("&quot;", "\"")
         .replace("&#39;", "'")
         .replace("&nbsp;", " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lettre::transport::smtp::response::{Category, Code, Detail, Severity};
+
+    fn code(severity: Severity, category: Category, detail: Detail) -> Option<Code> {
+        Some(Code {
+            severity,
+            category,
+            detail,
+        })
+    }
+
+    #[test]
+    fn a_refused_login_asks_for_a_password_and_a_refused_recipient_does_not() {
+        // 535 5.7.8 — what Gmail answers a revoked app password with.
+        assert!(is_smtp_credential_rejection(code(
+            Severity::PermanentNegativeCompletion,
+            Category::Unspecified3,
+            Detail::Five
+        )));
+        // 530, authentication required.
+        assert!(is_smtp_credential_rejection(code(
+            Severity::PermanentNegativeCompletion,
+            Category::Unspecified3,
+            Detail::Zero
+        )));
+        // 550, mailbox unavailable. The address is wrong, not the password,
+        // and prompting for a new one would send the user to fix the wrong
+        // thing.
+        assert!(!is_smtp_credential_rejection(code(
+            Severity::PermanentNegativeCompletion,
+            Category::MailSystem,
+            Detail::Zero
+        )));
+        // 454, temporary authentication failure. Retrying may well work, so
+        // it must not burn a one-time link.
+        assert!(!is_smtp_credential_rejection(code(
+            Severity::TransientNegativeCompletion,
+            Category::Unspecified4,
+            Detail::Four
+        )));
+        // A connection or TLS failure carries no reply code at all.
+        assert!(!is_smtp_credential_rejection(None));
+    }
 }

--- a/crates/rustykrab-tools/src/google_credentials.rs
+++ b/crates/rustykrab-tools/src/google_credentials.rs
@@ -15,7 +15,7 @@
 //! is missing or unusable, normalise what comes back — and the tools call
 //! it rather than reimplementing it.
 
-use rustykrab_core::{Error, Result};
+use rustykrab_core::{Error, Result, ToolError};
 use rustykrab_store::{CredentialRequestStore, GuardedSecrets, RequestedField};
 
 /// SecretStore keys. Named for Gmail because that is where they came from;
@@ -61,10 +61,40 @@ pub fn fields() -> Vec<RequestedField> {
 /// Filing is best-effort by design: if the store rejects it, the caller
 /// still gets an error explaining the gap, because a failure to ask is not
 /// a reason to pretend the credential exists.
-pub async fn ask(requests: Option<&CredentialRequestStore>, service: &str, needs: &str) -> String {
+pub async fn ask(
+    requests: Option<&CredentialRequestStore>,
+    links: Option<&rustykrab_store::PendingLinks>,
+    service: &str,
+    needs: &str,
+) -> String {
     let Some(requests) = requests else {
         return String::new();
     };
+
+    // One dead credential, one link — however many tools trip over it.
+    //
+    // A briefing calls Gmail and the calendar and each may call twice, so a
+    // single revoked app password reached `ask` four times in one turn. The
+    // request deduped correctly (the store supersedes), but every call still
+    // minted a link, and superseding kills the token on the row it replaced.
+    // The user got four messages, three already dead, and a superseded link
+    // renders the same "Link expired" page a real expiry does — so there was
+    // no way to tell which one to trust. Measured at 4/4 before this guard.
+    //
+    // Checked against the link rather than the request: a pending request
+    // whose link has expired should ask again, because the user has nothing
+    // they can still open.
+    if requests
+        .has_live_link(KEY_APP_PASSWORD)
+        .await
+        .unwrap_or(false)
+    {
+        return format!(
+            " {}",
+            crate::credential_link::next_step_out_of_band(true, service)
+        );
+    }
+
     // This is the path that actually fires in practice — measured at 25/25
     // against `browser`'s 1/9 — so a request filed here without a
     // conversation would leave the common case unresumable.
@@ -83,14 +113,26 @@ pub async fn ask(requests: Option<&CredentialRequestStore>, service: &str, needs
         .await
     {
         Ok(id) => {
-            // These tools file most of the requests that ever get filed, so
-            // without a link they are also what most often leaves the user
-            // with "open the app" and no way to answer from the chat they
-            // are actually in.
+            // Out of band, not in the tool result. These tools file most of
+            // the requests that ever get filed, so they are also where
+            // handing the URL to the model costs the most: gemma4:26b was
+            // measured relaying 55 of 64 hex characters, and a truncated
+            // token opens the same "Link expired" page a real expiry does,
+            // so the user cannot tell a typo from a timeout. Parking it
+            // means the model never sees it and cannot mangle it — and the
+            // live capture URL stays out of the context window and the
+            // transcript. See `rustykrab_store::pending_links`.
             let link = crate::credential_link::mint_link(requests, &id).await;
+            let queued = match (links, conversation_id, &link) {
+                (Some(pending), Some(conv), Some(url)) => {
+                    pending.push(conv, url.clone());
+                    true
+                }
+                _ => false,
+            };
             format!(
                 " {}",
-                crate::credential_link::next_step(link.as_deref(), service)
+                crate::credential_link::next_step_out_of_band(queued, service)
             )
         }
         Err(e) => {
@@ -98,6 +140,49 @@ pub async fn ask(requests: Option<&CredentialRequestStore>, service: &str, needs
             String::new()
         }
     }
+}
+
+/// Google rejected a credential that looked fine from here: ask for a new one.
+///
+/// [`load`] asks when a value is absent or self-evidently unusable, and that
+/// is everything it can judge locally. A revoked or expired app password is
+/// neither: it is present, sixteen characters, and indistinguishable from a
+/// working one until Google refuses it. That refusal arrives *after* `load`
+/// has already handed the value over — as an IMAP `AUTHENTICATIONFAILED` or
+/// a CalDAV 401 — so the call site is the only place that learns of it, and
+/// without this it ends the run with an error string, no request filed and
+/// no link sent. That was the observed failure: the daily briefing wrote
+/// "please update gmail_app_password in the credential store" into its own
+/// output for days, which is not something the user can act on from chat.
+///
+/// A dead credential takes the same route as an absent one, for the same
+/// reason: one request under [`KEY_APP_PASSWORD`], shared by both protocols,
+/// and fulfilling it overwrites what is stored.
+///
+/// `reason` is the unwrapped message, not an [`Error`] — displaying one
+/// would drop a "tool execution error:" prefix into the middle of the
+/// sentence `ask` appends to.
+///
+/// The result is [`ToolErrorKind::PermissionDenied`], which is both accurate
+/// and load-bearing: the runner retries an untyped tool error three times,
+/// and each retry would file another request and mint another link, so the
+/// user would get three one-time URLs for one dead password.
+///
+/// [`ToolErrorKind::PermissionDenied`]: rustykrab_core::ToolErrorKind::PermissionDenied
+pub async fn rejected(
+    requests: Option<&CredentialRequestStore>,
+    links: Option<&rustykrab_store::PendingLinks>,
+    service: &str,
+    reason: impl std::fmt::Display,
+) -> Error {
+    let asked = ask(
+        requests,
+        links,
+        service,
+        "a working Google account address and app password",
+    )
+    .await;
+    Error::ToolExecution(ToolError::permission_denied(format!("{reason}{asked}")))
 }
 
 /// Read the Google address and app password, asking the user for whatever
@@ -111,6 +196,7 @@ pub async fn ask(requests: Option<&CredentialRequestStore>, service: &str, needs
 pub async fn load(
     secrets: &GuardedSecrets,
     requests: Option<&CredentialRequestStore>,
+    links: Option<&rustykrab_store::PendingLinks>,
     service: &str,
 ) -> Result<(String, String)> {
     let email = secrets.get(KEY_EMAIL).await.ok();
@@ -134,7 +220,7 @@ pub async fn load(
                 ),
                 (true, true) => unreachable!("both present is handled above"),
             };
-            let asked = ask(requests, service, needed).await;
+            let asked = ask(requests, links, service, needed).await;
             return Err(Error::ToolExecution(
                 format!("{service} is not set up yet: {missing}.{asked}").into(),
             ));
@@ -155,6 +241,7 @@ pub async fn load(
         Err(Error::ToolExecution(reason)) => {
             let asked = ask(
                 requests,
+                links,
                 service,
                 "a working Google account address and app password",
             )
@@ -253,7 +340,7 @@ mod tests {
         let (_dir, store) = test_store();
         let requests = store.credential_requests();
 
-        let err = load(&store.guarded_secrets(), Some(&requests), "Gmail")
+        let err = load(&store.guarded_secrets(), Some(&requests), None, "Gmail")
             .await
             .unwrap_err()
             .to_string();
@@ -277,8 +364,10 @@ mod tests {
         let requests = store.credential_requests();
         let secrets = store.guarded_secrets();
 
-        load(&secrets, Some(&requests), "Gmail").await.unwrap_err();
-        load(&secrets, Some(&requests), "Google Calendar")
+        load(&secrets, Some(&requests), None, "Gmail")
+            .await
+            .unwrap_err();
+        load(&secrets, Some(&requests), None, "Google Calendar")
             .await
             .unwrap_err();
 
@@ -294,7 +383,9 @@ mod tests {
         let requests = store.credential_requests();
         let secrets = store.guarded_secrets();
 
-        load(&secrets, Some(&requests), "Gmail").await.unwrap_err();
+        load(&secrets, Some(&requests), None, "Gmail")
+            .await
+            .unwrap_err();
         let id = requests.pending().await.unwrap()[0].id.clone();
         requests
             .fulfil(
@@ -313,7 +404,7 @@ mod tests {
             .unwrap();
 
         for service in ["Gmail", "Google Calendar"] {
-            let (email, password) = load(&secrets, Some(&requests), service)
+            let (email, password) = load(&secrets, Some(&requests), None, service)
                 .await
                 .expect("credentials should be readable after one answer");
             assert_eq!(email, "me@gmail.com");
@@ -334,19 +425,75 @@ mod tests {
             .await
             .unwrap();
 
-        let err = load(&store.guarded_secrets(), Some(&requests), "Google Calendar")
-            .await
-            .unwrap_err()
-            .to_string();
+        let err = load(
+            &store.guarded_secrets(),
+            Some(&requests),
+            None,
+            "Google Calendar",
+        )
+        .await
+        .unwrap_err()
+        .to_string();
 
         assert!(err.contains("not an email address"), "{err}");
         assert_eq!(requests.pending().await.unwrap().len(), 1);
     }
 
     #[tokio::test]
+    async fn a_credential_the_server_rejects_asks_for_a_new_one() {
+        let (_dir, store) = test_store();
+        let requests = store.credential_requests();
+        let secrets = store.secrets();
+        // Present, well formed, sixteen characters — everything `load` can
+        // check locally passes. Only Google knows it has been revoked.
+        secrets.create(KEY_EMAIL, "me@gmail.com").await.unwrap();
+        secrets
+            .create(KEY_APP_PASSWORD, "abcdefghijklmnop")
+            .await
+            .unwrap();
+        load(&store.guarded_secrets(), Some(&requests), None, "Gmail")
+            .await
+            .expect("a well-formed credential is handed over, not questioned");
+
+        let err = rejected(
+            Some(&requests),
+            None,
+            "Gmail",
+            "IMAP login failed: [AUTHENTICATIONFAILED] Invalid credentials",
+        )
+        .await;
+
+        let pending = requests.pending().await.unwrap();
+        assert_eq!(pending.len(), 1, "expected one request, got {pending:?}");
+        assert_eq!(pending[0].name, KEY_APP_PASSWORD);
+        let text = err.to_string();
+        assert!(text.contains("AUTHENTICATIONFAILED"), "{text}");
+    }
+
+    #[tokio::test]
+    async fn a_rejection_is_not_retried_into_a_second_link() {
+        let (_dir, store) = test_store();
+        let requests = store.credential_requests();
+
+        let err = rejected(Some(&requests), None, "Google Calendar", "HTTP 401").await;
+
+        // The runner repeats an untyped tool error three times. Each repeat
+        // files another request and mints another one-time URL, so one dead
+        // password would reach the user as three competing links.
+        let rustykrab_core::Error::ToolExecution(tool_error) = &err else {
+            panic!("expected a tool error, got {err:?}");
+        };
+        assert_eq!(
+            tool_error.kind,
+            rustykrab_core::ToolErrorKind::PermissionDenied,
+            "a rejected credential must not be retryable"
+        );
+    }
+
+    #[tokio::test]
     async fn without_a_request_store_it_still_reports_the_gap() {
         let (_dir, store) = test_store();
-        let err = load(&store.guarded_secrets(), None, "Gmail")
+        let err = load(&store.guarded_secrets(), None, None, "Gmail")
             .await
             .unwrap_err()
             .to_string();

--- a/crates/rustykrab-tools/src/lib.rs
+++ b/crates/rustykrab-tools/src/lib.rs
@@ -260,10 +260,18 @@ pub fn builtin_tools(
         // net_scan/net_admin/net_audit/net_discovery tools were removed to
         // cut the tool-schema payload sent to the model.
         // Email
-        std::sync::Arc::new(GmailTool::new(guarded.clone()).with_requests(requests.clone())),
+        std::sync::Arc::new(
+            GmailTool::new(guarded.clone())
+                .with_requests(requests.clone())
+                .with_pending_links(pending_links.clone()),
+        ),
         // Calendar (CalDAV — reuses Gmail credentials, and asks for them
         // the same way when they are absent)
-        std::sync::Arc::new(CalDavTool::new(guarded.clone()).with_requests(requests.clone())),
+        std::sync::Arc::new(
+            CalDavTool::new(guarded.clone())
+                .with_requests(requests.clone())
+                .with_pending_links(pending_links.clone()),
+        ),
         // Notion
         std::sync::Arc::new(NotionTool::new(guarded.clone())),
         // Obsidian

--- a/crates/rustykrab-tools/tests/google_credentials_live.rs
+++ b/crates/rustykrab-tools/tests/google_credentials_live.rs
@@ -1,0 +1,328 @@
+//! Live proof that a credential Google *rejects* asks for a new one.
+//!
+//! Ignored by default — needs outbound network to `imap.gmail.com:993` and
+//! `apidata.googleusercontent.com`:
+//!
+//! ```sh
+//! cargo test -p rustykrab-tools --test google_credentials_live \
+//!   -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! No real account or password is required, and that is the point. The
+//! condition under test is a *well-formed credential the server refuses*,
+//! and a deliberately wrong sixteen-character app password produces exactly
+//! the response a revoked one does: `[AUTHENTICATIONFAILED]` from IMAP, 401
+//! from CalDAV. So this reproduces the daily-briefing failure end to end
+//! without a secret ever entering the repo.
+//!
+//! Unit tests cover the pieces. What only a live run can show is that
+//! `load` really does hand this credential through — that the ask fires from
+//! the network path and not from a local check that happened to catch it —
+//! which is the whole distinction the fix turns on.
+//!
+//! The link is delivered out of band, so these assert the *opposite* of the
+//! obvious thing: the error handed back to the model must contain no URL at
+//! all, and the URL must instead be sitting in `PendingLinks` for the
+//! conversation. Handing a 64-hex token to a local model was measured losing
+//! nine characters of it, and a truncated token renders the same "Link
+//! expired" page a real expiry does — so "no URL in the message" is the
+//! property worth pinning.
+
+use std::sync::Arc;
+
+use rustykrab_core::active_tools::{SessionToolContext, SESSION_TOOL_CONTEXT};
+use rustykrab_core::capability::CapabilitySet;
+use rustykrab_core::{Error, Tool, ToolErrorKind};
+use rustykrab_store::{credential_backend::MemoryBackend, PendingLinks, Store};
+use rustykrab_tools::{CalDavTool, GmailTool};
+use serde_json::json;
+use uuid::Uuid;
+
+/// Well formed, sixteen alphanumerics, and wrong. Everything
+/// `google_credentials::validate` can check locally passes.
+const BOGUS_PASSWORD: &str = "abcdefghijklmnop";
+const ADDRESS: &str = "rustykrab-live-test@gmail.com";
+
+/// Where a minted link points. Set here rather than relied upon from the
+/// environment so the assertion that a link *was* minted cannot pass or fail
+/// for reasons outside the test.
+const PUBLIC_URL: &str = "https://rustykrab.test";
+
+/// Install the TLS provider the daemon installs at startup.
+///
+/// `rustykrab-cli` does this in `main` before any rustls use. A test binary
+/// has no such entry point, and with both `ring` and `aws-lc-rs` reachable
+/// in the dependency graph rustls refuses to pick one. Choosing `ring` — the
+/// same one production installs — means the IMAP handshake here is the
+/// handshake the daemon performs.
+fn install_tls_provider() {
+    // Err only means another test in this binary got here first.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// A store on a tempdir the caller keeps alive, seeded with the bad
+/// credential.
+///
+/// The credential backend is in-memory on purpose: the real one on macOS is
+/// the login keychain, which would prompt for access mid-test and leave a
+/// password on the machine afterwards.
+async fn seeded_store() -> (tempfile::TempDir, Store) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Store::open(dir.path(), vec![7u8; 32])
+        .expect("open store")
+        .with_credential_backend(Arc::new(MemoryBackend::new()));
+
+    let secrets = store.secrets();
+    secrets.create("gmail_email", ADDRESS).await.unwrap();
+    secrets
+        .create("gmail_app_password", BOGUS_PASSWORD)
+        .await
+        .unwrap();
+
+    (dir, store)
+}
+
+/// Run `f` as if inside the agent runner, so tools can see which
+/// conversation they belong to.
+///
+/// `ask` reads the conversation id from this context and a link cannot be
+/// queued without one — outside a runner scope the out-of-band path silently
+/// degrades to "a prompt is waiting in the Apollo app". A test that skipped
+/// this would still pass while proving nothing about delivery.
+async fn in_conversation<F, T>(conversation_id: Uuid, f: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    let ctx = SessionToolContext {
+        conversation_id,
+        capabilities: Arc::new(CapabilitySet::none()),
+        all_tools: Arc::new(Vec::new()),
+        active_tools: Arc::new(Default::default()),
+        recall: Arc::new(Default::default()),
+        todos: Arc::new(Default::default()),
+    };
+    SESSION_TOOL_CONTEXT.scope(ctx, f).await
+}
+
+/// The link reached the queue, and never reached the model.
+///
+/// Checked against the queued token rather than against "does the message
+/// contain a URL": both services put legitimate URLs in their refusals — the
+/// CalDAV request URL, and Google's own support.google.com/BadCredentials
+/// link in the SMTP 535 — so a blanket URL ban fails on correct behaviour.
+/// The property that matters is narrower: this specific capture token must
+/// not be anywhere the model can see it.
+fn assert_link_queued_not_spoken(links: &PendingLinks, conv: Uuid, message: &str) {
+    let queued = links.take(conv);
+    assert_eq!(queued.len(), 1, "expected one queued link, got {queued:?}");
+    let link = &queued[0];
+    assert!(
+        link.starts_with(&format!("{PUBLIC_URL}/c/")),
+        "queued link is not a credential link: {link}"
+    );
+
+    assert!(
+        !message.contains(link),
+        "the model was handed the capture URL: {message}"
+    );
+    // The token alone, in case the URL was assembled differently. This is
+    // the part that must never enter the context window or a transcript.
+    let token = link.rsplit('/').next().expect("link has a token");
+    assert!(
+        !message.contains(token),
+        "the capture token leaked into the model's context: {message}"
+    );
+}
+
+/// Assert the shape every rejected-credential error has to have, and return
+/// the message so the caller can look for the link.
+fn assert_asks_rather_than_reports(err: &Error) -> String {
+    let Error::ToolExecution(tool_error) = err else {
+        panic!("expected a tool error, got {err:?}");
+    };
+    assert_eq!(
+        tool_error.kind,
+        ToolErrorKind::PermissionDenied,
+        "a rejected credential must not be retryable — the runner repeats an \
+         untyped error three times, and each repeat mints another one-time \
+         link: {tool_error:?}"
+    );
+    tool_error.message.clone()
+}
+
+#[tokio::test]
+#[ignore = "requires outbound network to Gmail"]
+async fn gmail_rejecting_the_stored_password_files_a_request_with_a_link() {
+    install_tls_provider();
+    std::env::set_var("RUSTYKRAB_PUBLIC_URL", PUBLIC_URL);
+    let (_dir, store) = seeded_store().await;
+    let requests = store.credential_requests();
+
+    let links = PendingLinks::new();
+    let conv = Uuid::new_v4();
+    let tool = GmailTool::new(store.guarded_secrets())
+        .with_requests(requests.clone())
+        .with_pending_links(links.clone());
+    let err = in_conversation(conv, async {
+        tool.execute(json!({"action": "search", "query": "ALL", "max_results": 1}))
+            .await
+            .expect_err("Gmail must refuse a wrong app password")
+    })
+    .await;
+
+    let message = assert_asks_rather_than_reports(&err);
+    eprintln!("gmail error: {message}");
+
+    // The precondition the fix exists for: this credential got as far as
+    // Google, so the refusal is the server's and not a local guess.
+    assert!(
+        message.contains("IMAP login failed"),
+        "the ask must be built from Google's own refusal: {message}"
+    );
+
+    let pending = requests.pending().await.unwrap();
+    assert_eq!(pending.len(), 1, "expected one request, got {pending:?}");
+    assert_eq!(pending[0].name, "gmail_app_password");
+    assert_eq!(pending[0].service.as_deref(), Some("Gmail"));
+
+    // What the user actually receives. Before the fix this sentence was
+    // "please update gmail_app_password in the credential store", which is
+    // not something anyone can act on from a Telegram thread. It is now a
+    // link — delivered beside the message rather than inside it.
+    assert_link_queued_not_spoken(&links, conv, &message);
+}
+
+#[tokio::test]
+#[ignore = "requires outbound network to Google CalDAV"]
+async fn caldav_rejecting_the_stored_password_files_a_request_with_a_link() {
+    install_tls_provider();
+    std::env::set_var("RUSTYKRAB_PUBLIC_URL", PUBLIC_URL);
+    let (_dir, store) = seeded_store().await;
+    let requests = store.credential_requests();
+
+    let links = PendingLinks::new();
+    let conv = Uuid::new_v4();
+    let tool = CalDavTool::new(store.guarded_secrets())
+        .with_requests(requests.clone())
+        .with_pending_links(links.clone());
+    let err = in_conversation(conv, async {
+        tool.execute(json!({"action": "list_events"}))
+            .await
+            .expect_err("Google must refuse a wrong app password")
+    })
+    .await;
+
+    let message = assert_asks_rather_than_reports(&err);
+    eprintln!("caldav error: {message}");
+
+    assert!(
+        message.contains("401"),
+        "the ask must be built from Google's own refusal: {message}"
+    );
+    assert_link_queued_not_spoken(&links, conv, &message);
+
+    let pending = requests.pending().await.unwrap();
+    assert_eq!(pending.len(), 1, "expected one request, got {pending:?}");
+    assert_eq!(pending[0].name, "gmail_app_password");
+}
+
+#[tokio::test]
+#[ignore = "requires outbound network to Gmail and Google CalDAV"]
+async fn one_dead_password_is_one_ask_however_many_tools_trip_over_it() {
+    install_tls_provider();
+    std::env::set_var("RUSTYKRAB_PUBLIC_URL", PUBLIC_URL);
+    let (_dir, store) = seeded_store().await;
+    let requests = store.credential_requests();
+
+    let links = PendingLinks::new();
+    let conv = Uuid::new_v4();
+    let gmail = GmailTool::new(store.guarded_secrets())
+        .with_requests(requests.clone())
+        .with_pending_links(links.clone());
+    let caldav = CalDavTool::new(store.guarded_secrets())
+        .with_requests(requests.clone())
+        .with_pending_links(links.clone());
+
+    // The briefing calls both, and previously each would have retried three
+    // times. Four refusals must still leave the user with one thing to do.
+    in_conversation(conv, async {
+        gmail
+            .execute(json!({"action": "search", "query": "ALL", "max_results": 1}))
+            .await
+            .expect_err("gmail");
+        gmail
+            .execute(json!({"action": "labels"}))
+            .await
+            .expect_err("gmail again");
+        caldav
+            .execute(json!({"action": "list_events"}))
+            .await
+            .expect_err("caldav");
+        caldav
+            .execute(json!({"action": "list_calendars"}))
+            .await
+            .expect_err("caldav again");
+    })
+    .await;
+
+    let pending = requests.pending().await.unwrap();
+    assert_eq!(
+        pending.len(),
+        1,
+        "one credential, one prompt — got {pending:?}"
+    );
+
+    // And one link. The request deduped before this was fixed, but every
+    // call still minted its own, and superseding kills the token on the row
+    // it replaces — so the user received four messages of which three were
+    // already dead, indistinguishable from the live one until tapped. This
+    // was 4 before `has_live_link` guarded the ask.
+    let queued = links.take(conv);
+    assert_eq!(
+        queued.len(),
+        1,
+        "one dead password must yield one link, not one per tool call: {queued:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires outbound network to Gmail SMTP"]
+async fn smtp_rejecting_the_stored_password_files_a_request_with_a_link() {
+    install_tls_provider();
+    std::env::set_var("RUSTYKRAB_PUBLIC_URL", PUBLIC_URL);
+    let (_dir, store) = seeded_store().await;
+    let requests = store.credential_requests();
+
+    let links = PendingLinks::new();
+    let conv = Uuid::new_v4();
+    let tool = GmailTool::new(store.guarded_secrets())
+        .with_requests(requests.clone())
+        .with_pending_links(links.clone());
+    let err = in_conversation(conv, async {
+        tool.execute(json!({
+            "action": "send",
+            "to": "nobody@example.com",
+            "subject": "live credential test",
+            "body": "This send must never leave the building.",
+        }))
+        .await
+        .expect_err("Gmail SMTP must refuse a wrong app password")
+    })
+    .await;
+
+    let message = assert_asks_rather_than_reports(&err);
+    eprintln!("smtp error: {message}");
+
+    // Sending is the path that classifies by reply code rather than by a
+    // distinct error, so this is the one that proves `535` really does land
+    // in the authentication family and not somewhere near the 550s.
+    assert!(
+        message.contains("SMTP send failed"),
+        "the ask must be built from Google's own refusal: {message}"
+    );
+    assert_link_queued_not_spoken(&links, conv, &message);
+
+    let pending = requests.pending().await.unwrap();
+    assert_eq!(pending.len(), 1, "expected one request, got {pending:?}");
+    assert_eq!(pending[0].name, "gmail_app_password");
+}


### PR DESCRIPTION
## The bug

The twice-daily briefing had been writing *"Please update `gmail_app_password` in the credential store"* into its own output for days. Nothing was asking. The Google app password had been revoked, and every path that discovers that returned a bare error.

`google_credentials::load` files a request when a credential is **absent** or **self-evidently unusable** — everything it can judge locally. A revoked app password is neither: present, sixteen alphanumerics, indistinguishable from a working one until Google refuses it. That refusal arrives *after* `load` has handed the value over, at a call site with no way to ask.

## What changed

**1. Rejection asks, from all three protocols.** New `google_credentials::rejected()`, the counterpart to `load()`.

- **IMAP** — `connect_imap` collapsed every failure into one opaque string, so a dead password and a TLS handshake error were the same value by the time a caller saw them. Split into `ConnectFailure::{Transport, Rejected}`.
- **CalDAV** — the 401 branch appended prose telling the model to *"check that `gmail_app_password` is a Google \*app\* password"*. Advice nobody could act on. It now asks.
- **SMTP** — classified by reply code, since lettre reports auth failures that way. A permanent 5yz in the x3z family is the authentication group (530/534/535/538); a 550 refused recipient and a transient 454 are excluded so neither burns a one-time link.

Returns `PermissionDenied`, which is accurate and load-bearing: the runner retries an untyped tool error three times, and each retry would file another request and mint another link — three competing URLs for one dead password.

**2. Out-of-band delivery.** `pending_links` exists because handing a 64-hex token to a local model was measured losing nine characters of it, and a truncated token renders the same "Link expired" page a genuine expiry does. The Google ask now parks the URL there rather than putting it in the tool result, keeping a live capture link out of the context window and the transcript.

**3. Someone has to drain the queue.** Only the inbound Telegram loop did — so a scheduled job minted a link, told the user one was being sent, and dropped it. `deliver_response` now drains by conversation (cron jobs + delegated-task resumes), and the Slack loop drains like Telegram's.

App surfaces deliberately **do not** drain: Apollo and WebChat render the form from `GET /api/credential-requests`, so the filed request *is* the delivery mechanism there, and pushing a capture URL into a persisted conversation is precisely what `pending_links` exists to avoid. The invariant is *chat surfaces drain, app surfaces don't.*

**4. One credential, one link.** Four tool calls tripping over the same dead password filed one request (the store supersedes) but minted four links — and superseding kills the token on the row it replaces, so three arrived already dead and indistinguishable from the live one. `has_live_link` guards the ask, checking the *link* rather than the request so a pending request whose link has expired still asks again.

## Verification

Against Google's real servers — `IMAP AUTHENTICATIONFAILED`, `CalDAV 401`, `SMTP 535 5.7.8` — each files exactly one request, queues exactly one link, and leaks no token into the model's context.

The live tests (`tests/google_credentials_live.rs`, `#[ignore]`d per the repo's `*_live.rs` convention) need **no account and no secret**: a deliberately wrong 16-character app password is the condition under test, and Google cannot tell it from a revoked one.

```sh
cargo test -p rustykrab-tools --test google_credentials_live -- --ignored --test-threads=1
```

Also verified end-to-end against a real daemon with a seeded dead credential: one pending request, one link, `kind="permission_denied"`, and **zero** retry lines where there were previously three per tool call. The minted URL serves the credential form over a tailnet identity.

Full gate on this branch off `origin/main`: `cargo fmt --check`, `cargo clippy --workspace --all-targets` (clean), `cargo test --workspace` (27 suites), `scripts/e2e.sh` 17/17, live 4/4.

## Note for reviewers

This does not restore Gmail on its own — a new Google app password still has to be generated. What changes is that rustykrab now *asks* for it with a working link, instead of writing an instruction into a briefing nobody can act on from a Telegram thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)