### PR TITLE
fix(store,memory): recover from every poisoned lock, not just the funnel

### DIFF
--- a/crates/rustykrab-memory/src/embedding.rs
+++ b/crates/rustykrab-memory/src/embedding.rs
@@ -257,9 +257,20 @@ mod fastembed_impl {
         async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>> {
             let model = Arc::clone(&self.model);
             tokio::task::spawn_blocking(move || {
-                let mut guard = model
-                    .lock()
-                    .map_err(|e| rustykrab_core::Error::Internal(format!("embedder lock: {e}")))?;
+                // Recover a poisoned lock rather than failing forever.
+                //
+                // `TextEmbedding::embed` runs ONNX inference, which can abort
+                // the thread — an OOM on a large batch is the realistic case.
+                // That poisons the mutex, and because the embedder is created
+                // once and shared, every later call returned "embedder lock:
+                // poisoned": one bad batch permanently disabled memory for the
+                // life of the process, with no path back short of a restart.
+                //
+                // The model behind the lock is not left invalid by a panic in
+                // `embed` — the next call re-enters it with its own inputs —
+                // so continuing is safe, and a subsequent smaller batch
+                // succeeds where the previous one died.
+                let mut guard = model.lock().unwrap_or_else(|p| p.into_inner());
                 guard
                     .embed(&texts, None)
                     .map_err(|e| rustykrab_core::Error::Internal(format!("fastembed: {e}")))

--- a/crates/rustykrab-store/src/recall_archive.rs
+++ b/crates/rustykrab-store/src/recall_archive.rs
@@ -94,7 +94,7 @@ fn delete_row(conn: &rusqlite::Connection, conversation_id: Uuid) -> Result<(), 
 /// `spawn_blocking`).
 impl RecallPersistence for RecallArchiveStore {
     fn load(&self, conversation_id: Uuid) -> Option<String> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
         match get_row(&conn, conversation_id) {
             Ok(archive) => archive,
             Err(e) => {
@@ -105,14 +105,14 @@ impl RecallPersistence for RecallArchiveStore {
     }
 
     fn upsert(&self, conversation_id: Uuid, archive: &str) {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
         if let Err(e) = upsert_row(&conn, conversation_id, archive) {
             tracing::warn!(error = %e, %conversation_id, "failed to persist recall archive");
         }
     }
 
     fn delete(&self, conversation_id: Uuid) {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
         if let Err(e) = delete_row(&conn, conversation_id) {
             tracing::warn!(error = %e, %conversation_id, "failed to delete recall archive");
         }
@@ -195,5 +195,47 @@ mod tests {
             .unwrap()
         };
         assert_eq!(created, created_after);
+    }
+}
+
+#[cfg(test)]
+mod poisoning_tests {
+    use super::*;
+
+    /// `with_conn` recovers from a poisoned lock, but this type does not go
+    /// through it — `RecallPersistence` is a synchronous trait, so it locks
+    /// the connection directly. Those direct locks were the half of the
+    /// problem that the `with_conn` fix did not reach: one panic anywhere
+    /// holding the connection and every later recall archive read or write
+    /// panicked with it, for the life of the process.
+    #[test]
+    fn a_poisoned_lock_does_not_disable_the_archive() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::Store::run_migrations(&conn).unwrap();
+        // The archive references its conversation, so one has to exist.
+        let id = Uuid::new_v4();
+        conn.execute(
+            "INSERT INTO conversations (id, data, created_at, updated_at)
+             VALUES (?1, '{}', 't', 't')",
+            rusqlite::params![id.to_string()],
+        )
+        .unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+
+        let poisoner = Arc::clone(&conn);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.lock().unwrap();
+            panic!("simulated panic while holding the connection");
+        })
+        .join();
+        assert!(conn.is_poisoned(), "the test must actually poison the lock");
+
+        // Reads and writes must both still work. These go through the
+        // synchronous `RecallPersistence` impl, which is what locks directly.
+        let store = RecallArchiveStore::new(Arc::clone(&conn));
+        let persistence: &dyn rustykrab_core::recall::RecallPersistence = &store;
+        assert_eq!(persistence.load(Uuid::new_v4()), None);
+        persistence.upsert(id, "[]");
+        assert_eq!(persistence.load(id).as_deref(), Some("[]"));
     }
 }

--- a/crates/rustykrab-store/src/secret.rs
+++ b/crates/rustykrab-store/src/secret.rs
@@ -127,7 +127,7 @@ impl SecretStore {
         let value = Zeroizing::new(value.to_string());
         run_blocking(move || {
             let encrypted = store.encrypt(&name, value.as_bytes())?;
-            let conn = store.conn.lock().unwrap();
+            let conn = store.conn.lock().unwrap_or_else(|p| p.into_inner());
             let now = now_ms();
             let rows = conn
                 .execute(
@@ -168,7 +168,7 @@ impl SecretStore {
         let value = Zeroizing::new(value.to_string());
         run_blocking(move || {
             let encrypted = store.encrypt(&name, value.as_bytes())?;
-            let mut conn = store.conn.lock().unwrap();
+            let mut conn = store.conn.lock().unwrap_or_else(|p| p.into_inner());
             let tx = conn
                 .transaction()
                 .map_err(|e| Error::Storage(e.to_string()))?;
@@ -243,7 +243,7 @@ impl SecretStore {
             // Empty ciphertext: the column is NOT NULL and the row has to
             // exist, but there is no credential to put in it.
             let empty = store.encrypt(&name_owned, b"")?;
-            let mut conn = store.conn.lock().unwrap();
+            let mut conn = store.conn.lock().unwrap_or_else(|p| p.into_inner());
             let tx = conn
                 .transaction()
                 .map_err(|e| Error::Storage(e.to_string()))?;
@@ -314,7 +314,7 @@ impl SecretStore {
         let name = name.to_string();
         run_blocking(move || {
             let encrypted: Vec<u8> = {
-                let conn = store.conn.lock().unwrap();
+                let conn = store.conn.lock().unwrap_or_else(|p| p.into_inner());
                 let mut stmt = conn
                     .prepare("SELECT data FROM secrets WHERE name = ?1")
                     .map_err(|e| Error::Storage(e.to_string()))?;
@@ -346,7 +346,7 @@ impl SecretStore {
         let store = self.clone();
         let name = name.to_string();
         run_blocking(move || {
-            let mut conn = store.conn.lock().unwrap();
+            let mut conn = store.conn.lock().unwrap_or_else(|p| p.into_inner());
             let tx = conn
                 .transaction()
                 .map_err(|e| Error::Storage(e.to_string()))?;


### PR DESCRIPTION
Closes #289. Closes #327.

> Top of stack #602.

## Why this isn't already done

#589 fixed `with_conn` on the reasoning that every database call funnels
through it. Checking that claim: **eight production sites don't.**

| Site | Count | Why it bypasses `with_conn` |
|---|---|---|
| `secret.rs` | 5 | locks the connection directly inside its own `run_blocking` closures |
| `recall_archive.rs` | 3 | `RecallPersistence` is a **synchronous** trait, so it can't use the async funnel |

Those kept the original behaviour exactly: one panic while holding the
connection, and every later secret read, secret write or recall-archive
access panics with it for the life of the process.

`keychain.rs`'s four `ENV_LOCK` sites are test-only and left alone.

## #327 — same shape, worse blast radius

`FastEmbedder`'s `Mutex<TextEmbedding>` guards ONNX inference, which can
abort the thread; an OOM on a large batch is the realistic case. The
embedder is constructed once and shared, so one bad batch returned
`"embedder lock: poisoned"` from then on and **the memory system was
disabled until restart**.

Recovering is safe here for a specific reason worth stating: nothing about
the model is left invalid by a panic inside `embed` — the next call
re-enters it with its own inputs — so a subsequent smaller batch succeeds
where the previous one died. That is exactly the case the old code made
unreachable.

## Test fixtures deliberately keep `.unwrap()`

The mechanical sweep initially caught two test-module sites; I reverted
them. A test that silently tolerates a poisoned lock is worth less than one
that fails on it.

## The test

`a_poisoned_lock_does_not_disable_the_archive` poisons the mutex the only
way it can be poisoned — panicking while holding it — asserts
`is_poisoned()` so it can't quietly stop testing anything, then requires
both a read and a write to succeed through the synchronous trait impl,
which is the path that bypasses the funnel.

Writing the fixture surfaced something worth noting: the archive row now
needs its conversation to exist. That's the foreign key from #590 doing its
job, and the first assertion failure was the test being wrong rather than
the code.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)