### PR TITLE
fix(release): keep lockfile reproducible after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
+      should_release: ${{ steps.release-owner.outputs.should_release }}
       version: ${{ steps.bump.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}
     steps:
@@ -46,13 +47,35 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Select release owner
+        id: release-owner
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || '' }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch origin main
+          MAIN_TIP=$(git rev-parse origin/main)
+          if [ "$MAIN_TIP" = "$MERGE_SHA" ]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping release for a non-tip member of an atomic PR stack merge."
+          fi
+
       - name: Configure git
+        if: steps.release-owner.outputs.should_release == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Determine bump type
         id: bump-type
+        if: steps.release-owner.outputs.should_release == 'true'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "bump=${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
@@ -69,6 +92,7 @@ jobs:
 
       - name: Bump version
         id: bump
+        if: steps.release-owner.outputs.should_release == 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title || 'Manual release' }}
           PR_NUMBER: ${{ github.event.pull_request.number || '0' }}
@@ -89,7 +113,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Verify reproducible lockfile
+        if: steps.release-owner.outputs.should_release == 'true'
+        run: |
+          cargo metadata --format-version 1 >/dev/null
+          git diff --exit-code -- Cargo.lock
+
       - name: Push version commit and tag
+        if: steps.release-owner.outputs.should_release == 'true'
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -105,6 +136,7 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     needs: bump
+    if: needs.bump.outputs.should_release == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -347,6 +379,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [bump, build]
+    if: needs.bump.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustykrab-agent"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-channels"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-cli"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-core"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-dream"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-e2e"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "anyhow",
  "axum",
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-gateway"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-memory"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4268,7 +4268,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-projects"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "chrono",
  "hex",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-providers"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-runtime"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-skills"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-store"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "rustykrab-tools"
-version = "5.2.28"
+version = "5.2.29"
 dependencies = [
  "async-imap",
  "async-trait",

--- a/docs/architecture/06-release-pipeline.md
+++ b/docs/architecture/06-release-pipeline.md
@@ -1,0 +1,52 @@
+# Release pipeline
+
+## Responsibility
+
+`.github/workflows/release.yml` turns a merged pull request or an explicit
+manual dispatch into one versioned release. `scripts/release.sh` owns the
+deterministic repository mutation: workspace version, changelog entry,
+`Cargo.lock`, commit, and annotated tag. The workflow owns GitHub credentials,
+pushes, cross-platform builds, signing, notarization, artifacts, and the GitHub
+Release object.
+
+The merge-triggered path amends the merge commit and force-pushes with a lease,
+so the version and changelog describe the exact released tree. A manual release
+uses a separate release commit because it does not own an existing pull-request
+merge commit.
+
+## Atomic-stack ownership
+
+An atomic GitHub stack merge closes every member pull request and therefore
+starts one workflow per member. Only the top member represents the final tree.
+Before any repository mutation, each run fetches `origin/main` and compares its
+event's `merge_commit_sha` with the current main tip. The matching run becomes
+the release owner; non-tip members report a notice and skip bump, build, and
+publication. A manual dispatch is always its own release owner.
+
+This gate is deliberately before the version bump. Relying on concurrent
+`--force-with-lease` pushes would make one run win accidentally while every
+other run failed, and serializing those runs would incorrectly publish one
+version per stack layer.
+
+## Reproducibility invariant
+
+Workspace package versions are materialized in both `Cargo.toml` and
+`Cargo.lock`. After changing `Cargo.toml`, the release script runs full
+`cargo metadata --format-version 1`; this resolves the lockfile without
+compiling dependencies or requiring their native build libraries. The workflow
+then runs the same resolution after the amended commit and fails if
+`git diff --exit-code -- Cargo.lock` observes any drift.
+
+The script uses `awk` plus same-directory temporary files for version and
+changelog edits. That keeps the documented local path portable between GNU and
+BSD/macOS userlands; GNU-only `sed -i` semantics are not part of the contract.
+
+## Failure boundaries
+
+- A dependency-resolution failure stops before commit or tag creation.
+- A dirty lockfile after the commit stops before pushing `main`.
+- The leased push stops rather than overwriting an unexpected newer main tip.
+- Release builds use the emitted tag, not a moving branch.
+- The macOS leg verifies its code signature before publishing and notarizes
+  when the Apple credentials are configured.
+- The GitHub Release is created only after both target builds complete.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -18,6 +18,7 @@ of the code holds; the judgement is one reviewer's opinion at one point in time.
 | [`02-extension-seams.md`](02-extension-seams.md) | Every trait/abstraction in the system, who implements it, and whether it earns its keep |
 | [`03-dead-code-audit.md`](03-dead-code-audit.md) | The unreferenced items, what each is for, and whether to wire or delete it |
 | [`05-first-pass-outcome.md`](05-first-pass-outcome.md) | Which first-pass findings were acted on, and which were wrong |
+| [`06-release-pipeline.md`](06-release-pipeline.md) | Merge-triggered versioning, stack ownership, reproducibility, build, signing, and publication |
 
 Per-component detail lives next to the code, one file per crate:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,7 +20,8 @@
 #   2. Computes the next version (or uses the one you gave)
 #   3. Updates workspace version in Cargo.toml
 #   4. Moves "Unreleased" entries in CHANGELOG.md under a new version heading
-#   5. Runs `cargo check` to regenerate Cargo.lock (skipped in --ci mode)
+#   5. Resolves workspace metadata to regenerate Cargo.lock without compiling
+#      native dependencies (local releases also run a best-effort cargo check)
 #   6. Commits (or amends HEAD with --amend) and tags as v<version>
 #
 # After running locally, push with:
@@ -80,7 +81,15 @@ NEXT="${MAJOR}.${MINOR}.${PATCH}"
 echo "Bumping version: $CURRENT -> $NEXT"
 
 # --- Update Cargo.toml workspace version ---
-sed -i "s/^version = \"$CURRENT\"/version = \"$NEXT\"/" "$CARGO_TOML"
+awk -v current="$CURRENT" -v next_version="$NEXT" '
+    $0 == "version = \"" current "\"" && !updated {
+        print "version = \"" next_version "\""
+        updated = 1
+        next
+    }
+    { print }
+    END { if (!updated) exit 1 }
+' "$CARGO_TOML" > "${CARGO_TOML}.tmp" && mv "${CARGO_TOML}.tmp" "$CARGO_TOML"
 echo "  Updated $CARGO_TOML"
 
 # --- Update CHANGELOG.md ---
@@ -111,14 +120,28 @@ if [ "$CI_MODE" = true ] && [ -n "$PR_TITLE" ]; then
     ' "$CHANGELOG" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "$CHANGELOG"
 else
     # Local: just promote the [Unreleased] section to the new version heading
-    sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEXT] - $DATE/" "$CHANGELOG"
+    awk -v ver="$NEXT" -v date="$DATE" '
+        /^## \[Unreleased\]/ {
+            print
+            print ""
+            printf "## [%s] - %s\n", ver, date
+            next
+        }
+        { print }
+    ' "$CHANGELOG" > "${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "$CHANGELOG"
 fi
 echo "  Updated $CHANGELOG"
 
-# --- Regenerate Cargo.lock (local only — CI may not have all native deps) ---
+# --- Regenerate Cargo.lock without compiling native dependencies ---
+# Workspace package versions are recorded in Cargo.lock. This must run in CI
+# too; otherwise the merge-time version bump leaves the first subsequent Cargo
+# command with a dirty worktree. `cargo metadata` resolves the lockfile but does
+# not build dependencies that may require unavailable native libraries.
+(cd "$REPO_ROOT" && cargo metadata --format-version 1 >/dev/null)
+echo "  Cargo.lock updated"
+
 if [ "$CI_MODE" = false ]; then
     (cd "$REPO_ROOT" && cargo check --quiet 2>/dev/null) || true
-    echo "  Cargo.lock updated"
 fi
 
 # --- Commit and tag ---


### PR DESCRIPTION
## Functional promise

Make merge-triggered releases reproducible after a workspace version bump and ensure an atomic GitHub stack merge produces exactly one release owner instead of one competing workflow per stack member.

## What changed

- Updates all 14 workspace package versions in `Cargo.lock` from 5.2.28 to the merged workspace version 5.2.29.
- Makes `scripts/release.sh` run full `cargo metadata --format-version 1` in CI, refreshing the lockfile without compiling native dependencies.
- Replaces GNU-only `sed -i` mutations with portable `awk` plus same-directory temporary files for macOS/BSD and Linux compatibility.
- Adds a workflow post-bump negative control: rerun metadata resolution and fail if `Cargo.lock` changes.
- Adds a release-owner gate: for PR merges, only the run whose `merge_commit_sha` equals current `origin/main` may bump, build, or publish. Non-tip atomic-stack members exit successfully with a notice.
- Documents release ownership, reproducibility, signing, publication, and failure boundaries in `docs/architecture/06-release-pipeline.md`.

## Exact validation evidence

Validated exact head: `16808bf14eb3f1e1193ef749aaea7ed8bff5146f`

- `bash -n scripts/release.sh` — passed.
- Ruby YAML parser loaded `.github/workflows/release.yml` successfully.
- `python3 scripts/check_architecture_docs.py` — 14 crates documented, metrics current.
- `cargo metadata --format-version 1` followed by `git diff --exit-code -- Cargo.lock` — passed and left the checkout clean.
- `git diff --check` — passed.

Isolated release simulation:

- Cloned the hotfix locally with independent refs and configured a throwaway Git identity.
- Ran `./scripts/release.sh patch --ci --amend --pr-title 'Release lockfile test' --pr-number 999` from workspace version 5.2.29.
- Observed version 5.2.30 in `Cargo.toml` and all 14 workspace package records in `Cargo.lock` (15 matching records total).
- Observed the expected v5.2.30 changelog entry, amended commit, and annotated `v5.2.30` tag.
- Reran full Cargo metadata resolution; `Cargo.lock` remained unchanged and the isolated checkout was clean.
- Exact-head blob identity confirms `16808bf` contains the same tested `release.sh` and `Cargo.lock` objects; its later changes are the ownership workflow and architecture document.

Observed production failure this prevents:

- Atomic Stack #614 launched five Release workflows at 08:10 UTC—one per merged PR.
- The top #609 run successfully published v5.2.29; the other four all failed at `git push --force-with-lease origin main` with `stale info`.
- Building merged main then changed all 14 workspace package versions in `Cargo.lock`, proving the version-bump commit was not reproducible.

## Scope

No runtime application behavior changes. This PR repairs repository release/deployment control and its architecture record.
