### PR TITLE
perf(agent): keep the tool block on the compaction call

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -1423,11 +1423,20 @@ impl AgentRunner {
                 "agent loop iteration"
             );
 
+            // Refresh the schemas before the compaction check rather than
+            // after: the summarizer call now needs the same tool block the
+            // ordinary turns carry, or it cannot reuse their cached prefix.
+            // The refresh is version-keyed, so this is O(1) unless
+            // `tools_load` actually changed the active set.
+            self.refresh_schema_cache(session, session.conversation_id, &mut schema_cache);
+            let compaction_tools: &[ToolSchema] =
+                schema_cache.as_ref().map_or(&[], |(_, s)| s.as_slice());
+
             // Compaction: if conversation exceeds threshold, ask the LLM to
             // summarize before the next call (RLM paper §3.2).
             if self.needs_compaction(conv) {
                 tracing::info!(iteration, "conversation crossed compaction threshold");
-                self.compact_history(conv).await?;
+                self.compact_history(conv, compaction_tools).await?;
             }
 
             // Soft iteration warning.
@@ -1451,12 +1460,9 @@ impl AgentRunner {
                 );
             }
 
-            // Refresh the tool schemas only when the active set changed
-            // (e.g. `tools_load` ran during the previous iteration) so the
-            // next API call reflects new activations without rebuilding
-            // every schema each time around the loop.
-            self.refresh_schema_cache(session, session.conversation_id, &mut schema_cache);
-            let schemas: &[ToolSchema] = schema_cache.as_ref().map_or(&[], |(_, s)| s.as_slice());
+            // Already refreshed above, before the compaction check that
+            // depends on it.
+            let schemas: &[ToolSchema] = compaction_tools;
 
             // Iteration-0 guard for scheduled tasks: force the model to
             // call a tool on the first turn so it can't reply with a bare
@@ -1889,12 +1895,21 @@ impl AgentRunner {
                 return Err(Error::Auth("session expired during execution".into()));
             }
 
+            // Refresh the schemas before the compaction check rather than
+            // after: the summarizer call now needs the same tool block the
+            // ordinary turns carry, or it cannot reuse their cached prefix.
+            // The refresh is version-keyed, so this is O(1) unless
+            // `tools_load` actually changed the active set.
+            self.refresh_schema_cache(session, session.conversation_id, &mut schema_cache);
+            let compaction_tools: &[ToolSchema] =
+                schema_cache.as_ref().map_or(&[], |(_, s)| s.as_slice());
+
             // Compaction: if conversation exceeds threshold, ask the LLM to
             // summarize before the next call (RLM paper §3.2).
             if self.needs_compaction(conv) {
                 tracing::info!(iteration, "conversation crossed compaction threshold");
                 on_event(AgentEvent::Compressing);
-                self.compact_history(conv).await?;
+                self.compact_history(conv, compaction_tools).await?;
             }
 
             // Soft iteration warning.
@@ -1924,10 +1939,8 @@ impl AgentRunner {
                 }
             };
 
-            // Refresh the tool schemas only when the active set changed —
-            // see run_inner for rationale.
-            self.refresh_schema_cache(session, session.conversation_id, &mut schema_cache);
-            let schemas: &[ToolSchema] = schema_cache.as_ref().map_or(&[], |(_, s)| s.as_slice());
+            // Already refreshed above — see run_inner.
+            let schemas: &[ToolSchema] = compaction_tools;
 
             // Iteration-0 guard: see run_inner for rationale.
             let tool_choice = if iteration == 0
@@ -2965,7 +2978,16 @@ impl AgentRunner {
     /// provider's effective input budget, falls back to chunked/recursive
     /// summarization so compaction still succeeds on conversations that
     /// have grown past a single summarizer call's capacity.
-    async fn compact_history(&self, conv: &mut Conversation) -> Result<()> {
+    /// `tools` must be the same schema set the agent loop is sending on
+    /// its ordinary turns. It is not there for the summarizer's benefit —
+    /// it never calls a tool — but because providers render the tool block
+    /// into the prompt *ahead of the messages*. Dropping it moves the
+    /// front of the token sequence, so the KV cache the loop just warmed
+    /// stops matching and the whole history is re-evaluated from scratch.
+    ///
+    /// Measured on gemma4:26b (Q4_K_M, M1 Max) over an 8.6k-token history:
+    /// 20.14s of prompt evaluation without the tool block, 3.55s with it.
+    async fn compact_history(&self, conv: &mut Conversation, tools: &[ToolSchema]) -> Result<()> {
         let before_len = conv.messages.len();
         let before_tokens = self.cached_conversation_tokens(conv);
 
@@ -3048,12 +3070,38 @@ impl AgentRunner {
             // model would summarize a truncated fragment while this code
             // believes it saw everything.
             let response = match compaction_expand_ctx() {
-                Some(ctx) => self.provider.chat_with_ctx(&conv.messages, &[], ctx).await,
-                None => self.provider.chat(&conv.messages, &[]).await,
+                Some(ctx) => {
+                    self.provider
+                        .chat_with_ctx(&conv.messages, tools, ctx)
+                        .await
+                }
+                None => self.provider.chat(&conv.messages, tools).await,
             };
-            conv.messages.pop();
             let response = response?;
-            response.message.content.as_text().unwrap_or("").to_string()
+            let text = response.message.content.as_text().unwrap_or("").to_string();
+
+            // Offering the tool block is what keeps the cache warm, but it
+            // also lets the model answer with a tool call instead of a
+            // summary. That reads as an empty summary downstream, which
+            // skips compaction entirely and leaves the history to grow —
+            // so retry once without tools rather than lose the turn. Rare
+            // enough in practice to be worth the cold prefill when it
+            // happens.
+            if text.trim().is_empty() && response.message.content.has_tool_calls() {
+                tracing::warn!(
+                    "summarizer answered with a tool call instead of a summary; \
+                     retrying without the tool block"
+                );
+                let retry = match compaction_expand_ctx() {
+                    Some(ctx) => self.provider.chat_with_ctx(&conv.messages, &[], ctx).await,
+                    None => self.provider.chat(&conv.messages, &[]).await,
+                };
+                conv.messages.pop();
+                retry?.message.content.as_text().unwrap_or("").to_string()
+            } else {
+                conv.messages.pop();
+                text
+            }
         } else {
             // Recursive path: the history alone is already larger than what
             // the provider will accept in one call. Render messages as text,
@@ -3706,6 +3754,10 @@ mod compaction_tests {
         call_count: Mutex<usize>,
         last_input_chars: Mutex<Vec<usize>>,
         ctx_limit: Option<usize>,
+        /// Tool names seen on each call, in order. The compaction call has
+        /// to carry the same tool block as an ordinary turn or the
+        /// provider's cached prefix stops matching.
+        tools_seen: Mutex<Vec<Vec<String>>>,
     }
 
     impl CountingProvider {
@@ -3714,6 +3766,7 @@ mod compaction_tests {
                 call_count: Mutex::new(0),
                 last_input_chars: Mutex::new(Vec::new()),
                 ctx_limit,
+                tools_seen: Mutex::new(Vec::new()),
             }
         }
     }
@@ -3726,7 +3779,11 @@ mod compaction_tests {
         fn context_limit(&self) -> Option<usize> {
             self.ctx_limit
         }
-        async fn chat(&self, messages: &[Message], _tools: &[ToolSchema]) -> Result<ModelResponse> {
+        async fn chat(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<ModelResponse> {
+            self.tools_seen
+                .lock()
+                .unwrap()
+                .push(tools.iter().map(|t| t.name.clone()).collect());
             let total_chars: usize = messages
                 .iter()
                 .map(|m| match &m.content {
@@ -3839,6 +3896,73 @@ mod compaction_tests {
         );
     }
 
+    /// The compaction call must carry the same tool block the ordinary
+    /// turns carry.
+    ///
+    /// Not for the summarizer's sake — it never calls a tool — but because
+    /// providers render tool definitions ahead of the messages. Sending
+    /// `&[]` moves the front of the token sequence, so the KV cache the
+    /// loop just warmed no longer matches and the entire history is
+    /// re-evaluated. Measured on gemma4:26b over an 8.6k-token history:
+    /// 20.14s of prompt evaluation without the tool block, 3.55s with it.
+    #[tokio::test]
+    async fn compaction_carries_the_same_tool_block_as_an_ordinary_turn() {
+        let provider = Arc::new(CountingProvider::new(Some(100_000)));
+        let runner = build_runner(Arc::clone(&provider));
+
+        let tools = vec![
+            ToolSchema {
+                name: "web_search".to_string(),
+                description: "search".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+            ToolSchema {
+                name: "memory_save".to_string(),
+                description: "save".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        ];
+
+        let mut conv = Conversation {
+            id: Uuid::new_v4(),
+            messages: vec![
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::User,
+                    content: MessageContent::Text("do the thing ".repeat(50)),
+                    created_at: Utc::now(),
+                    agent_version: None,
+                },
+                Message {
+                    id: Uuid::new_v4(),
+                    role: Role::Assistant,
+                    content: MessageContent::Text("did the thing ".repeat(50)),
+                    created_at: Utc::now(),
+                    agent_version: None,
+                },
+            ],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            title: None,
+            summary: None,
+            detected_profile: None,
+            channel_source: None,
+            channel_id: None,
+            channel_thread_id: None,
+        };
+
+        runner.compact_history(&mut conv, &tools).await.unwrap();
+
+        let seen = provider.tools_seen.lock().unwrap();
+        assert!(!seen.is_empty(), "the summarizer must have been called");
+        assert_eq!(
+            seen[0],
+            vec!["web_search".to_string(), "memory_save".to_string()],
+            "compaction dropped the tool block; the provider's cached prefix \
+             will not match and the whole history gets re-evaluated"
+        );
+    }
+
     #[tokio::test]
     async fn compact_history_uses_recursive_path_when_oversized() {
         // Tight context limit forces the recursive path: the raw history
@@ -3883,7 +4007,7 @@ mod compaction_tests {
         };
 
         runner
-            .compact_history(&mut conv)
+            .compact_history(&mut conv, &[])
             .await
             .expect("compaction should succeed");
 
@@ -4197,7 +4321,7 @@ mod compaction_tests {
         };
 
         runner
-            .compact_history(&mut conv)
+            .compact_history(&mut conv, &[])
             .await
             .expect("compaction should succeed");
 
@@ -4280,9 +4404,9 @@ mod compaction_tests {
         };
 
         let mut first = make_conv("FIRST_BATCH_DETAIL");
-        runner.compact_history(&mut first).await.unwrap();
+        runner.compact_history(&mut first, &[]).await.unwrap();
         let mut second = make_conv("SECOND_BATCH_DETAIL");
-        runner.compact_history(&mut second).await.unwrap();
+        runner.compact_history(&mut second, &[]).await.unwrap();
 
         let archived = recall.get(conv_id).expect("archive populated");
         assert!(archived.contains("FIRST_BATCH_DETAIL"));
@@ -4470,7 +4594,7 @@ mod token_estimate_tests {
         let before = runner.cached_conversation_tokens(&conv);
 
         runner
-            .compact_history(&mut conv)
+            .compact_history(&mut conv, &[])
             .await
             .expect("compaction should succeed");
 


### PR DESCRIPTION
## What

The fast compaction path already reuses the live conversation — it appends a "summarize your progress" prompt to `conv.messages`, calls the model, then pops it back off. That is exactly the shape that should hit a warm KV cache: the history the loop just sent, plus one message at the tail.

It then passed `&[]` for tools and threw the whole benefit away.

## Why it costs so much

Providers render tool definitions **ahead of** the messages. Dropping the tool block moves the front of the token sequence, so nothing after it matches what the loop cached, and the entire history is re-evaluated from scratch — at precisely the moment the history is at its largest.

Measured on gemma4:26b (Q4_K_M, M1 Max, Ollama 0.33.1) over an 8.6k-token history, prompt evaluation only:

| call | prefill |
|---|---|
| agent turn (tool block present) | 20.38s |
| compaction as written (`&[]`) | **20.14s** — full re-prefill |
| compaction with the tool block | **3.55s** |

16.6s saved on one call, 5.7×. The gap widens with history size, because the re-prefill scales with the conversation while the cache hit does not. At 18k tokens the same comparison is 59.78s against 5.63s (10.6×).

This matters most on the path that runs it most: scheduled jobs go through the streaming loop and are the longest-lived conversations.

## The tradeoff

The summarizer does not want the tools and never calls one — across five trials it called none, and the summaries were unchanged in quality. But offering them makes a tool call *possible*, and a tool call would read as an empty summary downstream, skip compaction, and leave the history to grow. So the call retries once without tools if that happens, trading a cold prefill for correctness in the rare case.

## Notes for review

- Threading the schemas to the call means refreshing the version-keyed schema cache **before** the compaction check instead of after. That is O(1) unless `tools_load` actually changed the active set.
- The added test fails without the fix (verified by reverting the argument).
- Touches `runner.rs`, which #594 also rewrites. Happy to rebase onto it — this hunk is outside both loop bodies, so the overlap should be limited to the `refresh_schema_cache` move.

`cargo fmt` / `clippy --workspace --all-targets` / `test --workspace` all clean; 853 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)