### PR TITLE
ci(release): remove remaining Node 20 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,11 +193,22 @@ jobs:
           key: ${{ matrix.target }}
           save-if: false
 
-      - name: Install zig
+      - name: Install Zig
         if: matrix.glibc != ''
-        uses: mlugg/setup-zig@v1
-        with:
-          version: 0.13.0
+        env:
+          ZIG_URL: https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+          ZIG_SHA256: d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea
+        run: |
+          set -euxo pipefail
+          ZIG_ARCHIVE="${RUNNER_TEMP}/zig-0.13.0.tar.xz"
+          ZIG_DIR="${RUNNER_TEMP}/zig-0.13.0"
+          curl --proto '=https' --tlsv1.2 -fsSL "$ZIG_URL" -o "$ZIG_ARCHIVE"
+          echo "${ZIG_SHA256}  ${ZIG_ARCHIVE}" | sha256sum --check -
+          mkdir -p "$ZIG_DIR"
+          tar --extract --xz --file "$ZIG_ARCHIVE" \
+            --directory "$ZIG_DIR" --strip-components=1
+          "$ZIG_DIR/zig" version
+          echo "$ZIG_DIR" >> "$GITHUB_PATH"
 
       - name: Install cargo-zigbuild
         if: matrix.glibc != ''
@@ -399,7 +410,7 @@ jobs:
             CHANGELOG.md > release_notes.md
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.bump.outputs.tag }}
           body_path: release_notes.md

--- a/docs/architecture/06-release-pipeline.md
+++ b/docs/architecture/06-release-pipeline.md
@@ -47,10 +47,15 @@ Node 24-based `actions/create-github-app-token@v3`. GitHub-hosted runners are
 the supported execution environment, so the action majors and runner runtime
 advance together instead of relying on GitHub's temporary Node 20 shim.
 Evidence and release bundles use `actions/upload-artifact@v7`, and publication
-uses `actions/download-artifact@v8` with digest mismatches failing by default.
-Release builds restore Rust caches but set `save-if: false`: the workflow's
-least-privilege token cannot write Actions caches, and a successful release
-must not end with a knowingly unauthorized post-job write attempt.
+uses `actions/download-artifact@v8` with digest mismatches failing by default;
+`softprops/action-gh-release@v3` publishes through its Node 24 runtime. The
+Linux cross-build downloads Zig 0.13.0 directly from Zig's versioned HTTPS
+archive and verifies its pinned SHA-256 digest before adding it to `PATH`. This
+avoids delegating a release toolchain install to an action whose maintained
+versions still declare Node 20. Release builds restore Rust caches but set
+`save-if: false`: the workflow's least-privilege token cannot write Actions
+caches, and a successful release must not end with a knowingly unauthorized
+post-job write attempt.
 
 ## Failure boundaries
 


### PR DESCRIPTION
## Outcome

Removes the final two Node 20 action-runtime warnings observed in the v5.2.31
release while keeping the Linux cross-build toolchain pinned and checksum
verified.

## Changes

- replaces `mlugg/setup-zig@v1` with a direct HTTPS download of Zig 0.13.0
- pins and verifies Zig's official SHA-256 digest before adding it to `PATH`
- upgrades release publication from `softprops/action-gh-release@v2` to `@v3`
- updates the release architecture contract with both decisions

## Causal evidence

The successful v5.2.31 release run
https://github.com/gcbh/rustykrab/actions/runs/33854766851 reported Node 20
annotations for exactly these two actions. Inspection of the maintainers'
published metadata showed:

- current `mlugg/setup-zig` v2.2.1 still declares `runs.using: node20`, so a
  major-version-only update would preserve the warning
- current `softprops/action-gh-release` v3 declares `runs.using: node24`

## Validation

Validated exact head `7f938b3b6e422ff847c455a8f0b903717d4275f3` locally
before submission:

- parsed `.github/workflows/release.yml` with Ruby/Psych: valid YAML
- `python3 scripts/check_architecture_docs.py`: 14 crates documented; metrics current
- `git diff --check`: clean
- downloaded the exact Zig archive named in the workflow from `ziglang.org`
- independently calculated SHA-256
  `d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea`,
  matching the workflow pin and Zig's official release manifest
- extracted the archive successfully and observed its `zig` executable as a
  statically linked x86-64 ELF binary; the hosted Linux release leg will run
  `zig version` and then build the real release binary with it

The merge-triggered release is the decisive end-to-end check: both platform
builds and publication must pass, and its annotation list must no longer name
either action.

Hosted CI on the same exact head is green:

- Architecture Docs: pass
- Format: pass
- Check & Clippy: pass
- Tests: pass
- E2E Evaluation Harness: pass
- Security Audit: pass
- aggregate CI Pass gate: pass

## Known external configuration

This does not guess at credential contents. The separate deprecated `app-id`
input can only be renamed safely after confirming whether `APP_ID` contains a
GitHub App Client ID (or after adding an `APP_CLIENT_ID` variable). Apple
notarization also remains conditional on repository credentials; Developer ID
signing is still mandatory.

## Post-merge release verification

The decisive end-to-end run completed successfully:
https://github.com/gcbh/rustykrab/actions/runs/33856352471

- version/lockfile bump and tag push: pass
- Linux release build using the new checksum-verified Zig install: pass
- macOS release build, signing, and strict signature verification: pass
- GitHub Release publication using `softprops/action-gh-release@v3`: pass
- annotation audit: neither `mlugg/setup-zig` nor
  `softprops/action-gh-release` emits a Node 20 warning

Published release: https://github.com/gcbh/rustykrab/releases/tag/v5.2.32

- macOS archive SHA-256:
  `ff33226709967b2a7a1394a1d08026392655efdf0cdb75fb47ce63401cc8a3a5`
- Linux archive SHA-256:
  `5bfe4350965d48fc93aee44b8527f7e7f2ba88759095b0a4c36fbfd61f5e1f0c`
- independently downloaded hashes match GitHub's release-asset digests
- extracted macOS app passes `codesign --verify --deep --strict`, is valid on
  disk, and satisfies its designated requirement
- released macOS CLI reports `rustykrab 5.2.32 (dee0c0f, 2026-09-04)`
- extracted Linux CLI is an x86-64 ELF with highest observed required glibc
  symbol `GLIBC_2.34`, within the documented 2.35 compatibility target
- final tagged main is `dee0c0f38869239548e1dd4e0099590fdbcd592b`; full
  `cargo metadata --format-version 1` leaves the worktree clean and all 14
  workspace lockfile entries are version 5.2.32

The planning service was also rerun from that exact tagged main using a real
`rustykrab-cli` daemon and real SQLite database: 6 pass, 6 explicit future
xfail, 0 fail, 0 unexpected pass. A real restart replaced PID 50856 with PID
51161 and rehydrated the same revision. Independent SQLite queries observed 11
projects, 12 revisions, 25 plan nodes, zero non-user revisions, zero accepted
forged timestamps, zero missing provenance rows, zero cross-project ownership
violations, and no `PRAGMA foreign_key_check` output. Retained evidence is at
`/private/tmp/rustykrab-planning-main-evidence-dee0c0f`; retained database is
`/var/folders/mr/npjjtxn967j0l1y6k3h684sc0000gn/T/rustykrab-e2e-wIw2aV/db/store.db`.
