### PR TITLE
ci(actions): move workflow runtime to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check & Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -31,7 +31,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
@@ -40,7 +40,7 @@ jobs:
     name: Architecture Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Guards the facts in docs/architecture and crates/*/ARCHITECTURE.md:
       # generated metrics match the tree, every crate is documented, and the
       # crate count in prose is right. Two structural docs had already
@@ -51,7 +51,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -67,7 +67,7 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
     name: E2E Evaluation Harness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       # Builds with --no-default-features (no ONNX runtime download), boots
@@ -88,7 +88,7 @@ jobs:
           E2E_ARTIFACT_DIR: e2e-artifacts
       - name: Upload scenario evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,12 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -158,7 +158,7 @@ jobs:
             glibc: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.bump.outputs.tag }}
 
@@ -191,6 +191,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          save-if: false
 
       - name: Install zig
         if: matrix.glibc != ''
@@ -370,7 +371,7 @@ jobs:
           shasum -a 256 dist/rustykrab-${{ matrix.target }}.* > \
             "dist/rustykrab-${{ matrix.target }}.sha256"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: rustykrab-${{ matrix.target }}
           path: dist/rustykrab-${{ matrix.target }}.tar.gz
@@ -382,11 +383,11 @@ jobs:
     if: needs.bump.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.bump.outputs.tag }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/docs/architecture/06-release-pipeline.md
+++ b/docs/architecture/06-release-pipeline.md
@@ -41,6 +41,17 @@ The script uses `awk` plus same-directory temporary files for version and
 changelog edits. That keeps the documented local path portable between GNU and
 BSD/macOS userlands; GNU-only `sed -i` semantics are not part of the contract.
 
+Workflow repository access uses the Node 24-based `actions/checkout@v7`; the
+release writer obtains its short-lived installation credential through the
+Node 24-based `actions/create-github-app-token@v3`. GitHub-hosted runners are
+the supported execution environment, so the action majors and runner runtime
+advance together instead of relying on GitHub's temporary Node 20 shim.
+Evidence and release bundles use `actions/upload-artifact@v7`, and publication
+uses `actions/download-artifact@v8` with digest mismatches failing by default.
+Release builds restore Rust caches but set `save-if: false`: the workflow's
+least-privilege token cannot write Actions caches, and a successful release
+must not end with a knowingly unauthorized post-job write attempt.
+
 ## Failure boundaries
 
 - A dependency-resolution failure stops before commit or tag creation.


### PR DESCRIPTION
## Functional promise

Remove the Node 20 compatibility shim from CI and release workflows by moving repository-access actions to their supported Node 24 majors.

## What changed

- Upgrades all nine `actions/checkout` uses across CI and release from v4 to v7.
- Upgrades `actions/create-github-app-token` from v1 to v3.
- Upgrades both `actions/upload-artifact` uses from v4 to v7 and the release `actions/download-artifact` use from v4 to v8.
- Makes release Rust caching explicitly restore-only (`save-if: false`) because the least-privilege release token cannot authorize cache writes.
- Records the action-runtime ownership decision in `docs/architecture/06-release-pipeline.md`.

## Why

The successful v5.2.30 Release run emitted a GitHub warning that the v4 checkout and v1 app-token actions target deprecated Node 20 and were being forcibly run under Node 24. GitHub's official action repositories document `actions/checkout@v7` as current and `actions/create-github-app-token@v3` as Node 24-based. This repository runs on GitHub-hosted runners, so their current action majors are supported.

## Exact validation evidence

Validated exact head: `d8bf37a2b77497739682f34499424fcf604dbf8c`

- Ruby parsed both workflow YAML files successfully.
- `rg` found six CI and three Release checkout uses, all at `actions/checkout@v7`.
- `rg` found the release credential action at `actions/create-github-app-token@v3`.
- `rg` found both upload uses at `actions/upload-artifact@v7` and release download at `actions/download-artifact@v8`.
- Negative search found zero old checkout, app-token, upload, or download action majors under `.github/workflows`.
- `python3 scripts/check_architecture_docs.py` — 14 crates documented, metrics current.
- `git diff --check` — passed.

Hosted CI on this PR is the behavioral compatibility test: every job must successfully initialize `checkout@v7`, and E2E must upload its evidence through `upload-artifact@v7`. The subsequent merge-triggered Release run must also initialize `create-github-app-token@v3`, select the release owner, verify the lockfile, build and upload both targets, download them with digest enforcement, and publish without the prior Node 20 or unauthorized cache-write annotations.

## Scope

No runtime application behavior or dependencies change.
