### PR TITLE
refactor(runtime): extract the turn-running layer out of the HTTP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4153,6 +4153,7 @@ dependencies = [
  "rustykrab-gateway",
  "rustykrab-memory",
  "rustykrab-providers",
+ "rustykrab-runtime",
  "rustykrab-skills",
  "rustykrab-store",
  "rustykrab-tools",
@@ -4169,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4183,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4198,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -4216,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4231,6 +4232,7 @@ dependencies = [
  "rustykrab-channels",
  "rustykrab-core",
  "rustykrab-memory",
+ "rustykrab-runtime",
  "rustykrab-skills",
  "rustykrab-store",
  "serde",
@@ -4243,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4264,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4281,8 +4283,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustykrab-runtime"
+version = "5.2.17"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rustykrab-agent",
+ "rustykrab-core",
+ "rustykrab-memory",
+ "rustykrab-skills",
+ "rustykrab-store",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rustykrab-skills"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4298,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4323,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.2.15"
+version = "5.2.17"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/rustykrab-core",
     "crates/rustykrab-store",
+    "crates/rustykrab-runtime",
     "crates/rustykrab-gateway",
     "crates/rustykrab-agent",
     "crates/rustykrab-providers",
@@ -99,6 +100,7 @@ rustls-native-certs = "0.8"
 # Internal crates
 rustykrab-core = { path = "crates/rustykrab-core" }
 rustykrab-store = { path = "crates/rustykrab-store" }
+rustykrab-runtime = { path = "crates/rustykrab-runtime" }
 rustykrab-gateway = { path = "crates/rustykrab-gateway" }
 rustykrab-agent = { path = "crates/rustykrab-agent" }
 rustykrab-providers = { path = "crates/rustykrab-providers" }

--- a/crates/rustykrab-cli/Cargo.toml
+++ b/crates/rustykrab-cli/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 rustykrab-core.workspace = true
 rustykrab-store.workspace = true
 rustykrab-gateway.workspace = true
+rustykrab-runtime.workspace = true
 rustykrab-agent.workspace = true
 rustykrab-tools.workspace = true
 rustykrab-channels.workspace = true

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -167,7 +167,7 @@ impl CronBackend for CronAdapter {
 ///
 /// The `message` tool is registered alongside the other built-in tools, before
 /// any channel is constructed (channels are attached to `AppState` later, and
-/// `state.tools` is captured by-value when state is cloned for spawned agent
+/// `state.agent.tools` is captured by-value when state is cloned for spawned agent
 /// loops). The adapter therefore reads its channels through this shared hub,
 /// which is populated in stages as each channel comes up during startup.
 #[derive(Default)]
@@ -1115,7 +1115,7 @@ async fn main() -> anyhow::Result<()> {
         .with_activity_tracker(activity_tracker.clone())
         .with_outcome_capture(outcome_capture_enabled)
         .with_credential_page_policy(rustykrab_gateway::PageIdentityPolicy::from_env());
-    state.active_tools = active_tools;
+    state.agent.active_tools = active_tools;
 
     // --- Attach video channel to state ---
     if let Some(vc) = video_channel {
@@ -1560,7 +1560,7 @@ async fn load_or_rebind(
     channel_id: Option<String>,
     channel_thread_id: Option<String>,
 ) -> Result<(rustykrab_core::types::Conversation, bool), rustykrab_core::Error> {
-    match state.store.conversations().get(conv_id).await {
+    match state.agent.store.conversations().get(conv_id).await {
         Ok(conv) => Ok((conv, false)),
         Err(rustykrab_core::Error::NotFound(_)) => {
             tracing::warn!(
@@ -1568,12 +1568,13 @@ async fn load_or_rebind(
                 stale_conv_id = %conv_id,
                 "bound conversation no longer exists — starting a new one"
             );
-            let mut conv = state.store.conversations().create().await?;
+            let mut conv = state.agent.store.conversations().create().await?;
             conv.channel_source = Some(channel_source.to_string());
             conv.channel_id = channel_id;
             conv.channel_thread_id = channel_thread_id;
-            state.store.conversations().save_meta(&conv).await?;
+            state.agent.store.conversations().save_meta(&conv).await?;
             state
+                .agent
                 .store
                 .channel_bindings()
                 .bind(address, conv.id)
@@ -1658,6 +1659,7 @@ async fn telegram_agent_loop(
                     states.remove(&key);
                 }
                 if let Err(e) = state
+                    .agent
                     .store
                     .channel_bindings()
                     .unbind(&telegram_address(chat_id, thread_id))
@@ -1712,6 +1714,7 @@ async fn telegram_agent_loop(
                     Some(cs) => cs.conv_id,
                     None => {
                         let db_id = state
+                            .agent
                             .store
                             .channel_bindings()
                             .lookup(&telegram_address(chat_id, thread_id))
@@ -1734,7 +1737,7 @@ async fn telegram_agent_loop(
                                 );
                                 id
                             }
-                            None => match state.store.conversations().create().await {
+                            None => match state.agent.store.conversations().create().await {
                                 Ok(mut conv) => {
                                     conv.channel_source = Some("telegram".to_string());
                                     conv.channel_id = Some(chat_id.to_string());
@@ -1742,7 +1745,7 @@ async fn telegram_agent_loop(
                                         conv.channel_thread_id = Some(thread_id.to_string());
                                     }
                                     if let Err(e) =
-                                        state.store.conversations().save_meta(&conv).await
+                                        state.agent.store.conversations().save_meta(&conv).await
                                     {
                                         tracing::warn!(
                                             chat_id,
@@ -1758,6 +1761,7 @@ async fn telegram_agent_loop(
                                         },
                                     );
                                     if let Err(e) = state
+                                        .agent
                                         .store
                                         .channel_bindings()
                                         .bind(&telegram_address(chat_id, thread_id), id)
@@ -1826,7 +1830,7 @@ async fn telegram_agent_loop(
             // message. It goes after the agent's text so the user reads
             // why before they are handed the form, and it never passed
             // through the model, so it cannot have been truncated.
-            for link in state.store.pending_links().take(conv_id) {
+            for link in state.agent.store.pending_links().take(conv_id) {
                 if let Err(e) = tg.send_text(chat_id, &link, thread_id).await {
                     tracing::error!(chat_id, thread_id, "failed to send credential link: {e}");
                 }
@@ -1922,7 +1926,9 @@ async fn process_telegram_message(
     let trace_id = Uuid::new_v4();
     tracing::info!(%trace_id, chat_id, ?thread_id, "telegram agent run starting");
     let (handle, mut event_rx, join_handle) =
-        match rustykrab_gateway::run_agent_interactive(state, conv, user_text, trace_id).await {
+        match rustykrab_runtime::run_agent_interactive(&state.agent, conv, user_text, trace_id)
+            .await
+        {
             Ok(triple) => triple,
             Err(_status) => {
                 typing_active.store(false, std::sync::atomic::Ordering::Relaxed);
@@ -1990,6 +1996,7 @@ async fn process_telegram_message(
                 // back to a full rewrite if compaction replaced the
                 // persisted prefix.
                 if let Err(e) = state
+                    .agent
                     .store
                     .conversations()
                     .save_turn(&final_conv, &persisted_ids)
@@ -2100,6 +2107,7 @@ async fn slack_agent_loop(
                     states.remove(&key);
                 }
                 if let Err(e) = state
+                    .agent
                     .store
                     .channel_bindings()
                     .unbind(&slack_address(
@@ -2131,6 +2139,7 @@ async fn slack_agent_loop(
                     Some(cs) => cs.conv_id,
                     None => {
                         let db_id = state
+                            .agent
                             .store
                             .channel_bindings()
                             .lookup(&slack_address(
@@ -2160,12 +2169,14 @@ async fn slack_agent_loop(
                                 );
                                 id
                             }
-                            None => match state.store.conversations().create().await {
+                            None => match state.agent.store.conversations().create().await {
                                 Ok(mut conv) => {
                                     conv.channel_source = Some("slack".to_string());
                                     conv.channel_id = Some(inbound.channel_id.clone());
                                     conv.channel_thread_id = Some(effective_thread_ts.clone());
-                                    if let Err(e) = state.store.conversations().save(&conv).await {
+                                    if let Err(e) =
+                                        state.agent.store.conversations().save(&conv).await
+                                    {
                                         tracing::warn!(
                                             channel_id = %inbound.channel_id,
                                             "failed to persist Slack channel metadata: {e}"
@@ -2180,6 +2191,7 @@ async fn slack_agent_loop(
                                         },
                                     );
                                     if let Err(e) = state
+                                        .agent
                                         .store
                                         .channel_bindings()
                                         .bind(
@@ -2351,8 +2363,13 @@ async fn process_slack_message(
 
     let trace_id = Uuid::new_v4();
     tracing::info!(%trace_id, conv_id = %conv.id, "slack agent run starting");
-    let agent_fut =
-        rustykrab_gateway::run_agent_streaming(state, &mut conv, user_text, &on_event, trace_id);
+    let agent_fut = rustykrab_runtime::run_agent_streaming(
+        &state.agent,
+        &mut conv,
+        user_text,
+        &on_event,
+        trace_id,
+    );
 
     let timeout_millis = HEARTBEAT_TIMEOUT_SECS * 1000;
     let heartbeat_monitor = async {
@@ -2388,6 +2405,7 @@ async fn process_slack_message(
     };
 
     if let Err(e) = state
+        .agent
         .store
         .conversations()
         .save_turn(&conv, &persisted_ids)

--- a/crates/rustykrab-cli/src/main.rs
+++ b/crates/rustykrab-cli/src/main.rs
@@ -2288,7 +2288,7 @@ async fn slack_agent_loop(
             // the link never passed through the model so it cannot have
             // been truncated. Slack has no app in the loop, so without
             // this the ask is a dead end here.
-            for link in state.store.pending_links().take(conv_id) {
+            for link in state.agent.store.pending_links().take(conv_id) {
                 if let Err(e) = sl
                     .send_text(&inbound.channel_id, &link, Some(&effective_thread_ts))
                     .await

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -878,7 +878,7 @@ async fn deliver_response(
 
     // Each link goes as its own message and never passed through the model,
     // so it cannot have been truncated or paraphrased on the way here.
-    for link in state.store.pending_links().take(conversation_id) {
+    for link in state.agent.store.pending_links().take(conversation_id) {
         deliver_text(target, channel, chat_id, thread_id, &link, state).await;
     }
 }

--- a/crates/rustykrab-cli/src/task_queue.rs
+++ b/crates/rustykrab-cli/src/task_queue.rs
@@ -222,7 +222,7 @@ async fn execute_credential_wake(
         return;
     };
 
-    let mut conv = match state.store.conversations().get(uuid).await {
+    let mut conv = match state.agent.store.conversations().get(uuid).await {
         Ok(c) => c,
         Err(e) => {
             // The conversation was deleted between asking and answering.
@@ -247,7 +247,7 @@ async fn execute_credential_wake(
 
     push_scheduled_user_turn(&mut conv, prompt);
 
-    let run_options = rustykrab_gateway::RunOptions {
+    let run_options = rustykrab_runtime::RunOptions {
         active_skill: None,
         // The point of waking is to finish the job, so the first move
         // should be acting rather than announcing that it can now act.
@@ -258,7 +258,7 @@ async fn execute_credential_wake(
         // spends all of it. One observed run reached 96 iterations
         // without ever attempting the login, and would have continued.
         max_iterations: Some(WAKE_MAX_ITERATIONS),
-        ..rustykrab_gateway::RunOptions::default()
+        ..rustykrab_runtime::RunOptions::default()
     };
 
     let trace_id = Uuid::new_v4();
@@ -270,8 +270,8 @@ async fn execute_credential_wake(
     );
 
     let no_op_event = |_event: AgentEvent| {};
-    let response_text = match rustykrab_gateway::run_agent_streaming_with_options(
-        state,
+    let response_text = match rustykrab_runtime::run_agent_streaming_with_options(
+        &state.agent,
         &mut conv,
         prompt,
         &no_op_event,
@@ -298,6 +298,7 @@ async fn execute_credential_wake(
     // on the next turn -- and the resumed turn is exactly the one that
     // did the work they asked for.
     if let Err(e) = state
+        .agent
         .store
         .conversations()
         .save_turn(&conv, &persisted)
@@ -453,7 +454,7 @@ async fn execute_cron_task(
     ) {
         // Metadata-only change — the resumed conversation's messages are
         // untouched here, so skip rewriting them.
-        if let Err(e) = state.store.conversations().save_meta(&conv).await {
+        if let Err(e) = state.agent.store.conversations().save_meta(&conv).await {
             tracing::warn!(
                 job_id = %job_id,
                 "failed to persist channel context onto job conversation: {e}"
@@ -469,7 +470,7 @@ async fn execute_cron_task(
     // content. Operators commonly schedule jobs with `task = "morning-briefing"`,
     // and without the body the model would have to make a tool round-trip
     // before doing any real work.
-    let resolved_skill = resolve_skill_for_task(&state.skill_registry, task_prompt);
+    let resolved_skill = resolve_skill_for_task(&state.agent.skill_registry, task_prompt);
     if let Some((ref name, _)) = resolved_skill {
         tracing::info!(
             job_id = %job_id,
@@ -488,14 +489,14 @@ async fn execute_cron_task(
     // A scheduled run must contribute its own user turn.
     push_scheduled_user_turn(&mut conv, &prompt);
 
-    let run_options = rustykrab_gateway::RunOptions {
+    let run_options = rustykrab_runtime::RunOptions {
         active_skill: resolved_skill,
         // Cron tasks must call a tool on iteration 0 — a bare "I'm ready"
         // reply is never the deliverable, and the model would otherwise
         // burn the slot.
         force_tool_use_first_iteration: true,
         max_iterations: None,
-        ..rustykrab_gateway::RunOptions::default()
+        ..rustykrab_runtime::RunOptions::default()
     };
 
     // Run the agent. Mint a fresh trace id per scheduled run so prompt-log
@@ -510,8 +511,8 @@ async fn execute_cron_task(
         "scheduled task starting"
     );
     let no_op_event = |_event: AgentEvent| {};
-    let result = rustykrab_gateway::run_agent_streaming_with_options(
-        state,
+    let result = rustykrab_runtime::run_agent_streaming_with_options(
+        &state.agent,
         &mut conv,
         &prompt,
         &no_op_event,
@@ -586,7 +587,7 @@ async fn resume_or_create_conversation(
 ) -> Result<Conversation, rustykrab_core::Error> {
     if let Some(cid) = &job.conversation_id {
         if let Ok(uuid) = Uuid::parse_str(cid) {
-            match state.store.conversations().get(uuid).await {
+            match state.agent.store.conversations().get(uuid).await {
                 Ok(c) => return Ok(c),
                 Err(rustykrab_core::Error::NotFound(_)) => {
                     tracing::warn!(
@@ -606,7 +607,7 @@ async fn resume_or_create_conversation(
         }
     }
 
-    let conv = state.store.conversations().create().await?;
+    let conv = state.agent.store.conversations().create().await?;
     store
         .jobs()
         .set_conversation_id(&job.id, &conv.id.to_string())

--- a/crates/rustykrab-gateway/Cargo.toml
+++ b/crates/rustykrab-gateway/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 rustykrab-core.workspace = true
 rustykrab-store.workspace = true
 rustykrab-agent.workspace = true
+rustykrab-runtime.workspace = true
 rustykrab-channels.workspace = true
 rustykrab-memory.workspace = true
 rustykrab-skills.workspace = true

--- a/crates/rustykrab-gateway/src/auth.rs
+++ b/crates/rustykrab-gateway/src/auth.rs
@@ -63,7 +63,7 @@ pub async fn require_auth(
     let principal = if is_master {
         Some(rustykrab_store::Principal::Master)
     } else if let Some(candidate) = token {
-        match state.store.devices().authenticate(candidate).await {
+        match state.agent.store.devices().authenticate(candidate).await {
             Ok(found) => found,
             Err(e) => {
                 tracing::error!(error = %e, "device token lookup failed");

--- a/crates/rustykrab-gateway/src/credential_page.rs
+++ b/crates/rustykrab-gateway/src/credential_page.rs
@@ -127,7 +127,13 @@ async fn show(
         tracing::warn!("credential page refused: no permitted tailnet identity");
         return refused();
     }
-    let Ok(Some(req)) = state.store.credential_requests().find_by_link(&token).await else {
+    let Ok(Some(req)) = state
+        .agent
+        .store
+        .credential_requests()
+        .find_by_link(&token)
+        .await
+    else {
         return refused();
     };
     Html(form_page(&req, &token, None)).into_response()
@@ -143,7 +149,13 @@ async fn submit(
         tracing::warn!("credential page submit refused: no permitted tailnet identity");
         return refused();
     }
-    let Ok(Some(req)) = state.store.credential_requests().find_by_link(&token).await else {
+    let Ok(Some(req)) = state
+        .agent
+        .store
+        .credential_requests()
+        .find_by_link(&token)
+        .await
+    else {
         return refused();
     };
 
@@ -176,6 +188,7 @@ async fn submit(
         .unwrap_or("credential page");
 
     match state
+        .agent
         .store
         .credential_requests()
         .fulfil(&req.id, &supplied, by)

--- a/crates/rustykrab-gateway/src/lib.rs
+++ b/crates/rustykrab-gateway/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod auth;
 mod credential_page;
 pub mod logging;
-mod orchestrate;
 pub mod origin;
 pub mod push;
 pub mod rate_limit;
@@ -13,13 +12,15 @@ mod telegram_webhook;
 mod webchat;
 
 pub use auth::generate_token;
-pub use orchestrate::{
-    run_agent, run_agent_interactive, run_agent_streaming, run_agent_streaming_with_options,
-    run_agent_with_options, RunOptions,
-};
+pub mod run;
 pub use origin::OriginPolicy;
 pub use push::{ApnsClient, ApnsConfig, ApnsEnvironment, PushNotifier};
 pub use rate_limit::RateLimitConfig;
+pub use run::{
+    run_agent, run_agent_interactive, run_agent_streaming, run_agent_streaming_with_options,
+    run_agent_with_options,
+};
+pub use rustykrab_runtime::{AgentContext, RunOptions, RuntimeError};
 pub use state::AppState;
 pub use tasks::{run_task_worker, TaskQueueSignal};
 

--- a/crates/rustykrab-gateway/src/rate_limit.rs
+++ b/crates/rustykrab-gateway/src/rate_limit.rs
@@ -365,7 +365,10 @@ async fn is_authenticated(state: &crate::AppState, token: Option<&str>) -> bool 
         return true;
     }
 
-    matches!(state.store.devices().authenticate(token).await, Ok(Some(_)))
+    matches!(
+        state.agent.store.devices().authenticate(token).await,
+        Ok(Some(_))
+    )
 }
 
 #[cfg(test)]

--- a/crates/rustykrab-gateway/src/routes.rs
+++ b/crates/rustykrab-gateway/src/routes.rs
@@ -239,6 +239,7 @@ async fn create_conversation(
 ) -> Result<Json<ApolloConversation>, StatusCode> {
     let title = body.and_then(|Json(b)| b.title).filter(|s| !s.is_empty());
     state
+        .agent
         .store
         .conversations()
         .create_with_title(title)
@@ -251,6 +252,7 @@ async fn list_conversations(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ApolloConversation>>, StatusCode> {
     state
+        .agent
         .store
         .conversations()
         .list_summaries()
@@ -271,6 +273,7 @@ async fn get_conversation(
     Path(id): Path<Uuid>,
 ) -> Result<Json<ApolloConversation>, StatusCode> {
     state
+        .agent
         .store
         .conversations()
         .get(id)
@@ -287,6 +290,7 @@ async fn delete_conversation(
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
     state
+        .agent
         .store
         .conversations()
         .delete(id)
@@ -299,8 +303,8 @@ async fn delete_conversation(
     // archive, channel bindings — goes with it by cascade, so this handler
     // no longer has to know the list. What is left is process state, which
     // the database cannot reach: the recall cache and the todo list.
-    state.recall.purge(id);
-    state.todos.clear(id);
+    state.agent.recall.purge(id);
+    state.agent.todos.clear(id);
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -316,6 +320,7 @@ async fn list_messages(
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<ApolloMessage>>, StatusCode> {
     let conv = state
+        .agent
         .store
         .conversations()
         .get(id)
@@ -365,6 +370,7 @@ async fn send_message(
     // save_turn falls back to a full rewrite if the agent compacted
     // history (the persisted prefix no longer matches).
     let mut conv = state
+        .agent
         .store
         .conversations()
         .get(id)
@@ -387,14 +393,14 @@ async fn send_message(
     conv.updated_at = Utc::now();
 
     // Run the full agent pipeline.
-    let assistant_msg =
-        crate::orchestrate::run_agent(&state, &mut conv, &user_content, trace_id).await?;
+    let assistant_msg = crate::run::run_agent(&state, &mut conv, &user_content, trace_id).await?;
 
     // Persist the turn (including intermediate tool call messages):
     // appends the new messages and bumps updated_at, or rewrites the
     // whole conversation if compaction replaced the persisted prefix.
     conv.updated_at = Utc::now();
     state
+        .agent
         .store
         .conversations()
         .save_turn(&conv, &persisted_ids)
@@ -517,6 +523,7 @@ async fn submit_task(
         .unwrap_or_else(|| trace_id.to_string());
 
     let task = state
+        .agent
         .store
         .tasks()
         .enqueue(
@@ -547,7 +554,7 @@ async fn get_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<TaskResponse>, StatusCode> {
-    match state.store.tasks().get(&id).await {
+    match state.agent.store.tasks().get(&id).await {
         Ok(Some(task)) => Ok(Json(TaskResponse::from_task(task))),
         Ok(None) => Err(StatusCode::NOT_FOUND),
         Err(e) => {
@@ -560,7 +567,7 @@ async fn get_task(
 /// Recent tasks, newest first. Bounded so a long-lived node cannot
 /// return an unbounded history.
 async fn list_tasks(State(state): State<AppState>) -> Result<Json<Vec<TaskResponse>>, StatusCode> {
-    match state.store.tasks().list(50).await {
+    match state.agent.store.tasks().list(50).await {
         Ok(tasks) => Ok(Json(
             tasks.into_iter().map(TaskResponse::from_task).collect(),
         )),
@@ -579,7 +586,7 @@ async fn cancel_task(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<TaskResponse>, StatusCode> {
-    let previous = state.store.tasks().cancel(&id).await.map_err(|e| {
+    let previous = state.agent.store.tasks().cancel(&id).await.map_err(|e| {
         tracing::error!(error = %e, "could not cancel delegated task");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -591,7 +598,7 @@ async fn cancel_task(
         tracing::info!(task_id = %id, aborted, "cancelled a running delegated task");
     }
 
-    match state.store.tasks().get(&id).await {
+    match state.agent.store.tasks().get(&id).await {
         Ok(Some(task)) => Ok(Json(TaskResponse::from_task(task))),
         Ok(None) => Err(StatusCode::NOT_FOUND),
         Err(e) => {
@@ -642,6 +649,7 @@ async fn send_message_stream(
     // save_turn append only the new messages (full rewrite if the agent
     // compacted history mid-run).
     let mut conv = state
+        .agent
         .store
         .conversations()
         .get(id)
@@ -713,7 +721,7 @@ async fn send_message_stream(
             }
         });
 
-        let agent_future = crate::orchestrate::run_agent_streaming(
+        let agent_future = crate::run::run_agent_streaming(
             &agent_state,
             &mut conv,
             &user_content,
@@ -738,6 +746,7 @@ async fn send_message_stream(
         // replaced the persisted prefix.
         conv.updated_at = Utc::now();
         if let Err(e) = agent_state
+            .agent
             .store
             .conversations()
             .save_turn(&conv, &persisted_ids)
@@ -941,7 +950,7 @@ struct ListSecretsResponse {
 async fn list_secrets(
     State(state): State<AppState>,
 ) -> Result<Json<ListSecretsResponse>, StatusCode> {
-    let meta = state.store.secrets().metadata().await.map_err(|e| {
+    let meta = state.agent.store.secrets().metadata().await.map_err(|e| {
         tracing::error!(error = %e, "list_secrets failed");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -975,7 +984,7 @@ async fn set_secret(
 
     match body.dest {
         SecretDest::Store => {
-            let secrets = state.store.secrets();
+            let secrets = state.agent.store.secrets();
             // Create-only by default. Replacing an existing credential is a
             // separate, explicit act — the client must have asked the user
             // first and sent `overwrite: true`.
@@ -1036,6 +1045,7 @@ async fn delete_secret(
     Path(name): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
     state
+        .agent
         .store
         .secrets()
         .delete(
@@ -1092,6 +1102,7 @@ async fn list_credential_requests(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ChangeRequestResponse>>, StatusCode> {
     let pending = state
+        .agent
         .store
         .credential_requests()
         .pending()
@@ -1162,6 +1173,7 @@ async fn fulfil_credential_request(
         .unwrap_or_else(|| "webchat".to_string());
     let values: Vec<(String, String)> = body.values.into_iter().collect();
     state
+        .agent
         .store
         .credential_requests()
         .fulfil(&id, &values, &decided_by)
@@ -1214,6 +1226,7 @@ async fn pair_device(
     Json(body): Json<PairRequest>,
 ) -> Result<Json<PairResponse>, StatusCode> {
     let (device, token) = state
+        .agent
         .store
         .devices()
         .redeem_pairing_code(&body.code, &body.device_name)
@@ -1244,7 +1257,7 @@ struct DeviceResponse {
 async fn list_devices(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<DeviceResponse>>, StatusCode> {
-    let devices = state.store.devices().list().await.map_err(|e| {
+    let devices = state.agent.store.devices().list().await.map_err(|e| {
         tracing::error!(error = %e, "listing devices failed");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -1282,6 +1295,7 @@ async fn set_push_token(
         return Err(StatusCode::BAD_REQUEST);
     }
     state
+        .agent
         .store
         .devices()
         .set_push_token(&id, token)
@@ -1304,6 +1318,7 @@ async fn revoke_device(
     Path(id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
     state
+        .agent
         .store
         .devices()
         .revoke(&id)
@@ -1325,7 +1340,7 @@ async fn decide_credential_request(
     approve: bool,
     principal: Option<rustykrab_store::Principal>,
 ) -> Result<StatusCode, StatusCode> {
-    let requests = state.store.credential_requests();
+    let requests = state.agent.store.credential_requests();
     // Which device decided, for the audit trail.
     let decided_by = principal
         .map(|p| p.describe())

--- a/crates/rustykrab-gateway/src/run.rs
+++ b/crates/rustykrab-gateway/src/run.rs
@@ -1,0 +1,98 @@
+//! Turn-running, adapted to this transport.
+//!
+//! The turn itself lives in `rustykrab-runtime`, which knows nothing about
+//! HTTP. These wrappers supply its [`AgentContext`] out of [`AppState`] and
+//! translate its errors into status codes — which is the only part of the
+//! job that is actually the web server's.
+//!
+//! Signatures are unchanged, so callers that took `&AppState` still do.
+
+use rustykrab_agent::{AgentEvent, AgentHandle};
+use rustykrab_core::types::{Conversation, Message};
+use rustykrab_runtime::{RunOptions, RuntimeError};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+use crate::AppState;
+
+/// Every runtime failure is an internal one from the web's point of view:
+/// the request was well-formed and the agent could not complete it.
+fn to_status(e: RuntimeError) -> axum::http::StatusCode {
+    match e {
+        RuntimeError::Internal => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+pub async fn run_agent(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    trace_id: Uuid,
+) -> Result<Message, axum::http::StatusCode> {
+    rustykrab_runtime::run_agent(&state.agent, conv, user_content, trace_id)
+        .await
+        .map_err(to_status)
+}
+
+pub async fn run_agent_with_options(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    trace_id: Uuid,
+    options: &RunOptions,
+) -> Result<Message, axum::http::StatusCode> {
+    rustykrab_runtime::run_agent_with_options(&state.agent, conv, user_content, trace_id, options)
+        .await
+        .map_err(to_status)
+}
+
+pub async fn run_agent_interactive(
+    state: &AppState,
+    conv: Conversation,
+    user_content: &str,
+    trace_id: Uuid,
+) -> Result<
+    (
+        AgentHandle,
+        mpsc::Receiver<AgentEvent>,
+        JoinHandle<rustykrab_core::Result<Conversation>>,
+    ),
+    axum::http::StatusCode,
+> {
+    rustykrab_runtime::run_agent_interactive(&state.agent, conv, user_content, trace_id)
+        .await
+        .map_err(to_status)
+}
+
+pub async fn run_agent_streaming(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    trace_id: Uuid,
+) -> Result<Message, axum::http::StatusCode> {
+    rustykrab_runtime::run_agent_streaming(&state.agent, conv, user_content, on_event, trace_id)
+        .await
+        .map_err(to_status)
+}
+
+pub async fn run_agent_streaming_with_options(
+    state: &AppState,
+    conv: &mut Conversation,
+    user_content: &str,
+    on_event: &(dyn Fn(AgentEvent) + Send + Sync),
+    trace_id: Uuid,
+    options: &RunOptions,
+) -> Result<Message, axum::http::StatusCode> {
+    rustykrab_runtime::run_agent_streaming_with_options(
+        &state.agent,
+        conv,
+        user_content,
+        on_event,
+        trace_id,
+        options,
+    )
+    .await
+    .map_err(to_status)
+}

--- a/crates/rustykrab-gateway/src/state.rs
+++ b/crates/rustykrab-gateway/src/state.rs
@@ -1,13 +1,11 @@
-use rustykrab_agent::{HarnessProfile, HarnessRouter, ProcessSandbox, Sandbox};
+use rustykrab_agent::{HarnessProfile, HarnessRouter, Sandbox};
 use rustykrab_channels::{SignalChannel, SlackChannel, TelegramChannel, VideoChannel};
-use rustykrab_core::active_tools::ActiveToolsRegistry;
 use rustykrab_core::activity::ActivityTracker;
 use rustykrab_core::model::ModelProvider;
 use rustykrab_core::orchestration::OrchestrationConfig;
-use rustykrab_core::recall::RecallStore;
 use rustykrab_core::retrieval_log::RetrievalLog;
-use rustykrab_core::todo::TodoStore;
 use rustykrab_memory::MemorySystem;
+use rustykrab_runtime::AgentContext;
 use rustykrab_skills::SkillRegistry;
 use rustykrab_store::Store;
 use std::sync::{Arc, RwLock};
@@ -17,78 +15,35 @@ use crate::origin::OriginPolicy;
 use crate::rate_limit::{RateLimitConfig, RateLimiter};
 
 /// Shared application state threaded through axum handlers.
+///
+/// Two halves, deliberately separated. `agent` is everything a turn needs
+/// and is [`AgentContext`], which lives in `rustykrab-runtime` so a caller
+/// with no HTTP in sight — a Telegram loop, a scheduled job, a test — can
+/// hold one without constructing a web server's state. The rest of this
+/// struct is the web server: auth, rate limiting, origin policy, the
+/// credential page, and the channel handles the webhook routes deliver to.
 #[derive(Clone)]
 pub struct AppState {
-    pub store: Store,
-    pub tools: Vec<Arc<dyn rustykrab_core::Tool>>,
-    pub provider: Arc<dyn ModelProvider>,
+    /// Everything needed to run a turn. See [`AgentContext`].
+    pub agent: AgentContext,
+
+    // --- HTTP-only ---
     pub auth_token: Arc<RwLock<String>>,
     pub rate_limiter: Arc<RateLimiter>,
     pub origin_policy: OriginPolicy,
-    pub telegram: Option<Arc<TelegramChannel>>,
-    pub signal: Option<Arc<SignalChannel>>,
-    pub slack: Option<Arc<SlackChannel>>,
-    /// Video communication channel (hyperframes MCP).
-    pub video: Option<Arc<VideoChannel>>,
-    /// Sandbox for tool execution isolation.
-    pub sandbox: Arc<dyn Sandbox>,
-    /// Base harness profile (used as fallback and template).
-    pub harness_profile: HarnessProfile,
-    /// Auto-router that classifies messages and selects profiles on-the-fly.
-    /// None = static profile mode (uses harness_profile directly).
-    pub harness_router: Option<Arc<HarnessRouter>>,
-    /// Orchestration configuration (used by RLM module).
-    pub orchestration_config: OrchestrationConfig,
-    /// Skill registry for SKILL.md-based skills.
-    pub skill_registry: Arc<SkillRegistry>,
-    /// Hybrid memory system for auto-persisting conversation turns.
-    /// `None` when no memory backend is configured.
-    pub memory: Option<Arc<MemorySystem>>,
-    /// Persistent agent identifier, used as the owner for memory writes.
-    /// `None` when memory is not configured.
-    pub agent_id: Option<Uuid>,
-    /// Shared registry backing the `tools_load` / `tools_list` meta-tools.
-    /// Tracks which tools are "active" per conversation so schemas sent to
-    /// the model stay compact until the agent explicitly loads more.
-    pub active_tools: Arc<ActiveToolsRegistry>,
-    /// Per-conversation archive of compaction-displaced history. Backs
-    /// the `recall_*` tools so the agent can recover detail dropped by
-    /// summarisation.
-    pub recall: Arc<RecallStore>,
-    /// Per-conversation todo list backing the `todo_*` tools. Shared across
-    /// a conversation's requests so the agent's plan persists between turns.
-    /// In-memory only: a todo list is short-horizon working state, not
-    /// durable history like `recall`.
-    pub todos: Arc<TodoStore>,
-    /// Whether sub-agent / session-management tools should be granted to
-    /// sessions created by this gateway. Default `false`. Driven by the
-    /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var at startup; threaded through
-    /// here so `prepare_agent` knows whether to grant `Capability::Subagent`.
-    pub subagents_enabled: bool,
-    /// Whether the computer-use tool should be granted to sessions created by
-    /// this gateway. Default `false`. Driven by `RUSTYKRAB_COMPUTER_USE` at
-    /// startup; threaded through so `prepare_agent` knows whether to grant
-    /// `Capability::ComputerUse`.
-    pub computer_use_enabled: bool,
-    /// When each agent last saw inbound activity. Gates the downtime
-    /// analysis worker, which must run only when nothing else needs the
-    /// machine and must yield the moment it does. See `DREAMING.md`.
-    pub activity: ActivityTracker,
-    /// Records which memories were surfaced into each conversation so a
-    /// completed run's outcome can be attributed to them. Shared with the
-    /// memory backend, which writes it, and the agent runner, which drains
-    /// it. See `DREAMING.md`.
-    pub retrieval_log: RetrievalLog,
-    /// Whether completed runs report their outcome to the store. Off by
-    /// default: instrumentation is opt-in, driven by
-    /// `RUSTYKRAB_OUTCOME_CAPTURE` at startup.
-    pub outcome_capture_enabled: bool,
     /// Who may open the credential page served at `/c/{token}`.
     pub credential_page_policy: crate::PageIdentityPolicy,
     /// Wake-up channel and cancellation registry for the delegated-task
     /// queue. Shared between the `/api/tasks` handlers, which enqueue and
     /// cancel, and the worker, which drains.
     pub task_signal: crate::tasks::TaskQueueSignal,
+
+    // --- Outbound channels, delivered to by the webhook routes ---
+    pub telegram: Option<Arc<TelegramChannel>>,
+    pub signal: Option<Arc<SignalChannel>>,
+    pub slack: Option<Arc<SlackChannel>>,
+    /// Video communication channel (hyperframes MCP).
+    pub video: Option<Arc<VideoChannel>>,
 }
 
 impl AppState {
@@ -98,144 +53,101 @@ impl AppState {
         provider: Arc<dyn ModelProvider>,
         auth_token: String,
     ) -> Self {
-        // Back the recall archive with SQLite so compaction-displaced
-        // history survives process restarts. The in-memory `RecallStore`
-        // acts as a write-through cache, lazily hydrated per conversation.
-        let recall = Arc::new(RecallStore::with_persistence(Arc::new(
-            store.recall_archive(),
-        )));
         Self {
-            store,
-            tools,
-            provider,
+            agent: AgentContext::new(store, tools, provider),
             auth_token: Arc::new(RwLock::new(auth_token)),
             rate_limiter: Arc::new(RateLimiter::new(RateLimitConfig::from_env())),
             origin_policy: OriginPolicy::default(),
+            credential_page_policy: crate::PageIdentityPolicy::default(),
+            task_signal: crate::tasks::TaskQueueSignal::new(),
             telegram: None,
             signal: None,
             slack: None,
             video: None,
-            sandbox: Arc::new(ProcessSandbox::new()),
-            harness_profile: HarnessProfile::default(),
-            harness_router: None,
-            orchestration_config: OrchestrationConfig::default(),
-            skill_registry: Arc::new(SkillRegistry::new()),
-            memory: None,
-            agent_id: None,
-            active_tools: Arc::new(ActiveToolsRegistry::new()),
-            recall,
-            todos: Arc::new(TodoStore::new()),
-            subagents_enabled: false,
-            computer_use_enabled: false,
-            activity: ActivityTracker::new(),
-            retrieval_log: RetrievalLog::new(),
-            outcome_capture_enabled: false,
-            credential_page_policy: crate::PageIdentityPolicy::default(),
-            task_signal: crate::tasks::TaskQueueSignal::new(),
         }
     }
 
-    /// Record how each completed run went, for later offline analysis.
-    ///
-    /// Purely observational — it changes nothing about how the agent
-    /// behaves. Driven by `RUSTYKRAB_OUTCOME_CAPTURE` in the CLI.
+    /// Replace the agent context wholesale, for callers that build one up
+    /// with `AgentContext`'s own builders.
+    pub fn with_agent_context(mut self, agent: AgentContext) -> Self {
+        self.agent = agent;
+        self
+    }
+
+    // --- Delegating builders -------------------------------------------
+    //
+    // Kept so existing wiring reads the same. Each defers to the
+    // `AgentContext` builder of the same name.
+
     pub fn with_outcome_capture(mut self, enabled: bool) -> Self {
-        self.outcome_capture_enabled = enabled;
+        self.agent = self.agent.with_outcome_capture(enabled);
         self
     }
 
-    /// Share the activity tracker with the downtime worker, so the worker
-    /// sees the traffic this gateway serves.
     pub fn with_activity_tracker(mut self, activity: ActivityTracker) -> Self {
-        self.activity = activity;
+        self.agent = self.agent.with_activity_tracker(activity);
         self
     }
 
-    /// Share the retrieval log with the memory backend, which records the
-    /// memories it surfaces so runs can be credited to them.
     pub fn with_retrieval_log(mut self, log: RetrievalLog) -> Self {
-        self.retrieval_log = log;
+        self.agent = self.agent.with_retrieval_log(log);
         self
     }
 
-    /// Enable the sub-agent / session-management tool family for every
-    /// session created by this gateway. Driven by the
-    /// `RUSTYKRAB_ENABLE_SUBAGENTS` env var in the CLI; off by default.
     pub fn with_subagents_enabled(mut self, enabled: bool) -> Self {
-        self.subagents_enabled = enabled;
+        self.agent = self.agent.with_subagents_enabled(enabled);
         self
     }
 
-    /// Grant the computer-use tool to every session created by this gateway.
-    /// Driven by `RUSTYKRAB_COMPUTER_USE` in the CLI; off by default. Only
-    /// meaningful when the tool is actually registered (built with the
-    /// `computer-use` feature).
     pub fn with_computer_use_enabled(mut self, enabled: bool) -> Self {
-        self.computer_use_enabled = enabled;
+        self.agent = self.agent.with_computer_use_enabled(enabled);
         self
     }
 
-    /// Attach the memory system and the agent identifier used for writes.
-    /// When set, the gateway wires an `on_message` hook into the agent
-    /// runner that persists every conversation turn into working memory.
     pub fn with_memory(mut self, memory: Arc<MemorySystem>, agent_id: Uuid) -> Self {
-        self.memory = Some(memory);
-        self.agent_id = Some(agent_id);
+        self.agent = self.agent.with_memory(memory, agent_id);
         self
     }
 
-    /// Override the origin policy.
+    pub fn with_sandbox(mut self, sandbox: Arc<dyn Sandbox>) -> Self {
+        self.agent = self.agent.with_sandbox(sandbox);
+        self
+    }
+
+    pub fn with_harness_profile(mut self, profile: HarnessProfile) -> Self {
+        self.agent = self.agent.with_harness_profile(profile);
+        self
+    }
+
+    pub fn with_harness_router(mut self, router: Arc<HarnessRouter>) -> Self {
+        self.agent = self.agent.with_harness_router(router);
+        self
+    }
+
+    pub fn with_harness_router_opt(mut self, router: Option<Arc<HarnessRouter>>) -> Self {
+        self.agent = self.agent.with_harness_router_opt(router);
+        self
+    }
+
+    pub fn with_skill_registry(mut self, registry: Arc<SkillRegistry>) -> Self {
+        self.agent = self.agent.with_skill_registry(registry);
+        self
+    }
+
+    pub fn with_orchestration_config(mut self, config: OrchestrationConfig) -> Self {
+        self.agent = self.agent.with_orchestration_config(config);
+        self
+    }
+
+    // --- HTTP-only builders ---------------------------------------------
+
     pub fn with_origin_policy(mut self, policy: OriginPolicy) -> Self {
         self.origin_policy = policy;
         self
     }
 
-    /// Override the rate limit configuration.
     pub fn with_rate_limit(mut self, config: RateLimitConfig) -> Self {
         self.rate_limiter = Arc::new(RateLimiter::new(config));
-        self
-    }
-
-    /// Attach a Telegram channel.
-    pub fn with_telegram(mut self, telegram: Arc<TelegramChannel>) -> Self {
-        self.telegram = Some(telegram);
-        self
-    }
-
-    /// Attach a Signal channel.
-    pub fn with_signal(mut self, signal: Arc<SignalChannel>) -> Self {
-        self.signal = Some(signal);
-        self
-    }
-
-    /// Attach a Slack channel.
-    pub fn with_slack(mut self, slack: Arc<SlackChannel>) -> Self {
-        self.slack = Some(slack);
-        self
-    }
-
-    /// Attach a Video communication channel.
-    pub fn with_video(mut self, video: Arc<VideoChannel>) -> Self {
-        self.video = Some(video);
-        self
-    }
-
-    /// Override the sandbox implementation.
-    pub fn with_sandbox(mut self, sandbox: Arc<dyn Sandbox>) -> Self {
-        self.sandbox = sandbox;
-        self
-    }
-
-    /// Set the harness profile.
-    pub fn with_harness_profile(mut self, profile: HarnessProfile) -> Self {
-        self.harness_profile = profile;
-        self
-    }
-
-    /// Enable auto-routing: a cheap model classifies each message and
-    /// selects the right harness profile on-the-fly.
-    pub fn with_harness_router(mut self, router: Arc<HarnessRouter>) -> Self {
-        self.harness_router = Some(router);
         self
     }
 
@@ -245,51 +157,32 @@ impl AppState {
         self
     }
 
-    /// Set the router, or leave static-profile mode in place when `None`.
-    pub fn with_harness_router_opt(mut self, router: Option<Arc<HarnessRouter>>) -> Self {
-        self.harness_router = router;
+    pub fn with_telegram(mut self, telegram: Arc<TelegramChannel>) -> Self {
+        self.telegram = Some(telegram);
         self
     }
 
-    /// Set the skill registry.
-    pub fn with_skill_registry(mut self, registry: Arc<SkillRegistry>) -> Self {
-        self.skill_registry = registry;
+    pub fn with_signal(mut self, signal: Arc<SignalChannel>) -> Self {
+        self.signal = Some(signal);
         self
     }
 
-    /// Set the orchestration configuration (used by RLM module).
-    pub fn with_orchestration_config(mut self, config: OrchestrationConfig) -> Self {
-        self.orchestration_config = config;
+    pub fn with_slack(mut self, slack: Arc<SlackChannel>) -> Self {
+        self.slack = Some(slack);
         self
     }
 
-    /// Rotate the auth token: generates a new random token, stores it,
-    /// and returns the new value. The old token is immediately invalidated.
+    pub fn with_video(mut self, video: Arc<VideoChannel>) -> Self {
+        self.video = Some(video);
+        self
+    }
+
+    /// Rotate the auth token: generates a new random token, stores it, and
+    /// returns the new value. The old token is immediately invalidated.
     pub fn rotate_token(&self) -> String {
         let new_token = crate::auth::generate_token();
         let mut guard = self.auth_token.write().unwrap_or_else(|e| e.into_inner());
         *guard = new_token.clone();
         new_token
-    }
-
-    /// Get the harness profile for a given user message.
-    /// If a router is configured, classifies the message automatically.
-    /// Otherwise, returns the static base profile.
-    pub async fn profile_for(&self, user_message: &str) -> HarnessProfile {
-        if let Some(router) = &self.harness_router {
-            router.route(user_message).await
-        } else {
-            self.harness_profile.clone()
-        }
-    }
-
-    /// Get a harness profile by name.
-    pub fn profile_for_name(&self, name: &str) -> HarnessProfile {
-        match name {
-            "coding" => HarnessProfile::coding(),
-            "research" => HarnessProfile::research(),
-            "creative" => HarnessProfile::creative(),
-            _ => self.harness_profile.clone(),
-        }
     }
 }

--- a/crates/rustykrab-gateway/src/tasks.rs
+++ b/crates/rustykrab-gateway/src/tasks.rs
@@ -21,8 +21,9 @@ use tokio::sync::Notify;
 use tokio::task::AbortHandle;
 use uuid::Uuid;
 
-use crate::orchestrate::{run_agent_with_options, RunOptions};
+use crate::run::run_agent_with_options;
 use crate::AppState;
+use rustykrab_runtime::RunOptions;
 
 /// Fallback poll interval. The queue also rings [`TaskQueueSignal`] on
 /// submit, so this only covers a missed notification or a task enqueued
@@ -89,7 +90,7 @@ impl TaskQueueSignal {
 /// Spawned once at startup and held in the CLI's `infra_handles`.
 pub async fn run_task_worker(state: AppState) {
     let signal = state.task_signal.clone();
-    let store = state.store.tasks();
+    let store = state.agent.store.tasks();
 
     // Tasks left `running` belonged to an agent loop that died with the
     // previous process. Nothing will ever complete them, so fail them
@@ -199,7 +200,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
         .as_deref()
         .and_then(|id| id.parse().ok())
     {
-        Some(id) => match state.store.conversations().get(id).await {
+        Some(id) => match state.agent.store.conversations().get(id).await {
             Ok(conv) => conv,
             Err(_) => {
                 tracing::warn!(
@@ -208,6 +209,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
                     "delegated task named an unknown conversation; opening a fresh one"
                 );
                 state
+                    .agent
                     .store
                     .conversations()
                     .create()
@@ -216,6 +218,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
             }
         },
         None => state
+            .agent
             .store
             .conversations()
             .create()
@@ -228,6 +231,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
         // Record it before the run, not after: a task that dies mid-turn
         // should still tell the peer which thread to resume.
         if let Err(e) = state
+            .agent
             .store
             .tasks()
             .set_conversation(&task.id, &conversation_id)
@@ -266,6 +270,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
 
     conv.updated_at = Utc::now();
     if let Err(e) = state
+        .agent
         .store
         .conversations()
         .save_turn(&conv, &persisted_ids)
@@ -292,6 +297,7 @@ async fn execute(state: AppState, task: DelegatedTask) -> Result<TaskReply, Stri
 /// against — a denial only means anything for a tool that exists.
 fn available_tool_names(state: &AppState) -> Vec<&str> {
     state
+        .agent
         .tools
         .iter()
         .filter(|t| t.available())

--- a/crates/rustykrab-runtime/Cargo.toml
+++ b/crates/rustykrab-runtime/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rustykrab-runtime"
+description = "Assembles and runs an agent turn, independent of any transport"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+rustykrab-core.workspace = true
+rustykrab-store.workspace = true
+rustykrab-agent.workspace = true
+rustykrab-memory.workspace = true
+rustykrab-skills.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+uuid.workspace = true

--- a/crates/rustykrab-runtime/src/context.rs
+++ b/crates/rustykrab-runtime/src/context.rs
@@ -1,0 +1,191 @@
+//! Everything needed to run an agent turn, and nothing about how the turn
+//! was requested.
+//!
+//! This was the non-HTTP half of the gateway's `AppState`. Splitting it out
+//! is what lets a Telegram or Slack loop — or a scheduled job, or a test —
+//! run a turn without constructing a web server's state, and without
+//! depending on an Axum crate to do work that has nothing to do with HTTP.
+
+use std::sync::Arc;
+
+use rustykrab_agent::{HarnessProfile, HarnessRouter, ProcessSandbox, Sandbox};
+use rustykrab_core::active_tools::ActiveToolsRegistry;
+use rustykrab_core::activity::ActivityTracker;
+use rustykrab_core::model::ModelProvider;
+use rustykrab_core::orchestration::OrchestrationConfig;
+use rustykrab_core::recall::RecallStore;
+use rustykrab_core::retrieval_log::RetrievalLog;
+use rustykrab_core::todo::TodoStore;
+use rustykrab_memory::MemorySystem;
+use rustykrab_skills::SkillRegistry;
+use rustykrab_store::Store;
+use uuid::Uuid;
+
+/// The agent's world: what it can call, what it remembers, what it is
+/// allowed to do, and where its history lives.
+///
+/// Cheap to clone — every field is an `Arc`, a handle, or a flag.
+#[derive(Clone)]
+pub struct AgentContext {
+    pub store: Store,
+    pub tools: Vec<Arc<dyn rustykrab_core::Tool>>,
+    pub provider: Arc<dyn ModelProvider>,
+    /// Sandbox for tool execution isolation.
+    pub sandbox: Arc<dyn Sandbox>,
+    /// Base harness profile, used as fallback and as the template a routed
+    /// preset is overlaid on.
+    pub harness_profile: HarnessProfile,
+    /// Classifies each message and selects a profile. `None` means static
+    /// profile mode, using `harness_profile` directly.
+    pub harness_router: Option<Arc<HarnessRouter>>,
+    pub orchestration_config: OrchestrationConfig,
+    pub skill_registry: Arc<SkillRegistry>,
+    /// Hybrid memory. `None` when no memory backend is configured.
+    pub memory: Option<Arc<MemorySystem>>,
+    /// Persistent agent identifier, the owner for memory writes. `None`
+    /// when memory is not configured.
+    pub agent_id: Option<Uuid>,
+    /// Backs the `tools_load` / `tools_list` meta-tools: which tools are
+    /// active per conversation, so the schemas sent to the model stay
+    /// compact until the agent asks for more.
+    pub active_tools: Arc<ActiveToolsRegistry>,
+    /// Per-conversation archive of compaction-displaced history, backing
+    /// the `recall_*` tools.
+    pub recall: Arc<RecallStore>,
+    /// Per-conversation todo list backing the `todo_*` tools. In memory
+    /// only: a todo list is short-horizon working state, not durable
+    /// history like `recall`.
+    pub todos: Arc<TodoStore>,
+    /// Whether sub-agent / session-management tools are granted to sessions
+    /// created here. Off by default — a sub-agent can spawn nested agent
+    /// loops, which amplifies any prompt-injection blast radius.
+    pub subagents_enabled: bool,
+    /// Whether the computer-use tool is granted. Off by default.
+    pub computer_use_enabled: bool,
+    /// When each agent last saw inbound activity. Gates the downtime
+    /// analysis worker. See `DREAMING.md`.
+    pub activity: ActivityTracker,
+    /// Records which memories were surfaced into each conversation so a
+    /// completed run's outcome can be attributed to them.
+    pub retrieval_log: RetrievalLog,
+    /// Whether completed runs report their outcome to the store. Off by
+    /// default: instrumentation is opt-in.
+    pub outcome_capture_enabled: bool,
+}
+
+impl AgentContext {
+    pub fn new(
+        store: Store,
+        tools: Vec<Arc<dyn rustykrab_core::Tool>>,
+        provider: Arc<dyn ModelProvider>,
+    ) -> Self {
+        // Back the recall archive with SQLite so compaction-displaced
+        // history survives restarts. The in-memory `RecallStore` acts as a
+        // write-through cache, lazily hydrated per conversation.
+        let recall = Arc::new(RecallStore::with_persistence(Arc::new(
+            store.recall_archive(),
+        )));
+        Self {
+            store,
+            tools,
+            provider,
+            sandbox: Arc::new(ProcessSandbox::new()),
+            harness_profile: HarnessProfile::default(),
+            harness_router: None,
+            orchestration_config: OrchestrationConfig::default(),
+            skill_registry: Arc::new(SkillRegistry::new()),
+            memory: None,
+            agent_id: None,
+            active_tools: Arc::new(ActiveToolsRegistry::new()),
+            recall,
+            todos: Arc::new(TodoStore::new()),
+            subagents_enabled: false,
+            computer_use_enabled: false,
+            activity: ActivityTracker::new(),
+            retrieval_log: RetrievalLog::new(),
+            outcome_capture_enabled: false,
+        }
+    }
+
+    pub fn with_outcome_capture(mut self, enabled: bool) -> Self {
+        self.outcome_capture_enabled = enabled;
+        self
+    }
+
+    pub fn with_activity_tracker(mut self, activity: ActivityTracker) -> Self {
+        self.activity = activity;
+        self
+    }
+
+    pub fn with_retrieval_log(mut self, log: RetrievalLog) -> Self {
+        self.retrieval_log = log;
+        self
+    }
+
+    pub fn with_subagents_enabled(mut self, enabled: bool) -> Self {
+        self.subagents_enabled = enabled;
+        self
+    }
+
+    pub fn with_computer_use_enabled(mut self, enabled: bool) -> Self {
+        self.computer_use_enabled = enabled;
+        self
+    }
+
+    pub fn with_memory(mut self, memory: Arc<MemorySystem>, agent_id: Uuid) -> Self {
+        self.memory = Some(memory);
+        self.agent_id = Some(agent_id);
+        self
+    }
+
+    pub fn with_sandbox(mut self, sandbox: Arc<dyn Sandbox>) -> Self {
+        self.sandbox = sandbox;
+        self
+    }
+
+    pub fn with_harness_profile(mut self, profile: HarnessProfile) -> Self {
+        self.harness_profile = profile;
+        self
+    }
+
+    pub fn with_harness_router(mut self, router: Arc<HarnessRouter>) -> Self {
+        self.harness_router = Some(router);
+        self
+    }
+
+    /// Set the router, or leave static-profile mode in place when `None`.
+    pub fn with_harness_router_opt(mut self, router: Option<Arc<HarnessRouter>>) -> Self {
+        self.harness_router = router;
+        self
+    }
+
+    pub fn with_skill_registry(mut self, registry: Arc<SkillRegistry>) -> Self {
+        self.skill_registry = registry;
+        self
+    }
+
+    pub fn with_orchestration_config(mut self, config: OrchestrationConfig) -> Self {
+        self.orchestration_config = config;
+        self
+    }
+
+    /// The harness profile for a given user message. Classifies via the
+    /// router when one is configured, otherwise returns the base profile.
+    pub async fn profile_for(&self, user_message: &str) -> HarnessProfile {
+        if let Some(router) = &self.harness_router {
+            router.route(user_message).await
+        } else {
+            self.harness_profile.clone()
+        }
+    }
+
+    /// A harness profile by name.
+    pub fn profile_for_name(&self, name: &str) -> HarnessProfile {
+        match name {
+            "coding" => HarnessProfile::coding(),
+            "research" => HarnessProfile::research(),
+            "creative" => HarnessProfile::creative(),
+            _ => self.harness_profile.clone(),
+        }
+    }
+}

--- a/crates/rustykrab-runtime/src/error.rs
+++ b/crates/rustykrab-runtime/src/error.rs
@@ -1,0 +1,16 @@
+//! What can go wrong assembling or running a turn.
+//!
+//! Deliberately not an HTTP status. This layer previously returned
+//! `StatusCode` — every failure was `INTERNAL_SERVER_ERROR` — which meant a
+//! Telegram loop received a web status code for a problem that had nothing
+//! to do with the web, and the only transport that could act on it was the
+//! one that never needed to.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    /// The agent loop failed, or the turn could not be assembled.
+    #[error("agent run failed")]
+    Internal,
+}

--- a/crates/rustykrab-runtime/src/lib.rs
+++ b/crates/rustykrab-runtime/src/lib.rs
@@ -1,0 +1,23 @@
+//! Running an agent turn, independent of how the turn was asked for.
+//!
+//! The gateway crate used to own this. It builds the system prompt, derives
+//! the session's capability set, creates the `AgentRunner`, installs the
+//! memory write-back hook and drives the loop — none of which is HTTP. The
+//! consequence was that `rustykrab-cli`'s Telegram and Slack loops depended
+//! on an Axum server crate to do non-HTTP work, and anything wanting to
+//! embed the agent inherited tower, APNs, rate limiting and origin policy
+//! with it.
+//!
+//! [`AgentContext`] is the state a turn needs; the gateway now holds one
+//! alongside its own HTTP-only fields.
+
+mod context;
+mod error;
+mod orchestrate;
+
+pub use context::AgentContext;
+pub use error::RuntimeError;
+pub use orchestrate::{
+    run_agent, run_agent_interactive, run_agent_streaming, run_agent_streaming_with_options,
+    run_agent_with_options, RunOptions,
+};

--- a/crates/rustykrab-runtime/src/orchestrate.rs
+++ b/crates/rustykrab-runtime/src/orchestrate.rs
@@ -1,13 +1,23 @@
+//! Assemble and run one agent turn.
+//!
+//! This was `rustykrab-gateway::orchestrate`. Nothing in it is about HTTP —
+//! it builds the system prompt, derives the session's capabilities, installs
+//! the memory write-back hook and drives the runner — but living in the Axum
+//! crate meant a Telegram loop had to depend on a web server to run a turn.
+//!
+//! Errors are a plain enum rather than an HTTP status. The gateway maps them
+//! at its own boundary, which is where that decision belongs.
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-use axum::http::StatusCode;
 use chrono::Utc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
-use crate::AppState;
+use crate::context::AgentContext;
+use crate::error::RuntimeError;
 use rustykrab_agent::{AgentEvent, AgentHandle, AgentRunner, HarnessProfile, OnMessageCallback};
 use rustykrab_core::capability::{Capability, CapabilitySet};
 use rustykrab_core::session::Session;
@@ -55,7 +65,7 @@ pub struct RunOptions {
 /// resolving it once and passing it in avoids a second (potentially
 /// LLM-backed) classification per turn.
 async fn build_and_inject_system_prompt(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     profile: &HarnessProfile,
     options: &RunOptions,
@@ -72,7 +82,7 @@ async fn build_and_inject_system_prompt(
         .with_security_policy();
 
     // Inject SKILL.md catalog (only satisfied skills).
-    let all_md = state.skill_registry.md_skills();
+    let all_md = ctx.skill_registry.md_skills();
     let (satisfied, unsatisfied): (Vec<_>, Vec<_>) = all_md
         .into_iter()
         .partition(|s| s.validation.is_satisfied());
@@ -226,9 +236,9 @@ fn message_to_turn(msg: &Message, session_id: Uuid, turn_number: u32) -> Convers
 /// infrastructure (agent prompt, warnings) rather than conversation content.
 /// Duplicate content is de-duplicated on the memory side via SHA-256 hash,
 /// so re-firing the callback for an already-persisted message is safe.
-fn build_memory_callback(state: &AppState, conv: &Conversation) -> Option<OnMessageCallback> {
-    let memory: Arc<MemorySystem> = state.memory.clone()?;
-    let agent_id = state.agent_id?;
+fn build_memory_callback(ctx: &AgentContext, conv: &Conversation) -> Option<OnMessageCallback> {
+    let memory: Arc<MemorySystem> = ctx.memory.clone()?;
+    let agent_id = ctx.agent_id?;
     let session_id = conv.id;
     // Start the turn counter from the current message count so turns
     // are numbered consistently across a multi-request conversation.
@@ -259,39 +269,39 @@ fn build_memory_callback(state: &AppState, conv: &Conversation) -> Option<OnMess
 /// `Capability::Subagent` in addition to the per-tool grant, so we only
 /// add it when the gateway has been opted in (see
 /// `AppState::with_subagents_enabled`).
-fn build_session_capabilities(state: &AppState, tool_names: &[&str]) -> CapabilitySet {
+fn build_session_capabilities(ctx: &AgentContext, tool_names: &[&str]) -> CapabilitySet {
     let mut caps = CapabilitySet::for_tools_permissive(tool_names);
-    if state.subagents_enabled {
+    if ctx.subagents_enabled {
         caps.grant(Capability::Subagent);
     }
-    if state.computer_use_enabled {
+    if ctx.computer_use_enabled {
         caps.grant(Capability::ComputerUse);
     }
     caps
 }
 
 async fn prepare_agent(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     user_content: &str,
     options: &RunOptions,
-) -> Result<(AgentRunner, Session), StatusCode> {
+) -> Result<(AgentRunner, Session), RuntimeError> {
     // Mark the system busy. Every channel reaches the agent through here,
     // so this one call covers Telegram, Slack, WebChat and scheduled runs
     // alike, and keeps the downtime worker from starting mid-turn.
-    if let Some(agent_id) = state.agent_id {
-        state.activity.record(agent_id);
+    if let Some(agent_id) = ctx.agent_id {
+        ctx.activity.record(agent_id);
     }
 
     // Resolve the harness profile once; it drives both the system prompt
     // and the agent config below.
-    let profile = state.profile_for(user_content).await;
+    let profile = ctx.profile_for(user_content).await;
     tracing::info!(profile = %profile.name, "harness profile selected");
 
-    build_and_inject_system_prompt(state, conv, &profile, options).await;
+    build_and_inject_system_prompt(ctx, conv, &profile, options).await;
 
     // Create an ephemeral session with capabilities for available registered tools.
-    let tool_names: Vec<&str> = state
+    let tool_names: Vec<&str> = ctx
         .tools
         .iter()
         .filter(|t| t.available())
@@ -301,10 +311,10 @@ async fn prepare_agent(
     tracing::debug!(
         tool_count = tool_names.len(),
         tools = ?tool_names,
-        subagents_enabled = state.subagents_enabled,
+        subagents_enabled = ctx.subagents_enabled,
         "granting session capabilities for available tools"
     );
-    let caps = build_session_capabilities(state, &tool_names);
+    let caps = build_session_capabilities(ctx, &tool_names);
     let session = Session::with_capabilities(conv.id, caps);
 
     let mut agent_config = profile.to_agent_config();
@@ -313,29 +323,25 @@ async fn prepare_agent(
         agent_config.max_iterations = cap;
     }
 
-    let mut runner = AgentRunner::new(
-        state.provider.clone(),
-        state.tools.clone(),
-        state.sandbox.clone(),
-    )
-    .with_config(agent_config)
-    .with_active_tools(state.active_tools.clone())
-    .with_recall_store(state.recall.clone())
-    .with_todo_store(state.todos.clone())
-    .with_retrieval_log(state.retrieval_log.clone());
+    let mut runner = AgentRunner::new(ctx.provider.clone(), ctx.tools.clone(), ctx.sandbox.clone())
+        .with_config(agent_config)
+        .with_active_tools(ctx.active_tools.clone())
+        .with_recall_store(ctx.recall.clone())
+        .with_todo_store(ctx.todos.clone())
+        .with_retrieval_log(ctx.retrieval_log.clone());
 
     // Outcome instrumentation (see `DREAMING.md`). Observational only: the
     // runner records how the run went and to which artifacts it should be
     // credited. Attributing to the active skill needs its name, which the
     // runner does not otherwise know.
-    if state.outcome_capture_enabled {
-        runner = runner.with_outcome_sink(Arc::new(state.store.outcomes()));
+    if ctx.outcome_capture_enabled {
+        runner = runner.with_outcome_sink(Arc::new(ctx.store.outcomes()));
         if let Some((name, _)) = options.active_skill.as_ref() {
             runner = runner.with_active_skill(name.clone());
         }
     }
 
-    if let Some(cb) = build_memory_callback(state, conv) {
+    if let Some(cb) = build_memory_callback(ctx, conv) {
         // The inbound user message was pushed onto conv.messages by
         // routes.rs before the runner was constructed, so it never goes
         // through push_message. Fire the callback once so the user turn
@@ -352,7 +358,7 @@ async fn prepare_agent(
 }
 
 /// Extract the last assistant text message from a conversation.
-fn extract_assistant_message(conv: &Conversation) -> Result<Message, StatusCode> {
+fn extract_assistant_message(conv: &Conversation) -> Result<Message, RuntimeError> {
     conv.messages
         .iter()
         .rev()
@@ -360,7 +366,7 @@ fn extract_assistant_message(conv: &Conversation) -> Result<Message, StatusCode>
         .cloned()
         .ok_or_else(|| {
             tracing::error!("agent loop completed but no assistant text message found");
-            StatusCode::INTERNAL_SERVER_ERROR
+            RuntimeError::Internal
         })
 }
 
@@ -371,35 +377,35 @@ fn extract_assistant_message(conv: &Conversation) -> Result<Message, StatusCode>
 /// channel/scheduler entry points should mint a fresh one with
 /// [`Uuid::new_v4`].
 pub async fn run_agent(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     user_content: &str,
     trace_id: Uuid,
-) -> Result<Message, StatusCode> {
-    run_agent_with_options(state, conv, user_content, trace_id, &RunOptions::default()).await
+) -> Result<Message, RuntimeError> {
+    run_agent_with_options(ctx, conv, user_content, trace_id, &RunOptions::default()).await
 }
 
 /// Like [`run_agent`] but accepts caller-supplied [`RunOptions`].
 pub async fn run_agent_with_options(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     user_content: &str,
     trace_id: Uuid,
     options: &RunOptions,
-) -> Result<Message, StatusCode> {
+) -> Result<Message, RuntimeError> {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
-        let (runner, session) = prepare_agent(state, conv, user_content, options).await?;
+        let (runner, session) = prepare_agent(ctx, conv, user_content, options).await?;
 
         runner.run(conv, &session).await.map_err(|e| {
             tracing::error!(%trace_id, "agent error: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
+            RuntimeError::Internal
         })?;
 
         // Mark busy again on the way out. Recording only at the start
         // would leave a long turn looking idle from the moment it began,
         // and the worker could fire while it was still running.
-        if let Some(agent_id) = state.agent_id {
-            state.activity.record(agent_id);
+        if let Some(agent_id) = ctx.agent_id {
+            ctx.activity.record(agent_id);
         }
 
         extract_assistant_message(conv)
@@ -415,7 +421,7 @@ pub async fn run_agent_with_options(
 /// them. The `Receiver<AgentEvent>` streams real-time progress events,
 /// and the `JoinHandle` resolves to the final conversation.
 pub async fn run_agent_interactive(
-    state: &AppState,
+    ctx: &AgentContext,
     mut conv: Conversation,
     user_content: &str,
     trace_id: Uuid,
@@ -425,32 +431,28 @@ pub async fn run_agent_interactive(
         mpsc::Receiver<AgentEvent>,
         JoinHandle<rustykrab_core::Result<Conversation>>,
     ),
-    StatusCode,
+    RuntimeError,
 > {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
         // Resolve the harness profile once for both the system prompt and
         // the agent config.
-        let profile = state.profile_for(user_content).await;
+        let profile = ctx.profile_for(user_content).await;
         tracing::info!(profile = %profile.name, "harness profile selected");
 
-        build_and_inject_system_prompt(state, &mut conv, &profile, &RunOptions::default()).await;
+        build_and_inject_system_prompt(ctx, &mut conv, &profile, &RunOptions::default()).await;
 
-        let tool_names: Vec<&str> = state
+        let tool_names: Vec<&str> = ctx
             .tools
             .iter()
             .filter(|t| t.available())
             .map(|t| t.name())
             .collect();
-        let caps = build_session_capabilities(state, &tool_names);
+        let caps = build_session_capabilities(ctx, &tool_names);
         let session = Session::with_capabilities(conv.id, caps);
 
-        let runner = AgentRunner::new(
-            state.provider.clone(),
-            state.tools.clone(),
-            state.sandbox.clone(),
-        )
-        .with_config(profile.to_agent_config())
-        .with_todo_store(state.todos.clone());
+        let runner = AgentRunner::new(ctx.provider.clone(), ctx.tools.clone(), ctx.sandbox.clone())
+            .with_config(profile.to_agent_config())
+            .with_todo_store(ctx.todos.clone());
 
         // The agent loop runs in a tokio::spawn'd task inside `start`, so
         // the task-local trace id won't follow it. Re-scope the spawned
@@ -465,14 +467,14 @@ pub async fn run_agent_interactive(
 
 /// Run the agent loop with streaming events.
 pub async fn run_agent_streaming(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     user_content: &str,
     on_event: &(dyn Fn(AgentEvent) + Send + Sync),
     trace_id: Uuid,
-) -> Result<Message, StatusCode> {
+) -> Result<Message, RuntimeError> {
     run_agent_streaming_with_options(
-        state,
+        ctx,
         conv,
         user_content,
         on_event,
@@ -484,28 +486,28 @@ pub async fn run_agent_streaming(
 
 /// Like [`run_agent_streaming`] but accepts caller-supplied [`RunOptions`].
 pub async fn run_agent_streaming_with_options(
-    state: &AppState,
+    ctx: &AgentContext,
     conv: &mut Conversation,
     user_content: &str,
     on_event: &(dyn Fn(AgentEvent) + Send + Sync),
     trace_id: Uuid,
     options: &RunOptions,
-) -> Result<Message, StatusCode> {
+) -> Result<Message, RuntimeError> {
     rustykrab_core::prompt_trace::with_trace_id(trace_id, async move {
-        let (runner, session) = prepare_agent(state, conv, user_content, options).await?;
+        let (runner, session) = prepare_agent(ctx, conv, user_content, options).await?;
 
         runner
             .run_streaming(conv, &session, on_event)
             .await
             .map_err(|e| {
                 tracing::error!(%trace_id, "agent error: {e}");
-                StatusCode::INTERNAL_SERVER_ERROR
+                RuntimeError::Internal
             })?;
 
         // See `run_agent_with_options` -- a long turn must not read as
         // idle from the moment it started.
-        if let Some(agent_id) = state.agent_id {
-            state.activity.record(agent_id);
+        if let Some(agent_id) = ctx.agent_id {
+            ctx.activity.record(agent_id);
         }
 
         extract_assistant_message(conv)


### PR DESCRIPTION
> Stacked on #595 → #594 → #593 → #592 → #591 → #590 → #589 → #588.

## What

New crate `rustykrab-runtime`, owning what was `gateway/src/orchestrate.rs`.
**No axum in its dependency tree** (`cargo tree -p rustykrab-runtime -e normal
| grep -c axum` → `0`).

## Why

`orchestrate.rs` builds the system prompt, derives the capability set,
creates the `AgentRunner`, installs the memory write-back hook and drives the
loop. None of that is HTTP. Living in the Axum crate meant:

- `rustykrab-cli`'s Telegram and Slack loops — which never serve a request —
  depended on a web server crate to run a turn.
- Anything embedding the agent inherited tower, APNs, rate limiting and
  origin policy with it.
- `AppState` was the de-facto application context but was named and typed as
  web-server state, so anything wanting the former had to build the latter.

## The seam was already there — I measured it before moving anything

| Consumer | Fields used |
|---|---|
| `orchestrate` | 16 — `provider`, `tools`, `sandbox`, `memory`, `agent_id`, `skill_registry`, `active_tools`, `recall`, `todos`, `activity`, `retrieval_log`, `subagents_enabled`, `computer_use_enabled`, `outcome_capture_enabled`, `store`, `profile_for` |
| HTTP handlers | 5 — `store`, `recall`, `todos`, `task_signal`, `credential_page_policy` |

Only three overlap. So `AgentContext` takes the agent half and `AppState`
composes it beside auth, rate limiter, origin policy, credential-page policy
and the channel handles the webhook routes deliver to.

`AppState`'s builders are kept as one-line delegations, so existing wiring
reads unchanged.

## Errors stop being status codes

The layer returned `Result<_, StatusCode>` and every failure was
`INTERNAL_SERVER_ERROR`. A Telegram loop was receiving an HTTP status for a
problem with nothing to do with HTTP, and the only caller that could act on
it was the one that never needed to.

`RuntimeError` is a plain enum. The gateway maps it at its own boundary in
`run.rs` — one `match`, in the layer whose job that is.

## No behaviour change

The gateway's public turn-running functions keep their names and signatures,
now as thin wrappers supplying the context and translating the error. The
CLI's channel loops and task queue call `rustykrab_runtime::` directly, so
the `cli → gateway` dependency for turn-running is gone; what remains is
genuine server wiring (`AppState`, `ApnsConfig`, `PushNotifier`,
`OriginPolicy`), which the CLI needs because it runs the server.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` clean.

## What this unlocks

The turn call-site collapse — `process_telegram_message`,
`process_slack_message` and the gateway's `send_message` each independently
implement load → snapshot ids → append → run with heartbeat → `save_turn` →
extract reply. That belongs in this crate, and #597 just demonstrated the
cost of the duplication: the `PendingLinks` drain existed in the Telegram
copy and not the Slack one, so scheduled jobs minted a credential link and
dropped it.

When that lands, one invariant must be carried explicitly: **chat surfaces
drain, app surfaces don't.** Apollo and WebChat render the credential form
from `GET /api/credential-requests`, so the filed request *is* the delivery
mechanism there; pushing a capture URL into an SSE stream and a persisted
transcript is precisely what `pending_links` exists to prevent. The
asymmetry looks like a bug if you don't know why.

Found by the architecture review — see
`docs/architecture/00-system-overview.md` ("Missing layer").

🤖 Generated with [Claude Code](https://claude.com/claude-code)