### PR TITLE
fix(memory): validate the config at construction, and fix a cap warning that could never fire

### DIFF
--- a/crates/rustykrab-memory/src/config.rs
+++ b/crates/rustykrab-memory/src/config.rs
@@ -123,3 +123,48 @@ impl Default for MemoryConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod validation_entry_tests {
+    use super::*;
+    use crate::embedding::HashEmbedder;
+    use crate::storage::SqliteMemoryStorage;
+    use crate::MemorySystem;
+    use std::sync::Arc;
+
+    fn parts() -> (Arc<SqliteMemoryStorage>, Arc<HashEmbedder>) {
+        (
+            Arc::new(SqliteMemoryStorage::open_in_memory().unwrap()),
+            Arc::new(HashEmbedder::new(768)),
+        )
+    }
+
+    /// `validate()` existed and guarded exactly the two values that cannot
+    /// be defended against downstream — but nothing called it, so both
+    /// surfaced as a panic on the first query instead of at construction.
+    #[test]
+    fn a_zero_rrf_k_is_refused_at_construction_not_at_query_time() {
+        let (storage, embedder) = parts();
+        let config = MemoryConfig {
+            rrf_k: 0.0,
+            ..MemoryConfig::default()
+        };
+        assert!(MemorySystem::try_new(config, storage, embedder).is_err());
+    }
+
+    #[test]
+    fn a_zero_chunk_size_is_refused_at_construction() {
+        let (storage, embedder) = parts();
+        let config = MemoryConfig {
+            chunk_max_tokens: 0,
+            ..MemoryConfig::default()
+        };
+        assert!(MemorySystem::try_new(config, storage, embedder).is_err());
+    }
+
+    #[test]
+    fn the_default_config_is_valid() {
+        let (storage, embedder) = parts();
+        assert!(MemorySystem::try_new(MemoryConfig::default(), storage, embedder).is_ok());
+    }
+}

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -107,11 +107,32 @@ impl MemorySystem {
     /// - `config`: tuning parameters for chunking, retrieval, and lifecycle.
     /// - `storage`: the backing store (SQLite, PostgreSQL, etc.).
     /// - `embedder`: the text embedding model (fastembed, API-based, etc.).
+    /// Build a memory system.
+    ///
+    /// Validates the config, because the values it guards are ones nothing
+    /// downstream can defend itself against: `rrf_k == 0.0` divides by zero
+    /// inside rank fusion, and `chunk_max_tokens == 0` loops forever. Both
+    /// used to surface as a panic on the first query, arbitrarily far from
+    /// the code that chose the value.
+    ///
+    /// # Panics
+    ///
+    /// If the config is invalid. Use [`Self::try_new`] to handle it.
     pub fn new(
         config: MemoryConfig,
         storage: Arc<dyn MemoryStorage>,
         embedder: Arc<dyn embedding::Embedder>,
     ) -> Self {
+        Self::try_new(config, storage, embedder).expect("invalid MemoryConfig")
+    }
+
+    /// [`Self::new`], returning the validation error instead of panicking.
+    pub fn try_new(
+        config: MemoryConfig,
+        storage: Arc<dyn MemoryStorage>,
+        embedder: Arc<dyn embedding::Embedder>,
+    ) -> std::result::Result<Self, config::ConfigValidationError> {
+        config.validate()?;
         let writer = MemoryWriter::new(Arc::clone(&storage), Arc::clone(&embedder), config.clone());
 
         let retriever =
@@ -120,13 +141,13 @@ impl MemorySystem {
         let lifecycle =
             LifecycleManager::new(Arc::clone(&storage), Arc::clone(&embedder), config.clone());
 
-        Self {
+        Ok(Self {
             writer,
             retriever,
             lifecycle,
             storage,
             config,
-        }
+        })
     }
 
     // ── Write path ──────────────────────────────────────────────

--- a/crates/rustykrab-memory/src/lib.rs
+++ b/crates/rustykrab-memory/src/lib.rs
@@ -107,7 +107,6 @@ impl MemorySystem {
     /// - `config`: tuning parameters for chunking, retrieval, and lifecycle.
     /// - `storage`: the backing store (SQLite, PostgreSQL, etc.).
     /// - `embedder`: the text embedding model (fastembed, API-based, etc.).
-    /// Build a memory system.
     ///
     /// Validates the config, because the values it guards are ones nothing
     /// downstream can defend itself against: `rrf_k == 0.0` divides by zero

--- a/crates/rustykrab-memory/src/lifecycle.rs
+++ b/crates/rustykrab-memory/src/lifecycle.rs
@@ -265,7 +265,11 @@ impl LifecycleManager {
             }
         }
 
-        if mem_embeddings.len() > MAX_DEDUP_MEMORIES {
+        // `memories.len()`, not `mem_embeddings.len()`. The latter is built
+        // by `.take(MAX_DEDUP_MEMORIES)` above, so it can never exceed the
+        // cap and this warning could never fire — the one case operators
+        // needed to hear about was the only one it stayed silent for.
+        if memories.len() > MAX_DEDUP_MEMORIES {
             tracing::warn!(
                 agent_id = %agent_id,
                 total = memories.len(),


### PR DESCRIPTION
Closes #313. Closes #326.

> Top of stack #602.

## #313 — `validate()` existed and nothing called it

`MemoryConfig::validate()` guards exactly the two values that nothing
downstream can defend itself against:

- `rrf_k == 0.0` → division by zero in `rrf_fuse`
- `chunk_max_tokens == 0` → non-terminating chunk loop

`MemorySystem::new()` never called it, so both surfaced as a panic on the
*first query*, arbitrarily far from the code that chose the value.

`try_new` validates and returns the error. `new` keeps its signature and
panics with a clear message, so the five existing call sites are untouched
and a caller who wants to handle it has somewhere to go. Failing at
construction is the point — the config is fixed for the life of the system,
so a value guaranteed to panic on every query shouldn't wait for the first
one to say so.

## #326 — the warning could never fire

```rust
for mem in memories.iter().take(MAX_DEDUP_MEMORIES) { ... }   // bounded here
if mem_embeddings.len() > MAX_DEDUP_MEMORIES { warn!(...) }   // ...then tested here
```

`mem_embeddings` is built by `.take(MAX_DEDUP_MEMORIES)`, so its length can
never exceed the cap. Now tests `memories.len()`, the unbounded source.

Worth noting what the dead branch cost: the single situation operators
needed to hear about — near-duplicate detection silently skipping memories
past the cap — was the only one it stayed quiet for.

## #312 was already fixed — closing separately

While checking, `list_by_session_and_stage` already uses the indexed
`session_id` column with a comment saying why, so #312 is stale on `main`.
No code change needed.

## Tests

Three, asserting the failure happens at construction rather than at query
time, plus that the default config is valid — otherwise the first two could
pass for the wrong reason.

`cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test
--workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)