### PR TITLE
fix(browser): validate action-specific arguments

### DIFF
--- a/crates/rustykrab-agent/src/runner.rs
+++ b/crates/rustykrab-agent/src/runner.rs
@@ -21,7 +21,7 @@ use rustykrab_core::todo::TodoStore;
 use rustykrab_core::types::{
     ContentPart, Conversation, Message, MessageContent, Role, ToolCall, ToolResult, ToolSchema,
 };
-use rustykrab_core::{Error, Result, SandboxRequirements, Tool, ToolErrorKind};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -3167,24 +3167,12 @@ async fn execute_with_watchdog(
 
 /// Retry a tool call up to `max_retries` times with exponential backoff.
 ///
-/// Invalid input, permission failures, and timeouts require the model to
-/// change its approach rather than repeating the exact same call. Preserve
-/// the existing retry behavior for other failures, which may be transient.
+/// Retry only errors whose structured kind explicitly says the identical call
+/// can succeed later. Treating the catch-all `Internal` kind as retryable is
+/// especially harmful for malformed calls: the runner repeats a deterministic
+/// failure several times before the model sees it.
 fn should_retry_unchanged_tool_call(error: &Error) -> bool {
-    if matches!(error, Error::Auth(_)) {
-        return false;
-    }
-
-    !matches!(
-        error,
-        Error::ToolExecution(tool_error)
-            if matches!(
-                tool_error.kind,
-                ToolErrorKind::InvalidInput
-                    | ToolErrorKind::PermissionDenied
-                    | ToolErrorKind::Timeout
-            )
-    )
+    error.kind().retryable()
 }
 
 async fn execute_with_retries(
@@ -3225,8 +3213,8 @@ async fn execute_with_retries(
 
 #[cfg(test)]
 mod retry_policy_tests {
-    use super::should_retry_unchanged_tool_call;
-    use rustykrab_core::{Error, ToolError};
+    use super::{should_retry_unchanged_tool_call, tool_error_output};
+    use rustykrab_core::{Error, Tool, ToolError, ToolErrorKind};
 
     #[test]
     fn avoids_retries_that_require_a_changed_call() {
@@ -3249,12 +3237,32 @@ mod retry_policy_tests {
         assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
             ToolError::permission_denied("Google rejected the stored app password")
         )));
-        assert!(should_retry_unchanged_tool_call(&Error::Internal(
+        assert!(!should_retry_unchanged_tool_call(&Error::Internal(
             "uncategorized execution failure".into()
+        )));
+        assert!(!should_retry_unchanged_tool_call(&Error::ToolExecution(
+            ToolError::not_found("stale ref")
         )));
         assert!(!should_retry_unchanged_tool_call(&Error::Auth(
             "permission denied".into()
         )));
+    }
+
+    #[tokio::test]
+    async fn malformed_browser_call_is_not_retried() {
+        let browser = rustykrab_tools::BrowserTool::new();
+        let error = browser
+            .execute(serde_json::json!({ "action": "act", "ref": "e12" }))
+            .await
+            .expect_err("act without actAction must fail before browser I/O");
+
+        assert_eq!(error.kind(), ToolErrorKind::InvalidInput);
+        assert!(!should_retry_unchanged_tool_call(&error));
+
+        let (output, _) = tool_error_output(&error);
+        assert_eq!(output["error_kind"], "invalid_input");
+        assert_eq!(output["retryable"], false);
+        assert!(output["error"].as_str().unwrap().contains("actAction"));
     }
 }
 

--- a/crates/rustykrab-core/src/schema_validate.rs
+++ b/crates/rustykrab-core/src/schema_validate.rs
@@ -6,9 +6,10 @@
 //! self-correct on the next round without re-reading the full schema.
 //!
 //! Only the subset of JSON Schema actually used by tools in this workspace
-//! is implemented: top-level `properties`, `required`, per-field `type`,
-//! and `enum`. Nested object/array validation is intentionally skipped —
-//! tools that need deeper checks keep doing them in `execute()`.
+//! is implemented: top-level `properties`, `required`, per-field `type` and
+//! `enum`, plus `allOf` clauses with `if`/`then` conditional requirements.
+//! Nested object/array validation is intentionally skipped — tools that need
+//! deeper checks keep doing them in `execute()`.
 
 use serde_json::Value;
 
@@ -19,13 +20,12 @@ use crate::error::ToolError;
 /// Returns an `InvalidInput` [`ToolError`] with a message the model can act
 /// on (enumerating valid enum values, naming the expected type, etc.).
 pub fn validate_tool_args(parameters: &Value, args: &Value) -> Result<(), ToolError> {
+    let empty_args = serde_json::Map::new();
     let args_obj = match args {
         Value::Object(map) => map,
-        Value::Null => {
-            // Treat missing args as an empty object so the required-field
-            // check below produces the right message.
-            return validate_required(parameters, &serde_json::Map::new());
-        }
+        // Treat missing args as an empty object so required-field checks
+        // produce the same useful message as an explicit `{}`.
+        Value::Null => &empty_args,
         other => {
             return Err(ToolError::invalid_input(format!(
                 "arguments must be a JSON object, got {}",
@@ -35,6 +35,7 @@ pub fn validate_tool_args(parameters: &Value, args: &Value) -> Result<(), ToolEr
     };
 
     validate_required(parameters, args_obj)?;
+    validate_conditional_requirements(parameters, args_obj)?;
 
     if let Some(properties) = parameters.get("properties").and_then(Value::as_object) {
         for (field_name, field_value) in args_obj {
@@ -52,10 +53,25 @@ fn validate_required(
     parameters: &Value,
     args_obj: &serde_json::Map<String, Value>,
 ) -> Result<(), ToolError> {
-    let Some(required) = parameters.get("required").and_then(Value::as_array) else {
+    validate_required_with_properties(
+        parameters,
+        args_obj,
+        parameters.get("properties").and_then(Value::as_object),
+    )
+}
+
+fn validate_required_with_properties(
+    schema: &Value,
+    args_obj: &serde_json::Map<String, Value>,
+    fallback_properties: Option<&serde_json::Map<String, Value>>,
+) -> Result<(), ToolError> {
+    let Some(required) = schema.get("required").and_then(Value::as_array) else {
         return Ok(());
     };
-    let properties = parameters.get("properties").and_then(Value::as_object);
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .or(fallback_properties);
 
     for req in required {
         let Some(name) = req.as_str() else { continue };
@@ -75,6 +91,76 @@ fn validate_required(
         return Err(ToolError::invalid_input(msg));
     }
     Ok(())
+}
+
+/// Apply the conditional required-field clauses used by polymorphic tools.
+///
+/// This deliberately implements a small, predictable JSON-Schema subset:
+/// each `allOf` entry may contain `if` plus `then`/`else`, and conditions may
+/// inspect `required`, `properties.const`, `properties.enum`, and
+/// `properties.type`. That covers the schemas currently emitted by the
+/// workspace without turning tool dispatch into a second schema engine.
+fn validate_conditional_requirements(
+    parameters: &Value,
+    args_obj: &serde_json::Map<String, Value>,
+) -> Result<(), ToolError> {
+    let Some(clauses) = parameters.get("allOf").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    let root_properties = parameters.get("properties").and_then(Value::as_object);
+
+    for clause in clauses {
+        if let Some(condition) = clause.get("if") {
+            let branch = if condition_matches(condition, args_obj) {
+                clause.get("then")
+            } else {
+                clause.get("else")
+            };
+            if let Some(branch) = branch {
+                validate_required_with_properties(branch, args_obj, root_properties)?;
+            }
+        } else {
+            validate_required_with_properties(clause, args_obj, root_properties)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn condition_matches(condition: &Value, args_obj: &serde_json::Map<String, Value>) -> bool {
+    if let Some(required) = condition.get("required").and_then(Value::as_array) {
+        for field in required.iter().filter_map(Value::as_str) {
+            if !args_obj.contains_key(field) {
+                return false;
+            }
+        }
+    }
+
+    let Some(properties) = condition.get("properties").and_then(Value::as_object) else {
+        return true;
+    };
+    for (name, field_schema) in properties {
+        // JSON Schema's `properties` keyword does not itself require a field.
+        let Some(value) = args_obj.get(name) else {
+            continue;
+        };
+        if let Some(expected) = field_schema.get("const") {
+            if value != expected {
+                return false;
+            }
+        }
+        if let Some(allowed) = field_schema.get("enum").and_then(Value::as_array) {
+            if !allowed.iter().any(|candidate| candidate == value) {
+                return false;
+            }
+        }
+        if let Some(expected_type) = field_schema.get("type").and_then(Value::as_str) {
+            if !value_matches_type(value, expected_type) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn validate_field(name: &str, field_schema: &Value, value: &Value) -> Result<(), ToolError> {
@@ -284,5 +370,67 @@ mod tests {
     fn valid_call_succeeds() {
         let args = json!({ "action": "create", "schedule": "0 9 * * *" });
         validate_tool_args(&cron_schema(), &args).unwrap();
+    }
+
+    #[test]
+    fn conditional_required_fields_are_enforced() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "action": { "type": "string", "enum": ["act", "evaluate", "snapshot"] },
+                "actAction": { "type": "string", "enum": ["click", "type"] },
+                "expression": { "type": "string" }
+            },
+            "required": ["action"],
+            "allOf": [
+                {
+                    "if": { "properties": { "action": { "const": "act" } }, "required": ["action"] },
+                    "then": { "required": ["actAction"] }
+                },
+                {
+                    "if": { "properties": { "action": { "const": "evaluate" } }, "required": ["action"] },
+                    "then": { "required": ["expression"] }
+                }
+            ]
+        });
+
+        let act_err = validate_tool_args(&schema, &json!({ "action": "act" })).unwrap_err();
+        assert_eq!(act_err.kind, crate::error::ToolErrorKind::InvalidInput);
+        assert!(act_err.message.contains("'actAction'"), "{act_err}");
+        assert!(act_err.message.contains("'click'"), "{act_err}");
+
+        let eval_err = validate_tool_args(&schema, &json!({ "action": "evaluate" })).unwrap_err();
+        assert!(eval_err.message.contains("'expression'"), "{eval_err}");
+
+        validate_tool_args(&schema, &json!({ "action": "snapshot" })).unwrap();
+        validate_tool_args(&schema, &json!({ "action": "act", "actAction": "click" })).unwrap();
+    }
+
+    #[test]
+    fn conditional_enum_matches_multiple_values() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "action": { "type": "string" },
+                "actAction": { "type": "string" },
+                "text": { "type": "string" }
+            },
+            "required": ["action"],
+            "allOf": [{
+                "if": {
+                    "properties": {
+                        "action": { "const": "act" },
+                        "actAction": { "enum": ["type", "fill"] }
+                    },
+                    "required": ["action", "actAction"]
+                },
+                "then": { "required": ["text"] }
+            }]
+        });
+
+        let err = validate_tool_args(&schema, &json!({ "action": "act", "actAction": "fill" }))
+            .unwrap_err();
+        assert!(err.message.contains("'text'"), "{err}");
+        validate_tool_args(&schema, &json!({ "action": "act", "actAction": "click" })).unwrap();
     }
 }

--- a/crates/rustykrab-tools/src/browser/mod.rs
+++ b/crates/rustykrab-tools/src/browser/mod.rs
@@ -23,7 +23,7 @@ use base64::Engine;
 use chromiumoxide::cdp::browser_protocol::network::Cookie;
 use chromiumoxide::page::ScreenshotParams;
 use rustykrab_core::types::ToolSchema;
-use rustykrab_core::{Error, Result, SandboxRequirements, Tool};
+use rustykrab_core::{Error, Result, SandboxRequirements, Tool, ToolError};
 use serde_json::{json, Value};
 
 use crate::security;
@@ -92,7 +92,7 @@ fn schema_parameters() -> serde_json::Value {
                     "fetch", "stealth_fetch", "select", "wait_for",
                     "fill_credential"
                 ],
-                "description": "Action to perform"
+                "description": "Action to perform. Required companion fields: open/navigate/fetch/stealth_fetch -> url; close/focus -> targetId; act -> ref + actAction; fill_credential -> ref; evaluate -> expression. Act sub-actions have additional requirements documented on actAction."
             },
             "field": {
                 "type": "string",
@@ -104,7 +104,7 @@ fn schema_parameters() -> serde_json::Value {
             },
             "url": {
                 "type": "string",
-                "description": "URL to navigate to or open (navigate/open actions)"
+                "description": "Required for open, navigate, fetch, and stealth_fetch"
             },
             "targetId": {
                 "type": "string",
@@ -112,28 +112,28 @@ fn schema_parameters() -> serde_json::Value {
             },
             "ref": {
                 "type": "string",
-                "description": "Element ref from a snapshot (e.g., '12' or 'e12'). Used by 'act' action"
+                "description": "Element ref from a snapshot (e.g., '12' or 'e12'). Required for act and fill_credential"
             },
             "actAction": {
                 "type": "string",
                 "enum": ["click", "type", "fill", "press", "hover", "select", "drag", "wait", "fill_credential"],
-                "description": "Sub-action for 'act' (e.g., click, type, press). Requires 'ref' from snapshot. 'fill_credential' fills a stored credential without its value passing through you — set 'field' to 'username' or 'password'; do not put the secret in 'text'"
+                "description": "Required when action='act'; every act also requires ref. Companion fields: type/fill -> text; press -> key; select -> value; drag -> targetRef. fill_credential uses field='username' or 'password' and never text, so the stored secret does not pass through you."
             },
             "text": {
                 "type": "string",
-                "description": "Text to type (act type/fill action)"
+                "description": "Required for actAction='type' or 'fill'"
             },
             "key": {
                 "type": "string",
-                "description": "Key to press (act press action, e.g., 'Enter', 'Tab', 'Escape')"
+                "description": "Required for actAction='press' (e.g., 'Enter', 'Tab', 'Escape')"
             },
             "value": {
                 "type": "string",
-                "description": "Value to select (act select action)"
+                "description": "Required for actAction='select'"
             },
             "targetRef": {
                 "type": "string",
-                "description": "Target element ref for drag action"
+                "description": "Required target element ref for actAction='drag'"
             },
             "clear": {
                 "type": "boolean",
@@ -145,7 +145,7 @@ fn schema_parameters() -> serde_json::Value {
             },
             "expression": {
                 "type": "string",
-                "description": "JavaScript to evaluate (evaluate action)"
+                "description": "Required when action='evaluate'; JavaScript to evaluate"
             },
             "format": {
                 "type": "string",
@@ -338,7 +338,84 @@ fn schema_parameters() -> serde_json::Value {
                 "description": "wait_for/stealth_fetch: extra delay in ms after other waits resolve"
             }
         },
-        "required": ["action"]
+        "required": ["action"],
+        "allOf": [
+            {
+                "if": {
+                    "properties": { "action": { "enum": ["open", "navigate", "fetch", "stealth_fetch"] } },
+                    "required": ["action"]
+                },
+                "then": { "required": ["url"] }
+            },
+            {
+                "if": {
+                    "properties": { "action": { "enum": ["close", "focus"] } },
+                    "required": ["action"]
+                },
+                "then": { "required": ["targetId"] }
+            },
+            {
+                "if": {
+                    "properties": { "action": { "const": "act" } },
+                    "required": ["action"]
+                },
+                "then": { "required": ["ref", "actAction"] }
+            },
+            {
+                "if": {
+                    "properties": {
+                        "action": { "const": "act" },
+                        "actAction": { "enum": ["type", "fill"] }
+                    },
+                    "required": ["action", "actAction"]
+                },
+                "then": { "required": ["text"] }
+            },
+            {
+                "if": {
+                    "properties": {
+                        "action": { "const": "act" },
+                        "actAction": { "const": "press" }
+                    },
+                    "required": ["action", "actAction"]
+                },
+                "then": { "required": ["key"] }
+            },
+            {
+                "if": {
+                    "properties": {
+                        "action": { "const": "act" },
+                        "actAction": { "const": "select" }
+                    },
+                    "required": ["action", "actAction"]
+                },
+                "then": { "required": ["value"] }
+            },
+            {
+                "if": {
+                    "properties": {
+                        "action": { "const": "act" },
+                        "actAction": { "const": "drag" }
+                    },
+                    "required": ["action", "actAction"]
+                },
+                "then": { "required": ["targetRef"] }
+            },
+            {
+                "if": {
+                    "properties": { "action": { "const": "fill_credential" } },
+                    "required": ["action"]
+                },
+                "then": { "required": ["ref"] }
+            },
+            {
+                "if": {
+                    "properties": { "action": { "const": "evaluate" } },
+                    "required": ["action"]
+                },
+                "then": { "required": ["expression"] }
+            }
+        ]
     })
 }
 
@@ -380,6 +457,73 @@ impl BrowserTool {
     pub fn with_secrets(mut self, secrets: rustykrab_store::GuardedSecrets) -> Self {
         self.secrets = Some(secrets);
         self
+    }
+
+    /// Validate action-specific arguments before touching a browser process.
+    ///
+    /// The schema exposes these requirements to the model and runner. This
+    /// runtime guard also protects direct `Tool::execute` callers and rejects
+    /// empty strings, which JSON Schema's `required` keyword cannot detect.
+    fn validate_action_args(action: &str, args: &Value) -> Result<()> {
+        fn require_non_empty(args: &Value, field: &str, action: &str) -> Result<()> {
+            if args
+                .get(field)
+                .and_then(Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+            {
+                return Ok(());
+            }
+            Err(Error::ToolExecution(ToolError::invalid_input(format!(
+                "browser action '{action}' requires non-empty '{field}'"
+            ))))
+        }
+
+        match action {
+            "open" | "navigate" | "fetch" | "stealth_fetch" => {
+                require_non_empty(args, "url", action)?;
+            }
+            "close" | "focus" => require_non_empty(args, "targetId", action)?,
+            "act" => {
+                require_non_empty(args, "ref", action)?;
+                require_non_empty(args, "actAction", action)?;
+                match args["actAction"].as_str().unwrap_or_default() {
+                    "type" => require_non_empty(args, "text", "act/type")?,
+                    "fill" => require_non_empty(args, "text", "act/fill")?,
+                    "press" => require_non_empty(args, "key", "act/press")?,
+                    "select" => require_non_empty(args, "value", "act/select")?,
+                    "drag" => require_non_empty(args, "targetRef", "act/drag")?,
+                    "click" | "hover" | "wait" | "fill_credential" => {}
+                    other => {
+                        return Err(Error::ToolExecution(ToolError::invalid_input(format!(
+                            "unknown act action '{other}'. Available: click, type, fill, press, hover, select, drag, wait, fill_credential"
+                        ))));
+                    }
+                }
+            }
+            "fill_credential" => require_non_empty(args, "ref", action)?,
+            "evaluate" => require_non_empty(args, "expression", action)?,
+            "wait_for" => {
+                let has_condition = args["wait_selector"]
+                    .as_str()
+                    .is_some_and(|value| !value.trim().is_empty())
+                    || args["network_idle"].as_bool().unwrap_or(false)
+                    || args["solve_cloudflare"].as_bool().unwrap_or(false)
+                    || args["delay_ms"].as_u64().is_some();
+                if !has_condition {
+                    return Err(Error::ToolExecution(ToolError::invalid_input(
+                        "browser action 'wait_for' requires at least one of: wait_selector, network_idle, solve_cloudflare, delay_ms",
+                    )));
+                }
+            }
+            "status" | "start" | "stop" | "profiles" | "tabs" | "snapshot" | "screenshot"
+            | "content" | "scroll" | "console" | "cookies" | "pdf" | "select" => {}
+            other => {
+                return Err(Error::ToolExecution(ToolError::invalid_input(format!(
+                    "unknown browser action '{other}'"
+                ))));
+            }
+        }
+        Ok(())
     }
 
     /// Resolve the profile name from args, falling back to the default.
@@ -583,9 +727,11 @@ impl Tool for BrowserTool {
     }
 
     async fn execute(&self, args: Value) -> Result<Value> {
-        let action = args["action"]
-            .as_str()
-            .ok_or_else(|| Error::ToolExecution("missing 'action' parameter".into()))?;
+        let action = args["action"].as_str().ok_or_else(|| {
+            Error::ToolExecution(ToolError::invalid_input("missing 'action' parameter"))
+        })?;
+
+        Self::validate_action_args(action, &args)?;
 
         let action = effective_action(action, &args);
 
@@ -1448,6 +1594,85 @@ impl Tool for BrowserTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn schema_enforces_action_specific_arguments() {
+        let parameters = schema_parameters();
+
+        let act_err = rustykrab_core::validate_tool_args(
+            &parameters,
+            &json!({ "action": "act", "ref": "e12" }),
+        )
+        .expect_err("act without actAction must fail schema validation");
+        assert_eq!(act_err.kind, rustykrab_core::ToolErrorKind::InvalidInput);
+        assert!(act_err.message.contains("'actAction'"), "{act_err}");
+        assert!(act_err.message.contains("'click'"), "{act_err}");
+
+        let evaluate_err =
+            rustykrab_core::validate_tool_args(&parameters, &json!({ "action": "evaluate" }))
+                .expect_err("evaluate without expression must fail schema validation");
+        assert!(
+            evaluate_err.message.contains("'expression'"),
+            "{evaluate_err}"
+        );
+
+        let type_err = rustykrab_core::validate_tool_args(
+            &parameters,
+            &json!({ "action": "act", "ref": "e12", "actAction": "type" }),
+        )
+        .expect_err("act/type without text must fail schema validation");
+        assert!(type_err.message.contains("'text'"), "{type_err}");
+
+        rustykrab_core::validate_tool_args(
+            &parameters,
+            &json!({ "action": "act", "ref": "e12", "actAction": "fill_credential" }),
+        )
+        .expect("fill_credential must not require text");
+        rustykrab_core::validate_tool_args(&parameters, &json!({ "action": "snapshot" }))
+            .expect("actions without conditional arguments must remain valid");
+    }
+
+    #[test]
+    fn schema_describes_companion_arguments_for_the_model() {
+        let parameters = schema_parameters();
+        let act_description = parameters["properties"]["actAction"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(act_description.contains("type/fill -> text"));
+        assert!(act_description.contains("press -> key"));
+        assert!(act_description.contains("drag -> targetRef"));
+
+        let expression_description = parameters["properties"]["expression"]["description"]
+            .as_str()
+            .unwrap();
+        assert!(expression_description.contains("Required when action='evaluate'"));
+    }
+
+    #[tokio::test]
+    async fn malformed_action_arguments_are_typed_invalid_input() {
+        let tool = BrowserTool::with_config(config::BrowserConfig::default());
+        for (args, missing_field) in [
+            (json!({ "action": "act", "ref": "e12" }), "actAction"),
+            (json!({ "action": "evaluate" }), "expression"),
+            (json!({ "action": "navigate" }), "url"),
+        ] {
+            let err = tool
+                .execute(args)
+                .await
+                .expect_err("malformed action must fail before browser I/O");
+            match err {
+                Error::ToolExecution(tool_err) => {
+                    assert_eq!(tool_err.kind, rustykrab_core::ToolErrorKind::InvalidInput);
+                    assert!(
+                        tool_err.message.contains(missing_field),
+                        "{}",
+                        tool_err.message
+                    );
+                }
+                other => panic!("expected ToolExecution, got {other}"),
+            }
+        }
+    }
 
     #[test]
     fn read_on_a_blank_tab_is_an_error() {


### PR DESCRIPTION
## Summary
- advertise and enforce action-specific browser arguments, including `actAction`, `expression`, and action-specific companion fields
- return typed `InvalidInput` failures before browser I/O so the model receives actionable, non-retryable feedback
- retry only explicitly transient or rate-limited tool failures, preventing identical malformed browser calls from repeating
- cover the current `fill_credential` action and subaction behavior

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace`